### PR TITLE
CI — GitHub Actions for build, test, lint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "deps"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,105 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: "1.25"
+          cache: true
+
+      - name: Build
+        run: go build ./...
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: "1.25"
+          cache: true
+
+      - name: Test
+        run: go test -race -coverprofile=coverage.out ./...
+
+      - name: Upload coverage
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: coverage
+          path: coverage.out
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: "1.25"
+          cache: true
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Install staticcheck
+        run: go install honnef.co/go/tools/cmd/staticcheck@2026.1
+
+      - name: Staticcheck
+        run: staticcheck ./...
+
+      - name: Format check
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "Files not formatted:"
+            echo "$unformatted"
+            exit 1
+          fi
+
+  mod:
+    name: Module checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: "1.25"
+          cache: true
+
+      - name: Tidy
+        run: |
+          go mod tidy
+          if ! git diff --exit-code go.mod go.sum; then
+            echo "go.mod or go.sum is not tidy — run 'go mod tidy' and commit"
+            exit 1
+          fi
+
+      - name: Verify
+        run: go mod verify

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,8 +96,9 @@ jobs:
       - name: Tidy
         run: |
           go mod tidy
-          if ! git diff --exit-code go.mod go.sum; then
+          if [ -n "$(git status --porcelain go.mod go.sum)" ]; then
             echo "go.mod or go.sum is not tidy — run 'go mod tidy' and commit"
+            git diff go.mod go.sum || true
             exit 1
           fi
 

--- a/schemas/implement.go
+++ b/schemas/implement.go
@@ -2,14 +2,14 @@ package schemas
 
 // ImplementOutput is the structured output for the implement phase.
 type ImplementOutput struct {
-	TicketKey     string            `json:"ticket_key"`
-	Branch        string            `json:"branch"`
-	Commits       []CommitRecord    `json:"commits"`
-	FilesChanged  []FileChange      `json:"files_changed"`
-	TaskResults   []TaskResult      `json:"task_results"`
-	TestsPassed   bool              `json:"tests_passed"`
-	TestOutput    string            `json:"test_output,omitempty"`
-	Deviations    []string          `json:"deviations,omitempty"`
+	TicketKey    string         `json:"ticket_key"`
+	Branch       string         `json:"branch"`
+	Commits      []CommitRecord `json:"commits"`
+	FilesChanged []FileChange   `json:"files_changed"`
+	TaskResults  []TaskResult   `json:"task_results"`
+	TestsPassed  bool           `json:"tests_passed"`
+	TestOutput   string         `json:"test_output,omitempty"`
+	Deviations   []string       `json:"deviations,omitempty"`
 }
 
 // CommitRecord is a single git commit made during implementation.
@@ -27,7 +27,7 @@ type FileChange struct {
 
 // TaskResult records the outcome of implementing a single task.
 type TaskResult struct {
-	TaskID    string `json:"task_id"`
-	Status    string `json:"status"` // completed, failed, skipped
-	Reason    string `json:"reason,omitempty"` // why failed/skipped
+	TaskID string `json:"task_id"`
+	Status string `json:"status"`           // completed, failed, skipped
+	Reason string `json:"reason,omitempty"` // why failed/skipped
 }

--- a/schemas/monitor.go
+++ b/schemas/monitor.go
@@ -2,12 +2,12 @@ package schemas
 
 // MonitorOutput is the structured output for a single monitor cycle.
 type MonitorOutput struct {
-	TicketKey      string           `json:"ticket_key"`
-	PRURL          string           `json:"pr_url"`
+	TicketKey       string          `json:"ticket_key"`
+	PRURL           string          `json:"pr_url"`
 	CommentsHandled []CommentAction `json:"comments_handled"`
-	FilesChanged   []FileChange    `json:"files_changed,omitempty"`
-	Commits        []CommitRecord  `json:"commits,omitempty"`
-	TestsPassed    bool            `json:"tests_passed"`
+	FilesChanged    []FileChange    `json:"files_changed,omitempty"`
+	Commits         []CommitRecord  `json:"commits,omitempty"`
+	TestsPassed     bool            `json:"tests_passed"`
 }
 
 // CommentAction records how a review comment was addressed.

--- a/schemas/plan.go
+++ b/schemas/plan.go
@@ -11,15 +11,15 @@ type PlanOutput struct {
 
 // PlanTask is an atomic unit of work within the plan.
 type PlanTask struct {
-	ID           string   `json:"id"`          // e.g. "T1", "T2"
-	Description  string   `json:"description"` // what to do
-	Files        []string `json:"files"`       // files to create or modify
-	DoneWhen     string   `json:"done_when"`   // verifiable condition
-	DependsOn    []string `json:"depends_on,omitempty"` // task IDs
+	ID          string   `json:"id"`                   // e.g. "T1", "T2"
+	Description string   `json:"description"`          // what to do
+	Files       []string `json:"files"`                // files to create or modify
+	DoneWhen    string   `json:"done_when"`            // verifiable condition
+	DependsOn   []string `json:"depends_on,omitempty"` // task IDs
 }
 
 // VerifyStrategy defines how to verify the implementation.
 type VerifyStrategy struct {
-	Commands    []string `json:"commands"`     // shell commands to run
+	Commands    []string `json:"commands"`               // shell commands to run
 	ManualSteps []string `json:"manual_steps,omitempty"` // human verification needed
 }

--- a/schemas/verify.go
+++ b/schemas/verify.go
@@ -2,12 +2,12 @@ package schemas
 
 // VerifyOutput is the structured output for the verify phase.
 type VerifyOutput struct {
-	TicketKey       string             `json:"ticket_key"`
-	Verdict         string             `json:"verdict"` // PASS, FAIL
-	CriteriaResults []CriterionResult  `json:"criteria_results"`
-	CommandResults  []CommandResult    `json:"command_results"`
-	CodeIssues      []CodeIssue        `json:"code_issues,omitempty"`
-	FixesRequired   []string           `json:"fixes_required,omitempty"`
+	TicketKey       string            `json:"ticket_key"`
+	Verdict         string            `json:"verdict"` // PASS, FAIL
+	CriteriaResults []CriterionResult `json:"criteria_results"`
+	CommandResults  []CommandResult   `json:"command_results"`
+	CodeIssues      []CodeIssue       `json:"code_issues,omitempty"`
+	FixesRequired   []string          `json:"fixes_required,omitempty"`
 }
 
 // CriterionResult is the pass/fail result for a single acceptance criterion.


### PR DESCRIPTION
## Summary

- Add GitHub Actions CI workflow with four parallel jobs: build, test (race + coverage), lint (vet, staticcheck, gofmt), and module checks (tidy, verify)
- Add Dependabot config for weekly Go module and GitHub Actions updates
- Triggers on push to `main` and PRs targeting `main`

### Security hardening
- All action versions pinned to full commit SHAs
- `staticcheck` pinned to `@2026.1`
- Top-level `permissions: contents: read`
- Job timeouts (10-15 min) to prevent runaway billing

Closes #10

## Test plan

- [ ] CI passes on this PR (build, test, lint, mod jobs all green)
- [ ] Verify `concurrency` cancels stale runs on rapid pushes
- [ ] Confirm Dependabot creates update PRs after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)