### PR TITLE
feat: pluggable ticket source with Jira implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,8 @@ config.yaml
 .vscode/
 *.swp
 
+# Worktrees
+.worktrees/
+
 # OS
 .DS_Store

--- a/internal/ticket/criteria.go
+++ b/internal/ticket/criteria.go
@@ -8,7 +8,7 @@ import (
 var (
 	// Matches common "Acceptance Criteria" headings in wiki markup, markdown, and plain text.
 	headingRe = regexp.MustCompile(
-		`(?i)^(?:h[1-6]\.\s+|\#{1,6}\s+|\*{2})?[Aa]cceptance\s+[Cc]riteria\*{0,2}:?\s*$`,
+		`(?i)^(?:h[1-6]\.\s+|\#{1,6}\s+|\*{2})?acceptance\s+criteria\*{0,2}:?\s*$`,
 	)
 	// Matches the start of a new heading (signals end of AC section).
 	nextHeadingRe = regexp.MustCompile(`^(?:h[1-6]\.\s+|\#{1,6}\s+)`)

--- a/internal/ticket/criteria.go
+++ b/internal/ticket/criteria.go
@@ -1,0 +1,54 @@
+package ticket
+
+import (
+	"regexp"
+	"strings"
+)
+
+var (
+	// Matches common "Acceptance Criteria" headings in wiki markup, markdown, and plain text.
+	headingRe = regexp.MustCompile(
+		`(?i)^(?:h[1-6]\.\s+|\#{1,6}\s+|\*{2})?[Aa]cceptance\s+[Cc]riteria\*{0,2}:?\s*$`,
+	)
+	// Matches the start of a new heading (signals end of AC section).
+	nextHeadingRe = regexp.MustCompile(`^(?:h[1-6]\.\s+|\#{1,6}\s+)`)
+	// Matches bullet items: *, -, or numbered (1., 2., etc.)
+	bulletRe = regexp.MustCompile(`^\s*(?:[-*]|\d+\.)\s+(.+)`)
+	// Strips checkbox prefixes: [ ], [x], [X]
+	checkboxRe = regexp.MustCompile(`^\[[ xX]\]\s*`)
+)
+
+// ExtractCriteria parses a ticket description and returns acceptance criteria
+// as a list of strings. It looks for a section headed "Acceptance Criteria"
+// (in various formats) and extracts bullet/numbered items from it.
+// Returns nil if no acceptance criteria section is found.
+func ExtractCriteria(description string) []string {
+	lines := strings.Split(description, "\n")
+	var criteria []string
+	inSection := false
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+
+		if headingRe.MatchString(trimmed) {
+			inSection = true
+			continue
+		}
+
+		if inSection {
+			if nextHeadingRe.MatchString(trimmed) {
+				break
+			}
+			if match := bulletRe.FindStringSubmatch(line); match != nil {
+				item := strings.TrimSpace(match[1])
+				item = checkboxRe.ReplaceAllString(item, "")
+				criteria = append(criteria, item)
+			}
+		}
+	}
+
+	return criteria
+}

--- a/internal/ticket/criteria_test.go
+++ b/internal/ticket/criteria_test.go
@@ -1,0 +1,152 @@
+package ticket
+
+import (
+	"testing"
+)
+
+func TestExtractCriteria(t *testing.T) {
+	tests := []struct {
+		name        string
+		description string
+		want        []string
+	}{
+		{
+			name: "wiki markup h3 heading with bullets",
+			description: `Some intro text.
+
+h3. Acceptance Criteria
+* Login page loads in under 2 seconds
+* Error message shown for invalid credentials
+* Session token stored securely
+
+h3. Notes
+Some other text.`,
+			want: []string{
+				"Login page loads in under 2 seconds",
+				"Error message shown for invalid credentials",
+				"Session token stored securely",
+			},
+		},
+		{
+			name: "markdown heading with dashes",
+			description: `## Description
+Fix the login flow.
+
+## Acceptance Criteria
+- Users can log in with email
+- Password reset sends email within 1 minute
+- Two-factor auth works with TOTP
+
+## Implementation Notes
+Use existing auth library.`,
+			want: []string{
+				"Users can log in with email",
+				"Password reset sends email within 1 minute",
+				"Two-factor auth works with TOTP",
+			},
+		},
+		{
+			name: "plain text heading with colon",
+			description: `Description of the ticket.
+
+Acceptance Criteria:
+- API returns 200 for valid input
+- API returns 400 for missing fields`,
+			want: []string{
+				"API returns 200 for valid input",
+				"API returns 400 for missing fields",
+			},
+		},
+		{
+			name: "bold heading",
+			description: `Do the thing.
+
+**Acceptance Criteria**
+- Feature A works
+- Feature B works`,
+			want: []string{
+				"Feature A works",
+				"Feature B works",
+			},
+		},
+		{
+			name: "case insensitive",
+			description: `h3. ACCEPTANCE CRITERIA
+* Item one
+* Item two`,
+			want: []string{
+				"Item one",
+				"Item two",
+			},
+		},
+		{
+			name: "no acceptance criteria section",
+			description: `Just a plain description with no AC section.
+This ticket does something useful.`,
+			want: nil,
+		},
+		{
+			name:        "empty description",
+			description: "",
+			want:        nil,
+		},
+		{
+			name: "numbered list items",
+			description: `## Acceptance Criteria
+1. First criterion
+2. Second criterion
+3. Third criterion`,
+			want: []string{
+				"First criterion",
+				"Second criterion",
+				"Third criterion",
+			},
+		},
+		{
+			name: "checkbox items",
+			description: `## Acceptance Criteria
+- [ ] Unchecked item
+- [x] Checked item
+- [ ] Another unchecked`,
+			want: []string{
+				"Unchecked item",
+				"Checked item",
+				"Another unchecked",
+			},
+		},
+		{
+			name: "stops at next heading",
+			description: `## Acceptance Criteria
+- First AC
+
+## Technical Details
+- This is not an AC`,
+			want: []string{
+				"First AC",
+			},
+		},
+		{
+			name: "wiki h2 heading",
+			description: `h2. Acceptance Criteria
+* Single criterion`,
+			want: []string{
+				"Single criterion",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractCriteria(tt.description)
+			if len(got) != len(tt.want) {
+				t.Fatalf("ExtractCriteria() returned %d items, want %d\ngot:  %v\nwant: %v",
+					len(got), len(tt.want), got, tt.want)
+			}
+			for idx := range got {
+				if got[idx] != tt.want[idx] {
+					t.Errorf("item[%d] = %q, want %q", idx, got[idx], tt.want[idx])
+				}
+			}
+		})
+	}
+}

--- a/internal/ticket/jira.go
+++ b/internal/ticket/jira.go
@@ -1,0 +1,210 @@
+package ticket
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// JiraConfig holds configuration for the Jira ticket source.
+type JiraConfig struct {
+	Command string // MCP server binary (e.g., "wtmcp")
+	Project string // Jira project key (e.g., "MYPROJECT")
+	Query   string // default JQL query for List when none is provided
+}
+
+// JiraSource fetches tickets from Jira via an MCP server (e.g., wtmcp).
+// Each call to Fetch or List spawns a short-lived MCP session.
+type JiraSource struct {
+	config JiraConfig
+}
+
+// NewJiraSource creates a Jira ticket source with the given configuration.
+func NewJiraSource(config JiraConfig) (*JiraSource, error) {
+	if config.Command == "" {
+		return nil, fmt.Errorf("ticket: jira command is required")
+	}
+	return &JiraSource{config: config}, nil
+}
+
+// Fetch retrieves a single Jira issue by key.
+func (s *JiraSource) Fetch(ctx context.Context, key string) (*Ticket, error) {
+	client, err := newMCPClient(ctx, s.config.Command)
+	if err != nil {
+		return nil, fmt.Errorf("ticket: jira fetch %s: %w", key, err)
+	}
+	defer client.close()
+
+	text, err := client.callTool("jira_get_issues", map[string]any{
+		"issue_keys": key,
+		"brief":      false,
+		"fields":     "*",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("ticket: jira fetch %s: %w", key, err)
+	}
+
+	var result jiraSearchResult
+	if err := json.Unmarshal([]byte(text), &result); err != nil {
+		return nil, fmt.Errorf("ticket: jira parse response for %s: %w", key, err)
+	}
+
+	if len(result.Issues) == 0 {
+		return nil, fmt.Errorf("ticket: jira issue %s not found", key)
+	}
+
+	issue := result.Issues[0]
+	if issue.Error != "" {
+		return nil, fmt.Errorf("ticket: jira issue %s: %s", key, issue.Error)
+	}
+
+	return issue.toTicket(), nil
+}
+
+// List returns tickets matching a JQL query. If query is empty, the
+// configured default query is used.
+func (s *JiraSource) List(ctx context.Context, query string) ([]Ticket, error) {
+	if query == "" {
+		query = s.config.Query
+	}
+	if query == "" {
+		return nil, fmt.Errorf("ticket: jira list requires a query")
+	}
+
+	client, err := newMCPClient(ctx, s.config.Command)
+	if err != nil {
+		return nil, fmt.Errorf("ticket: jira list: %w", err)
+	}
+	defer client.close()
+
+	text, err := client.callTool("jira_search", map[string]any{
+		"jql":         query,
+		"brief":       false,
+		"fields":      "summary,description,issuetype,priority,labels,status",
+		"max_results": 50,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("ticket: jira list: %w", err)
+	}
+
+	var result jiraSearchResult
+	if err := json.Unmarshal([]byte(text), &result); err != nil {
+		return nil, fmt.Errorf("ticket: jira parse search results: %w", err)
+	}
+
+	tickets := make([]Ticket, 0, len(result.Issues))
+	for _, issue := range result.Issues {
+		if issue.Error != "" {
+			continue // skip inaccessible issues
+		}
+		tickets = append(tickets, *issue.toTicket())
+	}
+
+	return tickets, nil
+}
+
+// Jira API response types
+
+type jiraSearchResult struct {
+	Issues []jiraIssue `json:"issues"`
+	Count  int         `json:"count"`
+	Total  int         `json:"total"`
+}
+
+type jiraIssue struct {
+	Key    string          `json:"key"`
+	Fields json.RawMessage `json:"fields"`
+	Error  string          `json:"error,omitempty"`
+}
+
+type jiraFields struct {
+	Summary     string         `json:"summary"`
+	Description any            `json:"description"` // string (Server) or ADF JSON (Cloud)
+	IssueType   *jiraNameField `json:"issuetype"`
+	Priority    *jiraNameField `json:"priority"`
+	Status      *jiraNameField `json:"status"`
+	Labels      []string       `json:"labels"`
+}
+
+type jiraNameField struct {
+	Name string `json:"name"`
+}
+
+func (issue *jiraIssue) toTicket() *Ticket {
+	var fields jiraFields
+	if err := json.Unmarshal(issue.Fields, &fields); err != nil {
+		return &Ticket{Key: issue.Key}
+	}
+
+	description := extractDescription(fields.Description)
+
+	var rawFields map[string]any
+	_ = json.Unmarshal(issue.Fields, &rawFields)
+
+	ticket := &Ticket{
+		Key:                issue.Key,
+		Summary:            fields.Summary,
+		Description:        description,
+		Labels:             fields.Labels,
+		AcceptanceCriteria: ExtractCriteria(description),
+		RawFields:          rawFields,
+	}
+
+	if fields.IssueType != nil {
+		ticket.Type = fields.IssueType.Name
+	}
+	if fields.Priority != nil {
+		ticket.Priority = fields.Priority.Name
+	}
+	if fields.Status != nil {
+		ticket.Status = fields.Status.Name
+	}
+
+	return ticket
+}
+
+// extractDescription converts the Jira description field to plain text.
+// Server/DC returns a string; Cloud v3 returns an ADF document (JSON object).
+func extractDescription(desc any) string {
+	switch val := desc.(type) {
+	case string:
+		return val
+	case map[string]any:
+		var builder strings.Builder
+		extractADFText(val, &builder)
+		return builder.String()
+	default:
+		return ""
+	}
+}
+
+// extractADFText recursively extracts text from an Atlassian Document Format node.
+func extractADFText(node map[string]any, builder *strings.Builder) {
+	if text, ok := node["text"].(string); ok {
+		builder.WriteString(text)
+	}
+
+	content, ok := node["content"].([]any)
+	if !ok {
+		return
+	}
+
+	for _, child := range content {
+		childMap, ok := child.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		childType, _ := childMap["type"].(string)
+		if childType == "listItem" {
+			builder.WriteString("- ")
+		}
+
+		extractADFText(childMap, builder)
+
+		if childType == "paragraph" || childType == "heading" || childType == "listItem" {
+			builder.WriteString("\n")
+		}
+	}
+}

--- a/internal/ticket/jira.go
+++ b/internal/ticket/jira.go
@@ -10,7 +10,6 @@ import (
 // JiraConfig holds configuration for the Jira ticket source.
 type JiraConfig struct {
 	Command string // MCP server binary (e.g., "wtmcp")
-	Project string // Jira project key (e.g., "MYPROJECT")
 	Query   string // default JQL query for List when none is provided
 }
 
@@ -42,7 +41,7 @@ func (s *JiraSource) Fetch(ctx context.Context, key string) (*Ticket, error) {
 		"fields":     "*",
 	})
 	if err != nil {
-		return nil, fmt.Errorf("ticket: jira fetch %s: %w", key, err)
+		return nil, fmt.Errorf("ticket: jira fetch %s: %w (stderr: %s)", key, err, client.stderrText())
 	}
 
 	var result jiraSearchResult
@@ -85,7 +84,7 @@ func (s *JiraSource) List(ctx context.Context, query string) ([]Ticket, error) {
 		"max_results": 50,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("ticket: jira list: %w", err)
+		return nil, fmt.Errorf("ticket: jira list: %w (stderr: %s)", err, client.stderrText())
 	}
 
 	var result jiraSearchResult

--- a/internal/ticket/jira_test.go
+++ b/internal/ticket/jira_test.go
@@ -208,6 +208,5 @@ func TestJiraSource_Fetch_BadBinary(t *testing.T) {
 var _ Source = (*JiraSource)(nil)
 
 func TestMain(m *testing.M) {
-	// Ensure mock_mcp.sh is executable
 	os.Exit(m.Run())
 }

--- a/internal/ticket/jira_test.go
+++ b/internal/ticket/jira_test.go
@@ -1,0 +1,213 @@
+package ticket
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func testdataDir(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot determine test file path")
+	}
+	return filepath.Join(filepath.Dir(file), "testdata")
+}
+
+func mockBinary(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(testdataDir(t), "mock_mcp.sh")
+}
+
+func TestJiraSource_Fetch(t *testing.T) {
+	t.Setenv("MOCK_MCP_FIXTURE", "jira_fetch.json")
+
+	source, err := NewJiraSource(JiraConfig{Command: mockBinary(t)})
+	if err != nil {
+		t.Fatalf("NewJiraSource: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	ticket, err := source.Fetch(ctx, "PROJ-42")
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+
+	if ticket.Key != "PROJ-42" {
+		t.Errorf("Key = %q, want %q", ticket.Key, "PROJ-42")
+	}
+	if ticket.Summary != "Add user authentication" {
+		t.Errorf("Summary = %q, want %q", ticket.Summary, "Add user authentication")
+	}
+	if ticket.Type != "Story" {
+		t.Errorf("Type = %q, want %q", ticket.Type, "Story")
+	}
+	if ticket.Priority != "High" {
+		t.Errorf("Priority = %q, want %q", ticket.Priority, "High")
+	}
+	if ticket.Status != "In Progress" {
+		t.Errorf("Status = %q, want %q", ticket.Status, "In Progress")
+	}
+	if len(ticket.Labels) != 2 || ticket.Labels[0] != "backend" || ticket.Labels[1] != "auth" {
+		t.Errorf("Labels = %v, want [backend auth]", ticket.Labels)
+	}
+
+	// Acceptance criteria should be extracted from description
+	wantAC := []string{
+		"Users can register with email",
+		"Users can log in with credentials",
+		"Session expires after 30 minutes",
+	}
+	if len(ticket.AcceptanceCriteria) != len(wantAC) {
+		t.Fatalf("AcceptanceCriteria len = %d, want %d: %v",
+			len(ticket.AcceptanceCriteria), len(wantAC), ticket.AcceptanceCriteria)
+	}
+	for idx, want := range wantAC {
+		if ticket.AcceptanceCriteria[idx] != want {
+			t.Errorf("AcceptanceCriteria[%d] = %q, want %q", idx, ticket.AcceptanceCriteria[idx], want)
+		}
+	}
+
+	// RawFields should contain all Jira fields
+	if ticket.RawFields == nil {
+		t.Fatal("RawFields is nil")
+	}
+	if _, ok := ticket.RawFields["summary"]; !ok {
+		t.Error("RawFields missing 'summary'")
+	}
+	if _, ok := ticket.RawFields["components"]; !ok {
+		t.Error("RawFields missing 'components' (source-specific field)")
+	}
+}
+
+func TestJiraSource_Fetch_NotFound(t *testing.T) {
+	t.Setenv("MOCK_MCP_FIXTURE", "jira_not_found.json")
+
+	source, err := NewJiraSource(JiraConfig{Command: mockBinary(t)})
+	if err != nil {
+		t.Fatalf("NewJiraSource: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_, err = source.Fetch(ctx, "PROJ-999")
+	if err == nil {
+		t.Fatal("Fetch should fail for not-found issue")
+	}
+}
+
+func TestJiraSource_List(t *testing.T) {
+	t.Setenv("MOCK_MCP_FIXTURE", "jira_search.json")
+
+	source, err := NewJiraSource(JiraConfig{
+		Command: mockBinary(t),
+		Query:   "project = PROJ",
+	})
+	if err != nil {
+		t.Fatalf("NewJiraSource: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	tickets, err := source.List(ctx, "")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+
+	if len(tickets) != 2 {
+		t.Fatalf("List returned %d tickets, want 2", len(tickets))
+	}
+
+	if tickets[0].Key != "PROJ-42" {
+		t.Errorf("tickets[0].Key = %q, want %q", tickets[0].Key, "PROJ-42")
+	}
+	if tickets[1].Key != "PROJ-43" {
+		t.Errorf("tickets[1].Key = %q, want %q", tickets[1].Key, "PROJ-43")
+	}
+	if tickets[1].Type != "Bug" {
+		t.Errorf("tickets[1].Type = %q, want %q", tickets[1].Type, "Bug")
+	}
+
+	// First ticket should have extracted AC from wiki markup
+	if len(tickets[0].AcceptanceCriteria) != 2 {
+		t.Errorf("tickets[0].AcceptanceCriteria = %v, want 2 items", tickets[0].AcceptanceCriteria)
+	}
+	// Second ticket has no AC section
+	if len(tickets[1].AcceptanceCriteria) != 0 {
+		t.Errorf("tickets[1].AcceptanceCriteria = %v, want empty", tickets[1].AcceptanceCriteria)
+	}
+}
+
+func TestJiraSource_List_ExplicitQuery(t *testing.T) {
+	t.Setenv("MOCK_MCP_FIXTURE", "jira_empty_search.json")
+
+	source, err := NewJiraSource(JiraConfig{Command: mockBinary(t)})
+	if err != nil {
+		t.Fatalf("NewJiraSource: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	tickets, err := source.List(ctx, "status = Done")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+
+	if len(tickets) != 0 {
+		t.Errorf("List returned %d tickets, want 0", len(tickets))
+	}
+}
+
+func TestJiraSource_List_NoQuery(t *testing.T) {
+	source, err := NewJiraSource(JiraConfig{Command: mockBinary(t)})
+	if err != nil {
+		t.Fatalf("NewJiraSource: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_, err = source.List(ctx, "")
+	if err == nil {
+		t.Fatal("List should fail when no query is provided and no default is configured")
+	}
+}
+
+func TestNewJiraSource_EmptyCommand(t *testing.T) {
+	_, err := NewJiraSource(JiraConfig{})
+	if err == nil {
+		t.Fatal("NewJiraSource should fail with empty command")
+	}
+}
+
+func TestJiraSource_Fetch_BadBinary(t *testing.T) {
+	source, err := NewJiraSource(JiraConfig{Command: "/nonexistent/binary"})
+	if err != nil {
+		t.Fatalf("NewJiraSource: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err = source.Fetch(ctx, "PROJ-1")
+	if err == nil {
+		t.Fatal("Fetch should fail with bad binary")
+	}
+}
+
+// Verify JiraSource satisfies Source interface at compile time.
+var _ Source = (*JiraSource)(nil)
+
+func TestMain(m *testing.M) {
+	// Ensure mock_mcp.sh is executable
+	os.Exit(m.Run())
+}

--- a/internal/ticket/mcp.go
+++ b/internal/ticket/mcp.go
@@ -1,0 +1,203 @@
+package ticket
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"sync/atomic"
+)
+
+// mcpClient is a thin MCP (Model Context Protocol) client that communicates
+// with an MCP server subprocess over stdio using JSON-RPC 2.0.
+type mcpClient struct {
+	cmd    *exec.Cmd
+	stdin  io.WriteCloser
+	reader *bufio.Reader
+	nextID atomic.Int64
+}
+
+type jsonRPCRequest struct {
+	JSONRPC string `json:"jsonrpc"`
+	ID      int64  `json:"id,omitempty"`
+	Method  string `json:"method"`
+	Params  any    `json:"params,omitempty"`
+}
+
+type jsonRPCResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      int64           `json:"id"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *jsonRPCError   `json:"error,omitempty"`
+}
+
+type jsonRPCError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+type mcpToolResult struct {
+	Content []mcpContent `json:"content"`
+	IsError bool         `json:"isError,omitempty"`
+}
+
+type mcpContent struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// newMCPClient spawns an MCP server process and performs the protocol
+// initialization handshake. The caller must call close() when done.
+func newMCPClient(ctx context.Context, binary string, extraArgs ...string) (*mcpClient, error) {
+	args := append(extraArgs, "serve")
+	cmd := exec.CommandContext(ctx, binary, args...)
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("mcp: stdin pipe: %w", err)
+	}
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("mcp: stdout pipe: %w", err)
+	}
+
+	cmd.Stderr = io.Discard
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("mcp: start %s: %w", binary, err)
+	}
+
+	client := &mcpClient{
+		cmd:    cmd,
+		stdin:  stdin,
+		reader: bufio.NewReaderSize(stdout, 1024*1024), // 1MB line buffer
+	}
+
+	if err := client.initialize(); err != nil {
+		client.close()
+		return nil, err
+	}
+
+	return client, nil
+}
+
+func (c *mcpClient) initialize() error {
+	initParams := map[string]any{
+		"protocolVersion": "2024-11-05",
+		"capabilities":    map[string]any{},
+		"clientInfo": map[string]any{
+			"name":    "soda",
+			"version": "0.1.0",
+		},
+	}
+
+	_, err := c.send("initialize", initParams)
+	if err != nil {
+		return fmt.Errorf("mcp: initialize: %w", err)
+	}
+
+	// Send initialized notification (no ID, no response expected)
+	notification := jsonRPCRequest{
+		JSONRPC: "2.0",
+		Method:  "notifications/initialized",
+	}
+	data, err := json.Marshal(notification)
+	if err != nil {
+		return fmt.Errorf("mcp: marshal notification: %w", err)
+	}
+	if _, err := fmt.Fprintf(c.stdin, "%s\n", data); err != nil {
+		return fmt.Errorf("mcp: send notification: %w", err)
+	}
+
+	return nil
+}
+
+func (c *mcpClient) send(method string, params any) (json.RawMessage, error) {
+	id := c.nextID.Add(1)
+
+	req := jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      id,
+		Method:  method,
+		Params:  params,
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("mcp: marshal request: %w", err)
+	}
+
+	if _, err := fmt.Fprintf(c.stdin, "%s\n", data); err != nil {
+		return nil, fmt.Errorf("mcp: write: %w", err)
+	}
+
+	// Read response lines until we find one with matching ID.
+	// Skip notifications and log lines the server may emit.
+	for {
+		line, err := c.reader.ReadBytes('\n')
+		if err != nil {
+			return nil, fmt.Errorf("mcp: read response: %w", err)
+		}
+
+		var resp jsonRPCResponse
+		if err := json.Unmarshal(line, &resp); err != nil {
+			continue // skip non-JSON lines
+		}
+
+		if resp.ID != id {
+			continue // skip notifications or other responses
+		}
+
+		if resp.Error != nil {
+			return nil, fmt.Errorf("mcp: server error %d: %s", resp.Error.Code, resp.Error.Message)
+		}
+
+		return resp.Result, nil
+	}
+}
+
+// callTool invokes a named tool and returns the concatenated text content.
+func (c *mcpClient) callTool(name string, arguments map[string]any) (string, error) {
+	params := map[string]any{
+		"name":      name,
+		"arguments": arguments,
+	}
+
+	raw, err := c.send("tools/call", params)
+	if err != nil {
+		return "", err
+	}
+
+	var result mcpToolResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return "", fmt.Errorf("mcp: unmarshal tool result: %w", err)
+	}
+
+	if result.IsError {
+		var msgs []string
+		for _, block := range result.Content {
+			if block.Type == "text" {
+				msgs = append(msgs, block.Text)
+			}
+		}
+		return "", fmt.Errorf("mcp: tool error: %s", strings.Join(msgs, "; "))
+	}
+
+	var texts []string
+	for _, block := range result.Content {
+		if block.Type == "text" {
+			texts = append(texts, block.Text)
+		}
+	}
+
+	return strings.Join(texts, ""), nil
+}
+
+func (c *mcpClient) close() error {
+	c.stdin.Close()
+	return c.cmd.Wait()
+}

--- a/internal/ticket/mcp.go
+++ b/internal/ticket/mcp.go
@@ -2,6 +2,7 @@ package ticket
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -17,6 +18,7 @@ type mcpClient struct {
 	cmd    *exec.Cmd
 	stdin  io.WriteCloser
 	reader *bufio.Reader
+	stderr *bytes.Buffer
 	nextID atomic.Int64
 }
 
@@ -52,7 +54,9 @@ type mcpContent struct {
 // newMCPClient spawns an MCP server process and performs the protocol
 // initialization handshake. The caller must call close() when done.
 func newMCPClient(ctx context.Context, binary string, extraArgs ...string) (*mcpClient, error) {
-	args := append(extraArgs, "serve")
+	args := make([]string, 0, len(extraArgs)+1)
+	args = append(args, extraArgs...)
+	args = append(args, "serve")
 	cmd := exec.CommandContext(ctx, binary, args...)
 
 	stdin, err := cmd.StdinPipe()
@@ -65,7 +69,8 @@ func newMCPClient(ctx context.Context, binary string, extraArgs ...string) (*mcp
 		return nil, fmt.Errorf("mcp: stdout pipe: %w", err)
 	}
 
-	cmd.Stderr = io.Discard
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = &limitedWriter{buf: &stderrBuf, max: 64 * 1024} // 64KB cap
 
 	if err := cmd.Start(); err != nil {
 		return nil, fmt.Errorf("mcp: start %s: %w", binary, err)
@@ -75,6 +80,7 @@ func newMCPClient(ctx context.Context, binary string, extraArgs ...string) (*mcp
 		cmd:    cmd,
 		stdin:  stdin,
 		reader: bufio.NewReaderSize(stdout, 1024*1024), // 1MB line buffer
+		stderr: &stderrBuf,
 	}
 
 	if err := client.initialize(); err != nil {
@@ -198,6 +204,29 @@ func (c *mcpClient) callTool(name string, arguments map[string]any) (string, err
 }
 
 func (c *mcpClient) close() error {
-	c.stdin.Close()
+	_ = c.stdin.Close() // best-effort; Wait() is the authoritative error
 	return c.cmd.Wait()
+}
+
+// stderrText returns captured server stderr for diagnostics.
+func (c *mcpClient) stderrText() string {
+	return c.stderr.String()
+}
+
+// limitedWriter writes up to max bytes, silently discarding excess.
+type limitedWriter struct {
+	buf *bytes.Buffer
+	max int
+}
+
+func (w *limitedWriter) Write(p []byte) (int, error) {
+	remaining := w.max - w.buf.Len()
+	if remaining <= 0 {
+		return len(p), nil
+	}
+	if len(p) > remaining {
+		w.buf.Write(p[:remaining])
+		return len(p), nil
+	}
+	return w.buf.Write(p)
 }

--- a/internal/ticket/source.go
+++ b/internal/ticket/source.go
@@ -1,0 +1,9 @@
+package ticket
+
+import "context"
+
+// Source provides read access to tickets from an external tracking system.
+type Source interface {
+	Fetch(ctx context.Context, key string) (*Ticket, error)
+	List(ctx context.Context, query string) ([]Ticket, error)
+}

--- a/internal/ticket/testdata/jira_empty_search.json
+++ b/internal/ticket/testdata/jira_empty_search.json
@@ -1,0 +1,5 @@
+{
+  "issues": [],
+  "count": 0,
+  "total": 0
+}

--- a/internal/ticket/testdata/jira_fetch.json
+++ b/internal/ticket/testdata/jira_fetch.json
@@ -1,0 +1,20 @@
+{
+  "issues": [
+    {
+      "key": "PROJ-42",
+      "id": "10042",
+      "fields": {
+        "summary": "Add user authentication",
+        "description": "Implement login and registration.\n\n## Acceptance Criteria\n- Users can register with email\n- Users can log in with credentials\n- Session expires after 30 minutes",
+        "issuetype": {"name": "Story", "id": "10001"},
+        "priority": {"name": "High", "id": "2"},
+        "status": {"name": "In Progress", "id": "3"},
+        "labels": ["backend", "auth"],
+        "assignee": {"displayName": "Alice", "emailAddress": "alice@example.com"},
+        "components": [{"name": "API"}],
+        "created": "2026-04-01T10:00:00.000+0000"
+      }
+    }
+  ],
+  "count": 1
+}

--- a/internal/ticket/testdata/jira_not_found.json
+++ b/internal/ticket/testdata/jira_not_found.json
@@ -1,0 +1,6 @@
+{
+  "issues": [
+    {"key": "PROJ-999", "error": "Issue not found or not accessible"}
+  ],
+  "count": 1
+}

--- a/internal/ticket/testdata/jira_search.json
+++ b/internal/ticket/testdata/jira_search.json
@@ -1,0 +1,30 @@
+{
+  "issues": [
+    {
+      "key": "PROJ-42",
+      "id": "10042",
+      "fields": {
+        "summary": "Add user authentication",
+        "description": "Implement login and registration.\n\nh3. Acceptance Criteria\n* Users can register with email\n* Users can log in with credentials",
+        "issuetype": {"name": "Story", "id": "10001"},
+        "priority": {"name": "High", "id": "2"},
+        "status": {"name": "In Progress", "id": "3"},
+        "labels": ["backend"]
+      }
+    },
+    {
+      "key": "PROJ-43",
+      "id": "10043",
+      "fields": {
+        "summary": "Fix payment processing",
+        "description": "Payment fails for some currencies.",
+        "issuetype": {"name": "Bug", "id": "10002"},
+        "priority": {"name": "Critical", "id": "1"},
+        "status": {"name": "Open", "id": "1"},
+        "labels": ["payments"]
+      }
+    }
+  ],
+  "count": 2,
+  "total": 2
+}

--- a/internal/ticket/testdata/mock_mcp.sh
+++ b/internal/ticket/testdata/mock_mcp.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Mock MCP server for testing. Responds to JSON-RPC initialize and tools/call
+# requests via stdin/stdout. Reads fixture responses from files specified
+# by the MOCK_MCP_FIXTURE env var (one fixture per tools/call, comma-separated).
+#
+# Usage:
+#   MOCK_MCP_FIXTURE=fetch.json ./mock_mcp.sh serve
+#
+# Protocol: newline-delimited JSON-RPC 2.0 over stdio.
+
+set -euo pipefail
+
+# Only handle "serve" subcommand (like real wtmcp)
+if [[ "${1:-}" != "serve" ]]; then
+    echo "mock_mcp: unknown command '${1:-}'" >&2
+    exit 1
+fi
+
+FIXTURE_DIR="$(dirname "$0")"
+IFS=',' read -ra FIXTURES <<< "${MOCK_MCP_FIXTURE:-}"
+fixture_idx=0
+
+while IFS= read -r line; do
+    # Parse the method from the JSON-RPC request
+    method=$(echo "$line" | python3 -c "import sys,json; print(json.load(sys.stdin).get('method',''))" 2>/dev/null || true)
+    id=$(echo "$line" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',0))" 2>/dev/null || true)
+
+    case "$method" in
+        initialize)
+            echo "{\"jsonrpc\":\"2.0\",\"id\":${id},\"result\":{\"protocolVersion\":\"2024-11-05\",\"capabilities\":{\"tools\":{}},\"serverInfo\":{\"name\":\"mock-mcp\",\"version\":\"0.0.1\"}}}"
+            ;;
+        notifications/initialized)
+            # Notification — no response
+            ;;
+        tools/call)
+            if [[ $fixture_idx -lt ${#FIXTURES[@]} ]]; then
+                fixture_file="${FIXTURE_DIR}/${FIXTURES[$fixture_idx]}"
+                fixture_idx=$((fixture_idx + 1))
+            else
+                echo "{\"jsonrpc\":\"2.0\",\"id\":${id},\"error\":{\"code\":-1,\"message\":\"no more fixtures\"}}"
+                continue
+            fi
+
+            if [[ ! -f "$fixture_file" ]]; then
+                echo "{\"jsonrpc\":\"2.0\",\"id\":${id},\"error\":{\"code\":-1,\"message\":\"fixture not found: $fixture_file\"}}" >&2
+                exit 1
+            fi
+
+            # Read fixture content as the tool result text
+            content=$(python3 -c "
+import json, sys
+with open('$fixture_file') as f:
+    data = f.read()
+result = {'content': [{'type': 'text', 'text': data}]}
+print(json.dumps({'jsonrpc': '2.0', 'id': $id, 'result': result}, separators=(',', ':')))" 2>/dev/null)
+            echo "$content"
+            ;;
+        *)
+            echo "{\"jsonrpc\":\"2.0\",\"id\":${id},\"error\":{\"code\":-32601,\"message\":\"method not found: $method\"}}"
+            ;;
+    esac
+done

--- a/internal/ticket/ticket.go
+++ b/internal/ticket/ticket.go
@@ -4,13 +4,13 @@ package ticket
 // Prompt templates access these fields directly (e.g., .Ticket.Key, .Ticket.Summary).
 // Source-specific data is available via RawFields.
 type Ticket struct {
-	Key                string
-	Summary            string
-	Description        string
-	Type               string
-	Priority           string
-	Status             string
-	Labels             []string
-	AcceptanceCriteria []string
-	RawFields          map[string]any
+	Key                string         `json:"key"`
+	Summary            string         `json:"summary"`
+	Description        string         `json:"description"`
+	Type               string         `json:"type"`
+	Priority           string         `json:"priority"`
+	Status             string         `json:"status"`
+	Labels             []string       `json:"labels"`
+	AcceptanceCriteria []string       `json:"acceptance_criteria"`
+	RawFields          map[string]any `json:"raw_fields,omitempty"`
 }

--- a/internal/ticket/ticket.go
+++ b/internal/ticket/ticket.go
@@ -1,0 +1,16 @@
+package ticket
+
+// Ticket holds the common fields extracted from any ticket source.
+// Prompt templates access these fields directly (e.g., .Ticket.Key, .Ticket.Summary).
+// Source-specific data is available via RawFields.
+type Ticket struct {
+	Key                string
+	Summary            string
+	Description        string
+	Type               string
+	Priority           string
+	Status             string
+	Labels             []string
+	AcceptanceCriteria []string
+	RawFields          map[string]any
+}


### PR DESCRIPTION
## Summary

- Adds `Source` interface with `Fetch(ctx, key)` and `List(ctx, query)` for pluggable ticket sources
- Implements Jira source via wtmcp MCP server (JSON-RPC 2.0 over stdio)
- Extracts acceptance criteria from ticket descriptions (wiki markup, markdown, plain text, numbered/checkbox lists)
- Populates `RawFields` with all Jira fields for prompt template access
- Config-driven via `JiraConfig` struct (command, default query)

Closes #6

## Files

| File | Purpose |
|------|---------|
| `ticket.go` | `Ticket` struct with JSON tags |
| `source.go` | `Source` interface |
| `criteria.go` | `ExtractCriteria()` parser |
| `mcp.go` | Thin MCP JSON-RPC client (unexported) |
| `jira.go` | `JiraSource` + `JiraConfig` |
| `*_test.go` | 18 tests (criteria + Jira source via mock MCP server) |
| `testdata/` | Mock MCP server script + 4 JSON fixtures |

## Test plan

- [x] `go test -race ./...` passes (18 new tests + existing claude/ tests)
- [x] `go vet ./...` clean
- [x] `gofmt` clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)