### PR TITLE
docs: add Co-Authored-By convention to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,7 +166,7 @@ Atomic writes: always write to `.tmp` then rename. Archive on re-run (`verify.js
 - Only stage specific files with `git add <file>`, never `git add .` or `git add -A`.
 - Do not force-push unless explicitly asked.
 - Do not amend published commits.
-- **Co-Authored-By**: use a single `Co-Authored-By: Claude <noreply@anthropic.com>` line at the end of the commit message. Do not include model name or version. Do not repeat the line per commit when squash-merging — one line at the end of the final message.
+- **Assisted-By**: use a single `Assisted-By: Claude <noreply@anthropic.com>` trailer at the end of the commit message. Do not include model name or version. Do not repeat the line per commit when squash-merging — one trailer at the end of the final message.
 - After PR is merged, start fresh — never build on already-merged branches.
 
 ## Conventions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,7 +166,7 @@ Atomic writes: always write to `.tmp` then rename. Archive on re-run (`verify.js
 - Only stage specific files with `git add <file>`, never `git add .` or `git add -A`.
 - Do not force-push unless explicitly asked.
 - Do not amend published commits.
-- **Assisted-By**: use a single `Assisted-By: Claude <noreply@anthropic.com>` trailer at the end of the commit message. Do not include model name or version. Do not repeat the line per commit when squash-merging — one trailer at the end of the final message.
+- **Assisted-By**: add an `Assisted-by:` trailer at the end of the commit message naming the model used (e.g., `Assisted-by: Claude Opus 4.6`, `Assisted-by: GPT-4o`). One trailer per commit. Do not repeat when squash-merging — one at the end of the final message.
 - After PR is merged, start fresh — never build on already-merged branches.
 
 ## Conventions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,6 +166,7 @@ Atomic writes: always write to `.tmp` then rename. Archive on re-run (`verify.js
 - Only stage specific files with `git add <file>`, never `git add .` or `git add -A`.
 - Do not force-push unless explicitly asked.
 - Do not amend published commits.
+- **Co-Authored-By**: use a single `Co-Authored-By: Claude <noreply@anthropic.com>` line at the end of the commit message. Do not include model name or version. Do not repeat the line per commit when squash-merging — one line at the end of the final message.
 - After PR is merged, start fresh — never build on already-merged branches.
 
 ## Conventions


### PR DESCRIPTION
## Summary

- Adds rule: single `Co-Authored-By: Claude <noreply@anthropic.com>` at end of commit message — no model name/version, no repetition when squash-merging

## Test plan

- [x] Docs-only change, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)