### PR TITLE
fix(engine): dispatch phase lifecycle events to OnEvent callback

### DIFF
--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -206,7 +206,8 @@ func (e *Engine) runPhase(ctx context.Context, phase PhaseConfig) error {
 		})
 	}
 
-	// Mark phase running.
+	// Mark phase running and notify callback.
+	e.emit(Event{Phase: phase.Name, Kind: EventPhaseStarted})
 	if err := e.state.MarkRunning(phase.Name); err != nil {
 		return fmt.Errorf("engine: mark running %s: %w", phase.Name, err)
 	}
@@ -215,18 +216,21 @@ func (e *Engine) runPhase(ctx context.Context, phase PhaseConfig) error {
 	promptData, err := e.buildPromptData(phase)
 	if err != nil {
 		_ = e.state.MarkFailed(phase.Name, err)
+		e.emit(Event{Phase: phase.Name, Kind: EventPhaseFailed, Data: map[string]any{"error": err.Error()}})
 		return fmt.Errorf("engine: build prompt data for %s: %w", phase.Name, err)
 	}
 
 	tmplContent, err := e.config.Loader.Load(phase.Prompt)
 	if err != nil {
 		_ = e.state.MarkFailed(phase.Name, err)
+		e.emit(Event{Phase: phase.Name, Kind: EventPhaseFailed, Data: map[string]any{"error": err.Error()}})
 		return fmt.Errorf("engine: load template for %s: %w", phase.Name, err)
 	}
 
 	rendered, err := RenderPrompt(tmplContent, promptData)
 	if err != nil {
 		_ = e.state.MarkFailed(phase.Name, err)
+		e.emit(Event{Phase: phase.Name, Kind: EventPhaseFailed, Data: map[string]any{"error": err.Error()}})
 		return fmt.Errorf("engine: render prompt for %s: %w", phase.Name, err)
 	}
 
@@ -253,6 +257,7 @@ func (e *Engine) runPhase(ctx context.Context, phase PhaseConfig) error {
 	result, err := e.runWithRetry(ctx, phase, opts)
 	if err != nil {
 		_ = e.state.MarkFailed(phase.Name, err)
+		e.emit(Event{Phase: phase.Name, Kind: EventPhaseFailed, Data: map[string]any{"error": err.Error()}})
 		return err
 	}
 
@@ -271,10 +276,15 @@ func (e *Engine) runPhase(ctx context.Context, phase PhaseConfig) error {
 		return fmt.Errorf("engine: accumulate cost for %s: %w", phase.Name, err)
 	}
 
-	// Mark completed.
+	// Mark completed and notify callback.
 	if err := e.state.MarkCompleted(phase.Name); err != nil {
 		return fmt.Errorf("engine: mark completed %s: %w", phase.Name, err)
 	}
+	e.emit(Event{
+		Phase: phase.Name,
+		Kind:  EventPhaseCompleted,
+		Data:  map[string]any{"duration_ms": e.state.Meta().Phases[phase.Name].DurationMs, "cost": e.state.Meta().Phases[phase.Name].Cost},
+	})
 
 	// Domain gating.
 	return e.gatePhase(phase)
@@ -534,6 +544,7 @@ func (e *Engine) gatePhase(phase PhaseConfig) error {
 func (e *Engine) runMonitorStub(phase PhaseConfig) error {
 	prURL := e.extractPRURL()
 
+	e.emit(Event{Phase: phase.Name, Kind: EventPhaseStarted})
 	if err := e.state.MarkRunning(phase.Name); err != nil {
 		return fmt.Errorf("engine: mark running %s: %w", phase.Name, err)
 	}
@@ -547,6 +558,11 @@ func (e *Engine) runMonitorStub(phase PhaseConfig) error {
 	if err := e.state.MarkCompleted(phase.Name); err != nil {
 		return fmt.Errorf("engine: mark completed %s: %w", phase.Name, err)
 	}
+	e.emit(Event{
+		Phase: phase.Name,
+		Kind:  EventPhaseCompleted,
+		Data:  map[string]any{"duration_ms": e.state.Meta().Phases[phase.Name].DurationMs, "cost": e.state.Meta().Phases[phase.Name].Cost},
+	})
 
 	return nil
 }

--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -1338,3 +1338,103 @@ func TestEngine_ResumeRerunsCompletedPhase(t *testing.T) {
 		t.Errorf("triage artifact = %q, want %q", string(artifact), "Triage v2")
 	}
 }
+
+func TestEngine_PhaseLifecycleEventsDispatchedToOnEvent(t *testing.T) {
+	phases := []PhaseConfig{
+		{
+			Name:   "triage",
+			Prompt: "triage.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+		{
+			Name:      "plan",
+			Prompt:    "plan.md",
+			DependsOn: []string{"triage"},
+			Retry:     RetryConfig{Transient: 0, Parse: 0, Semantic: 0},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"triage": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"automatable":true}`),
+					RawText: "Triage done",
+					CostUSD: 0.10,
+				},
+			}},
+			"plan": {{
+				err: fmt.Errorf("runner exploded"),
+			}},
+		},
+	}
+
+	var events []Event
+	engine, _ := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.OnEvent = func(e Event) {
+			events = append(events, e)
+		}
+	})
+
+	// plan will fail, but triage should succeed.
+	_ = engine.Run(context.Background())
+
+	// Collect event kinds by phase.
+	phaseEvents := map[string][]string{}
+	for _, e := range events {
+		if e.Phase != "" {
+			phaseEvents[e.Phase] = append(phaseEvents[e.Phase], e.Kind)
+		}
+	}
+
+	// Triage should have phase_started and phase_completed via OnEvent.
+	triageKinds := phaseEvents["triage"]
+	if !containsKind(triageKinds, EventPhaseStarted) {
+		t.Errorf("OnEvent missing %s for triage; got %v", EventPhaseStarted, triageKinds)
+	}
+	if !containsKind(triageKinds, EventPhaseCompleted) {
+		t.Errorf("OnEvent missing %s for triage; got %v", EventPhaseCompleted, triageKinds)
+	}
+
+	// Plan should have phase_started and phase_failed via OnEvent.
+	planKinds := phaseEvents["plan"]
+	if !containsKind(planKinds, EventPhaseStarted) {
+		t.Errorf("OnEvent missing %s for plan; got %v", EventPhaseStarted, planKinds)
+	}
+	if !containsKind(planKinds, EventPhaseFailed) {
+		t.Errorf("OnEvent missing %s for plan; got %v", EventPhaseFailed, planKinds)
+	}
+
+	// phase_completed for triage should carry duration and cost data.
+	for _, e := range events {
+		if e.Phase == "triage" && e.Kind == EventPhaseCompleted {
+			if _, ok := e.Data["duration_ms"]; !ok {
+				t.Error("phase_completed event should include duration_ms")
+			}
+			if _, ok := e.Data["cost"]; !ok {
+				t.Error("phase_completed event should include cost")
+			}
+		}
+	}
+
+	// phase_failed for plan should carry error data.
+	for _, e := range events {
+		if e.Phase == "plan" && e.Kind == EventPhaseFailed {
+			errStr, ok := e.Data["error"]
+			if !ok {
+				t.Error("phase_failed event should include error")
+			} else if errStr == "" {
+				t.Error("phase_failed event error should not be empty")
+			}
+		}
+	}
+}
+
+func containsKind(kinds []string, target string) bool {
+	for _, k := range kinds {
+		if k == target {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Add `e.emit()` calls for `phase_started`, `phase_completed`, and `phase_failed` events in `runPhase()` and `runMonitorStub()`. CLI and TUI consumers of `OnEvent` now receive all phase lifecycle events.

Closes #22

Assisted-by: Claude Opus 4.6