### PR TITLE
fix: restore CLI commands lost during rebase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Build
-soda
+/soda
 dist/
 
 # State

--- a/cmd/soda/clean.go
+++ b/cmd/soda/clean.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+
+	"github.com/decko/soda/internal/pipeline"
+	"github.com/spf13/cobra"
+)
+
+var errSkipped = errors.New("skipped")
+
+func newCleanCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "clean [ticket]",
+		Short: "Remove completed/failed pipeline state and worktrees",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := loadConfig(cmd)
+			if err != nil {
+				return err
+			}
+			all, _ := cmd.Flags().GetBool("all")
+			dryRun, _ := cmd.Flags().GetBool("dry-run")
+
+			if len(args) == 1 {
+				return cleanTicket(cfg.StateDir, args[0], dryRun)
+			}
+			if all {
+				return cleanAll(cfg.StateDir, dryRun)
+			}
+			return fmt.Errorf("specify a ticket key or use --all")
+		},
+	}
+
+	cmd.Flags().Bool("all", false, "clean all tickets in terminal state")
+	cmd.Flags().Bool("dry-run", false, "show what would be cleaned without doing it")
+
+	return cmd
+}
+
+func cleanAll(stateDir string, dryRun bool) error {
+	entries, err := os.ReadDir(stateDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			fmt.Println("No pipelines found.")
+			return nil
+		}
+		return fmt.Errorf("clean: read state dir: %w", err)
+	}
+
+	cleaned := 0
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if err := cleanTicket(stateDir, entry.Name(), dryRun); err != nil {
+			if !errors.Is(err, errSkipped) {
+				fmt.Fprintf(os.Stderr, "Warning: %s: %v\n", entry.Name(), err)
+			}
+		} else {
+			cleaned++
+		}
+	}
+
+	if cleaned == 0 {
+		fmt.Println("Nothing to clean.")
+	}
+	return nil
+}
+
+func cleanTicket(stateDir, ticketKey string, dryRun bool) error {
+	ticketDir := filepath.Join(stateDir, ticketKey)
+	metaPath := filepath.Join(ticketDir, "meta.json")
+
+	meta, err := pipeline.ReadMeta(metaPath)
+	if err != nil {
+		return fmt.Errorf("read meta: %w", err)
+	}
+
+	// Try to acquire flock to ensure pipeline is not running
+	lockPath := filepath.Join(ticketDir, "lock")
+	if !tryLock(lockPath) {
+		fmt.Fprintf(os.Stderr, "Skipping %s: pipeline is running\n", ticketKey)
+		return errSkipped
+	}
+
+	// Check terminal state
+	if !isTerminal(meta) {
+		fmt.Fprintf(os.Stderr, "Skipping %s: not in terminal state\n", ticketKey)
+		return errSkipped
+	}
+
+	// Remove worktree
+	if meta.Worktree != "" {
+		if dryRun {
+			fmt.Printf("Would remove worktree: %s\n", meta.Worktree)
+		} else {
+			out, wtErr := exec.Command("git", "worktree", "remove", meta.Worktree).CombinedOutput()
+			if wtErr != nil {
+				fmt.Fprintf(os.Stderr, "Warning: git worktree remove %s: %s\n", meta.Worktree, string(out))
+			} else {
+				fmt.Printf("Removed worktree: %s\n", meta.Worktree)
+			}
+		}
+	}
+
+	// Remove state directory
+	if dryRun {
+		fmt.Printf("Would remove state: %s\n", ticketDir)
+	} else {
+		if rmErr := os.RemoveAll(ticketDir); rmErr != nil {
+			return fmt.Errorf("remove state dir: %w", rmErr)
+		}
+		fmt.Printf("Removed state: %s\n", ticketDir)
+	}
+
+	return nil
+}
+
+// tryLock attempts a non-blocking flock. Returns true if lock was acquired
+// (meaning no other process holds it), and immediately releases it.
+func tryLock(lockPath string) bool {
+	fd, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		return true // no lock file means nothing is running
+	}
+	defer fd.Close()
+
+	err = syscall.Flock(int(fd.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+	if err != nil {
+		return false // lock is held
+	}
+	syscall.Flock(int(fd.Fd()), syscall.LOCK_UN)
+	return true
+}
+
+// isTerminal returns true if the pipeline is in a cleanable state.
+func isTerminal(meta *pipeline.PipelineMeta) bool {
+	if len(meta.Phases) == 0 {
+		return true
+	}
+	for _, ps := range meta.Phases {
+		if ps.Status == pipeline.PhaseRunning || ps.Status == pipeline.PhaseRetrying {
+			return false
+		}
+	}
+	// At least one phase must have completed or failed
+	for _, ps := range meta.Phases {
+		if ps.Status == pipeline.PhaseCompleted || ps.Status == pipeline.PhaseFailed {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/soda/embeds/phases.yaml
+++ b/cmd/soda/embeds/phases.yaml
@@ -1,0 +1,113 @@
+# SODA Phase Pipeline Configuration
+#
+# Each phase defines: prompt template, output schema, tool scope,
+# timeout, retry policy, and dependencies on previous phase artifacts.
+
+phases:
+  - name: triage
+    prompt: prompts/triage.md
+    schema: schemas/triage.go
+    tools:
+      - Read
+      - Glob
+      - Grep
+      - Bash(git:*)
+      - Bash(ls:*)
+    timeout: 3m
+    retry:
+      transient: 2
+      parse: 1
+      semantic: 1
+    depends_on: []
+
+  - name: plan
+    prompt: prompts/plan.md
+    schema: schemas/plan.go
+    tools:
+      - Read
+      - Glob
+      - Grep
+      - Bash(git:*)
+      - Bash(ls:*)
+    timeout: 5m
+    retry:
+      transient: 2
+      parse: 1
+      semantic: 1
+    depends_on:
+      - triage
+
+  - name: implement
+    prompt: prompts/implement.md
+    schema: schemas/implement.go
+    tools:
+      - Read
+      - Write
+      - Edit
+      - Glob
+      - Grep
+      - Bash
+    timeout: 15m
+    retry:
+      transient: 2
+      parse: 1
+      semantic: 0    # don't retry semantic failures — human decides
+    depends_on:
+      - plan
+
+  - name: verify
+    prompt: prompts/verify.md
+    schema: schemas/verify.go
+    tools:
+      - Read
+      - Glob
+      - Grep
+      - Bash
+    timeout: 5m
+    retry:
+      transient: 2
+      parse: 1
+      semantic: 1
+    depends_on:
+      - plan
+      - implement
+
+  - name: submit
+    prompt: prompts/submit.md
+    schema: schemas/submit.go
+    tools:
+      - Bash(git:*)
+      - Bash(gh:*)
+      - Bash(glab:*)
+    timeout: 3m
+    retry:
+      transient: 2
+      parse: 1
+      semantic: 0
+    depends_on:
+      - implement
+      - verify
+
+  - name: monitor
+    prompt: prompts/monitor.md
+    schema: schemas/monitor.go
+    type: polling     # not one-shot
+    tools:
+      - Read
+      - Write
+      - Edit
+      - Glob
+      - Grep
+      - Bash
+    polling:
+      initial_interval: 2m
+      max_interval: 5m
+      escalate_after: 30m
+      max_duration: 4h
+      max_response_rounds: 3
+    retry:
+      transient: 2
+      parse: 1
+      semantic: 0
+    depends_on:
+      - submit

--- a/cmd/soda/embeds/prompts/implement.md
+++ b/cmd/soda/embeds/prompts/implement.md
@@ -1,0 +1,49 @@
+You are a software engineer implementing a planned set of tasks.
+
+## Ticket
+
+Key: {{.Ticket.Key}}
+Summary: {{.Ticket.Summary}}
+
+## Implementation Plan
+{{.Artifacts.Plan}}
+
+{{- if .Context.RepoConventions}}
+
+## Repo Conventions
+{{.Context.RepoConventions}}
+{{- end}}
+
+{{- if .Context.Gotchas}}
+
+## Known Gotchas
+{{.Context.Gotchas}}
+{{- end}}
+
+## Working Directory
+
+You are working in a git worktree at: {{.WorktreePath}}
+Branch: {{.Branch}}
+Base: {{.BaseBranch}}
+
+## Your Task
+
+Implement each task from the plan, in dependency order. For each task:
+
+1. **Read the relevant files** to understand current state.
+2. **Make the changes** described in the task.
+3. **Follow repo conventions** — formatting, naming, patterns.
+4. **Write or update tests** as specified in the plan.
+5. **Run the formatter** if configured: `{{.Config.Formatter}}`
+6. **Run the tests** if configured: `{{.Config.TestCommand}}`
+7. **Commit** with a descriptive message referencing the ticket key.
+
+After all tasks are complete:
+
+- List every file you created, modified, or deleted.
+- List every commit you made (hash + message).
+- Report any deviations from the plan and why.
+- Report any test failures and whether they were resolved.
+
+Do NOT skip tasks. Do NOT combine tasks into a single commit.
+If a task cannot be completed, explain why and move to the next.

--- a/cmd/soda/embeds/prompts/monitor.md
+++ b/cmd/soda/embeds/prompts/monitor.md
@@ -1,0 +1,40 @@
+You are responding to review feedback on a pull request / merge request.
+
+## Ticket
+
+Key: {{.Ticket.Key}}
+Summary: {{.Ticket.Summary}}
+
+## PR/MR
+
+URL: {{.Artifacts.Submit.PRURL}}
+Forge: {{.Config.Repo.Forge}}
+
+## Implementation Plan
+{{.Artifacts.Plan}}
+
+## New Review Comments
+
+{{.ReviewComments}}
+
+## Working Directory
+
+Worktree: {{.WorktreePath}}
+Branch: {{.Branch}}
+
+## Your Task
+
+Address each review comment:
+
+1. **Read the comment** and understand what the reviewer is asking.
+2. **Assess the feedback**:
+   - Is it a valid concern? If so, fix it.
+   - Is it a style preference? Follow the reviewer's preference.
+   - Is it a misunderstanding? Explain clearly in a reply comment.
+   - Is it out of scope? Say so politely and suggest a follow-up ticket.
+3. **Make code changes** if needed. Follow repo conventions.
+4. **Run verification commands** after changes.
+5. **Commit and push** with a descriptive message.
+6. **Reply to comments** explaining what you did.
+
+Report all changes made and comments replied to.

--- a/cmd/soda/embeds/prompts/plan.md
+++ b/cmd/soda/embeds/prompts/plan.md
@@ -1,0 +1,48 @@
+You are a software architect planning the implementation of a ticket.
+
+## Ticket
+
+Key: {{.Ticket.Key}}
+Summary: {{.Ticket.Summary}}
+
+### Description
+{{.Ticket.Description}}
+
+{{- if .Ticket.AcceptanceCriteria}}
+
+### Acceptance Criteria
+{{range .Ticket.AcceptanceCriteria}}- {{.}}
+{{end}}
+{{- end}}
+
+## Triage Assessment
+{{.Artifacts.Triage}}
+
+{{- if .Context.RepoConventions}}
+
+## Repo Conventions
+{{.Context.RepoConventions}}
+{{- end}}
+
+{{- if .Context.Gotchas}}
+
+## Known Gotchas
+{{.Context.Gotchas}}
+{{- end}}
+
+## Your Task
+
+Read the candidate files identified in triage and the surrounding code. Then produce a detailed implementation plan:
+
+1. **Understand the current state** — read the files, understand the existing patterns and abstractions.
+2. **Design the approach** — how will you implement this? What patterns to follow? What to reuse?
+3. **Break into atomic tasks** — each task should be independently implementable and verifiable. A task should fit in one context window.
+4. **For each task, specify**:
+   - What to do (clear, unambiguous description)
+   - Which files to create or modify
+   - What the done state looks like (verifiable condition)
+   - Dependencies on other tasks (if any)
+5. **Define verification strategy** — what commands prove this works? Tests to run, manual checks.
+6. **Flag deviations** — if the plan differs from the triage assessment, explain why.
+
+Be concrete. Name files, functions, classes. Do not be vague.

--- a/cmd/soda/embeds/prompts/submit.md
+++ b/cmd/soda/embeds/prompts/submit.md
@@ -1,0 +1,60 @@
+You are submitting a verified implementation as a pull request or merge request.
+
+## Ticket
+
+Key: {{.Ticket.Key}}
+Summary: {{.Ticket.Summary}}
+
+## Implementation Report
+{{.Artifacts.Implement}}
+
+## Verification Report
+{{.Artifacts.Verify}}
+
+## Repo Configuration
+
+Forge: {{.Config.Repo.Forge}}
+Push to: {{.Config.Repo.PushTo}}
+Target: {{.Config.Repo.Target}}
+
+{{- if .Config.Repo.Labels}}
+Labels: {{range .Config.Repo.Labels}}{{.}}, {{end}}
+{{- end}}
+
+{{- if .Config.Repo.Trailers}}
+Commit trailers: {{range .Config.Repo.Trailers}}
+- {{.}}
+{{- end}}
+{{- end}}
+
+## Working Directory
+
+Worktree: {{.WorktreePath}}
+Branch: {{.Branch}}
+
+## Your Task
+
+1. **Push the branch** to the configured remote.
+2. **Create the PR/MR** with:
+   - Title: concise, under 70 characters, referencing the ticket key
+   - Body: summary of changes, test plan, acceptance criteria checklist
+   - Labels: as configured
+   - Any required trailers on the last commit (if not already present)
+
+{{- if eq .Config.Repo.Forge "github"}}
+
+Use `gh pr create`:
+```
+gh pr create --title "<title>" --body "<body>" {{range .Config.Repo.Labels}}--label "{{.}}" {{end}}
+```
+
+{{- else if eq .Config.Repo.Forge "gitlab"}}
+
+Use `glab mr create`:
+```
+glab mr create --title "<title>" --description "<body>" --remove-source-branch --squash-before-merge {{range .Config.Repo.Labels}}--label "{{.}}" {{end}}
+```
+
+{{- end}}
+
+3. **Report** the PR/MR URL and any issues encountered.

--- a/cmd/soda/embeds/prompts/triage.md
+++ b/cmd/soda/embeds/prompts/triage.md
@@ -1,0 +1,46 @@
+You are a triage engineer assessing a ticket for automated implementation.
+
+## Ticket
+
+Key: {{.Ticket.Key}}
+Summary: {{.Ticket.Summary}}
+Type: {{.Ticket.Type}}
+Priority: {{.Ticket.Priority}}
+
+### Description
+{{.Ticket.Description}}
+
+{{- if .Ticket.AcceptanceCriteria}}
+
+### Acceptance Criteria
+{{range .Ticket.AcceptanceCriteria}}- {{.}}
+{{end}}
+{{- end}}
+
+## Available Repos
+{{range .Config.Repos}}
+- **{{.Name}}** ({{.Forge}}) — {{.Description}}
+{{- end}}
+
+{{- if .Context.ProjectContext}}
+
+## Project Context
+{{.Context.ProjectContext}}
+{{- end}}
+
+## Your Task
+
+Assess this ticket and produce a structured classification:
+
+1. **Identify the target repo** — which repository should this change land in? If unclear, flag it.
+2. **Identify the code area** — which packages, modules, or directories are likely affected.
+3. **List candidate files** — specific files that will likely need changes. Read the codebase to verify.
+4. **Assess complexity**:
+   - `small`: 1-3 files, single concern, no architectural decisions
+   - `medium`: 4-10 files, clear feature, may touch tests
+   - `large`: 10+ files, multi-component, architectural decisions needed
+5. **Summarize approach** — 1-2 sentences on how to implement this.
+6. **Flag risks** — anything that could go wrong (breaking changes, auth implications, migration needed).
+7. **Decide if automatable** — can an agent implement this end-to-end, or does it need human decisions?
+
+Read the relevant codebase before answering. Do not guess file paths.

--- a/cmd/soda/embeds/prompts/verify.md
+++ b/cmd/soda/embeds/prompts/verify.md
@@ -1,0 +1,56 @@
+You are a quality engineer verifying an implementation against its plan and acceptance criteria.
+
+## Ticket
+
+Key: {{.Ticket.Key}}
+Summary: {{.Ticket.Summary}}
+
+{{- if .Ticket.AcceptanceCriteria}}
+
+### Acceptance Criteria
+{{range .Ticket.AcceptanceCriteria}}- {{.}}
+{{end}}
+{{- end}}
+
+## Implementation Plan
+{{.Artifacts.Plan}}
+
+## Implementation Report
+{{.Artifacts.Implement}}
+
+{{- if .Context.Gotchas}}
+
+## Known Gotchas
+{{.Context.Gotchas}}
+{{- end}}
+
+## Working Directory
+
+Worktree: {{.WorktreePath}}
+Branch: {{.Branch}}
+
+## Your Task
+
+Verify the implementation thoroughly. You are skeptical by default.
+
+### 1. Run verification commands
+{{range .Config.VerifyCommands}}
+- `{{.}}`
+{{- end}}
+
+### 2. Check acceptance criteria
+For each acceptance criterion, verify it is met. Read the actual code, not just the implementation report. Report pass/fail per criterion with evidence.
+
+### 3. Review the code
+- Does it follow repo conventions?
+- Are there obvious bugs, edge cases, or security issues?
+- Are tests adequate? Do they cover the acceptance criteria?
+- Does it match the plan? If deviations exist, are they justified?
+
+### 4. Check for regressions
+- Do existing tests still pass?
+- Are there unintended side effects?
+
+### 5. Verdict
+Produce a clear PASS or FAIL verdict. If FAIL, list exactly what needs to be fixed.
+Do not be lenient. A FAIL now is cheaper than a FAIL in review.

--- a/cmd/soda/history.go
+++ b/cmd/soda/history.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"text/tabwriter"
+	"time"
+
+	"github.com/decko/soda/internal/pipeline"
+	"github.com/spf13/cobra"
+)
+
+func newHistoryCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "history <ticket>",
+		Short: "Show phase details for a ticket",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := loadConfig(cmd)
+			if err != nil {
+				return err
+			}
+			return runHistory(cfg.StateDir, args[0])
+		},
+	}
+}
+
+func runHistory(stateDir, ticketKey string) error {
+	metaPath := filepath.Join(stateDir, ticketKey, "meta.json")
+	meta, err := pipeline.ReadMeta(metaPath)
+	if err != nil {
+		return fmt.Errorf("history: %w", err)
+	}
+
+	phasesPath, cleanup, err := resolvePhasesPath()
+	if err != nil {
+		return fmt.Errorf("history: %w", err)
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	pl, err := pipeline.LoadPipeline(phasesPath)
+	if err != nil {
+		return fmt.Errorf("history: %w", err)
+	}
+
+	// Header
+	fmt.Printf("%s", meta.Ticket)
+	if meta.Branch != "" {
+		fmt.Printf("\nBranch: %s", meta.Branch)
+	}
+	if meta.Worktree != "" {
+		fmt.Printf("\nWorktree: %s", meta.Worktree)
+	}
+	fmt.Println()
+	fmt.Println()
+
+	// Phase table
+	tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(tw, "Phase\tStatus\tDuration\tCost")
+
+	var totalCost float64
+	var lastFailPhase string
+	var lastFailError string
+
+	for _, phase := range pl.Phases {
+		ps, ok := meta.Phases[phase.Name]
+		if !ok {
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", phase.Name, "pending", "-", "-")
+			continue
+		}
+
+		dur := (time.Duration(ps.DurationMs) * time.Millisecond).Truncate(time.Second).String()
+		if ps.DurationMs == 0 {
+			dur = "-"
+		}
+		cost := fmt.Sprintf("$%.2f", ps.Cost)
+		totalCost += ps.Cost
+
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", phase.Name, string(ps.Status), dur, cost)
+
+		if ps.Status == pipeline.PhaseFailed && ps.Error != "" {
+			lastFailPhase = phase.Name
+			lastFailError = ps.Error
+		}
+	}
+
+	fmt.Fprintf(tw, "\t\t\t──────────\n")
+	fmt.Fprintf(tw, "\t\tTotal:\t$%.2f\n", totalCost)
+	tw.Flush()
+
+	if lastFailPhase != "" {
+		fmt.Printf("\nLast failure (%s):\n  Error: %s\n", lastFailPhase, lastFailError)
+	}
+
+	return nil
+}

--- a/cmd/soda/main.go
+++ b/cmd/soda/main.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"embed"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/decko/soda/internal/config"
+	"github.com/spf13/cobra"
+)
+
+//go:embed all:embeds/prompts
+var embeddedPrompts embed.FS
+
+//go:embed embeds/phases.yaml
+var embeddedPhases []byte
+
+var version = "dev"
+
+func main() {
+	rootCmd := newRootCmd()
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+func newRootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "soda",
+		Short:         "Session-Orchestrated Development Agent",
+		Version:       version,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+
+	defaultPath, _ := config.DefaultPath()
+	cmd.PersistentFlags().String("config", defaultPath, "config file path")
+
+	cmd.AddCommand(
+		newRunCmd(),
+		newStatusCmd(),
+		newHistoryCmd(),
+		newCleanCmd(),
+		newRenderCmd(),
+	)
+
+	return cmd
+}
+
+// loadConfig reads the config file specified by the --config flag.
+func loadConfig(cmd *cobra.Command) (*config.Config, error) {
+	cfgPath, err := cmd.Flags().GetString("config")
+	if err != nil {
+		return nil, fmt.Errorf("config flag: %w", err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+// extractEmbeddedPrompts writes embedded prompt files to a temp dir
+// and returns the path. Caller must clean up with os.RemoveAll.
+// The extracted tree preserves the prompts/ subdirectory so that
+// phases.yaml references (e.g. "prompts/triage.md") resolve correctly.
+func extractEmbeddedPrompts() (string, error) {
+	tmpDir, err := os.MkdirTemp("", "soda-prompts-*")
+	if err != nil {
+		return "", fmt.Errorf("create temp dir: %w", err)
+	}
+
+	// Use "embeds" (not "embeds/prompts") to preserve the prompts/ prefix.
+	promptsFS, err := fs.Sub(embeddedPrompts, "embeds")
+	if err != nil {
+		os.RemoveAll(tmpDir)
+		return "", fmt.Errorf("embedded prompts: %w", err)
+	}
+
+	err = fs.WalkDir(promptsFS, ".", func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return os.MkdirAll(filepath.Join(tmpDir, path), 0755)
+		}
+		data, readErr := fs.ReadFile(promptsFS, path)
+		if readErr != nil {
+			return readErr
+		}
+		dest := filepath.Join(tmpDir, path)
+		return os.WriteFile(dest, data, 0644)
+	})
+	if err != nil {
+		os.RemoveAll(tmpDir)
+		return "", fmt.Errorf("extract prompts: %w", err)
+	}
+
+	return tmpDir, nil
+}
+
+// resolvePhasesPath returns a path to phases.yaml.
+// Prefers a local file in the working directory; falls back to extracting
+// the embedded copy to a temp file. Caller must remove the temp file
+// if cleanup is non-nil.
+func resolvePhasesPath() (path string, cleanup func(), err error) {
+	if _, statErr := os.Stat("phases.yaml"); statErr == nil {
+		return "phases.yaml", nil, nil
+	}
+
+	tmpFile, tmpErr := os.CreateTemp("", "soda-phases-*.yaml")
+	if tmpErr != nil {
+		return "", nil, fmt.Errorf("create temp phases file: %w", tmpErr)
+	}
+	if _, writeErr := tmpFile.Write(embeddedPhases); writeErr != nil {
+		tmpFile.Close()
+		os.Remove(tmpFile.Name())
+		return "", nil, fmt.Errorf("write embedded phases: %w", writeErr)
+	}
+	tmpFile.Close()
+	return tmpFile.Name(), func() { os.Remove(tmpFile.Name()) }, nil
+}

--- a/cmd/soda/render.go
+++ b/cmd/soda/render.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/decko/soda/internal/config"
+	"github.com/decko/soda/internal/pipeline"
+	"github.com/decko/soda/internal/ticket"
+	"github.com/spf13/cobra"
+)
+
+func newRenderCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "render-prompt",
+		Short: "Render a phase prompt template and print to stdout",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := loadConfig(cmd)
+			if err != nil {
+				return err
+			}
+			phase, _ := cmd.Flags().GetString("phase")
+			ticketKey, _ := cmd.Flags().GetString("ticket")
+
+			return runRender(cmd, cfg, phase, ticketKey)
+		},
+	}
+
+	cmd.Flags().String("phase", "", "phase to render (required)")
+	cmd.Flags().String("ticket", "", "ticket key (required)")
+	cmd.MarkFlagRequired("phase")
+	cmd.MarkFlagRequired("ticket")
+
+	return cmd
+}
+
+func runRender(cmd *cobra.Command, cfg *config.Config, phaseName, ticketKey string) error {
+	ctx := cmd.Context()
+
+	// Load pipeline config
+	phasesPath, cleanup, err := resolvePhasesPath()
+	if err != nil {
+		return fmt.Errorf("render: %w", err)
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	pl, err := pipeline.LoadPipeline(phasesPath)
+	if err != nil {
+		return fmt.Errorf("render: %w", err)
+	}
+
+	// Find phase config
+	var phaseConfig *pipeline.PhaseConfig
+	for idx := range pl.Phases {
+		if pl.Phases[idx].Name == phaseName {
+			phaseConfig = &pl.Phases[idx]
+			break
+		}
+	}
+	if phaseConfig == nil {
+		return fmt.Errorf("render: phase %q not found in pipeline", phaseName)
+	}
+
+	// Fetch ticket
+	source, err := createTicketSource(cfg)
+	if err != nil {
+		return fmt.Errorf("render: %w", err)
+	}
+	t, err := source.Fetch(ctx, ticketKey)
+	if err != nil {
+		return fmt.Errorf("render: fetch ticket: %w", err)
+	}
+
+	// Build prompt data
+	promptData := pipeline.PromptData{
+		Ticket: pipeline.TicketData{
+			Key:                t.Key,
+			Summary:            t.Summary,
+			Description:        t.Description,
+			Type:               t.Type,
+			Priority:           t.Priority,
+			AcceptanceCriteria: t.AcceptanceCriteria,
+		},
+	}
+
+	// Load artifacts from state if they exist
+	stateDir := cfg.StateDir
+	if stateDir != "" {
+		state, stateErr := pipeline.LoadOrCreate(stateDir, ticketKey)
+		if stateErr == nil {
+			loadArtifacts(state, &promptData)
+		}
+	}
+
+	// Set up prompt loader
+	promptDir, extractErr := extractEmbeddedPrompts()
+	if extractErr != nil {
+		return fmt.Errorf("render: %w", extractErr)
+	}
+	defer os.RemoveAll(promptDir)
+
+	loaderDirs := []string{"."}
+	configDir, _ := os.UserConfigDir()
+	if configDir != "" {
+		loaderDirs = append([]string{filepath.Join(configDir, "soda")}, loaderDirs...)
+	}
+	loaderDirs = append(loaderDirs, promptDir)
+	loader := pipeline.NewPromptLoader(loaderDirs...)
+
+	// Load and render
+	tmplContent, err := loader.Load(phaseConfig.Prompt)
+	if err != nil {
+		return fmt.Errorf("render: %w", err)
+	}
+
+	rendered, err := pipeline.RenderPrompt(tmplContent, promptData)
+	if err != nil {
+		return fmt.Errorf("render: %w", err)
+	}
+
+	// Output
+	fmt.Printf("=== System Prompt (%s) ===\n\n", phaseName)
+	fmt.Println(rendered)
+	fmt.Printf("\n=== Tools ===\n%s\n", strings.Join(phaseConfig.Tools, ", "))
+	fmt.Printf("\n=== Output Schema ===\n%s\n", phaseConfig.Schema)
+
+	return nil
+}
+
+func createTicketSource(cfg *config.Config) (ticket.Source, error) {
+	switch cfg.TicketSource {
+	case "jira":
+		return ticket.NewJiraSource(ticket.JiraConfig{
+			Command: cfg.Jira.Command,
+			Query:   cfg.Jira.Query,
+		})
+	default:
+		return nil, fmt.Errorf("unsupported ticket source: %q", cfg.TicketSource)
+	}
+}
+
+func loadArtifacts(state *pipeline.State, data *pipeline.PromptData) {
+	if artifact, err := state.ReadArtifact("triage"); err == nil {
+		data.Artifacts.Triage = string(artifact)
+	}
+	if artifact, err := state.ReadArtifact("plan"); err == nil {
+		data.Artifacts.Plan = string(artifact)
+	}
+	if artifact, err := state.ReadArtifact("implement"); err == nil {
+		data.Artifacts.Implement = string(artifact)
+	}
+	if artifact, err := state.ReadArtifact("verify"); err == nil {
+		data.Artifacts.Verify = string(artifact)
+	}
+}

--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -1,0 +1,313 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/decko/soda/internal/config"
+	"github.com/decko/soda/internal/pipeline"
+	"github.com/decko/soda/internal/runner"
+	"github.com/spf13/cobra"
+)
+
+func newRunCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "run <ticket>",
+		Short: "Run the pipeline for a ticket",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := loadConfig(cmd)
+			if err != nil {
+				return err
+			}
+			return runPipeline(cmd, cfg, args[0])
+		},
+	}
+
+	cmd.Flags().String("mode", "", "execution mode: checkpoint or autonomous")
+	cmd.Flags().String("from", "", "resume from phase (or 'last')")
+	cmd.Flags().Bool("dry-run", false, "render prompts without executing")
+
+	return cmd
+}
+
+func runPipeline(cmd *cobra.Command, cfg *config.Config, ticketKey string) error {
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+
+	// Fetch ticket
+	source, err := createTicketSource(cfg)
+	if err != nil {
+		return err
+	}
+	t, err := source.Fetch(ctx, ticketKey)
+	if err != nil {
+		return fmt.Errorf("run: fetch ticket: %w", err)
+	}
+
+	ticketData := pipeline.TicketData{
+		Key:                t.Key,
+		Summary:            t.Summary,
+		Description:        t.Description,
+		Type:               t.Type,
+		Priority:           t.Priority,
+		AcceptanceCriteria: t.AcceptanceCriteria,
+	}
+
+	// Load pipeline config
+	phasesPath, phasesCleanup, err := resolvePhasesPath()
+	if err != nil {
+		return fmt.Errorf("run: %w", err)
+	}
+	if phasesCleanup != nil {
+		defer phasesCleanup()
+	}
+	pl, err := pipeline.LoadPipeline(phasesPath)
+	if err != nil {
+		return fmt.Errorf("run: %w", err)
+	}
+
+	// Set up prompt loader
+	promptDir, err := extractEmbeddedPrompts()
+	if err != nil {
+		return fmt.Errorf("run: %w", err)
+	}
+	defer os.RemoveAll(promptDir)
+
+	// Search order: user config dir > working dir > embedded.
+	// phases.yaml references prompts with the "prompts/" prefix
+	// (e.g. "prompts/triage.md"), so the base dirs should NOT
+	// include "prompts/" — the loader joins base + name.
+	loaderDirs := []string{"."}
+	configDir, _ := os.UserConfigDir()
+	if configDir != "" {
+		loaderDirs = append([]string{filepath.Join(configDir, "soda")}, loaderDirs...)
+	}
+	loaderDirs = append(loaderDirs, promptDir)
+	loader := pipeline.NewPromptLoader(loaderDirs...)
+
+	// Dry-run mode
+	if dryRun {
+		return runDryRun(cfg, pl, loader, ticketData)
+	}
+
+	// Load or create state
+	state, err := pipeline.LoadOrCreate(cfg.StateDir, ticketKey)
+	if err != nil {
+		return fmt.Errorf("run: %w", err)
+	}
+
+	// Resolve mode
+	mode := pipeline.Autonomous
+	modeStr := cfg.Mode
+	if cmd.Flags().Changed("mode") {
+		modeStr, _ = cmd.Flags().GetString("mode")
+	}
+	switch modeStr {
+	case "checkpoint":
+		mode = pipeline.Checkpoint
+	case "autonomous", "":
+		// default
+	default:
+		return fmt.Errorf("run: unknown mode %q (expected 'checkpoint' or 'autonomous')", modeStr)
+	}
+
+	// Build mock runner
+	mockRunner := buildMockRunner()
+
+	// Build engine config — use a closure that captures the engine pointer
+	var engine *pipeline.Engine
+
+	engineCfg := pipeline.EngineConfig{
+		Pipeline:     pl,
+		Loader:       loader,
+		Ticket:       ticketData,
+		Model:        cfg.Model,
+		WorkDir:      ".",
+		WorktreeBase: cfg.WorktreeDir,
+		BaseBranch:   "main",
+		MaxCostUSD:   cfg.Limits.MaxCostPerTicket,
+		Mode:         mode,
+		OnEvent: func(event pipeline.Event) {
+			handleEvent(ctx, cancel, engine, event)
+		},
+	}
+
+	engine = pipeline.NewEngine(mockRunner, state, engineCfg)
+
+	// Run or resume
+	fromPhase, _ := cmd.Flags().GetString("from")
+	startTime := time.Now()
+
+	var runErr error
+	if fromPhase != "" {
+		if fromPhase == "last" {
+			fromPhase, err = resolveLastPhase(state.Meta(), pl.Phases)
+			if err != nil {
+				return fmt.Errorf("run: %w", err)
+			}
+		}
+		fmt.Printf("Resuming from phase: %s\n", fromPhase)
+		runErr = engine.Resume(ctx, fromPhase)
+	} else {
+		runErr = engine.Run(ctx)
+	}
+
+	// Print summary
+	printSummary(state.Meta(), time.Since(startTime))
+
+	return runErr
+}
+
+func buildMockRunner() *runner.MockRunner {
+	return &runner.MockRunner{
+		Responses: map[string]*runner.RunResult{
+			"triage": {
+				Output:  json.RawMessage(`{"automatable":true,"ticket_key":"MOCK","complexity":"low","approach":"mock approach"}`),
+				RawText: "Mock triage: ticket is automatable",
+			},
+			"plan": {
+				Output:  json.RawMessage(`{"tasks":[{"id":"1","description":"mock task"}],"ticket_key":"MOCK"}`),
+				RawText: "Mock plan: one task defined",
+			},
+			"implement": {
+				Output:  json.RawMessage(`{"tests_passed":true,"ticket_key":"MOCK","branch":"mock-branch","commits":[],"files_changed":[]}`),
+				RawText: "Mock implement: tests passed",
+			},
+			"verify": {
+				Output:  json.RawMessage(`{"verdict":"PASS","ticket_key":"MOCK"}`),
+				RawText: "Mock verify: all checks passed",
+			},
+			"submit": {
+				Output:  json.RawMessage(`{"pr_url":"https://github.com/mock/repo/pull/0","ticket_key":"MOCK"}`),
+				RawText: "Mock submit: PR created",
+			},
+		},
+	}
+}
+
+func handleEvent(ctx context.Context, cancel context.CancelFunc, engine *pipeline.Engine, event pipeline.Event) {
+	switch event.Kind {
+	case pipeline.EventEngineStarted:
+		fmt.Println("Pipeline started")
+	case pipeline.EventEngineCompleted:
+		fmt.Println("Pipeline completed")
+	case pipeline.EventPhaseSkipped:
+		fmt.Printf("⏭ %s  skipped\n", event.Phase)
+	case pipeline.EventPhaseRetrying:
+		category, _ := event.Data["category"].(string)
+		attempt, _ := event.Data["attempt"].(int)
+		fmt.Printf("↻ %s  retrying (%s, attempt %d)\n", event.Phase, category, attempt)
+	case pipeline.EventBudgetWarning:
+		total, _ := event.Data["total_cost"].(float64)
+		limit, _ := event.Data["limit"].(float64)
+		fmt.Printf("⚠ Budget warning: $%.2f / $%.2f\n", total, limit)
+	case pipeline.EventCheckpointPause:
+		fmt.Printf("⏸ %s completed. Continue? [y/N] ", event.Phase)
+		if engine != nil && promptConfirm(ctx) {
+			engine.Confirm()
+		} else {
+			cancel()
+		}
+	case pipeline.EventWorktreeCreated:
+		wt, _ := event.Data["worktree"].(string)
+		branch, _ := event.Data["branch"].(string)
+		fmt.Printf("Created worktree: %s (%s)\n", wt, branch)
+	case pipeline.EventMonitorSkipped:
+		fmt.Printf("⏭ monitor  skipped (not yet implemented)\n")
+	}
+}
+
+func promptConfirm(ctx context.Context) bool {
+	ch := make(chan bool, 1)
+	go func() {
+		var input string
+		fmt.Scanln(&input)
+		ch <- strings.EqualFold(strings.TrimSpace(input), "y")
+	}()
+	select {
+	case confirmed := <-ch:
+		return confirmed
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func runDryRun(cfg *config.Config, pl *pipeline.PhasePipeline, loader *pipeline.PromptLoader, ticketData pipeline.TicketData) error {
+	promptData := pipeline.PromptData{
+		Ticket: ticketData,
+	}
+
+	// Load artifacts from state if available
+	if cfg.StateDir != "" {
+		state, err := pipeline.LoadOrCreate(cfg.StateDir, ticketData.Key)
+		if err == nil {
+			loadArtifacts(state, &promptData)
+		}
+	}
+
+	for _, phase := range pl.Phases {
+		tmplContent, err := loader.Load(phase.Prompt)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: could not load template for %s: %v\n", phase.Name, err)
+			continue
+		}
+
+		rendered, err := pipeline.RenderPrompt(tmplContent, promptData)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: could not render %s: %v\n", phase.Name, err)
+			continue
+		}
+
+		fmt.Printf("=== System Prompt (%s) ===\n\n", phase.Name)
+		fmt.Println(rendered)
+		fmt.Printf("\n=== Tools ===\n%s\n", strings.Join(phase.Tools, ", "))
+		fmt.Printf("\n=== Output Schema ===\n%s\n", phase.Schema)
+		fmt.Println()
+		fmt.Println("---")
+		fmt.Println()
+	}
+
+	return nil
+}
+
+func printSummary(meta *pipeline.PipelineMeta, elapsed time.Duration) {
+	fmt.Println()
+	fmt.Println("--- Summary ---")
+	fmt.Printf("Ticket:  %s\n", meta.Ticket)
+	fmt.Printf("Cost:    $%.2f\n", meta.TotalCost)
+	fmt.Printf("Elapsed: %s\n", elapsed.Truncate(time.Second))
+
+	for name, ps := range meta.Phases {
+		if ps.Status == pipeline.PhaseFailed {
+			fmt.Printf("Failed:  %s — %s\n", name, ps.Error)
+		}
+	}
+}
+
+// resolveLastPhase finds the last running or failed phase in pipeline order.
+func resolveLastPhase(meta *pipeline.PipelineMeta, phases []pipeline.PhaseConfig) (string, error) {
+	lastPhase := ""
+	for _, phase := range phases {
+		ps, ok := meta.Phases[phase.Name]
+		if !ok {
+			continue
+		}
+		if ps.Status == pipeline.PhaseRunning || ps.Status == pipeline.PhaseFailed {
+			lastPhase = phase.Name
+		}
+	}
+	if lastPhase == "" {
+		return "", fmt.Errorf("no running or failed phase found")
+	}
+	return lastPhase, nil
+}

--- a/cmd/soda/run_test.go
+++ b/cmd/soda/run_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/decko/soda/internal/pipeline"
+)
+
+func TestResolveLastPhase(t *testing.T) {
+	phases := []pipeline.PhaseConfig{
+		{Name: "triage"},
+		{Name: "plan"},
+		{Name: "implement"},
+		{Name: "verify"},
+	}
+
+	tests := []struct {
+		name    string
+		meta    *pipeline.PipelineMeta
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "single failed phase",
+			meta: &pipeline.PipelineMeta{
+				Phases: map[string]*pipeline.PhaseState{
+					"triage": {Status: pipeline.PhaseCompleted},
+					"plan":   {Status: pipeline.PhaseFailed},
+				},
+			},
+			want: "plan",
+		},
+		{
+			name: "running phase (stale)",
+			meta: &pipeline.PipelineMeta{
+				Phases: map[string]*pipeline.PhaseState{
+					"triage":    {Status: pipeline.PhaseCompleted},
+					"plan":      {Status: pipeline.PhaseCompleted},
+					"implement": {Status: pipeline.PhaseRunning},
+				},
+			},
+			want: "implement",
+		},
+		{
+			name: "multiple failed — latest in pipeline wins",
+			meta: &pipeline.PipelineMeta{
+				Phases: map[string]*pipeline.PhaseState{
+					"triage":    {Status: pipeline.PhaseFailed},
+					"plan":      {Status: pipeline.PhaseFailed},
+					"implement": {Status: pipeline.PhaseFailed},
+				},
+			},
+			want: "implement",
+		},
+		{
+			name: "no failed or running phases",
+			meta: &pipeline.PipelineMeta{
+				Phases: map[string]*pipeline.PhaseState{
+					"triage": {Status: pipeline.PhaseCompleted},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty phases",
+			meta: &pipeline.PipelineMeta{
+				Phases: map[string]*pipeline.PhaseState{},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveLastPhase(tt.meta, phases)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("resolveLastPhase() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/soda/status.go
+++ b/cmd/soda/status.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"text/tabwriter"
+	"time"
+
+	"github.com/decko/soda/internal/pipeline"
+	"github.com/spf13/cobra"
+)
+
+func newStatusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show active and recent pipelines",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := loadConfig(cmd)
+			if err != nil {
+				return err
+			}
+			return runStatus(cfg.StateDir)
+		},
+	}
+}
+
+func runStatus(stateDir string) error {
+	entries, err := os.ReadDir(stateDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			fmt.Println("No pipelines found.")
+			return nil
+		}
+		return fmt.Errorf("status: read state dir: %w", err)
+	}
+
+	// Load pipeline config for deterministic phase ordering.
+	phasesPath, cleanup, phasesErr := resolvePhasesPath()
+	if phasesErr != nil {
+		return fmt.Errorf("status: %w", phasesErr)
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	pl, phasesErr := pipeline.LoadPipeline(phasesPath)
+	if phasesErr != nil {
+		return fmt.Errorf("status: %w", phasesErr)
+	}
+
+	tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(tw, "TICKET\tPHASE\tSTATUS\tELAPSED\tCOST")
+
+	found := false
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		ticketDir := filepath.Join(stateDir, entry.Name())
+		metaPath := filepath.Join(ticketDir, "meta.json")
+
+		meta, metaErr := pipeline.ReadMeta(metaPath)
+		if metaErr != nil {
+			continue
+		}
+
+		phase, status := currentPhaseStatus(meta, pl.Phases)
+		lockPath := filepath.Join(ticketDir, "lock")
+		lockInfo, lockErr := pipeline.ReadLockInfo(lockPath)
+		if lockErr == nil {
+			if lockInfo.IsAlive {
+				status = "running"
+			} else {
+				status = "stale"
+			}
+		}
+
+		elapsed := formatElapsed(meta)
+		cost := fmt.Sprintf("$%.2f", meta.TotalCost)
+
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", meta.Ticket, phase, status, elapsed, cost)
+		found = true
+	}
+
+	if !found {
+		fmt.Println("No pipelines found.")
+		return nil
+	}
+
+	return tw.Flush()
+}
+
+// currentPhaseStatus returns the most advanced phase name and its status string.
+// Uses pipeline phase order for deterministic results when ranks are tied.
+func currentPhaseStatus(meta *pipeline.PipelineMeta, phases []pipeline.PhaseConfig) (string, string) {
+	latestPhase := ""
+	latestRank := -1
+	latestStatus := ""
+	for _, phase := range phases {
+		ps, ok := meta.Phases[phase.Name]
+		if !ok {
+			continue
+		}
+		rank := phaseRank(ps.Status)
+		if rank > latestRank {
+			latestPhase = phase.Name
+			latestRank = rank
+			latestStatus = string(ps.Status)
+		}
+	}
+	if latestPhase == "" {
+		return "-", "pending"
+	}
+	return latestPhase, latestStatus
+}
+
+func phaseRank(status pipeline.PhaseStatus) int {
+	switch status {
+	case pipeline.PhaseRunning:
+		return 4
+	case pipeline.PhaseFailed:
+		return 3
+	case pipeline.PhaseRetrying:
+		return 2
+	case pipeline.PhaseCompleted:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func formatElapsed(meta *pipeline.PipelineMeta) string {
+	var totalMs int64
+	hasRunning := false
+	for _, ps := range meta.Phases {
+		if ps.Status == pipeline.PhaseRunning {
+			hasRunning = true
+		}
+		totalMs += ps.DurationMs
+	}
+	if hasRunning {
+		return time.Since(meta.StartedAt).Truncate(time.Second).String()
+	}
+	return (time.Duration(totalMs) * time.Millisecond).Truncate(time.Second).String()
+}

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,15 @@ module github.com/decko/soda
 
 go 1.25.0
 
-require gopkg.in/yaml.v3 v3.0.1
+require (
+	github.com/sergio-correia/go-arapuca v0.1.0
+	github.com/spf13/cobra v1.10.2
+	gopkg.in/yaml.v3 v3.0.1
+)
 
-require github.com/sergio-correia/go-arapuca v0.1.0
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.9 // indirect
+)
 
 replace github.com/sergio-correia/go-arapuca => github.com/decko/go-arapuca v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,14 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/decko/go-arapuca v0.1.0 h1:pBzlTr8OnOOLFbC+Xp/BcqzHXsL7NXSqmBiqq+a3TwA=
 github.com/decko/go-arapuca v0.1.0/go.mod h1:n3QwYrcRa8hGT5Xc6T1OAogHNzn/lTm5XaQmQhOJhuM=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
+github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
+github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,93 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Config holds all SODA configuration loaded from a YAML file.
+type Config struct {
+	TicketSource string              `yaml:"ticket_source"`
+	Jira         JiraConfig          `yaml:"jira"`
+	Mode         string              `yaml:"mode"`
+	Model        string              `yaml:"model"`
+	Sandbox      SandboxConfig       `yaml:"sandbox"`
+	Limits       LimitsConfig        `yaml:"limits"`
+	WorktreeDir  string              `yaml:"worktree_dir"`
+	StateDir     string              `yaml:"state_dir"`
+	Context      []string            `yaml:"context"`
+	PhaseContext map[string][]string `yaml:"phase_context"`
+	Repos        []RepoConfig        `yaml:"repos"`
+}
+
+// JiraConfig holds Jira ticket source settings.
+type JiraConfig struct {
+	Command string `yaml:"command"`
+	Project string `yaml:"project"`
+	Query   string `yaml:"query"`
+}
+
+// SandboxConfig holds sandbox execution settings.
+type SandboxConfig struct {
+	Enabled bool          `yaml:"enabled"`
+	Binary  string        `yaml:"binary"`
+	Limits  SandboxLimits `yaml:"limits"`
+}
+
+// SandboxLimits holds resource limits for sandboxed execution.
+type SandboxLimits struct {
+	MemoryMB   int `yaml:"memory_mb"`
+	CPUPercent int `yaml:"cpu_percent"`
+	MaxPIDs    int `yaml:"max_pids"`
+}
+
+// LimitsConfig holds budget limits.
+type LimitsConfig struct {
+	MaxCostPerTicket float64 `yaml:"max_cost_per_ticket"`
+	MaxCostPerPhase  float64 `yaml:"max_cost_per_phase"`
+}
+
+// RepoConfig holds per-repo configuration.
+// Mirrors pipeline.RepoConfig — kept separate to avoid config importing pipeline.
+type RepoConfig struct {
+	Name        string   `yaml:"name"`
+	Forge       string   `yaml:"forge"`
+	PushTo      string   `yaml:"push_to"`
+	Target      string   `yaml:"target"`
+	Description string   `yaml:"description"`
+	Formatter   string   `yaml:"formatter"`
+	TestCommand string   `yaml:"test_command"`
+	Labels      []string `yaml:"labels"`
+	Trailers    []string `yaml:"trailers"`
+}
+
+// Load reads and parses a YAML config file.
+func Load(path string) (*Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("config: read %s: %w", path, err)
+	}
+
+	var cfg Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("config: parse %s: %w", path, err)
+	}
+
+	return &cfg, nil
+}
+
+// DefaultPath returns the default config file path: ~/.config/soda/config.yaml.
+func DefaultPath() (string, error) {
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		home, homeErr := os.UserHomeDir()
+		if homeErr != nil {
+			return "", fmt.Errorf("config: cannot determine config directory: %w", err)
+		}
+		configDir = filepath.Join(home, ".config")
+	}
+	return filepath.Join(configDir, "soda", "config.yaml"), nil
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,147 @@
+package config
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/decko/soda/internal/pipeline"
+)
+
+func TestLoad(t *testing.T) {
+	tests := []struct {
+		name    string
+		file    string
+		wantErr bool
+		check   func(t *testing.T, cfg *Config)
+	}{
+		{
+			name: "valid config parses all fields",
+			file: "testdata/valid.yaml",
+			check: func(t *testing.T, cfg *Config) {
+				if cfg.TicketSource != "jira" {
+					t.Errorf("TicketSource = %q, want %q", cfg.TicketSource, "jira")
+				}
+				if cfg.Jira.Command != "wtmcp" {
+					t.Errorf("Jira.Command = %q, want %q", cfg.Jira.Command, "wtmcp")
+				}
+				if cfg.Mode != "autonomous" {
+					t.Errorf("Mode = %q, want %q", cfg.Mode, "autonomous")
+				}
+				if cfg.Model != "claude-opus-4-6" {
+					t.Errorf("Model = %q, want %q", cfg.Model, "claude-opus-4-6")
+				}
+				if cfg.Limits.MaxCostPerTicket != 15.0 {
+					t.Errorf("MaxCostPerTicket = %f, want 15.0", cfg.Limits.MaxCostPerTicket)
+				}
+				if cfg.StateDir != ".soda" {
+					t.Errorf("StateDir = %q, want %q", cfg.StateDir, ".soda")
+				}
+				if len(cfg.Repos) != 1 {
+					t.Fatalf("len(Repos) = %d, want 1", len(cfg.Repos))
+				}
+				if cfg.Repos[0].Name != "my-service" {
+					t.Errorf("Repos[0].Name = %q, want %q", cfg.Repos[0].Name, "my-service")
+				}
+				if cfg.Repos[0].Forge != "github" {
+					t.Errorf("Repos[0].Forge = %q, want %q", cfg.Repos[0].Forge, "github")
+				}
+				if len(cfg.Context) != 1 || cfg.Context[0] != "AGENTS.md" {
+					t.Errorf("Context = %v, want [AGENTS.md]", cfg.Context)
+				}
+				if len(cfg.PhaseContext["plan"]) != 1 {
+					t.Errorf("PhaseContext[plan] = %v, want 1 entry", cfg.PhaseContext["plan"])
+				}
+			},
+		},
+		{
+			name: "minimal config",
+			file: "testdata/minimal.yaml",
+			check: func(t *testing.T, cfg *Config) {
+				if cfg.TicketSource != "jira" {
+					t.Errorf("TicketSource = %q, want %q", cfg.TicketSource, "jira")
+				}
+				if len(cfg.Repos) != 0 {
+					t.Errorf("len(Repos) = %d, want 0", len(cfg.Repos))
+				}
+			},
+		},
+		{
+			name:    "missing file",
+			file:    "testdata/nonexistent.yaml",
+			wantErr: true,
+			check: func(t *testing.T, _ *Config) {
+				// Error check is below
+			},
+		},
+		{
+			name:    "malformed yaml",
+			file:    "testdata/malformed.yaml",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := Load(tt.file)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tt.name == "missing file" && !errors.Is(err, os.ErrNotExist) {
+					t.Errorf("expected os.ErrNotExist, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.check != nil {
+				tt.check(t, cfg)
+			}
+		})
+	}
+}
+
+func TestDefaultPath(t *testing.T) {
+	path, err := DefaultPath()
+	if err != nil {
+		t.Fatalf("DefaultPath() error: %v", err)
+	}
+	if !filepath.IsAbs(path) {
+		t.Errorf("DefaultPath() = %q, want absolute path", path)
+	}
+	if filepath.Base(path) != "config.yaml" {
+		t.Errorf("DefaultPath() base = %q, want config.yaml", filepath.Base(path))
+	}
+}
+
+func TestRepoConfigFieldParity(t *testing.T) {
+	configType := reflect.TypeOf(RepoConfig{})
+	pipelineType := reflect.TypeOf(pipeline.RepoConfig{})
+
+	configFields := make(map[string]reflect.StructField)
+	for i := 0; i < configType.NumField(); i++ {
+		field := configType.Field(i)
+		configFields[field.Name] = field
+	}
+
+	for i := 0; i < pipelineType.NumField(); i++ {
+		pipeField := pipelineType.Field(i)
+		configField, ok := configFields[pipeField.Name]
+		if !ok {
+			t.Errorf("pipeline.RepoConfig has field %q not found in config.RepoConfig", pipeField.Name)
+			continue
+		}
+		if configField.Type != pipeField.Type {
+			t.Errorf("field %q type mismatch: config=%v, pipeline=%v", pipeField.Name, configField.Type, pipeField.Type)
+		}
+		delete(configFields, pipeField.Name)
+	}
+
+	for name := range configFields {
+		t.Errorf("config.RepoConfig has field %q not found in pipeline.RepoConfig", name)
+	}
+}

--- a/internal/config/testdata/malformed.yaml
+++ b/internal/config/testdata/malformed.yaml
@@ -1,0 +1,1 @@
+this is not: valid: yaml: [[[

--- a/internal/config/testdata/minimal.yaml
+++ b/internal/config/testdata/minimal.yaml
@@ -1,0 +1,6 @@
+ticket_source: jira
+jira:
+  command: wtmcp
+mode: autonomous
+model: claude-opus-4-6
+state_dir: .soda

--- a/internal/config/testdata/valid.yaml
+++ b/internal/config/testdata/valid.yaml
@@ -1,0 +1,38 @@
+ticket_source: jira
+jira:
+  command: wtmcp
+  project: MYPROJECT
+  query: "labels = ai-workable AND status = Refinement"
+mode: autonomous
+model: claude-opus-4-6
+sandbox:
+  enabled: true
+  binary: agent-node
+  limits:
+    memory_mb: 2048
+    cpu_percent: 200
+    max_pids: 256
+limits:
+  max_cost_per_ticket: 15.00
+  max_cost_per_phase: 8.00
+worktree_dir: .worktrees
+state_dir: .soda
+context:
+  - AGENTS.md
+phase_context:
+  plan:
+    - docs/gotchas.md
+  implement:
+    - docs/gotchas.md
+repos:
+  - name: my-service
+    forge: github
+    push_to: myuser/my-service
+    target: myorg/my-service
+    description: "Main service repo"
+    formatter: "black --line-length 100"
+    test_command: "pytest tests/"
+    labels:
+      - ai-assisted
+    trailers:
+      - "Assisted-by: SODA <noreply@soda.dev>"

--- a/internal/pipeline/lock.go
+++ b/internal/pipeline/lock.go
@@ -9,10 +9,12 @@ import (
 	"time"
 )
 
-// lockInfo holds the PID and acquisition time written to the lock file.
-type lockInfo struct {
+// LockInfo holds the PID and acquisition time written to the lock file.
+// IsAlive is computed at read time and not serialized.
+type LockInfo struct {
 	PID        int       `json:"pid"`
 	AcquiredAt time.Time `json:"acquired_at"`
+	IsAlive    bool      `json:"-"`
 }
 
 // acquireLock acquires an exclusive flock on the lock file in dir.
@@ -66,7 +68,7 @@ func releaseLock(fd *os.File) {
 
 // writeLockInfo truncates and writes PID + timestamp to the lock file.
 func writeLockInfo(fd *os.File) {
-	info := lockInfo{
+	info := LockInfo{
 		PID:        os.Getpid(),
 		AcquiredAt: time.Now(),
 	}
@@ -78,7 +80,7 @@ func writeLockInfo(fd *os.File) {
 }
 
 // readLockInfo reads and parses the lock file contents.
-func readLockInfo(fd *os.File) (*lockInfo, error) {
+func readLockInfo(fd *os.File) (*LockInfo, error) {
 	fd.Seek(0, 0)
 	data := make([]byte, 1024)
 	n, err := fd.Read(data)
@@ -88,10 +90,24 @@ func readLockInfo(fd *os.File) (*lockInfo, error) {
 		}
 		return nil, fmt.Errorf("pipeline: read lock info: %w", err)
 	}
-	var info lockInfo
+	var info LockInfo
 	if err := json.Unmarshal(data[:n], &info); err != nil {
 		return nil, fmt.Errorf("pipeline: parse lock info: %w", err)
 	}
+	return &info, nil
+}
+
+// ReadLockInfo reads and parses a lock file from a path, computing IsAlive.
+func ReadLockInfo(lockPath string) (*LockInfo, error) {
+	data, err := os.ReadFile(lockPath)
+	if err != nil {
+		return nil, fmt.Errorf("pipeline: read lock %s: %w", lockPath, err)
+	}
+	var info LockInfo
+	if err := json.Unmarshal(data, &info); err != nil {
+		return nil, fmt.Errorf("pipeline: parse lock %s: %w", lockPath, err)
+	}
+	info.IsAlive = isPIDAlive(info.PID)
 	return &info, nil
 }
 

--- a/internal/pipeline/lock_test.go
+++ b/internal/pipeline/lock_test.go
@@ -1,10 +1,13 @@
 package pipeline
 
 import (
+	"encoding/json"
 	"os"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"testing"
+	"time"
 )
 
 func TestAcquireLock(t *testing.T) {
@@ -132,4 +135,48 @@ func TestAcquireLock_AfterHolderCloses(t *testing.T) {
 		t.Fatalf("acquireLock after holder closed: %v", err)
 	}
 	releaseLock(fd)
+}
+
+func TestReadLockInfo(t *testing.T) {
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "lock")
+
+	info := LockInfo{
+		PID:        os.Getpid(),
+		AcquiredAt: time.Now().Truncate(time.Second),
+	}
+	data, _ := json.Marshal(info)
+	if err := os.WriteFile(lockPath, data, 0644); err != nil {
+		t.Fatalf("write lock file: %v", err)
+	}
+
+	got, err := ReadLockInfo(lockPath)
+	if err != nil {
+		t.Fatalf("ReadLockInfo: %v", err)
+	}
+	if got.PID != os.Getpid() {
+		t.Errorf("PID = %d, want %d", got.PID, os.Getpid())
+	}
+	if !got.IsAlive {
+		t.Error("IsAlive = false, want true (current process)")
+	}
+
+	// Write a dead PID
+	info.PID = 999999999
+	data, _ = json.Marshal(info)
+	os.WriteFile(lockPath, data, 0644)
+
+	got, err = ReadLockInfo(lockPath)
+	if err != nil {
+		t.Fatalf("ReadLockInfo (dead pid): %v", err)
+	}
+	if got.IsAlive {
+		t.Error("IsAlive = true for dead PID, want false")
+	}
+
+	// Missing file
+	_, err = ReadLockInfo(filepath.Join(dir, "nonexistent"))
+	if err == nil {
+		t.Error("expected error for missing lock file")
+	}
 }

--- a/internal/pipeline/meta.go
+++ b/internal/pipeline/meta.go
@@ -39,8 +39,8 @@ type PipelineMeta struct {
 	Phases    map[string]*PhaseState `json:"phases"`
 }
 
-// readMeta reads and unmarshals a meta.json file.
-func readMeta(path string) (*PipelineMeta, error) {
+// ReadMeta reads and unmarshals a meta.json file.
+func ReadMeta(path string) (*PipelineMeta, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("pipeline: read meta %s: %w", path, err)

--- a/internal/pipeline/meta_test.go
+++ b/internal/pipeline/meta_test.go
@@ -41,9 +41,9 @@ func TestMetaRoundTrip(t *testing.T) {
 		t.Fatalf("writeMeta: %v", err)
 	}
 
-	loaded, err := readMeta(path)
+	loaded, err := ReadMeta(path)
 	if err != nil {
-		t.Fatalf("readMeta: %v", err)
+		t.Fatalf("ReadMeta: %v", err)
 	}
 
 	if loaded.Ticket != original.Ticket {
@@ -103,9 +103,9 @@ func TestReadMeta_InitializesNilPhasesMap(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	meta, err := readMeta(path)
+	meta, err := ReadMeta(path)
 	if err != nil {
-		t.Fatalf("readMeta: %v", err)
+		t.Fatalf("ReadMeta: %v", err)
 	}
 	if meta.Phases == nil {
 		t.Error("Phases should be initialized to non-nil map")
@@ -113,9 +113,41 @@ func TestReadMeta_InitializesNilPhasesMap(t *testing.T) {
 }
 
 func TestReadMeta_FileNotExist(t *testing.T) {
-	_, err := readMeta("/nonexistent/path/meta.json")
+	_, err := ReadMeta("/nonexistent/path/meta.json")
 	if err == nil {
 		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestReadMeta(t *testing.T) {
+	dir := t.TempDir()
+	metaPath := filepath.Join(dir, "meta.json")
+
+	meta := &PipelineMeta{
+		Ticket:    "TEST-1",
+		Branch:    "feat/test",
+		StartedAt: time.Now().Truncate(time.Second),
+		TotalCost: 1.23,
+		Phases:    map[string]*PhaseState{},
+	}
+	if err := writeMeta(metaPath, meta); err != nil {
+		t.Fatalf("writeMeta: %v", err)
+	}
+
+	got, err := ReadMeta(metaPath)
+	if err != nil {
+		t.Fatalf("ReadMeta: %v", err)
+	}
+	if got.Ticket != "TEST-1" {
+		t.Errorf("Ticket = %q, want TEST-1", got.Ticket)
+	}
+	if got.TotalCost != 1.23 {
+		t.Errorf("TotalCost = %f, want 1.23", got.TotalCost)
+	}
+
+	_, err = ReadMeta(filepath.Join(dir, "nonexistent.json"))
+	if err == nil {
+		t.Error("expected error for missing file")
 	}
 }
 

--- a/internal/pipeline/state.go
+++ b/internal/pipeline/state.go
@@ -29,7 +29,7 @@ func LoadOrCreate(stateDir, ticketKey string) (*State, error) {
 	dir := filepath.Join(stateDir, ticketKey)
 	metaPath := filepath.Join(dir, "meta.json")
 
-	meta, err := readMeta(metaPath)
+	meta, err := ReadMeta(metaPath)
 	if err == nil {
 		return &State{dir: dir, ticket: ticketKey, meta: meta}, nil
 	}


### PR DESCRIPTION
## Summary

Cherry-pick the CLI merge commit (PR #28) which was orphaned from main during the rebase of #33/#34. Resolves go.mod conflict by merging cobra + go-arapuca dependencies.

Restores: cmd/soda/ (main, run, status, history, clean, render), internal/config/, embedded prompts and phases.

Assisted-by: Claude Opus 4.6