### PR TITLE
fix: inline JSON schemas and wire PromptConfig for E2E readiness

### DIFF
--- a/cmd/soda/embeds/phases.yaml
+++ b/cmd/soda/embeds/phases.yaml
@@ -6,7 +6,8 @@
 phases:
   - name: triage
     prompt: prompts/triage.md
-    schema: schemas/triage.go
+    schema: |
+      {"type":"object","properties":{"ticket_key":{"type":"string"},"repo":{"type":"string"},"code_area":{"type":"string"},"files":{"type":"array","items":{"type":"string"}},"complexity":{"type":"string"},"approach":{"type":"string"},"risks":{"type":"array","items":{"type":"string"}},"automatable":{"type":"boolean"},"block_reason":{"type":"string"}},"required":["ticket_key","repo","code_area","files","complexity","approach","risks","automatable"]}
     tools:
       - Read
       - Glob
@@ -22,7 +23,8 @@ phases:
 
   - name: plan
     prompt: prompts/plan.md
-    schema: schemas/plan.go
+    schema: |
+      {"type":"object","properties":{"ticket_key":{"type":"string"},"approach":{"type":"string"},"tasks":{"type":"array","items":{"type":"object","properties":{"id":{"type":"string"},"description":{"type":"string"},"files":{"type":"array","items":{"type":"string"}},"done_when":{"type":"string"},"depends_on":{"type":"array","items":{"type":"string"}}},"required":["id","description","files","done_when"]}},"verification":{"type":"object","properties":{"commands":{"type":"array","items":{"type":"string"}},"manual_steps":{"type":"array","items":{"type":"string"}}},"required":["commands"]},"deviations":{"type":"array","items":{"type":"string"}}},"required":["ticket_key","approach","tasks","verification"]}
     tools:
       - Read
       - Glob
@@ -39,7 +41,8 @@ phases:
 
   - name: implement
     prompt: prompts/implement.md
-    schema: schemas/implement.go
+    schema: |
+      {"type":"object","properties":{"ticket_key":{"type":"string"},"branch":{"type":"string"},"commits":{"type":"array","items":{"type":"object","properties":{"hash":{"type":"string"},"message":{"type":"string"},"task_id":{"type":"string"}},"required":["hash","message","task_id"]}},"files_changed":{"type":"array","items":{"type":"object","properties":{"path":{"type":"string"},"action":{"type":"string"}},"required":["path","action"]}},"task_results":{"type":"array","items":{"type":"object","properties":{"task_id":{"type":"string"},"status":{"type":"string"},"reason":{"type":"string"}},"required":["task_id","status"]}},"tests_passed":{"type":"boolean"},"test_output":{"type":"string"},"deviations":{"type":"array","items":{"type":"string"}}},"required":["ticket_key","branch","commits","files_changed","task_results","tests_passed"]}
     tools:
       - Read
       - Write
@@ -57,7 +60,8 @@ phases:
 
   - name: verify
     prompt: prompts/verify.md
-    schema: schemas/verify.go
+    schema: |
+      {"type":"object","properties":{"ticket_key":{"type":"string"},"verdict":{"type":"string"},"criteria_results":{"type":"array","items":{"type":"object","properties":{"criterion":{"type":"string"},"passed":{"type":"boolean"},"evidence":{"type":"string"}},"required":["criterion","passed","evidence"]}},"command_results":{"type":"array","items":{"type":"object","properties":{"command":{"type":"string"},"exit_code":{"type":"integer"},"output":{"type":"string"},"passed":{"type":"boolean"}},"required":["command","exit_code","output","passed"]}},"code_issues":{"type":"array","items":{"type":"object","properties":{"file":{"type":"string"},"line":{"type":"integer"},"severity":{"type":"string"},"issue":{"type":"string"}},"required":["file","severity","issue"]}},"fixes_required":{"type":"array","items":{"type":"string"}}},"required":["ticket_key","verdict","criteria_results","command_results"]}
     tools:
       - Read
       - Glob
@@ -74,7 +78,8 @@ phases:
 
   - name: submit
     prompt: prompts/submit.md
-    schema: schemas/submit.go
+    schema: |
+      {"type":"object","properties":{"ticket_key":{"type":"string"},"pr_url":{"type":"string"},"pr_number":{"type":"integer"},"title":{"type":"string"},"branch":{"type":"string"},"target":{"type":"string"},"forge":{"type":"string"}},"required":["ticket_key","pr_url","pr_number","title","branch","target","forge"]}
     tools:
       - Bash(git:*)
       - Bash(gh:*)
@@ -90,7 +95,8 @@ phases:
 
   - name: monitor
     prompt: prompts/monitor.md
-    schema: schemas/monitor.go
+    schema: |
+      {"type":"object","properties":{"ticket_key":{"type":"string"},"pr_url":{"type":"string"},"comments_handled":{"type":"array","items":{"type":"object","properties":{"comment_id":{"type":"string"},"author":{"type":"string"},"content":{"type":"string"},"action":{"type":"string"},"response":{"type":"string"}},"required":["comment_id","author","content","action","response"]}},"files_changed":{"type":"array","items":{"type":"object","properties":{"path":{"type":"string"},"action":{"type":"string"}},"required":["path","action"]}},"commits":{"type":"array","items":{"type":"object","properties":{"hash":{"type":"string"},"message":{"type":"string"},"task_id":{"type":"string"}},"required":["hash","message","task_id"]}},"tests_passed":{"type":"boolean"}},"required":["ticket_key","pr_url","comments_handled","tests_passed"]}
     type: polling     # not one-shot
     tools:
       - Read

--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -139,19 +139,27 @@ func runPipeline(cmd *cobra.Command, cfg *config.Config, ticketKey string) error
 		r = claudeRunner
 	}
 
+	// Build prompt config from repos
+	promptConfig := buildPromptConfig(cfg)
+
+	// Load project context files
+	promptContext := buildPromptContext(cfg)
+
 	// Build engine config — use a closure that captures the engine pointer
 	var engine *pipeline.Engine
 
 	engineCfg := pipeline.EngineConfig{
-		Pipeline:     pl,
-		Loader:       loader,
-		Ticket:       ticketData,
-		Model:        cfg.Model,
-		WorkDir:      ".",
-		WorktreeBase: cfg.WorktreeDir,
-		BaseBranch:   "main",
-		MaxCostUSD:   cfg.Limits.MaxCostPerTicket,
-		Mode:         mode,
+		Pipeline:      pl,
+		Loader:        loader,
+		Ticket:        ticketData,
+		PromptConfig:  promptConfig,
+		PromptContext: promptContext,
+		Model:         cfg.Model,
+		WorkDir:       ".",
+		WorktreeBase:  cfg.WorktreeDir,
+		BaseBranch:    "main",
+		MaxCostUSD:    cfg.Limits.MaxCostPerTicket,
+		Mode:          mode,
 		OnEvent: func(event pipeline.Event) {
 			handleEvent(ctx, cancel, engine, event)
 		},
@@ -259,7 +267,9 @@ func promptConfirm(ctx context.Context) bool {
 
 func runDryRun(cfg *config.Config, pl *pipeline.PhasePipeline, loader *pipeline.PromptLoader, ticketData pipeline.TicketData) error {
 	promptData := pipeline.PromptData{
-		Ticket: ticketData,
+		Ticket:  ticketData,
+		Config:  buildPromptConfig(cfg),
+		Context: buildPromptContext(cfg),
 	}
 
 	// Load artifacts from state if available
@@ -307,6 +317,68 @@ func printSummary(meta *pipeline.PipelineMeta, elapsed time.Duration) {
 			fmt.Printf("Failed:  %s — %s\n", name, ps.Error)
 		}
 	}
+}
+
+func buildPromptConfig(cfg *config.Config) pipeline.PromptConfigData {
+	repos := make([]pipeline.RepoConfig, len(cfg.Repos))
+	for i, r := range cfg.Repos {
+		repos[i] = pipeline.RepoConfig{
+			Name:        r.Name,
+			Forge:       r.Forge,
+			PushTo:      r.PushTo,
+			Target:      r.Target,
+			Description: r.Description,
+			Formatter:   r.Formatter,
+			TestCommand: r.TestCommand,
+			Labels:      r.Labels,
+			Trailers:    r.Trailers,
+		}
+	}
+
+	pc := pipeline.PromptConfigData{
+		Repos: repos,
+	}
+
+	// Set single Repo, Formatter, TestCommand from the first repo if available.
+	if len(repos) > 0 {
+		pc.Repo = repos[0]
+		pc.Formatter = repos[0].Formatter
+		pc.TestCommand = repos[0].TestCommand
+	}
+
+	return pc
+}
+
+func buildPromptContext(cfg *config.Config) pipeline.ContextData {
+	var ctx pipeline.ContextData
+
+	// Load project-wide context files
+	var projectParts []string
+	for _, path := range cfg.Context {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		projectParts = append(projectParts, string(data))
+	}
+	if len(projectParts) > 0 {
+		ctx.ProjectContext = strings.Join(projectParts, "\n\n---\n\n")
+	}
+
+	// Load gotchas if referenced in any phase context
+	if paths, ok := cfg.PhaseContext["plan"]; ok {
+		for _, path := range paths {
+			if strings.Contains(path, "gotchas") {
+				data, err := os.ReadFile(path)
+				if err == nil {
+					ctx.Gotchas = string(data)
+				}
+				break
+			}
+		}
+	}
+
+	return ctx
 }
 
 // resolveLastPhase finds the last running or failed phase in pipeline order.

--- a/phases.yaml
+++ b/phases.yaml
@@ -6,7 +6,8 @@
 phases:
   - name: triage
     prompt: prompts/triage.md
-    schema: schemas/triage.go
+    schema: |
+      {"type":"object","properties":{"ticket_key":{"type":"string"},"repo":{"type":"string"},"code_area":{"type":"string"},"files":{"type":"array","items":{"type":"string"}},"complexity":{"type":"string"},"approach":{"type":"string"},"risks":{"type":"array","items":{"type":"string"}},"automatable":{"type":"boolean"},"block_reason":{"type":"string"}},"required":["ticket_key","repo","code_area","files","complexity","approach","risks","automatable"]}
     tools:
       - Read
       - Glob
@@ -22,7 +23,8 @@ phases:
 
   - name: plan
     prompt: prompts/plan.md
-    schema: schemas/plan.go
+    schema: |
+      {"type":"object","properties":{"ticket_key":{"type":"string"},"approach":{"type":"string"},"tasks":{"type":"array","items":{"type":"object","properties":{"id":{"type":"string"},"description":{"type":"string"},"files":{"type":"array","items":{"type":"string"}},"done_when":{"type":"string"},"depends_on":{"type":"array","items":{"type":"string"}}},"required":["id","description","files","done_when"]}},"verification":{"type":"object","properties":{"commands":{"type":"array","items":{"type":"string"}},"manual_steps":{"type":"array","items":{"type":"string"}}},"required":["commands"]},"deviations":{"type":"array","items":{"type":"string"}}},"required":["ticket_key","approach","tasks","verification"]}
     tools:
       - Read
       - Glob
@@ -39,7 +41,8 @@ phases:
 
   - name: implement
     prompt: prompts/implement.md
-    schema: schemas/implement.go
+    schema: |
+      {"type":"object","properties":{"ticket_key":{"type":"string"},"branch":{"type":"string"},"commits":{"type":"array","items":{"type":"object","properties":{"hash":{"type":"string"},"message":{"type":"string"},"task_id":{"type":"string"}},"required":["hash","message","task_id"]}},"files_changed":{"type":"array","items":{"type":"object","properties":{"path":{"type":"string"},"action":{"type":"string"}},"required":["path","action"]}},"task_results":{"type":"array","items":{"type":"object","properties":{"task_id":{"type":"string"},"status":{"type":"string"},"reason":{"type":"string"}},"required":["task_id","status"]}},"tests_passed":{"type":"boolean"},"test_output":{"type":"string"},"deviations":{"type":"array","items":{"type":"string"}}},"required":["ticket_key","branch","commits","files_changed","task_results","tests_passed"]}
     tools:
       - Read
       - Write
@@ -57,7 +60,8 @@ phases:
 
   - name: verify
     prompt: prompts/verify.md
-    schema: schemas/verify.go
+    schema: |
+      {"type":"object","properties":{"ticket_key":{"type":"string"},"verdict":{"type":"string"},"criteria_results":{"type":"array","items":{"type":"object","properties":{"criterion":{"type":"string"},"passed":{"type":"boolean"},"evidence":{"type":"string"}},"required":["criterion","passed","evidence"]}},"command_results":{"type":"array","items":{"type":"object","properties":{"command":{"type":"string"},"exit_code":{"type":"integer"},"output":{"type":"string"},"passed":{"type":"boolean"}},"required":["command","exit_code","output","passed"]}},"code_issues":{"type":"array","items":{"type":"object","properties":{"file":{"type":"string"},"line":{"type":"integer"},"severity":{"type":"string"},"issue":{"type":"string"}},"required":["file","severity","issue"]}},"fixes_required":{"type":"array","items":{"type":"string"}}},"required":["ticket_key","verdict","criteria_results","command_results"]}
     tools:
       - Read
       - Glob
@@ -74,7 +78,8 @@ phases:
 
   - name: submit
     prompt: prompts/submit.md
-    schema: schemas/submit.go
+    schema: |
+      {"type":"object","properties":{"ticket_key":{"type":"string"},"pr_url":{"type":"string"},"pr_number":{"type":"integer"},"title":{"type":"string"},"branch":{"type":"string"},"target":{"type":"string"},"forge":{"type":"string"}},"required":["ticket_key","pr_url","pr_number","title","branch","target","forge"]}
     tools:
       - Bash(git:*)
       - Bash(gh:*)
@@ -90,7 +95,8 @@ phases:
 
   - name: monitor
     prompt: prompts/monitor.md
-    schema: schemas/monitor.go
+    schema: |
+      {"type":"object","properties":{"ticket_key":{"type":"string"},"pr_url":{"type":"string"},"comments_handled":{"type":"array","items":{"type":"object","properties":{"comment_id":{"type":"string"},"author":{"type":"string"},"content":{"type":"string"},"action":{"type":"string"},"response":{"type":"string"}},"required":["comment_id","author","content","action","response"]}},"files_changed":{"type":"array","items":{"type":"object","properties":{"path":{"type":"string"},"action":{"type":"string"}},"required":["path","action"]}},"commits":{"type":"array","items":{"type":"object","properties":{"hash":{"type":"string"},"message":{"type":"string"},"task_id":{"type":"string"}},"required":["hash","message","task_id"]}},"tests_passed":{"type":"boolean"}},"required":["ticket_key","pr_url","comments_handled","tests_passed"]}
     type: polling     # not one-shot
     tools:
       - Read

--- a/prompts/triage.md
+++ b/prompts/triage.md
@@ -5,7 +5,9 @@ You are a triage engineer assessing a ticket for automated implementation.
 Key: {{.Ticket.Key}}
 Summary: {{.Ticket.Summary}}
 Type: {{.Ticket.Type}}
+{{- if .Ticket.Priority}}
 Priority: {{.Ticket.Priority}}
+{{- end}}
 
 ### Description
 {{.Ticket.Description}}


### PR DESCRIPTION
## Summary

- Replace Go file path references in `phases.yaml` with inline JSON schema strings — `ClaudeRunner` validates JSON before passing to `--json-schema`, so file paths caused failures
- Wire `PromptConfig` (repos, formatter, test command) and `PromptContext` (project context, gotchas) from soda config into `EngineConfig` — templates like `{{.Config.Repos}}` were rendering empty
- Fix dry-run path to also populate Config and Context
- Guard Priority line in local `prompts/triage.md` override

Prerequisite for #5. See #46 for build-time schema generation follow-up.

## Test plan

- [x] All 6 phase schemas validate as JSON
- [x] `go build ./cmd/soda/` passes
- [x] `go test ./cmd/soda/ ./internal/pipeline/` passes
- [x] `soda run 36 --dry-run` renders all 6 phases with repos and context populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)