### PR TITLE
fix(engine): provide user prompt so claude --print has input

### DIFF
--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -260,7 +260,7 @@ func (e *Engine) runPhase(ctx context.Context, phase PhaseConfig) error {
 	opts := runner.RunOpts{
 		Phase:        phase.Name,
 		SystemPrompt: rendered,
-		UserPrompt:   "",
+		UserPrompt:   "Execute the task described in the system prompt.",
 		OutputSchema: phase.Schema,
 		AllowedTools: phase.Tools,
 		MaxBudgetUSD: remaining,


### PR DESCRIPTION
## Summary

- The Claude CLI's `--print` mode requires input via stdin or as a prompt argument
- The engine was passing an empty `UserPrompt`, causing `claude` to exit with code 1 (classified as transient error)
- Set a minimal user prompt: `"Execute the task described in the system prompt."`

Discovered during #5 E2E testing.

## Test plan

- [x] `soda run 36` completes triage → plan → implement → verify (previously failed on triage with exit code 1)
- [x] `go build ./cmd/soda/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)