### PR TITLE
feat(cli): add version command (#36)

### DIFF
--- a/cmd/soda/main.go
+++ b/cmd/soda/main.go
@@ -44,6 +44,7 @@ func newRootCmd() *cobra.Command {
 		newHistoryCmd(),
 		newCleanCmd(),
 		newRenderCmd(),
+		newVersionCmd(),
 	)
 
 	return cmd

--- a/cmd/soda/version.go
+++ b/cmd/soda/version.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+	"runtime/debug"
+
+	"github.com/spf13/cobra"
+)
+
+func newVersionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print detailed version information",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(buildVersionString())
+		},
+	}
+}
+
+func buildVersionString() string {
+	goVersion := "(unknown)"
+	commit := "(unknown)"
+
+	info, ok := debug.ReadBuildInfo()
+	if ok {
+		goVersion = info.GoVersion
+		for _, s := range info.Settings {
+			if s.Key == "vcs.revision" && len(s.Value) >= 12 {
+				commit = s.Value[:12]
+				break
+			} else if s.Key == "vcs.revision" {
+				commit = s.Value
+				break
+			}
+		}
+	}
+
+	return fmt.Sprintf("soda version %s (%s, commit %s)", version, goVersion, commit)
+}

--- a/cmd/soda/version_test.go
+++ b/cmd/soda/version_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildVersionString(t *testing.T) {
+	out := buildVersionString()
+
+	if !strings.Contains(out, version) {
+		t.Errorf("output %q does not contain version %q", out, version)
+	}
+
+	if !strings.Contains(out, "go") {
+		t.Errorf("output %q does not contain Go version info", out)
+	}
+
+	if !strings.HasPrefix(out, "soda version ") {
+		t.Errorf("output %q does not start with expected prefix", out)
+	}
+
+	if !strings.Contains(out, "commit ") {
+		t.Errorf("output %q does not contain commit info", out)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `soda version` subcommand that prints version string with Go version and build commit hash
- Uses `runtime/debug.ReadBuildInfo()` to extract build metadata at runtime
- Follows existing `newXxxCmd()` pattern with a dedicated `version.go` file

## Changes
- **`cmd/soda/version.go`** — `newVersionCmd()` cobra command and `buildVersionString()` helper with graceful fallback to `"(unknown)"` when build info is unavailable
- **`cmd/soda/main.go`** — Register `newVersionCmd()` in root command
- **`cmd/soda/version_test.go`** — Tests covering version string format, Go version presence, prefix, and commit info

## Acceptance Criteria
- [x] `soda version` outputs version string
- [x] Includes Go version and build commit hash
- [x] Uses `runtime/debug.ReadBuildInfo()`

## Test Plan
- [x] Unit tests pass for `buildVersionString()` output format
- [x] Verify output contains `"soda version"` prefix
- [x] Verify output includes Go version info
- [x] Verify output includes commit hash info

🤖 Generated with [Claude Code](https://claude.com/claude-code)