### PR TITLE
docs: add follow-up issue convention to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -351,6 +351,10 @@ Issues are numbered in dependency order:
 
 Parallelizable: #1, #3, and #6 have no dependencies on each other.
 
+## Follow-up issues
+
+When discovering bugs, tech debt, or improvement opportunities during a task, file them as separate GitHub issues with the `triage-needed` label. Do not fix them inline — stay focused on the current ticket's scope.
+
 ## What NOT to do
 
 - Do not hardcode project-specific references (repo names, Jira projects, ticket keys)


### PR DESCRIPTION
## Summary

- Add convention: file discovered bugs/debt as separate issues with `triage-needed` label, don't scope-creep

🤖 Generated with [Claude Code](https://claude.com/claude-code)