### PR TITLE
fix(clean): delete branch when cleaning a pipeline

### DIFF
--- a/cmd/soda/clean.go
+++ b/cmd/soda/clean.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"syscall"
 
+	sodagit "github.com/decko/soda/internal/git"
 	"github.com/decko/soda/internal/pipeline"
 	"github.com/spf13/cobra"
 )
@@ -109,6 +110,22 @@ func cleanTicket(stateDir, ticketKey string, dryRun bool) error {
 		}
 	}
 
+	// Delete branch
+	if meta.Branch != "" {
+		if dryRun {
+			fmt.Printf("Would delete branch: %s\n", meta.Branch)
+		} else {
+			repoDir, err := resolveRepoDir()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: cannot resolve repo dir to delete branch %s: %v\n", meta.Branch, err)
+			} else if brErr := sodagit.DeleteBranch(repoDir, meta.Branch); brErr != nil {
+				fmt.Fprintf(os.Stderr, "Warning: git branch delete %s: %v\n", meta.Branch, brErr)
+			} else {
+				fmt.Printf("Deleted branch: %s\n", meta.Branch)
+			}
+		}
+	}
+
 	// Remove state directory
 	if dryRun {
 		fmt.Printf("Would remove state: %s\n", ticketDir)
@@ -137,6 +154,20 @@ func tryLock(lockPath string) bool {
 	}
 	syscall.Flock(int(fd.Fd()), syscall.LOCK_UN)
 	return true
+}
+
+// resolveRepoDir returns the top-level directory of the current git repository.
+func resolveRepoDir() (string, error) {
+	out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		return "", fmt.Errorf("git rev-parse --show-toplevel: %w", err)
+	}
+	dir := string(out)
+	// Trim trailing newline
+	if len(dir) > 0 && dir[len(dir)-1] == '\n' {
+		dir = dir[:len(dir)-1]
+	}
+	return dir, nil
 }
 
 // isTerminal returns true if the pipeline is in a cleanable state.

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 )
 
 // CreateWorktree creates a git worktree for a new branch based on baseBranch.
@@ -41,4 +42,21 @@ func CreateWorktree(ctx context.Context, repoDir, worktreeBase, branch, baseBran
 	}
 
 	return absPath, nil
+}
+
+// DeleteBranch deletes a local git branch. It runs "git branch -D <branch>"
+// from the given repoDir. Returns nil if the branch was deleted or did not exist.
+func DeleteBranch(repoDir, branch string) error {
+	cmd := exec.Command("git", "branch", "-D", branch)
+	cmd.Dir = repoDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		// If the branch doesn't exist, treat as success.
+		outStr := string(output)
+		if strings.Contains(outStr, "not found") || strings.Contains(outStr, "not a valid branch") {
+			return nil
+		}
+		return fmt.Errorf("git: branch delete %s: %s: %w", branch, outStr, err)
+	}
+	return nil
 }

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -98,3 +98,52 @@ func TestCreateWorktree(t *testing.T) {
 		}
 	})
 }
+
+func TestDeleteBranch(t *testing.T) {
+	t.Run("deletes_existing_branch", func(t *testing.T) {
+		repoDir := initGitRepo(t)
+
+		// Create a branch
+		cmd := exec.Command("git", "branch", "feat/to-delete")
+		cmd.Dir = repoDir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git branch: %s: %v", out, err)
+		}
+
+		// Verify it exists
+		cmd = exec.Command("git", "branch", "--list", "feat/to-delete")
+		cmd.Dir = repoDir
+		out, err := cmd.Output()
+		if err != nil {
+			t.Fatalf("git branch --list: %v", err)
+		}
+		if len(out) == 0 {
+			t.Fatal("branch feat/to-delete should exist before deletion")
+		}
+
+		// Delete it
+		if err := DeleteBranch(repoDir, "feat/to-delete"); err != nil {
+			t.Fatalf("DeleteBranch: %v", err)
+		}
+
+		// Verify it no longer exists
+		cmd = exec.Command("git", "branch", "--list", "feat/to-delete")
+		cmd.Dir = repoDir
+		out, err = cmd.Output()
+		if err != nil {
+			t.Fatalf("git branch --list after delete: %v", err)
+		}
+		if len(out) != 0 {
+			t.Error("branch feat/to-delete should not exist after deletion")
+		}
+	})
+
+	t.Run("no_error_for_nonexistent_branch", func(t *testing.T) {
+		repoDir := initGitRepo(t)
+
+		err := DeleteBranch(repoDir, "feat/does-not-exist")
+		if err != nil {
+			t.Fatalf("DeleteBranch should not error for nonexistent branch: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- **Add `DeleteBranch` function** to the `internal/git` package that force-deletes a local branch (`git branch -D`), returning nil for nonexistent branches to keep cleanup idempotent.
- **Integrate branch deletion into `cleanTicket`** in `cmd/soda/clean.go`: after worktree removal and before state directory removal, delete the branch read from `meta.json`. Supports dry-run mode and prints warnings on failure (best-effort, matching worktree removal behavior).
- **Add tests** for `DeleteBranch` covering both existing and nonexistent branch scenarios.

## Acceptance Criteria

- [x] `DeleteBranch` calls `git branch -D` and is integrated into the clean flow after worktree removal
- [x] Correct ordering: branch name read from `meta.json`, worktree removed, branch deleted, state directory removed
- [x] Safety: nonexistent/already-deleted branches do not cause errors (idempotent)
- [x] Git natively refuses to delete branches checked out in worktrees; errors are properly propagated
- [x] Clean → re-run works: since the branch is deleted during clean, `CreateWorktree` (`git worktree add -b`) succeeds on re-run
- [x] Dry-run mode prints what would be deleted without acting

## Test Plan

- [x] Unit tests for `DeleteBranch` pass (`TestDeleteBranch/deletes_existing_branch`, `TestDeleteBranch/no_error_for_nonexistent_branch`)
- [x] Existing tests continue to pass
- [ ] Manual: run `soda clean <ticket>` and verify the branch is deleted along with the worktree and state

Refs: #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)