### PR TITLE
feat(cli): live progress with spinner and phase status (#65)

### DIFF
--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -15,8 +15,10 @@ import (
 
 	"github.com/decko/soda/internal/config"
 	"github.com/decko/soda/internal/pipeline"
+	"github.com/decko/soda/internal/progress"
 	"github.com/decko/soda/internal/runner"
 	"github.com/decko/soda/schemas"
+	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 )
 
@@ -148,6 +150,10 @@ func runPipeline(cmd *cobra.Command, cfg *config.Config, ticketKey string) error
 	// Load project context files
 	promptContext := buildPromptContext(cfg)
 
+	// Set up progress display
+	isTTY := isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd())
+	prog := progress.New(os.Stdout, isTTY)
+
 	// Build engine config — use a closure that captures the engine pointer
 	var engine *pipeline.Engine
 	skippedPhases := map[string]bool{}
@@ -168,7 +174,7 @@ func runPipeline(cmd *cobra.Command, cfg *config.Config, ticketKey string) error
 			if event.Kind == pipeline.EventPhaseSkipped || event.Kind == pipeline.EventMonitorSkipped {
 				skippedPhases[event.Phase] = true
 			}
-			handleEvent(ctx, cancel, engine, event)
+			handleEvent(ctx, cancel, engine, state, prog, event)
 		},
 	}
 
@@ -225,35 +231,82 @@ func buildMockRunner() *runner.MockRunner {
 	}
 }
 
-func handleEvent(ctx context.Context, cancel context.CancelFunc, engine *pipeline.Engine, event pipeline.Event) {
+func handleEvent(ctx context.Context, cancel context.CancelFunc, engine *pipeline.Engine, state *pipeline.State, prog *progress.Progress, event pipeline.Event) {
 	switch event.Kind {
 	case pipeline.EventEngineStarted:
-		fmt.Println("Pipeline started")
+		prog.Message("Pipeline started")
+		prog.Message("")
+
 	case pipeline.EventEngineCompleted:
-		fmt.Println("Pipeline completed")
+		prog.Message("")
+		prog.Message("Pipeline completed")
+
+	case pipeline.EventPhaseStarted:
+		prog.PhaseStarted(event.Phase)
+
+	case pipeline.EventPhaseCompleted:
+		durationMs, _ := event.Data["duration_ms"].(int64)
+		if durationMs == 0 {
+			// Try float64 (JSON numbers default to float64)
+			if dFloat, ok := event.Data["duration_ms"].(float64); ok {
+				durationMs = int64(dFloat)
+			}
+		}
+		elapsed := time.Duration(durationMs) * time.Millisecond
+		cost, _ := event.Data["cost"].(float64)
+
+		// Extract summary from structured output
+		summary := ""
+		if result, err := state.ReadResult(event.Phase); err == nil {
+			summary = progress.PhaseSummary(event.Phase, result)
+		}
+
+		prog.PhaseCompleted(event.Phase, summary, elapsed, cost)
+
+	case pipeline.EventPhaseFailed:
+		errMsg, _ := event.Data["error"].(string)
+		durationMs, _ := event.Data["duration_ms"].(int64)
+		if durationMs == 0 {
+			if dFloat, ok := event.Data["duration_ms"].(float64); ok {
+				durationMs = int64(dFloat)
+			}
+		}
+		elapsed := time.Duration(durationMs) * time.Millisecond
+		prog.PhaseFailed(event.Phase, errMsg, elapsed)
+
 	case pipeline.EventPhaseSkipped:
-		fmt.Printf("⏭ %s  skipped\n", event.Phase)
+		prog.PhaseSkipped(event.Phase)
+
 	case pipeline.EventPhaseRetrying:
 		category, _ := event.Data["category"].(string)
 		attempt, _ := event.Data["attempt"].(int)
-		fmt.Printf("↻ %s  retrying (%s, attempt %d)\n", event.Phase, category, attempt)
+		if attempt == 0 {
+			if aFloat, ok := event.Data["attempt"].(float64); ok {
+				attempt = int(aFloat)
+			}
+		}
+		prog.PhaseRetrying(event.Phase, category, attempt)
+
 	case pipeline.EventBudgetWarning:
 		total, _ := event.Data["total_cost"].(float64)
 		limit, _ := event.Data["limit"].(float64)
-		fmt.Printf("⚠ Budget warning: $%.2f / $%.2f\n", total, limit)
+		prog.BudgetWarning(total, limit)
+
 	case pipeline.EventCheckpointPause:
-		fmt.Printf("⏸ %s completed. Continue? [y/N] ", event.Phase)
+		prog.Message(fmt.Sprintf("⏸ %s completed. Continue? [y/N] ", event.Phase))
 		if engine != nil && promptConfirm(ctx) {
 			engine.Confirm()
 		} else {
 			cancel()
 		}
+
 	case pipeline.EventWorktreeCreated:
 		wt, _ := event.Data["worktree"].(string)
 		branch, _ := event.Data["branch"].(string)
-		fmt.Printf("Created worktree: %s (%s)\n", wt, branch)
+		prog.Message(fmt.Sprintf("Created worktree: %s (%s)", wt, branch))
+
 	case pipeline.EventMonitorSkipped:
-		fmt.Printf("⏭ monitor  skipped (not yet implemented)\n")
+		prog.PhaseSkipped("monitor")
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/mattn/go-isatty v0.0.20
 	github.com/sergio-correia/go-arapuca v0.1.0
 	github.com/spf13/cobra v1.10.2
 	gopkg.in/yaml.v3 v3.0.1
@@ -23,7 +24,6 @@ require (
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.19 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect

--- a/internal/progress/progress.go
+++ b/internal/progress/progress.go
@@ -72,13 +72,16 @@ func (p *Progress) PhaseStarted(phase string) {
 	p.desc = desc
 	p.startTime = p.NowFunc()
 	p.frame = 0
-	p.mu.Unlock()
 
 	if p.isTTY {
-		p.stopCh = make(chan struct{})
-		p.stoppedCh = make(chan struct{})
-		go p.spin()
+		stopCh := make(chan struct{})
+		stoppedCh := make(chan struct{})
+		p.stopCh = stopCh
+		p.stoppedCh = stoppedCh
+		p.mu.Unlock()
+		go p.runSpinner(stopCh, stoppedCh)
 	} else {
+		p.mu.Unlock()
 		fmt.Fprintf(p.w, "%s — %s\n", phase, desc)
 	}
 }
@@ -161,16 +164,18 @@ func (p *Progress) Message(msg string) {
 	}
 }
 
-// spin runs the animated spinner in a goroutine.
-func (p *Progress) spin() {
-	defer close(p.stoppedCh)
+// runSpinner runs the animated spinner in a goroutine.
+// stopCh and stoppedCh are captured as local variables to avoid races
+// with stopSpinner nullifying the struct fields.
+func (p *Progress) runSpinner(stopCh <-chan struct{}, stoppedCh chan<- struct{}) {
+	defer close(stoppedCh)
 
 	ticker := time.NewTicker(p.TickInterval)
 	defer ticker.Stop()
 
 	for {
 		select {
-		case <-p.stopCh:
+		case <-stopCh:
 			return
 		case <-ticker.C:
 			p.mu.Lock()

--- a/internal/progress/progress.go
+++ b/internal/progress/progress.go
@@ -1,0 +1,220 @@
+package progress
+
+import (
+	"fmt"
+	"io"
+	"sync"
+	"time"
+)
+
+// Spinner frames for the animated progress indicator.
+var frames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+
+// ANSI escape codes for terminal colors.
+const (
+	colorReset  = "\033[0m"
+	colorGreen  = "\033[32m"
+	colorRed    = "\033[31m"
+	colorYellow = "\033[33m"
+	colorDim    = "\033[2m"
+	clearLine   = "\033[K"
+)
+
+// Progress displays live pipeline progress in the terminal.
+// It shows an animated spinner while a phase is running and prints
+// a summary line when each phase completes or fails.
+//
+// When isTTY is false (e.g., CI or piped output), the spinner is
+// disabled and output is simple line-by-line text.
+type Progress struct {
+	w     io.Writer
+	isTTY bool
+
+	mu sync.Mutex
+
+	// Current phase state
+	phase     string
+	desc      string
+	startTime time.Time
+	totalCost float64
+
+	// Spinner goroutine control
+	frame     int
+	stopCh    chan struct{}
+	stoppedCh chan struct{}
+
+	// TickInterval controls the spinner animation speed.
+	// Exported for testing; defaults to 100ms.
+	TickInterval time.Duration
+
+	// NowFunc returns the current time. Exported for testing.
+	NowFunc func() time.Time
+}
+
+// New creates a new Progress writer.
+// If isTTY is false, the spinner animation is disabled and output is
+// line-by-line (suitable for CI/pipe).
+func New(w io.Writer, isTTY bool) *Progress {
+	return &Progress{
+		w:            w,
+		isTTY:        isTTY,
+		TickInterval: 100 * time.Millisecond,
+		NowFunc:      time.Now,
+	}
+}
+
+// PhaseStarted begins showing a spinner for the given phase.
+func (p *Progress) PhaseStarted(phase string) {
+	desc := phaseDescription(phase)
+
+	p.mu.Lock()
+	p.phase = phase
+	p.desc = desc
+	p.startTime = p.NowFunc()
+	p.frame = 0
+	p.mu.Unlock()
+
+	if p.isTTY {
+		p.stopCh = make(chan struct{})
+		p.stoppedCh = make(chan struct{})
+		go p.spin()
+	} else {
+		fmt.Fprintf(p.w, "%s — %s\n", phase, desc)
+	}
+}
+
+// PhaseCompleted stops the spinner and prints a completion line.
+func (p *Progress) PhaseCompleted(phase, summary string, elapsed time.Duration, cost float64) {
+	p.mu.Lock()
+	p.totalCost += cost
+	totalCost := p.totalCost
+	p.mu.Unlock()
+
+	p.stopSpinner()
+
+	summaryPart := ""
+	if summary != "" {
+		summaryPart = " — " + summary
+	}
+
+	if p.isTTY {
+		line := fmt.Sprintf("\r%s%s✓%s %-12s%s  %6s  $%.2f",
+			clearLine, colorGreen, colorReset, phase, summaryPart,
+			formatDuration(elapsed), totalCost)
+		fmt.Fprintln(p.w, line)
+	} else {
+		line := fmt.Sprintf("✓ %-12s%s  %6s  $%.2f",
+			phase, summaryPart, formatDuration(elapsed), totalCost)
+		fmt.Fprintln(p.w, line)
+	}
+}
+
+// PhaseFailed stops the spinner and prints a failure line.
+func (p *Progress) PhaseFailed(phase, errMsg string, elapsed time.Duration) {
+	p.mu.Lock()
+	totalCost := p.totalCost
+	p.mu.Unlock()
+
+	p.stopSpinner()
+
+	if p.isTTY {
+		line := fmt.Sprintf("\r%s%s✗%s %-12s — %s  %6s  $%.2f",
+			clearLine, colorRed, colorReset, phase, errMsg,
+			formatDuration(elapsed), totalCost)
+		fmt.Fprintln(p.w, line)
+	} else {
+		line := fmt.Sprintf("✗ %-12s — %s  %6s  $%.2f",
+			phase, errMsg, formatDuration(elapsed), totalCost)
+		fmt.Fprintln(p.w, line)
+	}
+}
+
+// PhaseSkipped prints a skip indicator.
+func (p *Progress) PhaseSkipped(phase string) {
+	fmt.Fprintf(p.w, "⏭ %s  skipped\n", phase)
+}
+
+// PhaseRetrying updates the spinner description for a retry.
+func (p *Progress) PhaseRetrying(phase, category string, attempt int) {
+	p.mu.Lock()
+	p.desc = fmt.Sprintf("retrying (%s, attempt %d)...", category, attempt)
+	p.mu.Unlock()
+}
+
+// BudgetWarning prints a budget warning line.
+func (p *Progress) BudgetWarning(total, limit float64) {
+	if p.isTTY {
+		// Temporarily clear the spinner line to print the warning
+		fmt.Fprintf(p.w, "\r%s%s⚠ Budget warning: $%.2f / $%.2f%s\n",
+			clearLine, colorYellow, total, limit, colorReset)
+	} else {
+		fmt.Fprintf(p.w, "⚠ Budget warning: $%.2f / $%.2f\n", total, limit)
+	}
+}
+
+// Message prints a plain message line, clearing the spinner if active.
+func (p *Progress) Message(msg string) {
+	if p.isTTY {
+		fmt.Fprintf(p.w, "\r%s%s\n", clearLine, msg)
+	} else {
+		fmt.Fprintln(p.w, msg)
+	}
+}
+
+// spin runs the animated spinner in a goroutine.
+func (p *Progress) spin() {
+	defer close(p.stoppedCh)
+
+	ticker := time.NewTicker(p.TickInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-p.stopCh:
+			return
+		case <-ticker.C:
+			p.mu.Lock()
+			frame := frames[p.frame%len(frames)]
+			phase := p.phase
+			desc := p.desc
+			elapsed := p.NowFunc().Sub(p.startTime)
+			totalCost := p.totalCost
+			p.frame++
+			p.mu.Unlock()
+
+			line := fmt.Sprintf("\r%s%s%s%s %-12s — %s  %6s  $%.2f",
+				clearLine, colorYellow, frame, colorReset, phase, desc,
+				formatDuration(elapsed), totalCost)
+			fmt.Fprint(p.w, line)
+		}
+	}
+}
+
+// stopSpinner stops the spinner goroutine if running.
+func (p *Progress) stopSpinner() {
+	if !p.isTTY {
+		return
+	}
+	p.mu.Lock()
+	stopCh := p.stopCh
+	stoppedCh := p.stoppedCh
+	p.stopCh = nil
+	p.stoppedCh = nil
+	p.mu.Unlock()
+
+	if stopCh != nil {
+		close(stopCh)
+		<-stoppedCh
+	}
+}
+
+// formatDuration formats a duration as "Xs" or "Xm0Ys".
+func formatDuration(d time.Duration) string {
+	d = d.Round(time.Second)
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	m := int(d.Minutes())
+	s := int(d.Seconds()) % 60
+	return fmt.Sprintf("%dm%02ds", m, s)
+}

--- a/internal/progress/progress_test.go
+++ b/internal/progress/progress_test.go
@@ -1,0 +1,364 @@
+package progress
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestNew(t *testing.T) {
+	var buf bytes.Buffer
+	prog := New(&buf, true)
+	if prog == nil {
+		t.Fatal("expected non-nil Progress")
+	}
+	if !prog.isTTY {
+		t.Error("expected isTTY to be true")
+	}
+}
+
+func TestPhaseStartedTTY(t *testing.T) {
+	var buf safeBuffer
+	prog := New(&buf, true)
+	prog.TickInterval = 10 * time.Millisecond
+
+	prog.PhaseStarted("triage")
+	// Give the spinner goroutine time to write at least one frame
+	time.Sleep(50 * time.Millisecond)
+	prog.stopSpinner()
+
+	output := buf.String()
+	if !strings.Contains(output, "triage") {
+		t.Errorf("expected output to contain 'triage', got %q", output)
+	}
+	if !strings.Contains(output, "classifying ticket...") {
+		t.Errorf("expected output to contain description, got %q", output)
+	}
+}
+
+func TestPhaseStartedNonTTY(t *testing.T) {
+	var buf bytes.Buffer
+	prog := New(&buf, false)
+
+	prog.PhaseStarted("plan")
+
+	output := buf.String()
+	if !strings.Contains(output, "plan") {
+		t.Errorf("expected output to contain 'plan', got %q", output)
+	}
+	if !strings.Contains(output, "designing implementation...") {
+		t.Errorf("expected output to contain description, got %q", output)
+	}
+}
+
+func TestPhaseCompletedTTY(t *testing.T) {
+	var buf bytes.Buffer
+	prog := New(&buf, true)
+
+	prog.PhaseCompleted("triage", "low", 40*time.Second, 0.15)
+
+	output := buf.String()
+	if !strings.Contains(output, "✓") {
+		t.Errorf("expected check mark, got %q", output)
+	}
+	if !strings.Contains(output, "triage") {
+		t.Errorf("expected phase name, got %q", output)
+	}
+	if !strings.Contains(output, "low") {
+		t.Errorf("expected summary 'low', got %q", output)
+	}
+	if !strings.Contains(output, "40s") {
+		t.Errorf("expected elapsed time '40s', got %q", output)
+	}
+	if !strings.Contains(output, "$0.15") {
+		t.Errorf("expected cost '$0.15', got %q", output)
+	}
+}
+
+func TestPhaseCompletedNonTTY(t *testing.T) {
+	var buf bytes.Buffer
+	prog := New(&buf, false)
+
+	prog.PhaseCompleted("plan", "2 tasks", 53*time.Second, 0.32)
+
+	output := buf.String()
+	if !strings.Contains(output, "✓") {
+		t.Errorf("expected check mark, got %q", output)
+	}
+	if !strings.Contains(output, "plan") {
+		t.Errorf("expected phase name, got %q", output)
+	}
+	if !strings.Contains(output, "2 tasks") {
+		t.Errorf("expected summary, got %q", output)
+	}
+	if !strings.Contains(output, "53s") {
+		t.Errorf("expected elapsed '53s', got %q", output)
+	}
+	if !strings.Contains(output, "$0.32") {
+		t.Errorf("expected cost, got %q", output)
+	}
+	// Non-TTY should NOT have ANSI escape codes
+	if strings.Contains(output, "\033[") {
+		t.Errorf("non-TTY output should not have ANSI codes, got %q", output)
+	}
+}
+
+func TestPhaseFailedTTY(t *testing.T) {
+	var buf bytes.Buffer
+	prog := New(&buf, true)
+
+	prog.PhaseFailed("verify", "missing ReadBuildInfo()", 95*time.Second)
+
+	output := buf.String()
+	if !strings.Contains(output, "✗") {
+		t.Errorf("expected X mark, got %q", output)
+	}
+	if !strings.Contains(output, "verify") {
+		t.Errorf("expected phase name, got %q", output)
+	}
+	if !strings.Contains(output, "missing ReadBuildInfo()") {
+		t.Errorf("expected error message, got %q", output)
+	}
+	if !strings.Contains(output, "1m35s") {
+		t.Errorf("expected elapsed '1m35s', got %q", output)
+	}
+}
+
+func TestPhaseFailedNonTTY(t *testing.T) {
+	var buf bytes.Buffer
+	prog := New(&buf, false)
+
+	prog.PhaseFailed("verify", "test failure", 60*time.Second)
+
+	output := buf.String()
+	if !strings.Contains(output, "✗") {
+		t.Errorf("expected X mark, got %q", output)
+	}
+	if !strings.Contains(output, "test failure") {
+		t.Errorf("expected error message, got %q", output)
+	}
+	if strings.Contains(output, "\033[") {
+		t.Errorf("non-TTY output should not have ANSI codes, got %q", output)
+	}
+}
+
+func TestPhaseSkipped(t *testing.T) {
+	var buf bytes.Buffer
+	prog := New(&buf, false)
+
+	prog.PhaseSkipped("monitor")
+
+	output := buf.String()
+	if !strings.Contains(output, "⏭") {
+		t.Errorf("expected skip icon, got %q", output)
+	}
+	if !strings.Contains(output, "monitor") {
+		t.Errorf("expected phase name, got %q", output)
+	}
+	if !strings.Contains(output, "skipped") {
+		t.Errorf("expected 'skipped', got %q", output)
+	}
+}
+
+func TestCostAccumulation(t *testing.T) {
+	var buf bytes.Buffer
+	prog := New(&buf, false)
+
+	prog.PhaseCompleted("triage", "", 10*time.Second, 0.15)
+	prog.PhaseCompleted("plan", "", 20*time.Second, 0.20)
+
+	output := buf.String()
+	// After plan, total cost should be 0.35
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d: %q", len(lines), output)
+	}
+	if !strings.Contains(lines[0], "$0.15") {
+		t.Errorf("first line should show $0.15, got %q", lines[0])
+	}
+	if !strings.Contains(lines[1], "$0.35") {
+		t.Errorf("second line should show $0.35, got %q", lines[1])
+	}
+}
+
+func TestBudgetWarningNonTTY(t *testing.T) {
+	var buf bytes.Buffer
+	prog := New(&buf, false)
+
+	prog.BudgetWarning(4.50, 5.00)
+
+	output := buf.String()
+	if !strings.Contains(output, "⚠") {
+		t.Errorf("expected warning icon, got %q", output)
+	}
+	if !strings.Contains(output, "$4.50") {
+		t.Errorf("expected total cost, got %q", output)
+	}
+	if !strings.Contains(output, "$5.00") {
+		t.Errorf("expected limit, got %q", output)
+	}
+}
+
+func TestBudgetWarningTTY(t *testing.T) {
+	var buf bytes.Buffer
+	prog := New(&buf, true)
+
+	prog.BudgetWarning(4.50, 5.00)
+
+	output := buf.String()
+	if !strings.Contains(output, "⚠") {
+		t.Errorf("expected warning icon, got %q", output)
+	}
+	if !strings.Contains(output, "$4.50") {
+		t.Errorf("expected total cost, got %q", output)
+	}
+}
+
+func TestMessage(t *testing.T) {
+	var buf bytes.Buffer
+	prog := New(&buf, false)
+
+	prog.Message("Pipeline started")
+
+	output := buf.String()
+	if !strings.Contains(output, "Pipeline started") {
+		t.Errorf("expected message, got %q", output)
+	}
+}
+
+func TestMessageTTY(t *testing.T) {
+	var buf bytes.Buffer
+	prog := New(&buf, true)
+
+	prog.Message("Created worktree: .worktrees/test (soda/test)")
+
+	output := buf.String()
+	if !strings.Contains(output, "Created worktree") {
+		t.Errorf("expected message, got %q", output)
+	}
+}
+
+func TestPhaseRetrying(t *testing.T) {
+	var buf safeBuffer
+	prog := New(&buf, true)
+	prog.TickInterval = 10 * time.Millisecond
+
+	prog.PhaseStarted("triage")
+	prog.PhaseRetrying("triage", "transient", 2)
+	// Give the spinner time to render with the updated description
+	time.Sleep(50 * time.Millisecond)
+	prog.stopSpinner()
+
+	output := buf.String()
+	if !strings.Contains(output, "retrying") {
+		t.Errorf("expected 'retrying' in spinner output, got %q", output)
+	}
+}
+
+func TestSpinnerFrames(t *testing.T) {
+	var buf safeBuffer
+	prog := New(&buf, true)
+	prog.TickInterval = 10 * time.Millisecond
+
+	prog.PhaseStarted("triage")
+	// Wait long enough for multiple frames to be written
+	time.Sleep(100 * time.Millisecond)
+	prog.stopSpinner()
+
+	output := buf.String()
+	// At least one frame character should appear
+	foundFrame := false
+	for _, frame := range frames {
+		if strings.Contains(output, frame) {
+			foundFrame = true
+			break
+		}
+	}
+	if !foundFrame {
+		t.Errorf("expected at least one spinner frame character, got %q", output)
+	}
+}
+
+func TestFormatDuration(t *testing.T) {
+	tests := []struct {
+		d    time.Duration
+		want string
+	}{
+		{0, "0s"},
+		{3 * time.Second, "3s"},
+		{45 * time.Second, "45s"},
+		{59 * time.Second, "59s"},
+		{60 * time.Second, "1m00s"},
+		{90 * time.Second, "1m30s"},
+		{127 * time.Second, "2m07s"},
+		{5*time.Minute + 9*time.Second, "5m09s"},
+	}
+	for _, tc := range tests {
+		got := formatDuration(tc.d)
+		if got != tc.want {
+			t.Errorf("formatDuration(%v) = %q, want %q", tc.d, got, tc.want)
+		}
+	}
+}
+
+func TestPhaseCompletedNoSummary(t *testing.T) {
+	var buf bytes.Buffer
+	prog := New(&buf, false)
+
+	prog.PhaseCompleted("triage", "", 10*time.Second, 0.10)
+
+	output := buf.String()
+	if strings.Contains(output, " — ") {
+		t.Errorf("expected no summary separator when summary is empty, got %q", output)
+	}
+}
+
+func TestStopSpinnerIdempotent(t *testing.T) {
+	var buf bytes.Buffer
+	prog := New(&buf, true)
+
+	// Stopping when no spinner is running should not panic
+	prog.stopSpinner()
+	prog.stopSpinner()
+}
+
+func TestPhaseDescriptions(t *testing.T) {
+	tests := []struct {
+		phase string
+		want  string
+	}{
+		{"triage", "classifying ticket..."},
+		{"plan", "designing implementation..."},
+		{"implement", "writing code..."},
+		{"verify", "checking acceptance criteria..."},
+		{"submit", "creating PR..."},
+		{"monitor", "monitoring PR..."},
+		{"unknown", "running..."},
+	}
+	for _, tc := range tests {
+		got := phaseDescription(tc.phase)
+		if got != tc.want {
+			t.Errorf("phaseDescription(%q) = %q, want %q", tc.phase, got, tc.want)
+		}
+	}
+}
+
+// safeBuffer is a thread-safe bytes.Buffer for use in spinner tests.
+type safeBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *safeBuffer) Write(p []byte) (n int, err error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *safeBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}

--- a/internal/progress/summary.go
+++ b/internal/progress/summary.go
@@ -1,0 +1,154 @@
+package progress
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// phaseDescription returns a human-readable description for a running phase.
+func phaseDescription(phase string) string {
+	switch phase {
+	case "triage":
+		return "classifying ticket..."
+	case "plan":
+		return "designing implementation..."
+	case "implement":
+		return "writing code..."
+	case "verify":
+		return "checking acceptance criteria..."
+	case "submit":
+		return "creating PR..."
+	case "monitor":
+		return "monitoring PR..."
+	default:
+		return "running..."
+	}
+}
+
+// PhaseSummary extracts a one-line summary from a phase's structured output.
+// Returns an empty string if the result cannot be parsed or has no useful info.
+func PhaseSummary(phase string, result json.RawMessage) string {
+	if len(result) == 0 {
+		return ""
+	}
+
+	switch phase {
+	case "triage":
+		return triageSummary(result)
+	case "plan":
+		return planSummary(result)
+	case "implement":
+		return implementSummary(result)
+	case "verify":
+		return verifySummary(result)
+	case "submit":
+		return submitSummary(result)
+	default:
+		return ""
+	}
+}
+
+func triageSummary(data json.RawMessage) string {
+	var result struct {
+		Complexity  string `json:"complexity"`
+		Automatable bool   `json:"automatable"`
+	}
+	if err := json.Unmarshal(data, &result); err != nil {
+		return ""
+	}
+	parts := []string{}
+	if result.Complexity != "" {
+		parts = append(parts, result.Complexity)
+	}
+	if !result.Automatable {
+		parts = append(parts, "not automatable")
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.Join(parts, ", ")
+}
+
+func planSummary(data json.RawMessage) string {
+	var result struct {
+		Tasks []json.RawMessage `json:"tasks"`
+	}
+	if err := json.Unmarshal(data, &result); err != nil {
+		return ""
+	}
+	count := len(result.Tasks)
+	if count == 0 {
+		return "no tasks"
+	}
+	if count == 1 {
+		return "1 task"
+	}
+	return fmt.Sprintf("%d tasks", count)
+}
+
+func implementSummary(data json.RawMessage) string {
+	var result struct {
+		FilesChanged []json.RawMessage `json:"files_changed"`
+		Commits      []json.RawMessage `json:"commits"`
+		TestsPassed  bool              `json:"tests_passed"`
+	}
+	if err := json.Unmarshal(data, &result); err != nil {
+		return ""
+	}
+	parts := []string{}
+	fileCount := len(result.FilesChanged)
+	commitCount := len(result.Commits)
+	if fileCount > 0 {
+		if fileCount == 1 {
+			parts = append(parts, "1 file changed")
+		} else {
+			parts = append(parts, fmt.Sprintf("%d files changed", fileCount))
+		}
+	}
+	if commitCount > 0 {
+		if commitCount == 1 {
+			parts = append(parts, "1 commit")
+		} else {
+			parts = append(parts, fmt.Sprintf("%d commits", commitCount))
+		}
+	}
+	if len(parts) == 0 {
+		if result.TestsPassed {
+			return "tests passed"
+		}
+		return ""
+	}
+	return strings.Join(parts, ", ")
+}
+
+func verifySummary(data json.RawMessage) string {
+	var result struct {
+		Verdict string `json:"verdict"`
+	}
+	if err := json.Unmarshal(data, &result); err != nil {
+		return ""
+	}
+	if result.Verdict == "" {
+		return ""
+	}
+	return strings.ToUpper(result.Verdict)
+}
+
+func submitSummary(data json.RawMessage) string {
+	var result struct {
+		PRURL string `json:"pr_url"`
+	}
+	if err := json.Unmarshal(data, &result); err != nil {
+		return ""
+	}
+	if result.PRURL == "" {
+		return ""
+	}
+	// Extract PR number from URL if possible (e.g., ".../pull/49" → "PR #49")
+	parts := strings.Split(result.PRURL, "/")
+	if len(parts) >= 2 && parts[len(parts)-2] == "pull" {
+		return "PR #" + parts[len(parts)-1]
+	}
+	return result.PRURL
+}

--- a/internal/progress/summary_test.go
+++ b/internal/progress/summary_test.go
@@ -1,0 +1,200 @@
+package progress
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestTriageSummary(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "complexity and automatable",
+			input: `{"automatable":true,"complexity":"low","ticket_key":"TEST-1"}`,
+			want:  "low",
+		},
+		{
+			name:  "not automatable",
+			input: `{"automatable":false,"complexity":"high","ticket_key":"TEST-1"}`,
+			want:  "high, not automatable",
+		},
+		{
+			name:  "complexity only",
+			input: `{"automatable":true,"complexity":"medium"}`,
+			want:  "medium",
+		},
+		{
+			name:  "no useful data",
+			input: `{"automatable":true}`,
+			want:  "",
+		},
+		{
+			name:  "invalid json",
+			input: `{broken`,
+			want:  "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := PhaseSummary("triage", json.RawMessage(tc.input))
+			if got != tc.want {
+				t.Errorf("PhaseSummary(triage, %s) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPlanSummary(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "multiple tasks",
+			input: `{"tasks":[{"id":"1"},{"id":"2"},{"id":"3"}]}`,
+			want:  "3 tasks",
+		},
+		{
+			name:  "single task",
+			input: `{"tasks":[{"id":"1"}]}`,
+			want:  "1 task",
+		},
+		{
+			name:  "no tasks",
+			input: `{"tasks":[]}`,
+			want:  "no tasks",
+		},
+		{
+			name:  "missing tasks field",
+			input: `{}`,
+			want:  "no tasks",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := PhaseSummary("plan", json.RawMessage(tc.input))
+			if got != tc.want {
+				t.Errorf("PhaseSummary(plan, %s) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestImplementSummary(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "files and commits",
+			input: `{"files_changed":[{"path":"a.go"},{"path":"b.go"},{"path":"c.go"}],"commits":[{"hash":"abc"},{"hash":"def"}],"tests_passed":true}`,
+			want:  "3 files changed, 2 commits",
+		},
+		{
+			name:  "single file single commit",
+			input: `{"files_changed":[{"path":"a.go"}],"commits":[{"hash":"abc"}]}`,
+			want:  "1 file changed, 1 commit",
+		},
+		{
+			name:  "only tests passed",
+			input: `{"tests_passed":true}`,
+			want:  "tests passed",
+		},
+		{
+			name:  "empty result",
+			input: `{}`,
+			want:  "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := PhaseSummary("implement", json.RawMessage(tc.input))
+			if got != tc.want {
+				t.Errorf("PhaseSummary(implement, %s) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestVerifySummary(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "pass verdict",
+			input: `{"verdict":"pass"}`,
+			want:  "PASS",
+		},
+		{
+			name:  "fail verdict",
+			input: `{"verdict":"FAIL"}`,
+			want:  "FAIL",
+		},
+		{
+			name:  "no verdict",
+			input: `{}`,
+			want:  "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := PhaseSummary("verify", json.RawMessage(tc.input))
+			if got != tc.want {
+				t.Errorf("PhaseSummary(verify, %s) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSubmitSummary(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "github PR URL",
+			input: `{"pr_url":"https://github.com/decko/soda/pull/49"}`,
+			want:  "PR #49",
+		},
+		{
+			name:  "no PR URL",
+			input: `{}`,
+			want:  "",
+		},
+		{
+			name:  "non-standard URL",
+			input: `{"pr_url":"https://gitlab.com/group/repo/-/merge_requests/42"}`,
+			want:  "https://gitlab.com/group/repo/-/merge_requests/42",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := PhaseSummary("submit", json.RawMessage(tc.input))
+			if got != tc.want {
+				t.Errorf("PhaseSummary(submit, %s) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPhaseSummaryUnknownPhase(t *testing.T) {
+	got := PhaseSummary("unknown", json.RawMessage(`{"foo":"bar"}`))
+	if got != "" {
+		t.Errorf("expected empty summary for unknown phase, got %q", got)
+	}
+}
+
+func TestPhaseSummaryEmptyResult(t *testing.T) {
+	got := PhaseSummary("triage", nil)
+	if got != "" {
+		t.Errorf("expected empty summary for nil result, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `internal/progress` package with animated spinner, phase status display, and structured summary extraction using plain ANSI escape codes (no bubbletea dependency)
- Wire progress display into `cmd/soda/run.go` replacing simple `fmt.Printf` event handler, with TTY/non-TTY detection via `go-isatty`
- Fix spinner race condition by passing channels as parameters to the goroutine instead of reading struct fields

## Acceptance Criteria

- [x] Animated spinner while phases run (TTY only)
- [x] Phase summaries extracted from structured output on completion
- [x] ✗ with error on failure, ⏭ on skip indicators
- [x] Running cost and elapsed time per phase
- [x] Non-TTY fallback with plain text output
- [x] No bubbletea dependency (stdlib + ANSI escape codes only)
- [x] Thread-safe spinner implementation
- [x] Comprehensive tests (26 tests pass, including with `-race`)

## Test Plan

- [x] `go test ./internal/progress/...` — all unit tests pass
- [x] `go test -race ./internal/progress/...` — no race conditions detected
- [x] `go test ./cmd/soda/...` — integration tests pass
- [x] Verify TTY mode shows animated spinner with phase descriptions
- [x] Verify non-TTY mode outputs plain text without ANSI codes

🤖 Generated with [Claude Code](https://claude.com/claude-code)