### PR TITLE
feat: cache ticket summary in meta.json

### DIFF
--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -122,6 +122,11 @@ func (e *Engine) Run(ctx context.Context) error {
 	}
 	defer e.state.ReleaseLock()
 
+	// Cache ticket summary in meta for soda sessions/history display.
+	if e.state.Meta().Summary == "" && e.config.Ticket.Summary != "" {
+		e.state.Meta().Summary = e.config.Ticket.Summary
+	}
+
 	if err := e.ensureWorktree(ctx); err != nil {
 		return err
 	}
@@ -178,6 +183,11 @@ func (e *Engine) Resume(ctx context.Context, fromPhase string) error {
 		return fmt.Errorf("engine: %w", err)
 	}
 	defer e.state.ReleaseLock()
+
+	// Cache ticket summary in meta for soda sessions/history display.
+	if e.state.Meta().Summary == "" && e.config.Ticket.Summary != "" {
+		e.state.Meta().Summary = e.config.Ticket.Summary
+	}
 
 	if err := e.ensureWorktree(ctx); err != nil {
 		return err

--- a/internal/pipeline/meta.go
+++ b/internal/pipeline/meta.go
@@ -32,6 +32,7 @@ type PhaseState struct {
 // PipelineMeta is the top-level state stored in meta.json.
 type PipelineMeta struct {
 	Ticket    string                 `json:"ticket"`
+	Summary   string                 `json:"summary,omitempty"`
 	Branch    string                 `json:"branch,omitempty"`
 	Worktree  string                 `json:"worktree,omitempty"`
 	StartedAt time.Time              `json:"started_at"`


### PR DESCRIPTION
## Summary

Store ticket summary in PipelineMeta at engine startup (both Run and Resume).
Enables `soda sessions` and `soda history` to display ticket summaries
without re-fetching from the ticket source.

Adds `Summary` field to `PipelineMeta` struct in `meta.go`.

Assisted-by: Claude Opus 4.6