### PR TITLE
fix(engine): stabilize TestEngine_CheckpointMode sync (#62)

### DIFF
--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -555,18 +555,27 @@ func TestEngine_CheckpointMode(t *testing.T) {
 		},
 	}
 
+	// checkpointReached signals the confirming goroutine that the engine
+	// has emitted a checkpoint_pause and is now blocked waiting for Confirm().
+	// Buffered so the synchronous OnEvent callback never blocks.
+	checkpointReached := make(chan struct{}, len(phases))
+
 	var events []Event
 	engine, state := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
 		cfg.Mode = Checkpoint
 		cfg.OnEvent = func(e Event) {
 			events = append(events, e)
+			if e.Kind == EventCheckpointPause {
+				checkpointReached <- struct{}{}
+			}
 		}
 	})
 
-	// Auto-confirm from a goroutine.
+	// Auto-confirm from a goroutine, waiting for each checkpoint_pause
+	// before calling Confirm() to avoid timing-fragile fire-and-forget sends.
 	go func() {
-		// Wait for each checkpoint_pause, then confirm.
 		for i := 0; i < len(phases); i++ {
+			<-checkpointReached
 			engine.Confirm()
 		}
 	}()


### PR DESCRIPTION
## Summary

- **Replaced timing-fragile goroutine synchronization** in `TestEngine_CheckpointMode` with an event-driven `checkpointReached` channel
- The confirming goroutine now waits for `EventCheckpointPause` via `OnEvent` before calling `Confirm()`, eliminating reliance on channel buffer capacity and scheduler ordering
- Only `internal/pipeline/engine_test.go` was modified (11 lines added, 2 removed); no production code changes

## Test plan

- [x] `TestEngine_CheckpointMode` passes reliably with `-count=5`
- [x] All `internal/pipeline` tests pass
- [x] No data races detected (`-race` flag, 50 iterations)

## Acceptance criteria

- [x] Test no longer relies on timing or scheduler ordering for correctness
- [x] Synchronization uses explicit signalling between `OnEvent` callback and confirming goroutine
- [x] No production code changes

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)