### PR TITLE
feat(engine): inject verify feedback into implement prompt on resume

### DIFF
--- a/cmd/soda/embeds/prompts/implement.md
+++ b/cmd/soda/embeds/prompts/implement.md
@@ -17,9 +17,12 @@ You MUST address every item below. Do not repeat the same mistakes.
 
 ### Verdict: {{.ReworkFeedback.Verdict}}
 
+{{- if .ReworkFeedback.FixesRequired}}
 ### Fixes Required
 {{range .ReworkFeedback.FixesRequired}}- **{{.}}**
 {{end}}
+{{- end}}
+
 {{- if .ReworkFeedback.FailedCriteria}}
 ### Failed Acceptance Criteria
 {{range .ReworkFeedback.FailedCriteria}}- **FAIL**: {{.Criterion}}

--- a/cmd/soda/embeds/prompts/implement.md
+++ b/cmd/soda/embeds/prompts/implement.md
@@ -8,12 +8,44 @@ Summary: {{.Ticket.Summary}}
 ## Implementation Plan
 {{.Artifacts.Plan}}
 
-{{- if .VerifyFeedback}}
+{{- if .ReworkFeedback}}
 
-## Previous Verification Feedback
+## MANDATORY: Previous Verification Failures
 
-{{.VerifyFeedback}}
-**You MUST address every item above before proceeding with the rest of the plan.**
+The following issues were identified in the previous implementation attempt.
+You MUST address every item below. Do not repeat the same mistakes.
+
+### Verdict: {{.ReworkFeedback.Verdict}}
+
+### Fixes Required
+{{range .ReworkFeedback.FixesRequired}}- **{{.}}**
+{{end}}
+{{- if .ReworkFeedback.FailedCriteria}}
+### Failed Acceptance Criteria
+{{range .ReworkFeedback.FailedCriteria}}- **FAIL**: {{.Criterion}}
+  Evidence: {{.Evidence}}
+{{end}}
+{{- end}}
+
+{{- if .ReworkFeedback.CodeIssues}}
+### Code Issues
+{{range .ReworkFeedback.CodeIssues}}- **{{.Severity}}** {{.File}}{{if .Line}}:{{.Line}}{{end}}: {{.Issue}}
+{{end}}
+{{- end}}
+
+{{- if .ReworkFeedback.FailedCommands}}
+### Failed Commands
+{{range .ReworkFeedback.FailedCommands}}- `{{.Command}}` (exit {{.ExitCode}})
+{{- if .Output}}
+```
+{{.Output}}
+```
+{{- end}}
+{{end}}
+{{- end}}
+
+If any feedback above contradicts the Implementation Plan, the plan takes precedence.
+After implementing, verify that each fix above is addressed before reporting completion.
 {{- end}}
 
 {{- if .Context.RepoConventions}}

--- a/cmd/soda/embeds/prompts/implement.md
+++ b/cmd/soda/embeds/prompts/implement.md
@@ -8,6 +8,14 @@ Summary: {{.Ticket.Summary}}
 ## Implementation Plan
 {{.Artifacts.Plan}}
 
+{{- if .VerifyFeedback}}
+
+## Previous Verification Feedback
+
+{{.VerifyFeedback}}
+**You MUST address every item above before proceeding with the rest of the plan.**
+{{- end}}
+
 {{- if .Context.RepoConventions}}
 
 ## Repo Conventions

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -491,7 +491,55 @@ func (e *Engine) buildPromptData(phase PhaseConfig) (PromptData, error) {
 		}
 	}
 
+	// When building the implement prompt, inject verify feedback if a
+	// previous verify run produced a FAIL verdict. This gives the
+	// implement phase actionable context on resume after verification
+	// failure.
+	if phase.Name == "implement" {
+		data.VerifyFeedback = e.extractVerifyFeedback()
+	}
+
 	return data, nil
+}
+
+// extractVerifyFeedback reads the verify result and returns a formatted
+// feedback string when the verdict is FAIL. Returns "" if no verify
+// result exists or the verdict is not FAIL.
+func (e *Engine) extractVerifyFeedback() string {
+	raw, err := e.state.ReadResult("verify")
+	if err != nil {
+		return ""
+	}
+	var result struct {
+		Verdict       string   `json:"verdict"`
+		FixesRequired []string `json:"fixes_required"`
+	}
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return ""
+	}
+	if !strings.EqualFold(result.Verdict, "FAIL") {
+		return ""
+	}
+
+	// Also include the verify artifact (raw text) for richer context.
+	artifact, _ := e.state.ReadArtifact("verify")
+
+	var sb strings.Builder
+	sb.WriteString("The previous verification failed.\n\nVerdict: FAIL\n")
+	if len(result.FixesRequired) > 0 {
+		sb.WriteString("\nFixes required:\n")
+		for _, fix := range result.FixesRequired {
+			sb.WriteString("- ")
+			sb.WriteString(fix)
+			sb.WriteString("\n")
+		}
+	}
+	if len(artifact) > 0 {
+		sb.WriteString("\nVerify phase output:\n")
+		sb.Write(artifact)
+		sb.WriteString("\n")
+	}
+	return sb.String()
 }
 
 // extractPRURL reads the submit result and extracts the pr_url field.

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -537,7 +537,7 @@ func (e *Engine) extractReworkFeedback() *ReworkFeedback {
 	}
 
 	var result struct {
-		Verdict         string `json:"verdict"`
+		Verdict         string   `json:"verdict"`
 		FixesRequired   []string `json:"fixes_required"`
 		CriteriaResults []struct {
 			Criterion string `json:"criterion"`
@@ -571,9 +571,9 @@ func (e *Engine) extractReworkFeedback() *ReworkFeedback {
 				Phase: "implement",
 				Kind:  EventReworkFeedbackSkipped,
 				Data: map[string]any{
-					"reason":             "plan changed since verify ran",
-					"verify_plan_hash":   verifyPS.PlanHash,
-					"current_plan_hash":  currentHash,
+					"reason":            "plan changed since verify ran",
+					"verify_plan_hash":  verifyPS.PlanHash,
+					"current_plan_hash": currentHash,
 				},
 			})
 			return nil
@@ -634,7 +634,8 @@ func (e *Engine) computePlanHash() string {
 
 // truncateLines returns at most maxLines lines from s.
 func truncateLines(s string, maxLines int) string {
-	lines := strings.Split(s, "\n")
+	trimmed := strings.TrimRight(s, "\n")
+	lines := strings.Split(trimmed, "\n")
 	if len(lines) <= maxLines {
 		return s
 	}

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -271,6 +272,16 @@ func (e *Engine) runPhase(ctx context.Context, phase PhaseConfig) error {
 		return fmt.Errorf("engine: build prompt data for %s: %w", phase.Name, err)
 	}
 
+	// Store plan hash for staleness guard on phases that depend on plan.
+	for _, dep := range phase.DependsOn {
+		if dep == "plan" {
+			if h := e.computePlanHash(); h != "" {
+				e.state.Meta().Phases[phase.Name].PlanHash = h
+			}
+			break
+		}
+	}
+
 	tmplContent, err := e.config.Loader.Load(phase.Prompt)
 	if err != nil {
 		_ = e.state.MarkFailed(phase.Name, err)
@@ -496,50 +507,138 @@ func (e *Engine) buildPromptData(phase PhaseConfig) (PromptData, error) {
 	// implement phase actionable context on resume after verification
 	// failure.
 	if phase.Name == "implement" {
-		data.VerifyFeedback = e.extractVerifyFeedback()
+		if fb := e.extractReworkFeedback(); fb != nil {
+			data.ReworkFeedback = fb
+			e.emit(Event{
+				Phase: phase.Name,
+				Kind:  EventReworkFeedbackInjected,
+				Data: map[string]any{
+					"verdict":         fb.Verdict,
+					"fixes_count":     len(fb.FixesRequired),
+					"failed_criteria": len(fb.FailedCriteria),
+					"code_issues":     len(fb.CodeIssues),
+					"failed_commands": len(fb.FailedCommands),
+				},
+			})
+		}
 	}
 
 	return data, nil
 }
 
-// extractVerifyFeedback reads the verify result and returns a formatted
-// feedback string when the verdict is FAIL. Returns "" if no verify
-// result exists or the verdict is not FAIL.
-func (e *Engine) extractVerifyFeedback() string {
+// extractReworkFeedback reads the verify result and returns structured
+// feedback when the verdict is FAIL. Returns nil if no verify result
+// exists, the verdict is not FAIL, or the plan has changed since verify
+// ran (staleness guard).
+func (e *Engine) extractReworkFeedback() *ReworkFeedback {
 	raw, err := e.state.ReadResult("verify")
+	if err != nil {
+		return nil
+	}
+
+	var result struct {
+		Verdict         string `json:"verdict"`
+		FixesRequired   []string `json:"fixes_required"`
+		CriteriaResults []struct {
+			Criterion string `json:"criterion"`
+			Passed    bool   `json:"passed"`
+			Evidence  string `json:"evidence"`
+		} `json:"criteria_results"`
+		CodeIssues []struct {
+			File     string `json:"file"`
+			Line     int    `json:"line"`
+			Severity string `json:"severity"`
+			Issue    string `json:"issue"`
+		} `json:"code_issues"`
+		CommandResults []struct {
+			Command  string `json:"command"`
+			ExitCode int    `json:"exit_code"`
+			Output   string `json:"output"`
+			Passed   bool   `json:"passed"`
+		} `json:"command_results"`
+	}
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil
+	}
+	if !strings.EqualFold(result.Verdict, "FAIL") {
+		return nil
+	}
+
+	// Staleness guard: skip if plan changed since verify ran.
+	if verifyPS := e.state.Meta().Phases["verify"]; verifyPS != nil && verifyPS.PlanHash != "" {
+		if currentHash := e.computePlanHash(); currentHash != "" && currentHash != verifyPS.PlanHash {
+			e.emit(Event{
+				Phase: "implement",
+				Kind:  EventReworkFeedbackSkipped,
+				Data: map[string]any{
+					"reason":             "plan changed since verify ran",
+					"verify_plan_hash":   verifyPS.PlanHash,
+					"current_plan_hash":  currentHash,
+				},
+			})
+			return nil
+		}
+	}
+
+	fb := &ReworkFeedback{
+		Verdict:       result.Verdict,
+		FixesRequired: result.FixesRequired,
+	}
+
+	// Failed criteria only.
+	for _, cr := range result.CriteriaResults {
+		if !cr.Passed {
+			fb.FailedCriteria = append(fb.FailedCriteria, FailedCriterion{
+				Criterion: cr.Criterion,
+				Evidence:  cr.Evidence,
+			})
+		}
+	}
+
+	// Critical and major code issues only.
+	for _, ci := range result.CodeIssues {
+		sev := strings.ToLower(ci.Severity)
+		if sev == "critical" || sev == "major" {
+			fb.CodeIssues = append(fb.CodeIssues, ReworkCodeIssue{
+				File:     ci.File,
+				Line:     ci.Line,
+				Severity: ci.Severity,
+				Issue:    ci.Issue,
+			})
+		}
+	}
+
+	// Failed commands only, output truncated to 50 lines.
+	for _, cmd := range result.CommandResults {
+		if !cmd.Passed {
+			fb.FailedCommands = append(fb.FailedCommands, FailedCommand{
+				Command:  cmd.Command,
+				ExitCode: cmd.ExitCode,
+				Output:   truncateLines(cmd.Output, 50),
+			})
+		}
+	}
+
+	return fb
+}
+
+// computePlanHash returns the SHA-256 hex digest of the plan artifact.
+func (e *Engine) computePlanHash() string {
+	artifact, err := e.state.ReadArtifact("plan")
 	if err != nil {
 		return ""
 	}
-	var result struct {
-		Verdict       string   `json:"verdict"`
-		FixesRequired []string `json:"fixes_required"`
-	}
-	if err := json.Unmarshal(raw, &result); err != nil {
-		return ""
-	}
-	if !strings.EqualFold(result.Verdict, "FAIL") {
-		return ""
-	}
+	h := sha256.Sum256(artifact)
+	return fmt.Sprintf("%x", h)
+}
 
-	// Also include the verify artifact (raw text) for richer context.
-	artifact, _ := e.state.ReadArtifact("verify")
-
-	var sb strings.Builder
-	sb.WriteString("The previous verification failed.\n\nVerdict: FAIL\n")
-	if len(result.FixesRequired) > 0 {
-		sb.WriteString("\nFixes required:\n")
-		for _, fix := range result.FixesRequired {
-			sb.WriteString("- ")
-			sb.WriteString(fix)
-			sb.WriteString("\n")
-		}
+// truncateLines returns at most maxLines lines from s.
+func truncateLines(s string, maxLines int) string {
+	lines := strings.Split(s, "\n")
+	if len(lines) <= maxLines {
+		return s
 	}
-	if len(artifact) > 0 {
-		sb.WriteString("\nVerify phase output:\n")
-		sb.Write(artifact)
-		sb.WriteString("\n")
-	}
-	return sb.String()
+	return strings.Join(lines[:maxLines], "\n") + "\n... (truncated)"
 }
 
 // extractPRURL reads the submit result and extracts the pr_url field.

--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -2079,6 +2079,278 @@ func TestEngine_RunChecksGateOnSkippedPhases(t *testing.T) {
 	}
 }
 
+func TestEngine_ResumeImplementInjectsVerifyFeedback(t *testing.T) {
+	// When verify FAILs and we resume from implement, the implement prompt
+	// should contain the verify feedback (fixes_required + artifact text).
+	phases := []PhaseConfig{
+		{
+			Name:   "implement",
+			Prompt: "implement.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+		{
+			Name:      "verify",
+			Prompt:    "verify.md",
+			DependsOn: []string{"implement"},
+			Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+	}
+
+	// First run: implement succeeds, verify FAILs.
+	mock1 := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"implement": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"tests_passed":true,"commits":1}`),
+					RawText: "Impl v1",
+					CostUSD: 0.50,
+				},
+			}},
+			"verify": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"verdict":"FAIL","fixes_required":["add missing test for edge case","fix nil pointer in handler"]}`),
+					RawText: "Verify report: tests incomplete, nil pointer found",
+					CostUSD: 0.15,
+				},
+			}},
+		},
+	}
+
+	stateDir := t.TempDir()
+	promptDir := t.TempDir()
+	workDir := t.TempDir()
+
+	// Write prompt template that includes VerifyFeedback.
+	implTmpl := "Phase: implement\nTicket: {{.Ticket.Key}}\n{{if .VerifyFeedback}}VerifyFeedback:\n{{.VerifyFeedback}}{{end}}\n"
+	verifyTmpl := "Phase: verify\nTicket: {{.Ticket.Key}}\n"
+
+	if err := os.WriteFile(filepath.Join(promptDir, "implement.md"), []byte(implTmpl), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(promptDir, "verify.md"), []byte(verifyTmpl), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := LoadOrCreate(stateDir, "VERIFY-FB-1")
+	if err != nil {
+		t.Fatalf("LoadOrCreate: %v", err)
+	}
+
+	cfg := EngineConfig{
+		Pipeline:   &PhasePipeline{Phases: phases},
+		Loader:     NewPromptLoader(promptDir),
+		Ticket:     TicketData{Key: "VERIFY-FB-1", Summary: "Verify feedback test"},
+		Model:      "test-model",
+		WorkDir:    workDir,
+		MaxCostUSD: 0,
+		Mode:       Autonomous,
+		SleepFunc:  func(time.Duration) {},
+		JitterFunc: func(time.Duration) time.Duration { return 0 },
+	}
+
+	engine1 := NewEngine(mock1, state, cfg)
+
+	// First run should fail at verify gate.
+	runErr := engine1.Run(context.Background())
+	if runErr == nil {
+		t.Fatal("expected PhaseGateError from verify FAIL")
+	}
+	var gateErr *PhaseGateError
+	if !errors.As(runErr, &gateErr) {
+		t.Fatalf("expected PhaseGateError, got: %v", runErr)
+	}
+
+	// Now resume from implement — the verify FAIL feedback should be injected.
+	mock2 := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"implement": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"tests_passed":true,"commits":2}`),
+					RawText: "Impl v2 with fixes",
+					CostUSD: 0.60,
+				},
+			}},
+			"verify": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"verdict":"PASS"}`),
+					RawText: "All checks pass",
+					CostUSD: 0.20,
+				},
+			}},
+		},
+	}
+
+	engine2 := NewEngine(mock2, state, cfg)
+
+	if err := engine2.Resume(context.Background(), "implement"); err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+
+	// Verify the implement prompt contained the verify feedback.
+	if len(mock2.calls) < 1 {
+		t.Fatal("expected at least 1 runner call")
+	}
+
+	implPrompt := mock2.calls[0].SystemPrompt
+	if !strings.Contains(implPrompt, "VerifyFeedback:") {
+		t.Errorf("implement prompt should contain VerifyFeedback section;\ngot: %s", implPrompt)
+	}
+	if !strings.Contains(implPrompt, "add missing test for edge case") {
+		t.Errorf("implement prompt should contain first fix;\ngot: %s", implPrompt)
+	}
+	if !strings.Contains(implPrompt, "fix nil pointer in handler") {
+		t.Errorf("implement prompt should contain second fix;\ngot: %s", implPrompt)
+	}
+	if !strings.Contains(implPrompt, "Verify report: tests incomplete") {
+		t.Errorf("implement prompt should contain verify artifact text;\ngot: %s", implPrompt)
+	}
+	if !strings.Contains(implPrompt, "Verdict: FAIL") {
+		t.Errorf("implement prompt should contain FAIL verdict;\ngot: %s", implPrompt)
+	}
+}
+
+func TestEngine_ImplementPromptNoVerifyFeedbackOnFirstRun(t *testing.T) {
+	// On the very first run (no verify result exists), VerifyFeedback should be empty.
+	phases := []PhaseConfig{
+		{
+			Name:   "implement",
+			Prompt: "implement.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"implement": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"tests_passed":true,"commits":1}`),
+					RawText: "Impl done",
+					CostUSD: 0.50,
+				},
+			}},
+		},
+	}
+
+	stateDir := t.TempDir()
+	promptDir := t.TempDir()
+	workDir := t.TempDir()
+
+	implTmpl := "Phase: implement\n{{if .VerifyFeedback}}FEEDBACK:{{.VerifyFeedback}}{{end}}\n"
+	if err := os.WriteFile(filepath.Join(promptDir, "implement.md"), []byte(implTmpl), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := LoadOrCreate(stateDir, "NOFB-1")
+	if err != nil {
+		t.Fatalf("LoadOrCreate: %v", err)
+	}
+
+	cfg := EngineConfig{
+		Pipeline:   &PhasePipeline{Phases: phases},
+		Loader:     NewPromptLoader(promptDir),
+		Ticket:     TicketData{Key: "NOFB-1"},
+		Model:      "test-model",
+		WorkDir:    workDir,
+		MaxCostUSD: 0,
+		Mode:       Autonomous,
+		SleepFunc:  func(time.Duration) {},
+		JitterFunc: func(time.Duration) time.Duration { return 0 },
+	}
+
+	engine := NewEngine(mock, state, cfg)
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if len(mock.calls) != 1 {
+		t.Fatalf("runner called %d times, want 1", len(mock.calls))
+	}
+
+	implPrompt := mock.calls[0].SystemPrompt
+	if strings.Contains(implPrompt, "FEEDBACK:") {
+		t.Errorf("implement prompt should NOT contain verify feedback on first run;\ngot: %s", implPrompt)
+	}
+}
+
+func TestEngine_ImplementPromptNoVerifyFeedbackOnPass(t *testing.T) {
+	// When verify passed previously, VerifyFeedback should be empty on resume.
+	phases := []PhaseConfig{
+		{
+			Name:   "implement",
+			Prompt: "implement.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"implement": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"tests_passed":true,"commits":1}`),
+					RawText: "Impl done",
+					CostUSD: 0.50,
+				},
+			}},
+		},
+	}
+
+	stateDir := t.TempDir()
+	promptDir := t.TempDir()
+	workDir := t.TempDir()
+
+	implTmpl := "Phase: implement\n{{if .VerifyFeedback}}FEEDBACK:{{.VerifyFeedback}}{{end}}\n"
+	if err := os.WriteFile(filepath.Join(promptDir, "implement.md"), []byte(implTmpl), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := LoadOrCreate(stateDir, "PASSFB-1")
+	if err != nil {
+		t.Fatalf("LoadOrCreate: %v", err)
+	}
+
+	// Pre-populate a PASS verify result.
+	if err := state.MarkRunning("verify"); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.WriteResult("verify", json.RawMessage(`{"verdict":"PASS"}`)); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.WriteArtifact("verify", []byte("All tests pass")); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.MarkCompleted("verify"); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := EngineConfig{
+		Pipeline:   &PhasePipeline{Phases: phases},
+		Loader:     NewPromptLoader(promptDir),
+		Ticket:     TicketData{Key: "PASSFB-1"},
+		Model:      "test-model",
+		WorkDir:    workDir,
+		MaxCostUSD: 0,
+		Mode:       Autonomous,
+		SleepFunc:  func(time.Duration) {},
+		JitterFunc: func(time.Duration) time.Duration { return 0 },
+	}
+
+	engine := NewEngine(mock, state, cfg)
+
+	if err := engine.Resume(context.Background(), "implement"); err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+
+	if len(mock.calls) != 1 {
+		t.Fatalf("runner called %d times, want 1", len(mock.calls))
+	}
+
+	implPrompt := mock.calls[0].SystemPrompt
+	if strings.Contains(implPrompt, "FEEDBACK:") {
+		t.Errorf("implement prompt should NOT contain verify feedback when verdict was PASS;\ngot: %s", implPrompt)
+	}
+}
+
 // phaseNames extracts phase names from runner calls for test error messages.
 func phaseNames(calls []runner.RunOpts) []string {
 	names := make([]string, len(calls))

--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -2079,9 +2080,9 @@ func TestEngine_RunChecksGateOnSkippedPhases(t *testing.T) {
 	}
 }
 
-func TestEngine_ResumeImplementInjectsVerifyFeedback(t *testing.T) {
+func TestEngine_ResumeImplementInjectsReworkFeedback(t *testing.T) {
 	// When verify FAILs and we resume from implement, the implement prompt
-	// should contain the verify feedback (fixes_required + artifact text).
+	// should contain structured rework feedback with selective extraction.
 	phases := []PhaseConfig{
 		{
 			Name:   "implement",
@@ -2096,7 +2097,24 @@ func TestEngine_ResumeImplementInjectsVerifyFeedback(t *testing.T) {
 		},
 	}
 
-	// First run: implement succeeds, verify FAILs.
+	verifyOutput := `{
+		"verdict": "FAIL",
+		"fixes_required": ["add missing test for edge case", "fix nil pointer in handler"],
+		"criteria_results": [
+			{"criterion": "handles valid input", "passed": true, "evidence": "test passes"},
+			{"criterion": "handles nil input", "passed": false, "evidence": "panics on nil"}
+		],
+		"code_issues": [
+			{"file": "handler.go", "line": 42, "severity": "critical", "issue": "nil deref"},
+			{"file": "handler.go", "line": 100, "severity": "minor", "issue": "unused var"},
+			{"file": "util.go", "line": 10, "severity": "major", "issue": "unchecked error"}
+		],
+		"command_results": [
+			{"command": "go test ./...", "exit_code": 1, "output": "FAIL handler_test.go", "passed": false},
+			{"command": "go vet ./...", "exit_code": 0, "output": "ok", "passed": true}
+		]
+	}`
+
 	mock1 := &flexMockRunner{
 		responses: map[string][]flexResponse{
 			"implement": {{
@@ -2108,8 +2126,8 @@ func TestEngine_ResumeImplementInjectsVerifyFeedback(t *testing.T) {
 			}},
 			"verify": {{
 				result: &runner.RunResult{
-					Output:  json.RawMessage(`{"verdict":"FAIL","fixes_required":["add missing test for edge case","fix nil pointer in handler"]}`),
-					RawText: "Verify report: tests incomplete, nil pointer found",
+					Output:  json.RawMessage(verifyOutput),
+					RawText: "Verify report",
 					CostUSD: 0.15,
 				},
 			}},
@@ -2120,8 +2138,22 @@ func TestEngine_ResumeImplementInjectsVerifyFeedback(t *testing.T) {
 	promptDir := t.TempDir()
 	workDir := t.TempDir()
 
-	// Write prompt template that includes VerifyFeedback.
-	implTmpl := "Phase: implement\nTicket: {{.Ticket.Key}}\n{{if .VerifyFeedback}}VerifyFeedback:\n{{.VerifyFeedback}}{{end}}\n"
+	// Template that renders ReworkFeedback fields.
+	implTmpl := `Phase: implement
+Ticket: {{.Ticket.Key}}
+{{- if .ReworkFeedback}}
+REWORK:
+Verdict: {{.ReworkFeedback.Verdict}}
+{{range .ReworkFeedback.FixesRequired}}Fix: {{.}}
+{{end}}
+{{- range .ReworkFeedback.FailedCriteria}}FailedCrit: {{.Criterion}} | {{.Evidence}}
+{{end}}
+{{- range .ReworkFeedback.CodeIssues}}Issue: {{.Severity}} {{.File}}:{{.Line}} {{.Issue}}
+{{end}}
+{{- range .ReworkFeedback.FailedCommands}}Cmd: {{.Command}} exit={{.ExitCode}}
+{{end}}
+{{- end}}
+`
 	verifyTmpl := "Phase: verify\nTicket: {{.Ticket.Key}}\n"
 
 	if err := os.WriteFile(filepath.Join(promptDir, "implement.md"), []byte(implTmpl), 0644); err != nil {
@@ -2131,21 +2163,25 @@ func TestEngine_ResumeImplementInjectsVerifyFeedback(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	state, err := LoadOrCreate(stateDir, "VERIFY-FB-1")
+	state, err := LoadOrCreate(stateDir, "REWORK-1")
 	if err != nil {
 		t.Fatalf("LoadOrCreate: %v", err)
 	}
 
+	var events []Event
 	cfg := EngineConfig{
 		Pipeline:   &PhasePipeline{Phases: phases},
 		Loader:     NewPromptLoader(promptDir),
-		Ticket:     TicketData{Key: "VERIFY-FB-1", Summary: "Verify feedback test"},
+		Ticket:     TicketData{Key: "REWORK-1", Summary: "Rework feedback test"},
 		Model:      "test-model",
 		WorkDir:    workDir,
 		MaxCostUSD: 0,
 		Mode:       Autonomous,
 		SleepFunc:  func(time.Duration) {},
 		JitterFunc: func(time.Duration) time.Duration { return 0 },
+		OnEvent: func(e Event) {
+			events = append(events, e)
+		},
 	}
 
 	engine1 := NewEngine(mock1, state, cfg)
@@ -2160,7 +2196,8 @@ func TestEngine_ResumeImplementInjectsVerifyFeedback(t *testing.T) {
 		t.Fatalf("expected PhaseGateError, got: %v", runErr)
 	}
 
-	// Now resume from implement — the verify FAIL feedback should be injected.
+	// Resume from implement — rework feedback should be injected.
+	events = nil
 	mock2 := &flexMockRunner{
 		responses: map[string][]flexResponse{
 			"implement": {{
@@ -2186,31 +2223,69 @@ func TestEngine_ResumeImplementInjectsVerifyFeedback(t *testing.T) {
 		t.Fatalf("Resume: %v", err)
 	}
 
-	// Verify the implement prompt contained the verify feedback.
 	if len(mock2.calls) < 1 {
 		t.Fatal("expected at least 1 runner call")
 	}
 
 	implPrompt := mock2.calls[0].SystemPrompt
-	if !strings.Contains(implPrompt, "VerifyFeedback:") {
-		t.Errorf("implement prompt should contain VerifyFeedback section;\ngot: %s", implPrompt)
+
+	// Fixes required should be present.
+	if !strings.Contains(implPrompt, "Fix: add missing test for edge case") {
+		t.Errorf("prompt should contain first fix;\ngot: %s", implPrompt)
 	}
-	if !strings.Contains(implPrompt, "add missing test for edge case") {
-		t.Errorf("implement prompt should contain first fix;\ngot: %s", implPrompt)
+	if !strings.Contains(implPrompt, "Fix: fix nil pointer in handler") {
+		t.Errorf("prompt should contain second fix;\ngot: %s", implPrompt)
 	}
-	if !strings.Contains(implPrompt, "fix nil pointer in handler") {
-		t.Errorf("implement prompt should contain second fix;\ngot: %s", implPrompt)
+
+	// Only failed criteria should appear (not the passed one).
+	if !strings.Contains(implPrompt, "FailedCrit: handles nil input | panics on nil") {
+		t.Errorf("prompt should contain failed criterion;\ngot: %s", implPrompt)
 	}
-	if !strings.Contains(implPrompt, "Verify report: tests incomplete") {
-		t.Errorf("implement prompt should contain verify artifact text;\ngot: %s", implPrompt)
+	if strings.Contains(implPrompt, "handles valid input") {
+		t.Errorf("prompt should NOT contain passed criterion;\ngot: %s", implPrompt)
 	}
+
+	// Only critical/major code issues (not minor).
+	if !strings.Contains(implPrompt, "Issue: critical handler.go:42 nil deref") {
+		t.Errorf("prompt should contain critical issue;\ngot: %s", implPrompt)
+	}
+	if !strings.Contains(implPrompt, "Issue: major util.go:10 unchecked error") {
+		t.Errorf("prompt should contain major issue;\ngot: %s", implPrompt)
+	}
+	if strings.Contains(implPrompt, "unused var") {
+		t.Errorf("prompt should NOT contain minor issue;\ngot: %s", implPrompt)
+	}
+
+	// Only failed commands (not the passing go vet).
+	if !strings.Contains(implPrompt, "Cmd: go test ./... exit=1") {
+		t.Errorf("prompt should contain failed command;\ngot: %s", implPrompt)
+	}
+	if strings.Contains(implPrompt, "go vet") {
+		t.Errorf("prompt should NOT contain passing command;\ngot: %s", implPrompt)
+	}
+
+	// Verdict should be present.
 	if !strings.Contains(implPrompt, "Verdict: FAIL") {
-		t.Errorf("implement prompt should contain FAIL verdict;\ngot: %s", implPrompt)
+		t.Errorf("prompt should contain FAIL verdict;\ngot: %s", implPrompt)
+	}
+
+	// Injection event should have been logged.
+	hasInjectionEvent := false
+	for _, e := range events {
+		if e.Kind == EventReworkFeedbackInjected {
+			hasInjectionEvent = true
+			if e.Phase != "implement" {
+				t.Errorf("injection event phase = %q, want %q", e.Phase, "implement")
+			}
+		}
+	}
+	if !hasInjectionEvent {
+		t.Error("rework_feedback_injected event not emitted")
 	}
 }
 
-func TestEngine_ImplementPromptNoVerifyFeedbackOnFirstRun(t *testing.T) {
-	// On the very first run (no verify result exists), VerifyFeedback should be empty.
+func TestEngine_ImplementPromptNoReworkFeedbackOnFirstRun(t *testing.T) {
+	// On the very first run (no verify result exists), ReworkFeedback should be nil.
 	phases := []PhaseConfig{
 		{
 			Name:   "implement",
@@ -2235,7 +2310,7 @@ func TestEngine_ImplementPromptNoVerifyFeedbackOnFirstRun(t *testing.T) {
 	promptDir := t.TempDir()
 	workDir := t.TempDir()
 
-	implTmpl := "Phase: implement\n{{if .VerifyFeedback}}FEEDBACK:{{.VerifyFeedback}}{{end}}\n"
+	implTmpl := "Phase: implement\n{{if .ReworkFeedback}}FEEDBACK:yes{{end}}\n"
 	if err := os.WriteFile(filepath.Join(promptDir, "implement.md"), []byte(implTmpl), 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -2269,12 +2344,12 @@ func TestEngine_ImplementPromptNoVerifyFeedbackOnFirstRun(t *testing.T) {
 
 	implPrompt := mock.calls[0].SystemPrompt
 	if strings.Contains(implPrompt, "FEEDBACK:") {
-		t.Errorf("implement prompt should NOT contain verify feedback on first run;\ngot: %s", implPrompt)
+		t.Errorf("implement prompt should NOT contain rework feedback on first run;\ngot: %s", implPrompt)
 	}
 }
 
-func TestEngine_ImplementPromptNoVerifyFeedbackOnPass(t *testing.T) {
-	// When verify passed previously, VerifyFeedback should be empty on resume.
+func TestEngine_ImplementPromptNoReworkFeedbackOnPass(t *testing.T) {
+	// When verify passed previously, ReworkFeedback should be nil on resume.
 	phases := []PhaseConfig{
 		{
 			Name:   "implement",
@@ -2299,7 +2374,7 @@ func TestEngine_ImplementPromptNoVerifyFeedbackOnPass(t *testing.T) {
 	promptDir := t.TempDir()
 	workDir := t.TempDir()
 
-	implTmpl := "Phase: implement\n{{if .VerifyFeedback}}FEEDBACK:{{.VerifyFeedback}}{{end}}\n"
+	implTmpl := "Phase: implement\n{{if .ReworkFeedback}}FEEDBACK:yes{{end}}\n"
 	if err := os.WriteFile(filepath.Join(promptDir, "implement.md"), []byte(implTmpl), 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -2347,7 +2422,171 @@ func TestEngine_ImplementPromptNoVerifyFeedbackOnPass(t *testing.T) {
 
 	implPrompt := mock.calls[0].SystemPrompt
 	if strings.Contains(implPrompt, "FEEDBACK:") {
-		t.Errorf("implement prompt should NOT contain verify feedback when verdict was PASS;\ngot: %s", implPrompt)
+		t.Errorf("implement prompt should NOT contain rework feedback when verdict was PASS;\ngot: %s", implPrompt)
+	}
+}
+
+func TestEngine_ReworkFeedbackStalePlanSkipped(t *testing.T) {
+	// When the plan has changed since verify ran, rework feedback should
+	// be skipped and a warning event emitted.
+	phases := []PhaseConfig{
+		{
+			Name:      "implement",
+			Prompt:    "implement.md",
+			DependsOn: []string{"plan"},
+			Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+		{
+			Name:      "verify",
+			Prompt:    "verify.md",
+			DependsOn: []string{"implement"},
+			Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"implement": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"tests_passed":true,"commits":1}`),
+					RawText: "Impl v2",
+					CostUSD: 0.50,
+				},
+			}},
+			"verify": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"verdict":"PASS"}`),
+					RawText: "All pass",
+					CostUSD: 0.20,
+				},
+			}},
+		},
+	}
+
+	stateDir := t.TempDir()
+	promptDir := t.TempDir()
+	workDir := t.TempDir()
+
+	implTmpl := "Phase: implement\n{{if .ReworkFeedback}}FEEDBACK:yes{{end}}\n"
+	verifyTmpl := "Phase: verify\n"
+
+	if err := os.WriteFile(filepath.Join(promptDir, "implement.md"), []byte(implTmpl), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(promptDir, "verify.md"), []byte(verifyTmpl), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := LoadOrCreate(stateDir, "STALE-1")
+	if err != nil {
+		t.Fatalf("LoadOrCreate: %v", err)
+	}
+
+	// Write a plan artifact (version 1).
+	if err := state.MarkRunning("plan"); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.WriteResult("plan", json.RawMessage(`{"tasks":["t1"]}`)); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.WriteArtifact("plan", []byte("Plan version 1")); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.MarkCompleted("plan"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pre-populate a FAIL verify result with a plan_hash from the OLD plan.
+	if err := state.MarkRunning("verify"); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.WriteResult("verify", json.RawMessage(`{"verdict":"FAIL","fixes_required":["fix it"]}`)); err != nil {
+		t.Fatal(err)
+	}
+	// Store plan hash from "Plan version 1".
+	state.Meta().Phases["verify"].PlanHash = fmt.Sprintf("%x", sha256.Sum256([]byte("Plan version 1")))
+	if err := state.MarkCompleted("verify"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Now change the plan artifact (version 2) — simulates re-running plan.
+	if err := state.WriteArtifact("plan", []byte("Plan version 2 - different")); err != nil {
+		t.Fatal(err)
+	}
+
+	var events []Event
+	cfg := EngineConfig{
+		Pipeline:   &PhasePipeline{Phases: phases},
+		Loader:     NewPromptLoader(promptDir),
+		Ticket:     TicketData{Key: "STALE-1"},
+		Model:      "test-model",
+		WorkDir:    workDir,
+		MaxCostUSD: 0,
+		Mode:       Autonomous,
+		SleepFunc:  func(time.Duration) {},
+		JitterFunc: func(time.Duration) time.Duration { return 0 },
+		OnEvent: func(e Event) {
+			events = append(events, e)
+		},
+	}
+
+	engine := NewEngine(mock, state, cfg)
+
+	if err := engine.Resume(context.Background(), "implement"); err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+
+	// Implement prompt should NOT contain feedback (stale plan).
+	if len(mock.calls) < 1 {
+		t.Fatal("expected at least 1 runner call")
+	}
+	implPrompt := mock.calls[0].SystemPrompt
+	if strings.Contains(implPrompt, "FEEDBACK:") {
+		t.Errorf("prompt should NOT contain rework feedback when plan is stale;\ngot: %s", implPrompt)
+	}
+
+	// Should have emitted a rework_feedback_skipped event.
+	hasSkipEvent := false
+	for _, e := range events {
+		if e.Kind == EventReworkFeedbackSkipped {
+			hasSkipEvent = true
+			if reason, ok := e.Data["reason"].(string); !ok || !strings.Contains(reason, "plan changed") {
+				t.Errorf("skip event reason should mention plan changed, got: %v", e.Data["reason"])
+			}
+		}
+	}
+	if !hasSkipEvent {
+		t.Error("rework_feedback_skipped event not emitted for stale plan")
+	}
+}
+
+func TestEngine_TruncateLines(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		max      int
+		contains string
+		notLong  bool
+	}{
+		{"under_limit", "line1\nline2\nline3", 5, "line1", false},
+		{"at_limit", "a\nb\nc", 3, "a\nb\nc", false},
+		{"over_limit", "1\n2\n3\n4\n5", 3, "... (truncated)", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := truncateLines(tt.input, tt.max)
+			if !strings.Contains(got, tt.contains) {
+				t.Errorf("truncateLines() = %q, want to contain %q", got, tt.contains)
+			}
+			if tt.notLong {
+				lines := strings.Split(got, "\n")
+				// max lines + 1 for the truncation marker
+				if len(lines) > tt.max+1 {
+					t.Errorf("truncateLines() has %d lines, want <= %d", len(lines), tt.max+1)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/pipeline/events.go
+++ b/internal/pipeline/events.go
@@ -18,21 +18,21 @@ type Event struct {
 
 // Event kinds emitted by the engine.
 const (
-	EventEngineStarted   = "engine_started"
-	EventEngineCompleted = "engine_completed"
-	EventEngineFailed    = "engine_failed"
-	EventPhaseStarted    = "phase_started"
-	EventPhaseCompleted  = "phase_completed"
-	EventPhaseFailed     = "phase_failed"
-	EventPhaseRetrying   = "phase_retrying"
-	EventPhaseSkipped    = "phase_skipped"
-	EventOutputChunk     = "output_chunk"
-	EventBudgetWarning   = "budget_warning"
-	EventCheckpointPause = "checkpoint_pause"
-	EventWorktreeCreated = "worktree_created"
-	EventMonitorSkipped           = "monitor_skipped"
-	EventReworkFeedbackInjected   = "rework_feedback_injected"
-	EventReworkFeedbackSkipped    = "rework_feedback_skipped"
+	EventEngineStarted          = "engine_started"
+	EventEngineCompleted        = "engine_completed"
+	EventEngineFailed           = "engine_failed"
+	EventPhaseStarted           = "phase_started"
+	EventPhaseCompleted         = "phase_completed"
+	EventPhaseFailed            = "phase_failed"
+	EventPhaseRetrying          = "phase_retrying"
+	EventPhaseSkipped           = "phase_skipped"
+	EventOutputChunk            = "output_chunk"
+	EventBudgetWarning          = "budget_warning"
+	EventCheckpointPause        = "checkpoint_pause"
+	EventWorktreeCreated        = "worktree_created"
+	EventMonitorSkipped         = "monitor_skipped"
+	EventReworkFeedbackInjected = "rework_feedback_injected"
+	EventReworkFeedbackSkipped  = "rework_feedback_skipped"
 )
 
 // logEvent appends an event to the events.jsonl file in dir.

--- a/internal/pipeline/events.go
+++ b/internal/pipeline/events.go
@@ -30,7 +30,9 @@ const (
 	EventBudgetWarning   = "budget_warning"
 	EventCheckpointPause = "checkpoint_pause"
 	EventWorktreeCreated = "worktree_created"
-	EventMonitorSkipped  = "monitor_skipped"
+	EventMonitorSkipped           = "monitor_skipped"
+	EventReworkFeedbackInjected   = "rework_feedback_injected"
+	EventReworkFeedbackSkipped    = "rework_feedback_skipped"
 )
 
 // logEvent appends an event to the events.jsonl file in dir.

--- a/internal/pipeline/meta.go
+++ b/internal/pipeline/meta.go
@@ -26,6 +26,7 @@ type PhaseState struct {
 	DurationMs int64       `json:"duration_ms,omitempty"`
 	Error      string      `json:"error,omitempty"`
 	Generation int         `json:"generation,omitempty"`
+	PlanHash   string      `json:"plan_hash,omitempty"`
 	startedAt  time.Time
 }
 

--- a/internal/pipeline/prompt.go
+++ b/internal/pipeline/prompt.go
@@ -22,6 +22,7 @@ type PromptData struct {
 	Branch         string
 	BaseBranch     string
 	ReviewComments string
+	VerifyFeedback string
 }
 
 // TicketData holds ticket fields for prompt templates.

--- a/internal/pipeline/prompt.go
+++ b/internal/pipeline/prompt.go
@@ -22,7 +22,38 @@ type PromptData struct {
 	Branch         string
 	BaseBranch     string
 	ReviewComments string
-	VerifyFeedback string
+	ReworkFeedback *ReworkFeedback
+}
+
+// ReworkFeedback holds selective feedback from a failed verify phase,
+// injected into implement's prompt on resume.
+type ReworkFeedback struct {
+	Verdict        string
+	FixesRequired  []string
+	FailedCriteria []FailedCriterion
+	CodeIssues     []ReworkCodeIssue
+	FailedCommands []FailedCommand
+}
+
+// FailedCriterion is a single acceptance criterion that failed verification.
+type FailedCriterion struct {
+	Criterion string
+	Evidence  string
+}
+
+// ReworkCodeIssue is a critical or major code issue found during verification.
+type ReworkCodeIssue struct {
+	File     string
+	Line     int
+	Severity string
+	Issue    string
+}
+
+// FailedCommand is a verification command that failed, with truncated output.
+type FailedCommand struct {
+	Command  string
+	ExitCode int
+	Output   string
 }
 
 // TicketData holds ticket fields for prompt templates.

--- a/internal/pipeline/prompt_test.go
+++ b/internal/pipeline/prompt_test.go
@@ -174,4 +174,39 @@ func TestRenderPrompt(t *testing.T) {
 			t.Errorf("result should list criteria, got: %s", result)
 		}
 	})
+
+	t.Run("renders_verify_feedback_when_present", func(t *testing.T) {
+		tmpl := `{{- if .VerifyFeedback}}
+## Verification Feedback
+{{.VerifyFeedback}}
+{{- end}}`
+		data := PromptData{
+			VerifyFeedback: "The previous verification failed.\n\nVerdict: FAIL\n\nFixes required:\n- fix the test\n",
+		}
+		result, err := RenderPrompt(tmpl, data)
+		if err != nil {
+			t.Fatalf("RenderPrompt: %v", err)
+		}
+		if !strings.Contains(result, "Verification Feedback") {
+			t.Errorf("result should contain feedback header, got: %s", result)
+		}
+		if !strings.Contains(result, "fix the test") {
+			t.Errorf("result should contain fix message, got: %s", result)
+		}
+	})
+
+	t.Run("omits_verify_feedback_when_empty", func(t *testing.T) {
+		tmpl := `{{- if .VerifyFeedback}}
+## Verification Feedback
+{{.VerifyFeedback}}
+{{- end}}`
+		data := PromptData{}
+		result, err := RenderPrompt(tmpl, data)
+		if err != nil {
+			t.Fatalf("RenderPrompt: %v", err)
+		}
+		if strings.Contains(result, "Verification Feedback") {
+			t.Errorf("result should not contain feedback section when empty, got: %s", result)
+		}
+	})
 }

--- a/internal/pipeline/prompt_test.go
+++ b/internal/pipeline/prompt_test.go
@@ -175,19 +175,24 @@ func TestRenderPrompt(t *testing.T) {
 		}
 	})
 
-	t.Run("renders_verify_feedback_when_present", func(t *testing.T) {
-		tmpl := `{{- if .VerifyFeedback}}
-## Verification Feedback
-{{.VerifyFeedback}}
+	t.Run("renders_rework_feedback_when_present", func(t *testing.T) {
+		tmpl := `{{- if .ReworkFeedback}}
+## Rework Feedback
+Verdict: {{.ReworkFeedback.Verdict}}
+{{range .ReworkFeedback.FixesRequired}}- {{.}}
+{{end}}
 {{- end}}`
 		data := PromptData{
-			VerifyFeedback: "The previous verification failed.\n\nVerdict: FAIL\n\nFixes required:\n- fix the test\n",
+			ReworkFeedback: &ReworkFeedback{
+				Verdict:       "FAIL",
+				FixesRequired: []string{"fix the test"},
+			},
 		}
 		result, err := RenderPrompt(tmpl, data)
 		if err != nil {
 			t.Fatalf("RenderPrompt: %v", err)
 		}
-		if !strings.Contains(result, "Verification Feedback") {
+		if !strings.Contains(result, "Rework Feedback") {
 			t.Errorf("result should contain feedback header, got: %s", result)
 		}
 		if !strings.Contains(result, "fix the test") {
@@ -195,18 +200,17 @@ func TestRenderPrompt(t *testing.T) {
 		}
 	})
 
-	t.Run("omits_verify_feedback_when_empty", func(t *testing.T) {
-		tmpl := `{{- if .VerifyFeedback}}
-## Verification Feedback
-{{.VerifyFeedback}}
+	t.Run("omits_rework_feedback_when_nil", func(t *testing.T) {
+		tmpl := `{{- if .ReworkFeedback}}
+## Rework Feedback
 {{- end}}`
 		data := PromptData{}
 		result, err := RenderPrompt(tmpl, data)
 		if err != nil {
 			t.Fatalf("RenderPrompt: %v", err)
 		}
-		if strings.Contains(result, "Verification Feedback") {
-			t.Errorf("result should not contain feedback section when empty, got: %s", result)
+		if strings.Contains(result, "Rework Feedback") {
+			t.Errorf("result should not contain feedback section when nil, got: %s", result)
 		}
 	})
 }

--- a/internal/pipeline/state.go
+++ b/internal/pipeline/state.go
@@ -124,6 +124,7 @@ func (s *State) MarkRunning(phase string) error {
 	ps.Cost = 0
 	ps.DurationMs = 0
 	ps.Error = ""
+	ps.PlanHash = ""
 	ps.startedAt = time.Now()
 
 	if err := s.flushMeta(); err != nil {

--- a/prompts/implement.md
+++ b/prompts/implement.md
@@ -8,6 +8,14 @@ Summary: {{.Ticket.Summary}}
 ## Implementation Plan
 {{.Artifacts.Plan}}
 
+{{- if .VerifyFeedback}}
+
+## Previous Verification Feedback
+
+{{.VerifyFeedback}}
+**You MUST address every item above before proceeding with the rest of the plan.**
+{{- end}}
+
 {{- if .Context.RepoConventions}}
 
 ## Repo Conventions


### PR DESCRIPTION
## Summary

- Replace plain-string `VerifyFeedback` with structured `ReworkFeedback` type that selectively extracts only actionable data from failed verify runs: failed criteria, critical/major code issues, failed commands (truncated to 50 lines)
- Add plan_hash staleness guard (SHA-256) to skip stale feedback when the plan has changed since verify ran
- Emit `rework_feedback_injected` / `rework_feedback_skipped` events to events.jsonl for observability

## Test plan

- [x] Resume after FAIL verify → implement prompt contains structured feedback
- [x] Selective extraction: only failed criteria, critical/major issues, failed commands appear
- [x] Passed criteria and successful commands excluded
- [x] First-run implement (no prior verify) works unchanged
- [x] Resume after PASS verify → no feedback injected
- [x] Stale plan (hash mismatch) → feedback skipped with warning event
- [x] `truncateLines` handles edge cases correctly
- [x] Template renders all ReworkFeedback fields correctly
- [x] All existing tests pass (`go test ./internal/pipeline/...`)

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)