### PR TITLE
chore: add prompts/ to .gitignore (#88)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ config.yaml
 
 # OS
 .DS_Store
+
+# Prompt overrides (use ~/.config/soda/prompts/ instead)
+prompts/


### PR DESCRIPTION
## Summary
- Add `prompts/` to `.gitignore` to prevent local prompt overrides from being committed
- Users should place custom prompts in `~/.config/soda/prompts/` instead
- Follows existing `.gitignore` conventions (commented section, blank-line separated)

## Test plan
- [x] Verify `prompts/` entry is appended to `.gitignore` with explanatory comment
- [x] Verify no existing tracked files are affected
- [x] Verify repo conventions (comment style, spacing) are followed

🤖 Generated with [Claude Code](https://claude.com/claude-code)