### PR TITLE
fix(prompt): set missingkey=error on template parsing

### DIFF
--- a/internal/pipeline/prompt.go
+++ b/internal/pipeline/prompt.go
@@ -161,7 +161,7 @@ func (loader *PromptLoader) Load(name string) (string, error) {
 
 // RenderPrompt executes a Go text/template against the given data.
 func RenderPrompt(tmpl string, data PromptData) (string, error) {
-	parsed, err := template.New("prompt").Parse(tmpl)
+	parsed, err := template.New("prompt").Option("missingkey=error").Parse(tmpl)
 	if err != nil {
 		return "", fmt.Errorf("prompt: parse template: %w", err)
 	}

--- a/internal/pipeline/prompt_test.go
+++ b/internal/pipeline/prompt_test.go
@@ -213,4 +213,11 @@ Verdict: {{.ReworkFeedback.Verdict}}
 			t.Errorf("result should not contain feedback section when nil, got: %s", result)
 		}
 	})
+
+	t.Run("errors_on_nonexistent_field", func(t *testing.T) {
+		_, err := RenderPrompt("{{.NonExistentField}}", PromptData{})
+		if err == nil {
+			t.Fatal("expected error for non-existent field on PromptData")
+		}
+	})
 }


### PR DESCRIPTION
## Summary

- Set `missingkey=error` option on `template.New("prompt")` in `prompt.go` so that `Execute()` returns an error when a template references a non-existent field on `PromptData`, instead of silently rendering `<no value>`
- Added `errors_on_nonexistent_field` subtest to `TestRenderPrompt` verifying the new behavior

## Test plan

- [x] New subtest `errors_on_nonexistent_field` passes — confirms `RenderPrompt("{{.NonExistentField}}", PromptData{})` returns a non-nil error
- [x] All 10 existing+new `TestRenderPrompt` subtests pass
- [x] Full repo test suite passes (no regressions)

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)