### PR TITLE
fix(claude): prefer result envelopes in extractJSONByDepth (#106)

### DIFF
--- a/docs/superpowers/specs/2026-04-14-parser-extractjsonbydepth-fix-design.md
+++ b/docs/superpowers/specs/2026-04-14-parser-extractjsonbydepth-fix-design.md
@@ -1,0 +1,78 @@
+# Fix: extractJSONByDepth extracts wrong JSON from truncated CLI output
+
+**Issue:** #106
+**Date:** 2026-04-14
+
+## Problem
+
+`extractJSONByDepth` in `internal/claude/parser.go:121` doesn't validate that extracted JSON is a result envelope. When Claude CLI output is truncated (missing closing `}`), Strategy 1 fails and Strategy 2 finds the inner `structured_output` JSON instead, producing: `unexpected response type: ""`.
+
+This is a known limitation documented as a skipped test at `parser_test.go:239`.
+
+## Root Cause
+
+Strategy 1 (`extractJSON`) checks `isResultEnvelope`. Strategy 2 (`extractJSONByDepth`) does not. The asymmetry means truncated output extracts the wrong JSON object.
+
+Trigger: resource contention from 3 concurrent pipeline runs causes truncated CLI stdout.
+
+## Approach
+
+**Approach B: prefer envelopes, fall back to any JSON for diagnostics.**
+
+Both the Go Specialist and AI Harness Specialist independently recommended this approach:
+
+- Makes Strategy 2 symmetric with Strategy 1 (both prefer envelopes)
+- Preserves diagnostic value — fallback JSON appears in `ParseError.Raw` for operators
+- No new error types needed — `ParseResponse` already handles `type != "result"`
+- No context budget concern — `ParseError.Error()` excludes raw data
+- Most resilient to future CLI format changes
+
+## Implementation
+
+### `extractJSONByDepth` (parser.go)
+
+Scan all `{` candidates, prefer result envelopes, fall back to outermost valid JSON:
+
+```go
+func extractJSONByDepth(output []byte) ([]byte, error) {
+    end := bytes.LastIndexByte(output, '}')
+    if end == -1 {
+        return nil, errNoJSON
+    }
+
+    var fallback []byte
+    for i := end; i >= 0; i-- {
+        if output[i] == '{' {
+            candidate := output[i : end+1]
+            if json.Valid(candidate) {
+                if isResultEnvelope(candidate) {
+                    return candidate, nil
+                }
+                fallback = candidate // keep overwriting; last is outermost
+            }
+        }
+    }
+
+    if fallback != nil {
+        return fallback, nil
+    }
+    return nil, errNoJSON
+}
+```
+
+Key detail: `fallback` is overwritten on each valid-but-non-envelope candidate. Since the scan moves leftward (larger candidates), the final `fallback` is the outermost (largest) valid JSON — most diagnostic value.
+
+### Tests
+
+1. **Un-skip `last_line_non_envelope_json`** — remove `t.Skip`, assert result envelope is extracted when both envelope and non-envelope JSON exist in output
+2. **Add `truncated_envelope`** — outer envelope missing closing `}`, inner `structured_output` is valid JSON. Assert inner JSON is returned (non-envelope), and `ParseResponse` produces `ParseError`
+3. **Add `envelope_after_non_envelope`** — result envelope appears before non-envelope JSON. Assert envelope is found and preferred
+
+### Files changed
+
+- `internal/claude/parser.go` — `extractJSONByDepth` function (~15 lines changed)
+- `internal/claude/parser_test.go` — un-skip 1 test, add 2 new tests (~30 lines added)
+
+## Follow-up
+
+File a separate ticket for `sandbox.ExitError` classification gap: `classifyError` in `engine.go` doesn't handle `sandbox.ExitError`. OOM kills and signal kills fall into "unknown" category and are NOT retried. This likely contributes to concurrent pipeline failures.

--- a/internal/claude/parser.go
+++ b/internal/claude/parser.go
@@ -115,24 +115,38 @@ func isResultEnvelope(data []byte) bool {
 	return json.Unmarshal(data, &check) == nil && check.Type == "result"
 }
 
-// extractJSONByDepth scans backwards for the last valid JSON object.
-// NOTE: This function does not validate the envelope type — the ParseResponse
-// type check handles that after extraction.
+// extractJSONByDepth scans backwards for valid JSON objects in the output,
+// preferring result envelopes over other valid JSON. Tries each closing '}'
+// as a potential endpoint to handle multiple top-level JSON objects.
+// Falls back to the outermost valid non-envelope JSON for diagnostics.
 func extractJSONByDepth(output []byte) ([]byte, error) {
-	end := bytes.LastIndexByte(output, '}')
-	if end == -1 {
-		return nil, errNoJSON
-	}
+	var fallback []byte
 
-	for i := end; i >= 0; i-- {
-		if output[i] == '{' {
-			candidate := output[i : end+1]
-			if json.Valid(candidate) {
-				return candidate, nil
+	// Scan each '}' as a potential JSON endpoint, from last to first.
+	for end := len(output) - 1; end >= 0; end-- {
+		if output[end] != '}' {
+			continue
+		}
+
+		for i := end; i >= 0; i-- {
+			if output[i] == '{' {
+				candidate := output[i : end+1]
+				if json.Valid(candidate) {
+					if isResultEnvelope(candidate) {
+						return candidate, nil
+					}
+					if fallback == nil {
+						fallback = candidate
+					}
+					break // found valid JSON for this end; try next '}'
+				}
 			}
 		}
 	}
 
+	if fallback != nil {
+		return fallback, nil
+	}
 	return nil, errNoJSON
 }
 

--- a/internal/claude/parser_test.go
+++ b/internal/claude/parser_test.go
@@ -236,13 +236,45 @@ func TestExtractJSON(t *testing.T) {
 			name:  "last_line_non_envelope_json",
 			input: "{\"type\":\"result\",\"subtype\":\"success\"}\n{\"error\":\"not found\"}\n",
 			check: func(t *testing.T, raw []byte) {
-				t.Skip("known limitation: strategy 2 does not validate envelope type")
 				var obj map[string]string
 				if err := json.Unmarshal(raw, &obj); err != nil {
 					t.Fatalf("unmarshal: %v", err)
 				}
 				if obj["type"] != "result" {
 					t.Errorf("should extract result envelope, got type=%q", obj["type"])
+				}
+			},
+		},
+		{
+			name:  "truncated_envelope_returns_inner_json",
+			input: `{"type":"result","subtype":"success","structured_output":{"ticket_key":"60","approach":"test"}`,
+			check: func(t *testing.T, raw []byte) {
+				// Outer envelope is truncated (missing closing }).
+				// Strategy 2 should return the inner JSON as fallback.
+				var obj map[string]string
+				if err := json.Unmarshal(raw, &obj); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				if obj["ticket_key"] != "60" {
+					t.Errorf("expected inner JSON with ticket_key=60, got %s", raw)
+				}
+				// Verify ParseResponse rejects this as non-envelope.
+				_, parseErr := ParseResponse([]byte(`{"type":"result","subtype":"success","structured_output":{"ticket_key":"60","approach":"test"}`))
+				if parseErr == nil {
+					t.Error("expected ParseResponse to reject truncated envelope")
+				}
+			},
+		},
+		{
+			name:  "envelope_preferred_over_later_non_envelope",
+			input: "some log output\n{\"type\":\"result\",\"subtype\":\"success\"}\nmore output\n{\"status\":\"ok\"}\n",
+			check: func(t *testing.T, raw []byte) {
+				var obj map[string]string
+				if err := json.Unmarshal(raw, &obj); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				if obj["type"] != "result" {
+					t.Errorf("should prefer result envelope, got type=%q", obj["type"])
 				}
 			},
 		},


### PR DESCRIPTION
## Summary

- Fix `extractJSONByDepth` to scan all closing braces and prefer result envelopes over inner JSON objects
- Handles truncated CLI output by falling back to outermost valid JSON for diagnostics
- Un-skip known-limitation test, add 2 new test cases (truncated envelope, envelope after non-envelope)

Fixes #106

## Test plan

- [x] `go test ./internal/claude/...` — all pass
- [x] `go vet ./...` — clean
- [x] TDD: tests written first, saw them fail, then implemented fix
- [x] Existing tests still pass (no regressions)

Assisted-by: SODA