### PR TITLE
fix(prompt): remove literal template syntax from review-harness.md (#109)

### DIFF
--- a/cmd/soda/embeds/prompts/review-harness.md
+++ b/cmd/soda/embeds/prompts/review-harness.md
@@ -38,7 +38,7 @@ Review the implementation as an AI harness specialist. Focus on:
 ### 1. Prompt template correctness
 - Do templates use valid Go text/template syntax?
 - Are all referenced fields present in PromptData?
-- Are optional sections guarded with `{{if}}` blocks?
+- Are optional sections guarded with if blocks?
 - Could templates cause rendering failures?
 
 ### 2. Context budget impact


### PR DESCRIPTION
## Summary

Remove unescaped `{{if}}` from markdown text in the review-harness prompt template. Go `text/template` was parsing it as a directive, causing all review phases to fail with: `template: prompt:41: missing value for if`.

Fixes #109

## Test plan

- [x] `go test ./internal/pipeline/... -run TestRenderPrompt` — all pass
- [x] No other prompt templates have unescaped template syntax in markdown

Assisted-by: SODA