### PR TITLE
chore: bump review phase timeout from 5m to 8m

### DIFF
--- a/cmd/soda/embeds/phases.yaml
+++ b/cmd/soda/embeds/phases.yaml
@@ -85,7 +85,7 @@ phases:
       - Glob
       - Grep
       - Bash
-    timeout: 5m
+    timeout: 8m
     retry:
       transient: 2
       parse: 1


### PR DESCRIPTION
## Summary

Increase review phase timeout from 5m to 8m. Parallel reviewer subagents consistently hit the 5m deadline — both #60 and #78 failed review with context deadline exceeded.

## Test plan

- [x] Config-only change, no code affected

Assisted-by: SODA