### PR TITLE
feat(cli): show retries, generations, and accurate total cost in history (#60)

### DIFF
--- a/cmd/soda/history.go
+++ b/cmd/soda/history.go
@@ -27,20 +27,9 @@ func newHistoryCmd() *cobra.Command {
 }
 
 func runHistory(stateDir, ticketKey string) error {
-	metaPath := filepath.Join(stateDir, ticketKey, "meta.json")
+	ticketDir := filepath.Join(stateDir, ticketKey)
+	metaPath := filepath.Join(ticketDir, "meta.json")
 	meta, err := pipeline.ReadMeta(metaPath)
-	if err != nil {
-		return fmt.Errorf("history: %w", err)
-	}
-
-	phasesPath, cleanup, err := resolvePhasesPath()
-	if err != nil {
-		return fmt.Errorf("history: %w", err)
-	}
-	if cleanup != nil {
-		defer cleanup()
-	}
-	pl, err := pipeline.LoadPipeline(phasesPath)
 	if err != nil {
 		return fmt.Errorf("history: %w", err)
 	}
@@ -56,11 +45,98 @@ func runHistory(stateDir, ticketKey string) error {
 	fmt.Println()
 	fmt.Println()
 
-	// Phase table
+	// Try to read events for rich multi-generation history.
+	events, _ := pipeline.ReadEvents(ticketDir)
+	if len(events) > 0 {
+		return renderEventsHistory(meta, events, ticketDir)
+	}
+
+	// Fallback: meta-only rendering for old state dirs without events.jsonl.
+	return renderMetaHistory(meta)
+}
+
+// renderEventsHistory renders the full multi-generation history table
+// reconstructed from events.jsonl.
+func renderEventsHistory(meta *pipeline.PipelineMeta, events []pipeline.Event, stateDir string) error {
+	h := pipeline.BuildHistory(events, stateDir)
+
+	tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(tw, "Phase\tGen\tStatus\tDuration\tCost\tDetails")
+
+	var lastFailPhase string
+	var lastFailError string
+
+	for _, entry := range h.Entries {
+		sym := statusSymbol(entry.Status, entry.Superseded)
+
+		gen := fmt.Sprintf("%d", entry.Generation)
+		if entry.Generation == 0 {
+			gen = "-"
+		}
+
+		dur := "-"
+		if entry.DurationMs > 0 {
+			dur = pipeline.FormatDuration(entry.DurationMs)
+		}
+
+		cost := "-"
+		if entry.Cost > 0 || entry.Status == pipeline.PhaseCompleted || entry.Status == pipeline.PhaseFailed {
+			cost = fmt.Sprintf("$%.2f", entry.Cost)
+		}
+
+		details := entry.Details
+		if entry.Superseded {
+			details = "(superseded)"
+		}
+		if entry.Error != "" && !entry.Superseded {
+			details = entry.Error
+			if len(details) > 60 {
+				details = details[:57] + "..."
+			}
+		}
+
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			entry.Phase, gen, sym, dur, cost, details)
+
+		if entry.Status == pipeline.PhaseFailed && entry.Error != "" && !entry.Superseded {
+			lastFailPhase = entry.Phase
+			lastFailError = entry.Error
+		}
+	}
+
+	// Total line using meta.TotalCost as the authoritative total.
+	fmt.Fprintf(tw, "\t\t\t\t──────────\t\n")
+	fmt.Fprintf(tw, "\t\t\tTotal:\t$%.2f\t\n", meta.TotalCost)
+	if h.SupersededCost > 0 {
+		fmt.Fprintf(tw, "\t\t\tSuperseded:\t$%.2f\t\n", h.SupersededCost)
+	}
+	tw.Flush()
+
+	if lastFailPhase != "" {
+		fmt.Printf("\nLast failure (%s):\n  Error: %s\n", lastFailPhase, lastFailError)
+	}
+
+	return nil
+}
+
+// renderMetaHistory renders a simple history table from meta.json only.
+// Used as a fallback when events.jsonl does not exist.
+func renderMetaHistory(meta *pipeline.PipelineMeta) error {
+	phasesPath, cleanup, err := resolvePhasesPath()
+	if err != nil {
+		return fmt.Errorf("history: %w", err)
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	pl, err := pipeline.LoadPipeline(phasesPath)
+	if err != nil {
+		return fmt.Errorf("history: %w", err)
+	}
+
 	tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
 	fmt.Fprintln(tw, "Phase\tStatus\tDuration\tCost")
 
-	var totalCost float64
 	var lastFailPhase string
 	var lastFailError string
 
@@ -76,7 +152,6 @@ func runHistory(stateDir, ticketKey string) error {
 			dur = "-"
 		}
 		cost := fmt.Sprintf("$%.2f", ps.Cost)
-		totalCost += ps.Cost
 
 		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", phase.Name, string(ps.Status), dur, cost)
 
@@ -86,8 +161,9 @@ func runHistory(stateDir, ticketKey string) error {
 		}
 	}
 
+	// Use meta.TotalCost as the authoritative total.
 	fmt.Fprintf(tw, "\t\t\t──────────\n")
-	fmt.Fprintf(tw, "\t\tTotal:\t$%.2f\n", totalCost)
+	fmt.Fprintf(tw, "\t\tTotal:\t$%.2f\n", meta.TotalCost)
 	tw.Flush()
 
 	if lastFailPhase != "" {
@@ -95,4 +171,30 @@ func runHistory(stateDir, ticketKey string) error {
 	}
 
 	return nil
+}
+
+// statusSymbol returns a status symbol for display.
+func statusSymbol(status pipeline.PhaseStatus, superseded bool) string {
+	if superseded {
+		switch status {
+		case pipeline.PhaseCompleted:
+			return "✓ ⏭"
+		case pipeline.PhaseFailed:
+			return "✗ ⏭"
+		default:
+			return "⏭"
+		}
+	}
+	switch status {
+	case pipeline.PhaseCompleted:
+		return "✓"
+	case pipeline.PhaseFailed:
+		return "✗"
+	case pipeline.PhaseRunning:
+		return "⧗"
+	case "skipped":
+		return "⏭"
+	default:
+		return string(status)
+	}
 }

--- a/cmd/soda/history.go
+++ b/cmd/soda/history.go
@@ -46,7 +46,10 @@ func runHistory(stateDir, ticketKey string) error {
 	fmt.Println()
 
 	// Try to read events for rich multi-generation history.
-	events, _ := pipeline.ReadEvents(ticketDir)
+	events, eventsErr := pipeline.ReadEvents(ticketDir)
+	if eventsErr != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not read events: %v\n", eventsErr)
+	}
 	if len(events) > 0 {
 		return renderEventsHistory(meta, events, ticketDir)
 	}
@@ -110,7 +113,9 @@ func renderEventsHistory(meta *pipeline.PipelineMeta, events []pipeline.Event, s
 	if h.SupersededCost > 0 {
 		fmt.Fprintf(tw, "\t\t\tSuperseded:\t$%.2f\t\n", h.SupersededCost)
 	}
-	tw.Flush()
+	if err := tw.Flush(); err != nil {
+		return fmt.Errorf("history: flush output: %w", err)
+	}
 
 	if lastFailPhase != "" {
 		fmt.Printf("\nLast failure (%s):\n  Error: %s\n", lastFailPhase, lastFailError)
@@ -164,7 +169,9 @@ func renderMetaHistory(meta *pipeline.PipelineMeta) error {
 	// Use meta.TotalCost as the authoritative total.
 	fmt.Fprintf(tw, "\t\t\t──────────\n")
 	fmt.Fprintf(tw, "\t\tTotal:\t$%.2f\n", meta.TotalCost)
-	tw.Flush()
+	if err := tw.Flush(); err != nil {
+		return fmt.Errorf("history: flush output: %w", err)
+	}
 
 	if lastFailPhase != "" {
 		fmt.Printf("\nLast failure (%s):\n  Error: %s\n", lastFailPhase, lastFailError)

--- a/cmd/soda/history_test.go
+++ b/cmd/soda/history_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/decko/soda/internal/pipeline"
+)
+
+func TestStatusSymbol(t *testing.T) {
+	tests := []struct {
+		status     pipeline.PhaseStatus
+		superseded bool
+		want       string
+	}{
+		{pipeline.PhaseCompleted, false, "✓"},
+		{pipeline.PhaseFailed, false, "✗"},
+		{pipeline.PhaseRunning, false, "⧗"},
+		{"skipped", false, "⏭"},
+		{pipeline.PhasePending, false, "pending"},
+
+		// Superseded variants.
+		{pipeline.PhaseCompleted, true, "✓ ⏭"},
+		{pipeline.PhaseFailed, true, "✗ ⏭"},
+		{pipeline.PhaseRunning, true, "⏭"},
+	}
+	for _, tc := range tests {
+		got := statusSymbol(tc.status, tc.superseded)
+		if got != tc.want {
+			t.Errorf("statusSymbol(%q, %v) = %q, want %q", tc.status, tc.superseded, got, tc.want)
+		}
+	}
+}

--- a/cmd/soda/status.go
+++ b/cmd/soda/status.go
@@ -76,6 +76,7 @@ func runStatus(stateDir string) error {
 		}
 
 		elapsed := formatElapsed(meta)
+		// Use meta.TotalCost — the authoritative accumulated total across all generations.
 		cost := fmt.Sprintf("$%.2f", meta.TotalCost)
 
 		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", meta.Ticket, phase, status, elapsed, cost)

--- a/internal/pipeline/events.go
+++ b/internal/pipeline/events.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -51,6 +52,38 @@ const (
 	EventReviewerFailed         = "reviewer_failed"
 	EventReviewMerged           = "review_merged"
 )
+
+// ReadEvents reads and parses all events from the events.jsonl file in dir.
+// Returns an empty slice if the file does not exist.
+// Malformed lines are silently skipped.
+func ReadEvents(dir string) ([]Event, error) {
+	path := filepath.Join(dir, "events.jsonl")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("pipeline: read events %s: %w", path, err)
+	}
+
+	if len(data) == 0 {
+		return nil, nil
+	}
+
+	var events []Event
+	for _, line := range strings.Split(strings.TrimRight(string(data), "\n"), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var ev Event
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			continue // skip malformed lines
+		}
+		events = append(events, ev)
+	}
+	return events, nil
+}
 
 // logEvent appends an event to the events.jsonl file in dir.
 func logEvent(dir string, event Event) error {

--- a/internal/pipeline/events_test.go
+++ b/internal/pipeline/events_test.go
@@ -9,6 +9,94 @@ import (
 	"time"
 )
 
+func TestReadEvents(t *testing.T) {
+	t.Run("normal", func(t *testing.T) {
+		dir := t.TempDir()
+		ts := time.Date(2026, 4, 11, 10, 0, 0, 0, time.UTC)
+		logEvent(dir, Event{Timestamp: ts, Phase: "triage", Kind: EventPhaseStarted, Data: map[string]any{"generation": float64(1)}})
+		logEvent(dir, Event{Timestamp: ts, Phase: "triage", Kind: EventPhaseCompleted, Data: map[string]any{"cost": 0.12}})
+
+		events, err := ReadEvents(dir)
+		if err != nil {
+			t.Fatalf("ReadEvents: %v", err)
+		}
+		if len(events) != 2 {
+			t.Fatalf("expected 2 events, got %d", len(events))
+		}
+		if events[0].Kind != EventPhaseStarted {
+			t.Errorf("events[0].Kind = %q, want %q", events[0].Kind, EventPhaseStarted)
+		}
+		if events[1].Kind != EventPhaseCompleted {
+			t.Errorf("events[1].Kind = %q, want %q", events[1].Kind, EventPhaseCompleted)
+		}
+	})
+
+	t.Run("empty_file", func(t *testing.T) {
+		dir := t.TempDir()
+		os.WriteFile(filepath.Join(dir, "events.jsonl"), []byte(""), 0644)
+
+		events, err := ReadEvents(dir)
+		if err != nil {
+			t.Fatalf("ReadEvents: %v", err)
+		}
+		if len(events) != 0 {
+			t.Fatalf("expected 0 events, got %d", len(events))
+		}
+	})
+
+	t.Run("missing_file", func(t *testing.T) {
+		dir := t.TempDir()
+
+		events, err := ReadEvents(dir)
+		if err != nil {
+			t.Fatalf("ReadEvents: %v", err)
+		}
+		if events != nil {
+			t.Fatalf("expected nil, got %v", events)
+		}
+	})
+
+	t.Run("malformed_lines_skipped", func(t *testing.T) {
+		dir := t.TempDir()
+		content := `{"timestamp":"2026-04-11T10:00:00Z","phase":"triage","kind":"phase_started"}
+not valid json
+{"timestamp":"2026-04-11T10:00:01Z","phase":"triage","kind":"phase_completed"}
+`
+		os.WriteFile(filepath.Join(dir, "events.jsonl"), []byte(content), 0644)
+
+		events, err := ReadEvents(dir)
+		if err != nil {
+			t.Fatalf("ReadEvents: %v", err)
+		}
+		if len(events) != 2 {
+			t.Fatalf("expected 2 events (malformed skipped), got %d", len(events))
+		}
+		if events[0].Kind != EventPhaseStarted {
+			t.Errorf("events[0].Kind = %q, want %q", events[0].Kind, EventPhaseStarted)
+		}
+		if events[1].Kind != EventPhaseCompleted {
+			t.Errorf("events[1].Kind = %q, want %q", events[1].Kind, EventPhaseCompleted)
+		}
+	})
+
+	t.Run("blank_lines_skipped", func(t *testing.T) {
+		dir := t.TempDir()
+		content := `{"timestamp":"2026-04-11T10:00:00Z","phase":"triage","kind":"phase_started"}
+
+{"timestamp":"2026-04-11T10:00:01Z","phase":"triage","kind":"phase_completed"}
+`
+		os.WriteFile(filepath.Join(dir, "events.jsonl"), []byte(content), 0644)
+
+		events, err := ReadEvents(dir)
+		if err != nil {
+			t.Fatalf("ReadEvents: %v", err)
+		}
+		if len(events) != 2 {
+			t.Fatalf("expected 2 events (blank lines skipped), got %d", len(events))
+		}
+	})
+}
+
 func TestLogEvent(t *testing.T) {
 	t.Run("appends_event_to_jsonl", func(t *testing.T) {
 		dir := t.TempDir()

--- a/internal/pipeline/history.go
+++ b/internal/pipeline/history.go
@@ -131,13 +131,13 @@ func loadPhaseDetails(phase string, generation int, stateDir string) string {
 		return ""
 	}
 
-	// Try the current result file first.
+	// Try archived path first for non-latest generations.
 	path := filepath.Join(stateDir, phase+".json")
-	data, err := os.ReadFile(path)
+	archivePath := fmt.Sprintf("%s.%d", path, generation)
+	data, err := os.ReadFile(archivePath)
 	if err != nil {
-		// Try archived path.
-		archivePath := fmt.Sprintf("%s.%d", path, generation)
-		data, err = os.ReadFile(archivePath)
+		// Fall back to current result file.
+		data, err = os.ReadFile(path)
 		if err != nil {
 			return ""
 		}

--- a/internal/pipeline/history.go
+++ b/internal/pipeline/history.go
@@ -1,0 +1,205 @@
+package pipeline
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/decko/soda/internal/progress"
+)
+
+// PhaseGeneration represents a single generation (attempt) of a phase.
+type PhaseGeneration struct {
+	Phase      string
+	Generation int
+	Status     PhaseStatus
+	Cost       float64
+	DurationMs int64
+	Error      string
+	Details    string // one-line summary from result JSON
+	Superseded bool   // true if a later generation exists
+}
+
+// History holds the reconstructed multi-generation history for a ticket.
+type History struct {
+	Entries        []PhaseGeneration
+	SupersededCost float64
+}
+
+// BuildHistory reconstructs multi-generation phase history from a sequence
+// of events. It reads archived result files (e.g. verify.json.1) from
+// stateDir to populate the Details field via progress.PhaseSummary.
+//
+// The events are processed in order. Each phase_started event begins a new
+// generation entry. phase_completed and phase_failed events finalize it.
+// When a phase has multiple generations, earlier ones are marked Superseded.
+func BuildHistory(events []Event, stateDir string) History {
+	var h History
+
+	// Track the index of the current (latest started, not yet finalized) entry
+	// per phase, and a list of all entry indices per phase for superseded marking.
+	currentIdx := map[string]int{} // phase → index in h.Entries
+	allIdx := map[string][]int{}   // phase → all indices
+
+	for _, ev := range events {
+		switch ev.Kind {
+		case EventPhaseStarted:
+			gen := 1
+			if v, ok := ev.Data["generation"]; ok {
+				gen = toInt(v)
+			}
+
+			// Mark any previous entry for this phase as superseded.
+			if indices, ok := allIdx[ev.Phase]; ok {
+				for _, idx := range indices {
+					h.Entries[idx].Superseded = true
+				}
+			}
+
+			entry := PhaseGeneration{
+				Phase:      ev.Phase,
+				Generation: gen,
+				Status:     PhaseRunning,
+			}
+			idx := len(h.Entries)
+			h.Entries = append(h.Entries, entry)
+			currentIdx[ev.Phase] = idx
+			allIdx[ev.Phase] = append(allIdx[ev.Phase], idx)
+
+		case EventPhaseCompleted:
+			idx, ok := currentIdx[ev.Phase]
+			if !ok {
+				continue
+			}
+			h.Entries[idx].Status = PhaseCompleted
+			if v, ok := ev.Data["cost"]; ok {
+				h.Entries[idx].Cost = toFloat64(v)
+			}
+			if v, ok := ev.Data["duration_ms"]; ok {
+				h.Entries[idx].DurationMs = toInt64(v)
+			}
+			// Load details from result JSON.
+			h.Entries[idx].Details = loadPhaseDetails(ev.Phase, h.Entries[idx].Generation, stateDir)
+
+		case EventPhaseFailed:
+			idx, ok := currentIdx[ev.Phase]
+			if !ok {
+				continue
+			}
+			h.Entries[idx].Status = PhaseFailed
+			if v, ok := ev.Data["error"]; ok {
+				if s, ok := v.(string); ok {
+					h.Entries[idx].Error = s
+				}
+			}
+			if v, ok := ev.Data["duration_ms"]; ok {
+				h.Entries[idx].DurationMs = toInt64(v)
+			}
+			if v, ok := ev.Data["cost"]; ok {
+				h.Entries[idx].Cost = toFloat64(v)
+			}
+
+		case EventPhaseSkipped:
+			entry := PhaseGeneration{
+				Phase:  ev.Phase,
+				Status: "skipped",
+			}
+			idx := len(h.Entries)
+			h.Entries = append(h.Entries, entry)
+			allIdx[ev.Phase] = append(allIdx[ev.Phase], idx)
+		}
+	}
+
+	// Calculate superseded cost.
+	for i := range h.Entries {
+		if h.Entries[i].Superseded {
+			h.SupersededCost += h.Entries[i].Cost
+		}
+	}
+
+	return h
+}
+
+// loadPhaseDetails reads the result JSON for a phase generation and returns
+// a one-line summary via progress.PhaseSummary. For the current (latest)
+// generation, the file is <phase>.json. For archived generations, it is
+// <phase>.json.<generation>.
+func loadPhaseDetails(phase string, generation int, stateDir string) string {
+	if stateDir == "" {
+		return ""
+	}
+
+	// Try the current result file first.
+	path := filepath.Join(stateDir, phase+".json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		// Try archived path.
+		archivePath := fmt.Sprintf("%s.%d", path, generation)
+		data, err = os.ReadFile(archivePath)
+		if err != nil {
+			return ""
+		}
+	}
+
+	return progress.PhaseSummary(phase, json.RawMessage(data))
+}
+
+// FormatDuration formats a duration from milliseconds as "Xs" or "XmYYs".
+func FormatDuration(ms int64) string {
+	d := (time.Duration(ms) * time.Millisecond).Round(time.Second)
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	m := int(d.Minutes())
+	s := int(d.Seconds()) % 60
+	return fmt.Sprintf("%dm%02ds", m, s)
+}
+
+// toInt converts a JSON number (float64) to int.
+func toInt(v any) int {
+	switch n := v.(type) {
+	case float64:
+		return int(n)
+	case int:
+		return n
+	case json.Number:
+		i, _ := n.Int64()
+		return int(i)
+	default:
+		return 0
+	}
+}
+
+// toInt64 converts a JSON number (float64) to int64.
+func toInt64(v any) int64 {
+	switch n := v.(type) {
+	case float64:
+		return int64(n)
+	case int64:
+		return n
+	case int:
+		return int64(n)
+	case json.Number:
+		i, _ := n.Int64()
+		return i
+	default:
+		return 0
+	}
+}
+
+// toFloat64 converts a JSON number to float64.
+func toFloat64(v any) float64 {
+	switch n := v.(type) {
+	case float64:
+		return n
+	case int:
+		return float64(n)
+	case json.Number:
+		f, _ := n.Float64()
+		return f
+	default:
+		return 0
+	}
+}

--- a/internal/pipeline/history_integration_test.go
+++ b/internal/pipeline/history_integration_test.go
@@ -1,0 +1,268 @@
+package pipeline
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestBuildHistory_FullPipeline tests a complete pipeline run with all phases.
+func TestBuildHistory_FullPipeline(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write result files.
+	writeJSON(t, filepath.Join(dir, "triage.json"), map[string]any{"complexity": "low", "automatable": true})
+	writeJSON(t, filepath.Join(dir, "plan.json"), map[string]any{"tasks": []any{map[string]any{"id": "1"}, map[string]any{"id": "2"}}})
+	writeJSON(t, filepath.Join(dir, "implement.json"), map[string]any{"files_changed": []any{map[string]any{"path": "a.go"}}, "commits": []any{map[string]any{"hash": "abc"}}, "tests_passed": true})
+	writeJSON(t, filepath.Join(dir, "verify.json"), map[string]any{"verdict": "PASS"})
+	writeJSON(t, filepath.Join(dir, "submit.json"), map[string]any{"pr_url": "https://github.com/decko/soda/pull/99"})
+
+	events := []Event{
+		{Phase: "triage", Kind: EventPhaseStarted, Data: map[string]any{"generation": float64(1)}},
+		{Phase: "triage", Kind: EventPhaseCompleted, Data: map[string]any{"cost": 0.10, "duration_ms": float64(5000)}},
+		{Phase: "plan", Kind: EventPhaseStarted, Data: map[string]any{"generation": float64(1)}},
+		{Phase: "plan", Kind: EventPhaseCompleted, Data: map[string]any{"cost": 0.30, "duration_ms": float64(15000)}},
+		{Phase: "implement", Kind: EventPhaseStarted, Data: map[string]any{"generation": float64(1)}},
+		{Phase: "implement", Kind: EventPhaseCompleted, Data: map[string]any{"cost": 1.20, "duration_ms": float64(120000)}},
+		{Phase: "verify", Kind: EventPhaseStarted, Data: map[string]any{"generation": float64(1)}},
+		{Phase: "verify", Kind: EventPhaseCompleted, Data: map[string]any{"cost": 0.25, "duration_ms": float64(30000)}},
+		{Phase: "submit", Kind: EventPhaseStarted, Data: map[string]any{"generation": float64(1)}},
+		{Phase: "submit", Kind: EventPhaseCompleted, Data: map[string]any{"cost": 0.05, "duration_ms": float64(10000)}},
+	}
+
+	h := BuildHistory(events, dir)
+
+	if len(h.Entries) != 5 {
+		t.Fatalf("expected 5 entries, got %d", len(h.Entries))
+	}
+
+	// Verify details are populated.
+	expectedDetails := map[string]string{
+		"triage":    "low",
+		"plan":      "2 tasks",
+		"implement": "1 file changed, 1 commit",
+		"verify":    "PASS",
+		"submit":    "PR #99",
+	}
+	for _, entry := range h.Entries {
+		if want, ok := expectedDetails[entry.Phase]; ok {
+			if entry.Details != want {
+				t.Errorf("%s details = %q, want %q", entry.Phase, entry.Details, want)
+			}
+		}
+	}
+
+	// No superseded entries.
+	if h.SupersededCost != 0 {
+		t.Errorf("superseded cost = %f, want 0", h.SupersededCost)
+	}
+	for _, entry := range h.Entries {
+		if entry.Superseded {
+			t.Errorf("%s should not be superseded", entry.Phase)
+		}
+	}
+}
+
+// TestBuildHistory_FailAndRetryScenario tests a phase that fails and is rerun.
+func TestBuildHistory_FailAndRetryScenario(t *testing.T) {
+	dir := t.TempDir()
+	writeJSON(t, filepath.Join(dir, "verify.json"), map[string]any{"verdict": "PASS"})
+
+	events := []Event{
+		{Phase: "triage", Kind: EventPhaseStarted, Data: map[string]any{"generation": float64(1)}},
+		{Phase: "triage", Kind: EventPhaseCompleted, Data: map[string]any{"cost": 0.10, "duration_ms": float64(5000)}},
+		{Phase: "plan", Kind: EventPhaseStarted, Data: map[string]any{"generation": float64(1)}},
+		{Phase: "plan", Kind: EventPhaseCompleted, Data: map[string]any{"cost": 0.30, "duration_ms": float64(15000)}},
+		{Phase: "implement", Kind: EventPhaseStarted, Data: map[string]any{"generation": float64(1)}},
+		{Phase: "implement", Kind: EventPhaseCompleted, Data: map[string]any{"cost": 1.00, "duration_ms": float64(100000)}},
+		// Verify fails on first attempt.
+		{Phase: "verify", Kind: EventPhaseStarted, Data: map[string]any{"generation": float64(1)}},
+		{Phase: "verify", Kind: EventPhaseFailed, Data: map[string]any{"error": "tests did not pass", "duration_ms": float64(20000), "cost": 0.15}},
+		// Implement re-run (generation 2).
+		{Phase: "implement", Kind: EventPhaseStarted, Data: map[string]any{"generation": float64(2)}},
+		{Phase: "implement", Kind: EventPhaseCompleted, Data: map[string]any{"cost": 0.80, "duration_ms": float64(90000)}},
+		// Verify re-run (generation 2).
+		{Phase: "verify", Kind: EventPhaseStarted, Data: map[string]any{"generation": float64(2)}},
+		{Phase: "verify", Kind: EventPhaseCompleted, Data: map[string]any{"cost": 0.20, "duration_ms": float64(25000)}},
+	}
+
+	h := BuildHistory(events, dir)
+
+	if len(h.Entries) != 6 {
+		t.Fatalf("expected 6 entries, got %d", len(h.Entries))
+	}
+
+	// Check superseded entries.
+	superseded := 0
+	for _, entry := range h.Entries {
+		if entry.Superseded {
+			superseded++
+		}
+	}
+	if superseded != 2 { // implement gen 1 + verify gen 1
+		t.Errorf("expected 2 superseded entries, got %d", superseded)
+	}
+
+	// Verify gen 1 should be superseded with cost.
+	verifyGen1 := h.Entries[3] // verify gen 1 (failed)
+	if verifyGen1.Phase != "verify" || verifyGen1.Generation != 1 {
+		t.Errorf("entry 3: phase=%q gen=%d, want verify gen 1", verifyGen1.Phase, verifyGen1.Generation)
+	}
+	if !verifyGen1.Superseded {
+		t.Error("verify gen 1 should be superseded")
+	}
+	if verifyGen1.Status != PhaseFailed {
+		t.Errorf("verify gen 1 status = %q, want failed", verifyGen1.Status)
+	}
+
+	// Verify gen 2 should NOT be superseded.
+	verifyGen2 := h.Entries[5]
+	if verifyGen2.Superseded {
+		t.Error("verify gen 2 should not be superseded")
+	}
+	if verifyGen2.Status != PhaseCompleted {
+		t.Errorf("verify gen 2 status = %q, want completed", verifyGen2.Status)
+	}
+
+	// Superseded cost = implement gen 1 (1.00) + verify gen 1 (0.15).
+	expectedSuperseded := 1.15
+	if h.SupersededCost < expectedSuperseded-0.01 || h.SupersededCost > expectedSuperseded+0.01 {
+		t.Errorf("superseded cost = %f, want ~%f", h.SupersededCost, expectedSuperseded)
+	}
+}
+
+// TestBuildHistory_MixedSkipAndRun tests a pipeline where some phases are skipped.
+func TestBuildHistory_MixedSkipAndRun(t *testing.T) {
+	events := []Event{
+		{Phase: "triage", Kind: EventPhaseSkipped},
+		{Phase: "plan", Kind: EventPhaseSkipped},
+		{Phase: "implement", Kind: EventPhaseStarted, Data: map[string]any{"generation": float64(2)}},
+		{Phase: "implement", Kind: EventPhaseCompleted, Data: map[string]any{"cost": 0.50, "duration_ms": float64(60000)}},
+		{Phase: "verify", Kind: EventPhaseStarted, Data: map[string]any{"generation": float64(2)}},
+		{Phase: "verify", Kind: EventPhaseCompleted, Data: map[string]any{"cost": 0.20, "duration_ms": float64(25000)}},
+	}
+
+	h := BuildHistory(events, "")
+
+	if len(h.Entries) != 4 {
+		t.Fatalf("expected 4 entries, got %d", len(h.Entries))
+	}
+
+	// First two should be skipped.
+	if h.Entries[0].Status != "skipped" {
+		t.Errorf("triage status = %q, want skipped", h.Entries[0].Status)
+	}
+	if h.Entries[1].Status != "skipped" {
+		t.Errorf("plan status = %q, want skipped", h.Entries[1].Status)
+	}
+
+	// Next two are real runs.
+	if h.Entries[2].Status != PhaseCompleted {
+		t.Errorf("implement status = %q, want completed", h.Entries[2].Status)
+	}
+	if h.Entries[3].Status != PhaseCompleted {
+		t.Errorf("verify status = %q, want completed", h.Entries[3].Status)
+	}
+}
+
+// TestBuildHistory_ThreeGenerations tests a phase that runs three times.
+func TestBuildHistory_ThreeGenerations(t *testing.T) {
+	events := []Event{
+		{Phase: "implement", Kind: EventPhaseStarted, Data: map[string]any{"generation": float64(1)}},
+		{Phase: "implement", Kind: EventPhaseFailed, Data: map[string]any{"error": "compile error", "cost": 0.50}},
+		{Phase: "implement", Kind: EventPhaseStarted, Data: map[string]any{"generation": float64(2)}},
+		{Phase: "implement", Kind: EventPhaseFailed, Data: map[string]any{"error": "test failure", "cost": 0.60}},
+		{Phase: "implement", Kind: EventPhaseStarted, Data: map[string]any{"generation": float64(3)}},
+		{Phase: "implement", Kind: EventPhaseCompleted, Data: map[string]any{"cost": 0.70, "duration_ms": float64(90000)}},
+	}
+
+	h := BuildHistory(events, "")
+
+	if len(h.Entries) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(h.Entries))
+	}
+
+	// Gens 1 and 2 are superseded.
+	if !h.Entries[0].Superseded || !h.Entries[1].Superseded {
+		t.Error("generations 1 and 2 should be superseded")
+	}
+	if h.Entries[2].Superseded {
+		t.Error("generation 3 should not be superseded")
+	}
+
+	// Superseded cost = 0.50 + 0.60 = 1.10.
+	if h.SupersededCost < 1.09 || h.SupersededCost > 1.11 {
+		t.Errorf("superseded cost = %f, want ~1.10", h.SupersededCost)
+	}
+}
+
+// TestReadEventsAndBuildHistory_Integration tests the full ReadEvents → BuildHistory flow.
+func TestReadEventsAndBuildHistory_Integration(t *testing.T) {
+	dir := t.TempDir()
+	ts := time.Date(2026, 4, 11, 10, 0, 0, 0, time.UTC)
+
+	// Log events via logEvent.
+	logEvent(dir, Event{Timestamp: ts, Phase: "triage", Kind: EventPhaseStarted, Data: map[string]any{"generation": 1}})
+	logEvent(dir, Event{Timestamp: ts.Add(5 * time.Second), Phase: "triage", Kind: EventPhaseCompleted, Data: map[string]any{"cost": 0.10, "duration_ms": int64(5000)}})
+	logEvent(dir, Event{Timestamp: ts.Add(6 * time.Second), Phase: "plan", Kind: EventPhaseStarted, Data: map[string]any{"generation": 1}})
+	logEvent(dir, Event{Timestamp: ts.Add(20 * time.Second), Phase: "plan", Kind: EventPhaseCompleted, Data: map[string]any{"cost": 0.30, "duration_ms": int64(14000)}})
+
+	// Read events back.
+	events, err := ReadEvents(dir)
+	if err != nil {
+		t.Fatalf("ReadEvents: %v", err)
+	}
+	if len(events) != 4 {
+		t.Fatalf("expected 4 events, got %d", len(events))
+	}
+
+	// Build history.
+	h := BuildHistory(events, dir)
+	if len(h.Entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(h.Entries))
+	}
+
+	if h.Entries[0].Phase != "triage" || h.Entries[0].Status != PhaseCompleted {
+		t.Errorf("triage entry: phase=%q status=%q", h.Entries[0].Phase, h.Entries[0].Status)
+	}
+	if h.Entries[1].Phase != "plan" || h.Entries[1].Status != PhaseCompleted {
+		t.Errorf("plan entry: phase=%q status=%q", h.Entries[1].Phase, h.Entries[1].Status)
+	}
+}
+
+// TestFormatDuration_Comprehensive tests additional edge cases.
+func TestFormatDuration_Comprehensive(t *testing.T) {
+	tests := []struct {
+		ms   int64
+		want string
+	}{
+		{0, "0s"},
+		{500, "1s"},  // rounds to nearest second
+		{1499, "1s"}, // rounds down
+		{1500, "2s"}, // rounds up
+		{45000, "45s"},
+		{59999, "1m00s"},
+		{60000, "1m00s"},
+		{90000, "1m30s"},
+		{3600000, "60m00s"},
+	}
+	for _, tc := range tests {
+		got := FormatDuration(tc.ms)
+		if got != tc.want {
+			t.Errorf("FormatDuration(%d) = %q, want %q", tc.ms, got, tc.want)
+		}
+	}
+}
+
+func writeJSON(t *testing.T, path string, v any) {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/internal/pipeline/history_test.go
+++ b/internal/pipeline/history_test.go
@@ -1,0 +1,258 @@
+package pipeline
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestBuildHistory_SingleGeneration(t *testing.T) {
+	events := []Event{
+		{Phase: "triage", Kind: EventPhaseStarted, Data: map[string]any{"generation": float64(1)}},
+		{Phase: "triage", Kind: EventPhaseCompleted, Data: map[string]any{"cost": 0.12, "duration_ms": float64(8000)}},
+		{Phase: "plan", Kind: EventPhaseStarted, Data: map[string]any{"generation": float64(1)}},
+		{Phase: "plan", Kind: EventPhaseCompleted, Data: map[string]any{"cost": 0.31, "duration_ms": float64(15000)}},
+	}
+
+	h := BuildHistory(events, "")
+	if len(h.Entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(h.Entries))
+	}
+
+	if h.Entries[0].Phase != "triage" || h.Entries[0].Generation != 1 {
+		t.Errorf("entry 0: phase=%q gen=%d", h.Entries[0].Phase, h.Entries[0].Generation)
+	}
+	if h.Entries[0].Status != PhaseCompleted {
+		t.Errorf("entry 0: status=%q, want completed", h.Entries[0].Status)
+	}
+	if h.Entries[0].Cost != 0.12 {
+		t.Errorf("entry 0: cost=%f, want 0.12", h.Entries[0].Cost)
+	}
+	if h.Entries[0].Superseded {
+		t.Error("entry 0 should not be superseded")
+	}
+
+	if h.Entries[1].Phase != "plan" || h.Entries[1].Generation != 1 {
+		t.Errorf("entry 1: phase=%q gen=%d", h.Entries[1].Phase, h.Entries[1].Generation)
+	}
+	if h.SupersededCost != 0 {
+		t.Errorf("superseded cost = %f, want 0", h.SupersededCost)
+	}
+}
+
+func TestBuildHistory_MultiGeneration(t *testing.T) {
+	events := []Event{
+		{Phase: "verify", Kind: EventPhaseStarted, Data: map[string]any{"generation": float64(1)}},
+		{Phase: "verify", Kind: EventPhaseFailed, Data: map[string]any{"error": "test failure", "duration_ms": float64(5000), "cost": 0.20}},
+		{Phase: "verify", Kind: EventPhaseStarted, Data: map[string]any{"generation": float64(2)}},
+		{Phase: "verify", Kind: EventPhaseCompleted, Data: map[string]any{"cost": 0.25, "duration_ms": float64(6000)}},
+	}
+
+	h := BuildHistory(events, "")
+	if len(h.Entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(h.Entries))
+	}
+
+	// First generation should be superseded.
+	if !h.Entries[0].Superseded {
+		t.Error("entry 0 should be superseded")
+	}
+	if h.Entries[0].Status != PhaseFailed {
+		t.Errorf("entry 0: status=%q, want failed", h.Entries[0].Status)
+	}
+	if h.Entries[0].Error != "test failure" {
+		t.Errorf("entry 0: error=%q, want 'test failure'", h.Entries[0].Error)
+	}
+	if h.Entries[0].Cost != 0.20 {
+		t.Errorf("entry 0: cost=%f, want 0.20", h.Entries[0].Cost)
+	}
+
+	// Second generation is current.
+	if h.Entries[1].Superseded {
+		t.Error("entry 1 should not be superseded")
+	}
+	if h.Entries[1].Generation != 2 {
+		t.Errorf("entry 1: gen=%d, want 2", h.Entries[1].Generation)
+	}
+	if h.Entries[1].Status != PhaseCompleted {
+		t.Errorf("entry 1: status=%q, want completed", h.Entries[1].Status)
+	}
+
+	if h.SupersededCost != 0.20 {
+		t.Errorf("superseded cost = %f, want 0.20", h.SupersededCost)
+	}
+}
+
+func TestBuildHistory_RunningPhase(t *testing.T) {
+	events := []Event{
+		{Phase: "triage", Kind: EventPhaseStarted, Data: map[string]any{"generation": float64(1)}},
+		{Phase: "triage", Kind: EventPhaseCompleted, Data: map[string]any{"cost": 0.10, "duration_ms": float64(5000)}},
+		{Phase: "plan", Kind: EventPhaseStarted, Data: map[string]any{"generation": float64(1)}},
+		// plan is still running — no completed/failed event
+	}
+
+	h := BuildHistory(events, "")
+	if len(h.Entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(h.Entries))
+	}
+
+	if h.Entries[1].Status != PhaseRunning {
+		t.Errorf("plan status=%q, want running", h.Entries[1].Status)
+	}
+}
+
+func TestBuildHistory_SkippedPhase(t *testing.T) {
+	events := []Event{
+		{Phase: "triage", Kind: EventPhaseStarted, Data: map[string]any{"generation": float64(1)}},
+		{Phase: "triage", Kind: EventPhaseCompleted, Data: map[string]any{"cost": 0.10, "duration_ms": float64(5000)}},
+		{Phase: "plan", Kind: EventPhaseSkipped},
+	}
+
+	h := BuildHistory(events, "")
+	if len(h.Entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(h.Entries))
+	}
+
+	if h.Entries[1].Status != "skipped" {
+		t.Errorf("plan status=%q, want skipped", h.Entries[1].Status)
+	}
+}
+
+func TestBuildHistory_EmptyEvents(t *testing.T) {
+	h := BuildHistory(nil, "")
+	if len(h.Entries) != 0 {
+		t.Fatalf("expected 0 entries, got %d", len(h.Entries))
+	}
+	if h.SupersededCost != 0 {
+		t.Errorf("superseded cost = %f, want 0", h.SupersededCost)
+	}
+}
+
+func TestBuildHistory_WithDetails(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write a triage result JSON.
+	triageResult := map[string]any{
+		"complexity":  "low",
+		"automatable": true,
+	}
+	data, _ := json.Marshal(triageResult)
+	os.WriteFile(filepath.Join(dir, "triage.json"), data, 0644)
+
+	events := []Event{
+		{Phase: "triage", Kind: EventPhaseStarted, Data: map[string]any{"generation": float64(1)}},
+		{Phase: "triage", Kind: EventPhaseCompleted, Data: map[string]any{"cost": 0.12, "duration_ms": float64(8000)}},
+	}
+
+	h := BuildHistory(events, dir)
+	if len(h.Entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(h.Entries))
+	}
+	if h.Entries[0].Details != "low" {
+		t.Errorf("details = %q, want %q", h.Entries[0].Details, "low")
+	}
+}
+
+func TestBuildHistory_ArchivedDetails(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write an archived triage result (generation 1).
+	triageResult := map[string]any{
+		"complexity":  "high",
+		"automatable": false,
+	}
+	data, _ := json.Marshal(triageResult)
+	os.WriteFile(filepath.Join(dir, "triage.json.1"), data, 0644)
+
+	// Write the current triage result (generation 2).
+	triageResult2 := map[string]any{
+		"complexity":  "medium",
+		"automatable": true,
+	}
+	data2, _ := json.Marshal(triageResult2)
+	os.WriteFile(filepath.Join(dir, "triage.json"), data2, 0644)
+
+	events := []Event{
+		{Phase: "triage", Kind: EventPhaseStarted, Data: map[string]any{"generation": float64(1)}},
+		{Phase: "triage", Kind: EventPhaseCompleted, Data: map[string]any{"cost": 0.10, "duration_ms": float64(5000)}},
+		{Phase: "triage", Kind: EventPhaseStarted, Data: map[string]any{"generation": float64(2)}},
+		{Phase: "triage", Kind: EventPhaseCompleted, Data: map[string]any{"cost": 0.15, "duration_ms": float64(7000)}},
+	}
+
+	h := BuildHistory(events, dir)
+	if len(h.Entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(h.Entries))
+	}
+
+	// First generation should try the current file first, which now has gen 2 data.
+	// Since the archived file exists at triage.json.1, it should read from there
+	// only if the current file doesn't exist. But since both exist, gen 1 will
+	// try triage.json (which exists), returning "medium".
+	// For gen 2 (current), it will also read triage.json returning "medium".
+	if h.Entries[1].Details != "medium" {
+		t.Errorf("entry 1 details = %q, want %q", h.Entries[1].Details, "medium")
+	}
+}
+
+func TestFormatDuration(t *testing.T) {
+	tests := []struct {
+		ms   int64
+		want string
+	}{
+		{0, "0s"},
+		{3000, "3s"},
+		{59000, "59s"},
+		{60000, "1m00s"},
+		{95000, "1m35s"},
+		{309000, "5m09s"},
+	}
+	for _, tc := range tests {
+		got := FormatDuration(tc.ms)
+		if got != tc.want {
+			t.Errorf("FormatDuration(%d) = %q, want %q", tc.ms, got, tc.want)
+		}
+	}
+}
+
+func TestToInt(t *testing.T) {
+	if got := toInt(float64(3)); got != 3 {
+		t.Errorf("toInt(float64(3)) = %d", got)
+	}
+	if got := toInt(42); got != 42 {
+		t.Errorf("toInt(42) = %d", got)
+	}
+	if got := toInt("nope"); got != 0 {
+		t.Errorf("toInt(string) = %d, want 0", got)
+	}
+}
+
+func TestToFloat64(t *testing.T) {
+	if got := toFloat64(float64(1.23)); got != 1.23 {
+		t.Errorf("toFloat64(1.23) = %f", got)
+	}
+	if got := toFloat64(42); got != 42.0 {
+		t.Errorf("toFloat64(42) = %f", got)
+	}
+	if got := toFloat64("nope"); got != 0 {
+		t.Errorf("toFloat64(string) = %f, want 0", got)
+	}
+}
+
+// Ensure Event timestamp parsing works with BuildHistory.
+func TestBuildHistory_PreservesTimestamps(t *testing.T) {
+	ts := time.Date(2026, 4, 11, 10, 0, 0, 0, time.UTC)
+	events := []Event{
+		{Timestamp: ts, Phase: "triage", Kind: EventPhaseStarted, Data: map[string]any{"generation": float64(1)}},
+		{Timestamp: ts.Add(10 * time.Second), Phase: "triage", Kind: EventPhaseCompleted, Data: map[string]any{"cost": 0.10, "duration_ms": float64(10000)}},
+	}
+
+	h := BuildHistory(events, "")
+	if len(h.Entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(h.Entries))
+	}
+	if h.Entries[0].DurationMs != 10000 {
+		t.Errorf("DurationMs = %d, want 10000", h.Entries[0].DurationMs)
+	}
+}


### PR DESCRIPTION
## Summary

- Show all generations per phase (not just latest), mark failed/superseded
- Fix cost mismatch: display `meta.TotalCost` instead of summing per-phase latest-gen costs
- Scan archived artifacts (`<phase>.json.<generation>`) for generation history

Closes #60

## Test plan

- [x] `go test ./...` passes
- [x] `go vet` clean
- [x] Verify phase completed

Assisted-by: SODA