### PR TITLE
feat(pipeline): review phase B — finding classification and routing (#78)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,9 @@ soda (Go CLI/TUI)
 ## Pipeline phases
 
 ```
-Triage → Plan → Implement → Verify → Submit → Monitor
+Triage → Plan → Implement → Verify → Review → Submit → Monitor
+                    ↑                    │
+                    └── rework ──────────┘ (max 2 cycles)
 ```
 
 | Phase | Purpose | Tools | Timeout |
@@ -39,10 +41,23 @@ Triage → Plan → Implement → Verify → Submit → Monitor
 | Plan | Design approach, break into atomic tasks | Read-only | 5m |
 | Implement | Write code, run tests, commit | Full | 15m |
 | Verify | Run tests, check acceptance criteria, review code | Read + Bash | 5m |
+| Review | Parallel specialist review (Go + AI harness) | Read + Bash | 5m |
 | Submit | Push branch, create PR/MR | git + gh/glab | 3m |
 | Monitor | Poll for review comments, respond (polling loop) | Full | 4h max |
 
 Phase definitions, tools, timeouts, and retry policies are in `phases.yaml`.
+
+### Review rework routing
+
+After the review phase, findings are classified by severity:
+
+| Verdict | Condition | Action |
+|---------|-----------|--------|
+| `pass` | No findings | Proceed to submit |
+| `pass-with-follow-ups` | Minor findings only | Proceed to submit, queue follow-up |
+| `rework` | Any critical or major findings | Route back to implement |
+
+Rework routing: when review verdict is "rework", the engine automatically routes back to implement with the review findings injected into the prompt. The cycle is: implement → verify → review → (check verdict). Max rework cycles default to 2; after that, the engine stops with a `PhaseGateError` for human intervention. The cycle count is persisted in `meta.json` as `rework_cycles`.
 
 ### Worktree-first execution
 

--- a/cmd/soda/embeds/prompts/implement.md
+++ b/cmd/soda/embeds/prompts/implement.md
@@ -9,6 +9,23 @@ Summary: {{.Ticket.Summary}}
 {{.Artifacts.Plan}}
 
 {{- if .ReworkFeedback}}
+{{- if eq .ReworkFeedback.Source "review"}}
+
+## MANDATORY: Specialist Review Findings (MUST address)
+
+The following issues were identified by specialist reviewers.
+You MUST address every critical and major finding below. Do not repeat the same mistakes.
+
+{{- range .ReworkFeedback.ReviewFindings}}
+
+### {{.Source}}
+- [{{.Severity}}] {{.File}}{{if .Line}}:{{.Line}}{{end}} — {{.Issue}}
+  Suggestion: {{.Suggestion}}
+{{- end}}
+
+After implementing, verify that each finding above is addressed before reporting completion.
+If any feedback above contradicts the Implementation Plan, the plan takes precedence.
+{{- else}}
 
 ## MANDATORY: Previous Verification Failures
 
@@ -49,6 +66,7 @@ You MUST address every item below. Do not repeat the same mistakes.
 
 If any feedback above contradicts the Implementation Plan, the plan takes precedence.
 After implementing, verify that each fix above is addressed before reporting completion.
+{{- end}}
 {{- end}}
 
 {{- if .Context.RepoConventions}}

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -527,17 +527,29 @@ func (e *Engine) buildPromptData(phase PhaseConfig) (PromptData, error) {
 		}
 	}
 
-	// When building the implement prompt, inject verify feedback if a
-	// previous verify run produced a FAIL verdict. This gives the
-	// implement phase actionable context on resume after verification
-	// failure.
+	// When building the implement prompt, inject rework feedback from
+	// either a failed verify or a review-rework verdict. Review feedback
+	// takes precedence since it comes later in the pipeline and is more
+	// specific.
 	if phase.Name == "implement" {
-		if fb := e.extractReworkFeedback(); fb != nil {
+		if fb := e.extractReviewReworkFeedback(); fb != nil {
 			data.ReworkFeedback = fb
 			e.emit(Event{
 				Phase: phase.Name,
 				Kind:  EventReworkFeedbackInjected,
 				Data: map[string]any{
+					"source":          fb.Source,
+					"verdict":         fb.Verdict,
+					"review_findings": len(fb.ReviewFindings),
+				},
+			})
+		} else if fb := e.extractReworkFeedback(); fb != nil {
+			data.ReworkFeedback = fb
+			e.emit(Event{
+				Phase: phase.Name,
+				Kind:  EventReworkFeedbackInjected,
+				Data: map[string]any{
+					"source":          fb.Source,
 					"verdict":         fb.Verdict,
 					"fixes_count":     len(fb.FixesRequired),
 					"failed_criteria": len(fb.FailedCriteria),
@@ -607,6 +619,7 @@ func (e *Engine) extractReworkFeedback() *ReworkFeedback {
 
 	fb := &ReworkFeedback{
 		Verdict:       result.Verdict,
+		Source:        "verify",
 		FixesRequired: result.FixesRequired,
 	}
 
@@ -640,6 +653,56 @@ func (e *Engine) extractReworkFeedback() *ReworkFeedback {
 				Command:  cmd.Command,
 				ExitCode: cmd.ExitCode,
 				Output:   truncateLines(cmd.Output, 50),
+			})
+		}
+	}
+
+	return fb
+}
+
+// extractReviewReworkFeedback reads the review result and returns
+// structured feedback when the verdict is "rework". Returns nil if no
+// review result exists or the verdict is not "rework".
+func (e *Engine) extractReviewReworkFeedback() *ReworkFeedback {
+	raw, err := e.state.ReadResult("review")
+	if err != nil {
+		return nil
+	}
+
+	var result struct {
+		Verdict  string `json:"verdict"`
+		Findings []struct {
+			Source     string `json:"source"`
+			Severity   string `json:"severity"`
+			File       string `json:"file"`
+			Line       int    `json:"line,omitempty"`
+			Issue      string `json:"issue"`
+			Suggestion string `json:"suggestion"`
+		} `json:"findings"`
+	}
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil
+	}
+	if !strings.EqualFold(result.Verdict, "rework") {
+		return nil
+	}
+
+	fb := &ReworkFeedback{
+		Verdict: result.Verdict,
+		Source:  "review",
+	}
+
+	// Only include critical and major findings.
+	for _, finding := range result.Findings {
+		sev := strings.ToLower(finding.Severity)
+		if sev == "critical" || sev == "major" {
+			fb.ReviewFindings = append(fb.ReviewFindings, ReviewReworkFinding{
+				Source:     finding.Source,
+				Severity:   finding.Severity,
+				File:       finding.File,
+				Line:       finding.Line,
+				Issue:      finding.Issue,
+				Suggestion: finding.Suggestion,
 			})
 		}
 	}
@@ -810,8 +873,8 @@ type reviewFinding struct {
 
 // reviewerMsg is sent from reviewer goroutines to the parent via channel.
 type reviewerMsg struct {
-	Event  *Event  // emit this event (nil if not an event)
-	Log    *reviewerLog // write this log (nil if not a log)
+	Event  *Event          // emit this event (nil if not an event)
+	Log    *reviewerLog    // write this log (nil if not a log)
 	Result *reviewerResult // final result (nil if not done)
 	Index  int
 }

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -26,24 +26,36 @@ const (
 	Checkpoint
 )
 
+// DefaultMaxReworkCycles is the default limit for review→implement rework loops.
+const DefaultMaxReworkCycles = 2
+
 // EngineConfig holds everything needed to construct an Engine.
 type EngineConfig struct {
-	Pipeline      *PhasePipeline
-	Loader        *PromptLoader
-	Ticket        TicketData
-	PromptConfig  PromptConfigData
-	PromptContext ContextData
-	Model         string
-	WorkDir       string
-	WorktreeBase  string
-	BaseBranch    string
-	MaxCostUSD    float64
-	Mode          Mode
-	OnEvent       func(Event)
-	SleepFunc     func(time.Duration)
-	JitterFunc    func(max time.Duration) time.Duration
-	PRPoller      PRPoller         // for monitor phase polling; nil disables monitor
-	NowFunc       func() time.Time // for testability; defaults to time.Now
+	Pipeline        *PhasePipeline
+	Loader          *PromptLoader
+	Ticket          TicketData
+	PromptConfig    PromptConfigData
+	PromptContext   ContextData
+	Model           string
+	WorkDir         string
+	WorktreeBase    string
+	BaseBranch      string
+	MaxCostUSD      float64
+	MaxReworkCycles int // max review→implement rework loops; 0 means use default (2)
+	Mode            Mode
+	OnEvent         func(Event)
+	SleepFunc       func(time.Duration)
+	JitterFunc      func(max time.Duration) time.Duration
+	PRPoller        PRPoller         // for monitor phase polling; nil disables monitor
+	NowFunc         func() time.Time // for testability; defaults to time.Now
+}
+
+// maxReworkCycles returns the configured max rework cycles, defaulting to DefaultMaxReworkCycles.
+func (c *EngineConfig) maxReworkCycles() int {
+	if c.MaxReworkCycles > 0 {
+		return c.MaxReworkCycles
+	}
+	return DefaultMaxReworkCycles
 }
 
 // Engine orchestrates a pipeline run, tying together the runner,

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -150,32 +150,8 @@ func (e *Engine) Run(ctx context.Context) error {
 	e.reranPhases = make(map[string]bool)
 	e.emit(Event{Kind: EventEngineStarted})
 
-	for _, phase := range e.config.Pipeline.Phases {
-		if err := ctx.Err(); err != nil {
-			return fmt.Errorf("engine: context cancelled: %w", err)
-		}
-
-		if e.shouldSkip(phase) {
-			if err := e.gatePhase(phase); err != nil {
-				return err
-			}
-			e.emit(Event{Phase: phase.Name, Kind: EventPhaseSkipped})
-			continue
-		}
-
-		if err := e.runPhase(ctx, phase); err != nil {
-			return err
-		}
-		e.reranPhases[phase.Name] = true
-
-		if e.config.Mode == Checkpoint {
-			e.emit(Event{Phase: phase.Name, Kind: EventCheckpointPause})
-			select {
-			case <-e.confirmCh:
-			case <-ctx.Done():
-				return fmt.Errorf("engine: context cancelled during checkpoint: %w", ctx.Err())
-			}
-		}
+	if err := e.executePhases(ctx, e.config.Pipeline.Phases, false); err != nil {
+		return err
 	}
 
 	e.emit(Event{Kind: EventEngineCompleted})
@@ -212,15 +188,30 @@ func (e *Engine) Resume(ctx context.Context, fromPhase string) error {
 	e.reranPhases = make(map[string]bool)
 	e.emit(Event{Kind: EventEngineStarted, Data: map[string]any{"resumed_from": fromPhase}})
 
-	for i, phase := range e.config.Pipeline.Phases[startIdx:] {
+	// The fromPhase (first in slice) is always re-run, even if completed.
+	// Mark it with forceFirst=true so executePhases skips the shouldSkip check.
+	if err := e.executePhases(ctx, e.config.Pipeline.Phases[startIdx:], true); err != nil {
+		return err
+	}
+
+	e.emit(Event{Kind: EventEngineCompleted})
+	return nil
+}
+
+// executePhases runs a slice of phases, handling skip logic, checkpoint
+// pauses, and review rework routing. When forceFirst is true, the first
+// phase in the slice is always re-run regardless of completion status.
+func (e *Engine) executePhases(ctx context.Context, phases []PhaseConfig, forceFirst bool) error {
+	for idx, phase := range phases {
 		if err := ctx.Err(); err != nil {
 			return fmt.Errorf("engine: context cancelled: %w", err)
 		}
 
-		// The fromPhase (i==0) is always re-run, even if completed.
-		// Subsequent phases use shouldSkip to check dependency invalidation.
-		if i > 0 && e.shouldSkip(phase) {
+		skipCheck := !(forceFirst && idx == 0)
+		if skipCheck && e.shouldSkip(phase) {
 			if err := e.gatePhase(phase); err != nil {
+				// reviewReworkSignal on a skipped phase shouldn't happen
+				// in practice, but treat it as a normal gate error.
 				return err
 			}
 			e.emit(Event{Phase: phase.Name, Kind: EventPhaseSkipped})
@@ -228,6 +219,11 @@ func (e *Engine) Resume(ctx context.Context, fromPhase string) error {
 		}
 
 		if err := e.runPhase(ctx, phase); err != nil {
+			// Check for review rework signal — route back to implement.
+			var reworkSig *reviewReworkSignal
+			if errors.As(err, &reworkSig) {
+				return e.handleReviewRework(ctx, phase)
+			}
 			return err
 		}
 		e.reranPhases[phase.Name] = true
@@ -242,8 +238,48 @@ func (e *Engine) Resume(ctx context.Context, fromPhase string) error {
 		}
 	}
 
-	e.emit(Event{Kind: EventEngineCompleted})
 	return nil
+}
+
+// handleReviewRework routes the pipeline back to implement after a review
+// produces a "rework" verdict. It increments the rework cycle counter,
+// emits a routing event, and resumes execution from the implement phase.
+func (e *Engine) handleReviewRework(ctx context.Context, reviewPhase PhaseConfig) error {
+	e.state.Meta().ReworkCycles++
+	cycle := e.state.Meta().ReworkCycles
+
+	e.emit(Event{
+		Phase: reviewPhase.Name,
+		Kind:  EventReviewReworkRouted,
+		Data: map[string]any{
+			"rework_cycle":      cycle,
+			"max_rework_cycles": e.config.maxReworkCycles(),
+			"routing_to":        "implement",
+		},
+	})
+
+	// Flush meta to persist the rework cycle count.
+	if err := e.state.flushMeta(); err != nil {
+		return fmt.Errorf("engine: flush meta after rework routing: %w", err)
+	}
+
+	// Find implement's index and re-run from there.
+	implIdx := -1
+	for idx, phase := range e.config.Pipeline.Phases {
+		if phase.Name == "implement" {
+			implIdx = idx
+			break
+		}
+	}
+	if implIdx < 0 {
+		return fmt.Errorf("engine: review rework routing requires an implement phase in the pipeline")
+	}
+
+	// Mark implement and all downstream phases as needing re-run.
+	// The forceFirst=true flag on executePhases ensures implement runs
+	// even if completed, and shouldSkip will invalidate downstream phases
+	// because we mark implement as re-ran.
+	return e.executePhases(ctx, e.config.Pipeline.Phases[implIdx:], true)
 }
 
 // Confirm unblocks the engine in Checkpoint mode.
@@ -837,18 +873,33 @@ func (e *Engine) gatePhase(phase PhaseConfig) error {
 			return nil
 		}
 		if strings.EqualFold(result.Verdict, "rework") {
-			var issues []string
-			for _, finding := range result.Findings {
-				sev := strings.ToLower(finding.Severity)
-				if sev == "critical" || sev == "major" {
-					issues = append(issues, finding.Issue)
+			// Rework routing is handled by the engine loop, not the gate.
+			// The gate only blocks when max rework cycles are exceeded.
+			maxCycles := e.config.maxReworkCycles()
+			if e.state.Meta().ReworkCycles >= maxCycles {
+				var issues []string
+				for _, finding := range result.Findings {
+					sev := strings.ToLower(finding.Severity)
+					if sev == "critical" || sev == "major" {
+						issues = append(issues, finding.Issue)
+					}
 				}
+				reason := fmt.Sprintf("review requires rework but max cycles (%d) reached", maxCycles)
+				if len(issues) > 0 {
+					reason += ": " + strings.Join(issues, "; ")
+				}
+				e.emit(Event{
+					Phase: phase.Name,
+					Kind:  EventReviewReworkMaxCycles,
+					Data: map[string]any{
+						"rework_cycles":     e.state.Meta().ReworkCycles,
+						"max_rework_cycles": maxCycles,
+					},
+				})
+				return &PhaseGateError{Phase: phase.Name, Reason: reason}
 			}
-			reason := "review requires rework"
-			if len(issues) > 0 {
-				reason = "review requires rework: " + strings.Join(issues, "; ")
-			}
-			return &PhaseGateError{Phase: phase.Name, Reason: reason}
+			// Signal rework needed — the engine loop will handle routing.
+			return &reviewReworkSignal{findings: result.Findings}
 		}
 
 	case "submit":

--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -3476,3 +3476,679 @@ func TestComputeReviewVerdict(t *testing.T) {
 		})
 	}
 }
+
+func TestEngine_ReviewReworkRouting(t *testing.T) {
+	t.Run("rework_routes_back_to_implement", func(t *testing.T) {
+		// Pipeline: implement → verify → review → submit
+		// Review produces "rework" verdict → engine routes back to implement.
+		// Second cycle: review passes → submit proceeds.
+		phases := []PhaseConfig{
+			{
+				Name:   "implement",
+				Prompt: "implement.md",
+				Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			},
+			{
+				Name:      "verify",
+				Prompt:    "verify.md",
+				DependsOn: []string{"implement"},
+				Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			},
+			{
+				Name:      "review",
+				Type:      "parallel-review",
+				DependsOn: []string{"implement", "verify"},
+				Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+				Reviewers: []ReviewerConfig{
+					{Name: "go-specialist", Prompt: "prompts/review-go.md", Focus: "Go idioms"},
+				},
+			},
+			{
+				Name:      "submit",
+				Prompt:    "submit.md",
+				DependsOn: []string{"review"},
+				Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			},
+		}
+
+		mock := &flexMockRunner{
+			responses: map[string][]flexResponse{
+				// First implement run.
+				"implement": {
+					{result: &runner.RunResult{
+						Output:  json.RawMessage(`{"tests_passed":true,"commits":1}`),
+						RawText: "Impl v1",
+						CostUSD: 0.50,
+					}},
+					// Second implement run (rework).
+					{result: &runner.RunResult{
+						Output:  json.RawMessage(`{"tests_passed":true,"commits":2}`),
+						RawText: "Impl v2 with fixes",
+						CostUSD: 0.60,
+					}},
+				},
+				// Verify runs twice (once per cycle).
+				"verify": {
+					{result: &runner.RunResult{
+						Output:  json.RawMessage(`{"verdict":"PASS"}`),
+						RawText: "Verify v1",
+						CostUSD: 0.15,
+					}},
+					{result: &runner.RunResult{
+						Output:  json.RawMessage(`{"verdict":"PASS"}`),
+						RawText: "Verify v2",
+						CostUSD: 0.15,
+					}},
+				},
+				// First review: rework.
+				"review/go-specialist": {
+					{result: &runner.RunResult{
+						Output:  json.RawMessage(`{"findings":[{"severity":"critical","file":"handler.go","line":42,"issue":"nil deref","suggestion":"add nil check"}]}`),
+						RawText: "Critical issue found",
+						CostUSD: 0.20,
+					}},
+					// Second review: pass.
+					{result: &runner.RunResult{
+						Output:  json.RawMessage(`{"findings":[]}`),
+						RawText: "No issues",
+						CostUSD: 0.15,
+					}},
+				},
+				"submit": {{
+					result: &runner.RunResult{
+						Output:  json.RawMessage(`{"pr_url":"https://github.com/org/repo/pull/1"}`),
+						RawText: "PR created",
+						CostUSD: 0.05,
+					},
+				}},
+			},
+		}
+
+		var events []Event
+		engine, state := setupReviewEngine(t, phases, mock, func(cfg *EngineConfig) {
+			cfg.OnEvent = func(e Event) {
+				events = append(events, e)
+			}
+		})
+
+		if err := engine.Run(context.Background()); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+
+		// All phases should be completed.
+		for _, name := range []string{"implement", "verify", "review", "submit"} {
+			if !state.IsCompleted(name) {
+				t.Errorf("phase %q should be completed", name)
+			}
+		}
+
+		// Rework cycle counter should be 1.
+		if state.Meta().ReworkCycles != 1 {
+			t.Errorf("ReworkCycles = %d, want 1", state.Meta().ReworkCycles)
+		}
+
+		// Should have review_rework_routed event.
+		hasRouted := false
+		for _, e := range events {
+			if e.Kind == EventReviewReworkRouted {
+				hasRouted = true
+				routingTo, _ := e.Data["routing_to"].(string)
+				if routingTo != "implement" {
+					t.Errorf("routing_to = %q, want %q", routingTo, "implement")
+				}
+			}
+		}
+		if !hasRouted {
+			t.Error("review_rework_routed event not emitted")
+		}
+
+		// Implement should have been called twice (original + rework).
+		implCalls := 0
+		for _, call := range mock.calls {
+			if call.Phase == "implement" {
+				implCalls++
+			}
+		}
+		if implCalls != 2 {
+			t.Errorf("implement called %d times, want 2", implCalls)
+		}
+	})
+
+	t.Run("max_rework_cycles_blocks", func(t *testing.T) {
+		// Pipeline: implement → review
+		// Review always returns "rework", max cycles = 1.
+		// First cycle routes back, second cycle gates.
+		phases := []PhaseConfig{
+			{
+				Name:   "implement",
+				Prompt: "implement.md",
+				Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			},
+			{
+				Name:      "review",
+				Type:      "parallel-review",
+				DependsOn: []string{"implement"},
+				Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+				Reviewers: []ReviewerConfig{
+					{Name: "go-specialist", Prompt: "prompts/review-go.md", Focus: "Go idioms"},
+				},
+			},
+		}
+
+		reworkFindings := `{"findings":[{"severity":"major","file":"x.go","line":1,"issue":"error not wrapped","suggestion":"use fmt.Errorf"}]}`
+
+		mock := &flexMockRunner{
+			responses: map[string][]flexResponse{
+				"implement": {
+					{result: &runner.RunResult{
+						Output:  json.RawMessage(`{"tests_passed":true,"commits":1}`),
+						RawText: "Impl v1",
+						CostUSD: 0.50,
+					}},
+					{result: &runner.RunResult{
+						Output:  json.RawMessage(`{"tests_passed":true,"commits":2}`),
+						RawText: "Impl v2",
+						CostUSD: 0.50,
+					}},
+				},
+				"review/go-specialist": {
+					{result: &runner.RunResult{
+						Output:  json.RawMessage(reworkFindings),
+						RawText: "Rework needed",
+						CostUSD: 0.15,
+					}},
+					{result: &runner.RunResult{
+						Output:  json.RawMessage(reworkFindings),
+						RawText: "Still needs rework",
+						CostUSD: 0.15,
+					}},
+				},
+			},
+		}
+
+		var events []Event
+		engine, state := setupReviewEngine(t, phases, mock, func(cfg *EngineConfig) {
+			cfg.MaxReworkCycles = 1
+			cfg.OnEvent = func(e Event) {
+				events = append(events, e)
+			}
+		})
+
+		err := engine.Run(context.Background())
+		if err == nil {
+			t.Fatal("expected PhaseGateError after max rework cycles")
+		}
+
+		var gateErr *PhaseGateError
+		if !errors.As(err, &gateErr) {
+			t.Fatalf("expected PhaseGateError, got: %T: %v", err, err)
+		}
+		if gateErr.Phase != "review" {
+			t.Errorf("gate error phase = %q, want %q", gateErr.Phase, "review")
+		}
+		if !strings.Contains(gateErr.Reason, "max cycles") {
+			t.Errorf("gate error should mention max cycles, got: %q", gateErr.Reason)
+		}
+
+		// Should have 1 rework cycle.
+		if state.Meta().ReworkCycles != 1 {
+			t.Errorf("ReworkCycles = %d, want 1", state.Meta().ReworkCycles)
+		}
+
+		// Should have both routing and max cycles events.
+		hasRouted := false
+		hasMaxCycles := false
+		for _, e := range events {
+			if e.Kind == EventReviewReworkRouted {
+				hasRouted = true
+			}
+			if e.Kind == EventReviewReworkMaxCycles {
+				hasMaxCycles = true
+			}
+		}
+		if !hasRouted {
+			t.Error("review_rework_routed event not emitted")
+		}
+		if !hasMaxCycles {
+			t.Error("review_rework_max_cycles event not emitted")
+		}
+	})
+
+	t.Run("pass_with_follow_ups_proceeds", func(t *testing.T) {
+		// Minor-only findings should not block and should proceed to submit.
+		phases := []PhaseConfig{
+			{
+				Name:   "implement",
+				Prompt: "implement.md",
+				Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			},
+			{
+				Name:      "review",
+				Type:      "parallel-review",
+				DependsOn: []string{"implement"},
+				Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+				Reviewers: []ReviewerConfig{
+					{Name: "go-specialist", Prompt: "prompts/review-go.md", Focus: "Go idioms"},
+				},
+			},
+			{
+				Name:      "submit",
+				Prompt:    "submit.md",
+				DependsOn: []string{"review"},
+				Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			},
+		}
+
+		mock := &flexMockRunner{
+			responses: map[string][]flexResponse{
+				"implement": {{
+					result: &runner.RunResult{
+						Output:  json.RawMessage(`{"tests_passed":true,"commits":1}`),
+						RawText: "Impl done",
+						CostUSD: 0.50,
+					},
+				}},
+				"review/go-specialist": {{
+					result: &runner.RunResult{
+						Output:  json.RawMessage(`{"findings":[{"severity":"minor","file":"util.go","issue":"naming style","suggestion":"rename var"}]}`),
+						RawText: "Minor issues only",
+						CostUSD: 0.10,
+					},
+				}},
+				"submit": {{
+					result: &runner.RunResult{
+						Output:  json.RawMessage(`{"pr_url":"https://github.com/org/repo/pull/1"}`),
+						RawText: "PR created",
+						CostUSD: 0.05,
+					},
+				}},
+			},
+		}
+
+		engine, state := setupReviewEngine(t, phases, mock)
+
+		if err := engine.Run(context.Background()); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+
+		// All phases including submit should complete.
+		for _, name := range []string{"implement", "review", "submit"} {
+			if !state.IsCompleted(name) {
+				t.Errorf("phase %q should be completed", name)
+			}
+		}
+
+		// No rework cycles should have occurred.
+		if state.Meta().ReworkCycles != 0 {
+			t.Errorf("ReworkCycles = %d, want 0", state.Meta().ReworkCycles)
+		}
+
+		// Verify verdict is pass-with-follow-ups.
+		result, err := state.ReadResult("review")
+		if err != nil {
+			t.Fatalf("ReadResult: %v", err)
+		}
+		var reviewOutput struct {
+			Verdict string `json:"verdict"`
+		}
+		if err := json.Unmarshal(result, &reviewOutput); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if reviewOutput.Verdict != "pass-with-follow-ups" {
+			t.Errorf("verdict = %q, want %q", reviewOutput.Verdict, "pass-with-follow-ups")
+		}
+	})
+
+	t.Run("no_findings_passes", func(t *testing.T) {
+		// No findings → proceed to submit without rework.
+		phases := []PhaseConfig{
+			{
+				Name:   "implement",
+				Prompt: "implement.md",
+				Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			},
+			{
+				Name:      "review",
+				Type:      "parallel-review",
+				DependsOn: []string{"implement"},
+				Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+				Reviewers: []ReviewerConfig{
+					{Name: "go-specialist", Prompt: "prompts/review-go.md", Focus: "Go idioms"},
+				},
+			},
+			{
+				Name:      "submit",
+				Prompt:    "submit.md",
+				DependsOn: []string{"review"},
+				Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			},
+		}
+
+		mock := &flexMockRunner{
+			responses: map[string][]flexResponse{
+				"implement": {{
+					result: &runner.RunResult{
+						Output:  json.RawMessage(`{"tests_passed":true,"commits":1}`),
+						RawText: "Impl done",
+						CostUSD: 0.50,
+					},
+				}},
+				"review/go-specialist": {{
+					result: &runner.RunResult{
+						Output:  json.RawMessage(`{"findings":[]}`),
+						RawText: "No issues",
+						CostUSD: 0.10,
+					},
+				}},
+				"submit": {{
+					result: &runner.RunResult{
+						Output:  json.RawMessage(`{"pr_url":"https://github.com/org/repo/pull/1"}`),
+						RawText: "PR created",
+						CostUSD: 0.05,
+					},
+				}},
+			},
+		}
+
+		engine, state := setupReviewEngine(t, phases, mock)
+
+		if err := engine.Run(context.Background()); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+
+		for _, name := range []string{"implement", "review", "submit"} {
+			if !state.IsCompleted(name) {
+				t.Errorf("phase %q should be completed", name)
+			}
+		}
+
+		if state.Meta().ReworkCycles != 0 {
+			t.Errorf("ReworkCycles = %d, want 0", state.Meta().ReworkCycles)
+		}
+	})
+}
+
+func TestEngine_ReviewReworkFeedbackInjected(t *testing.T) {
+	// When review rework routes back to implement, the implement prompt
+	// should contain the review findings.
+	phases := []PhaseConfig{
+		{
+			Name:   "implement",
+			Prompt: "implement.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+		{
+			Name:      "review",
+			Type:      "parallel-review",
+			DependsOn: []string{"implement"},
+			Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			Reviewers: []ReviewerConfig{
+				{Name: "go-specialist", Prompt: "prompts/review-go.md", Focus: "Go idioms"},
+				{Name: "ai-harness", Prompt: "prompts/review-harness.md", Focus: "AI harness"},
+			},
+		},
+	}
+
+	goFindings := `{"findings":[
+		{"severity":"critical","file":"handler.go","line":42,"issue":"nil pointer dereference","suggestion":"add nil check"}
+	]}`
+
+	harnessFindings := `{"findings":[
+		{"severity":"major","file":"prompts/plan.md","line":0,"issue":"missing template guard","suggestion":"add if block"}
+	]}`
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"implement": {
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(`{"tests_passed":true,"commits":1}`),
+					RawText: "Impl v1",
+					CostUSD: 0.50,
+				}},
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(`{"tests_passed":true,"commits":2}`),
+					RawText: "Impl v2",
+					CostUSD: 0.60,
+				}},
+			},
+			"review/go-specialist": {
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(goFindings),
+					RawText: "Critical issue",
+					CostUSD: 0.15,
+				}},
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(`{"findings":[]}`),
+					RawText: "All clear",
+					CostUSD: 0.10,
+				}},
+			},
+			"review/ai-harness": {
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(harnessFindings),
+					RawText: "Major issue",
+					CostUSD: 0.15,
+				}},
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(`{"findings":[]}`),
+					RawText: "All clear",
+					CostUSD: 0.10,
+				}},
+			},
+		},
+	}
+
+	stateDir := t.TempDir()
+	promptDir := t.TempDir()
+	workDir := t.TempDir()
+
+	// Write a prompt template that renders review rework feedback.
+	implTmpl := `Phase: implement
+Ticket: {{.Ticket.Key}}
+{{- if .ReworkFeedback}}
+REWORK_SOURCE: {{.ReworkFeedback.Source}}
+REWORK_VERDICT: {{.ReworkFeedback.Verdict}}
+{{- range .ReworkFeedback.ReviewFindings}}
+FINDING: {{.Source}} {{.Severity}} {{.File}}:{{.Line}} {{.Issue}} -> {{.Suggestion}}
+{{- end}}
+{{- end}}
+`
+	for _, name := range []string{"implement.md", "prompts/review-go.md", "prompts/review-harness.md"} {
+		tmplPath := filepath.Join(promptDir, name)
+		if err := os.MkdirAll(filepath.Dir(tmplPath), 0755); err != nil {
+			t.Fatal(err)
+		}
+		content := implTmpl
+		if strings.Contains(name, "review") {
+			content = fmt.Sprintf("Reviewer: %s\nTicket: {{.Ticket.Key}}\n", name)
+		}
+		if err := os.WriteFile(tmplPath, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	state, err := LoadOrCreate(stateDir, "REVFB-1")
+	if err != nil {
+		t.Fatalf("LoadOrCreate: %v", err)
+	}
+
+	var events []Event
+	cfg := EngineConfig{
+		Pipeline:   &PhasePipeline{Phases: phases},
+		Loader:     NewPromptLoader(promptDir),
+		Ticket:     TicketData{Key: "REVFB-1", Summary: "Review feedback test"},
+		Model:      "test-model",
+		WorkDir:    workDir,
+		MaxCostUSD: 0,
+		Mode:       Autonomous,
+		SleepFunc:  func(time.Duration) {},
+		JitterFunc: func(time.Duration) time.Duration { return 0 },
+		OnEvent: func(e Event) {
+			events = append(events, e)
+		},
+	}
+
+	engine := NewEngine(mock, state, cfg)
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// Find the second implement call (the rework run).
+	implCalls := 0
+	var reworkPrompt string
+	for _, call := range mock.calls {
+		if call.Phase == "implement" {
+			implCalls++
+			if implCalls == 2 {
+				reworkPrompt = call.SystemPrompt
+			}
+		}
+	}
+	if implCalls != 2 {
+		t.Fatalf("implement called %d times, want 2", implCalls)
+	}
+
+	// The rework prompt should contain review findings.
+	if !strings.Contains(reworkPrompt, "REWORK_SOURCE: review") {
+		t.Errorf("rework prompt should contain REWORK_SOURCE: review;\ngot: %s", reworkPrompt)
+	}
+	if !strings.Contains(reworkPrompt, "REWORK_VERDICT: rework") {
+		t.Errorf("rework prompt should contain REWORK_VERDICT: rework;\ngot: %s", reworkPrompt)
+	}
+	if !strings.Contains(reworkPrompt, "FINDING: go-specialist critical handler.go:42 nil pointer dereference -> add nil check") {
+		t.Errorf("rework prompt should contain go-specialist finding;\ngot: %s", reworkPrompt)
+	}
+	if !strings.Contains(reworkPrompt, "FINDING: ai-harness major prompts/plan.md:0 missing template guard -> add if block") {
+		t.Errorf("rework prompt should contain ai-harness finding;\ngot: %s", reworkPrompt)
+	}
+
+	// Should have rework_feedback_injected event.
+	hasInjection := false
+	for _, e := range events {
+		if e.Kind == EventReworkFeedbackInjected {
+			hasInjection = true
+			source, _ := e.Data["source"].(string)
+			if source != "review" {
+				t.Errorf("injection event source = %q, want %q", source, "review")
+			}
+		}
+	}
+	if !hasInjection {
+		t.Error("rework_feedback_injected event not emitted for review rework")
+	}
+}
+
+func TestEngine_ReviewReworkDefaultMaxCycles(t *testing.T) {
+	// Verify that the default max rework cycles is 2.
+	cfg := EngineConfig{}
+	if cfg.maxReworkCycles() != DefaultMaxReworkCycles {
+		t.Errorf("default maxReworkCycles() = %d, want %d", cfg.maxReworkCycles(), DefaultMaxReworkCycles)
+	}
+	if DefaultMaxReworkCycles != 2 {
+		t.Errorf("DefaultMaxReworkCycles = %d, want 2", DefaultMaxReworkCycles)
+	}
+}
+
+func TestEngine_ReviewReworkCyclesPersisted(t *testing.T) {
+	// Verify rework cycles are persisted to meta.json across engine restarts.
+	stateDir := t.TempDir()
+	state, err := LoadOrCreate(stateDir, "PERSIST-1")
+	if err != nil {
+		t.Fatalf("LoadOrCreate: %v", err)
+	}
+
+	state.Meta().ReworkCycles = 3
+	if err := state.flushMeta(); err != nil {
+		t.Fatalf("flushMeta: %v", err)
+	}
+
+	// Re-read state from disk.
+	state2, err := LoadOrCreate(stateDir, "PERSIST-1")
+	if err != nil {
+		t.Fatalf("LoadOrCreate: %v", err)
+	}
+
+	if state2.Meta().ReworkCycles != 3 {
+		t.Errorf("ReworkCycles after reload = %d, want 3", state2.Meta().ReworkCycles)
+	}
+}
+
+func TestExtractReviewReworkFeedback(t *testing.T) {
+	t.Run("returns_nil_when_no_review_result", func(t *testing.T) {
+		stateDir := t.TempDir()
+		state, _ := LoadOrCreate(stateDir, "TEST-1")
+
+		engine := &Engine{state: state, config: EngineConfig{}}
+		if fb := engine.extractReviewReworkFeedback(); fb != nil {
+			t.Error("expected nil when no review result exists")
+		}
+	})
+
+	t.Run("returns_nil_when_verdict_is_pass", func(t *testing.T) {
+		stateDir := t.TempDir()
+		state, _ := LoadOrCreate(stateDir, "TEST-1")
+		_ = state.MarkRunning("review")
+		_ = state.WriteResult("review", json.RawMessage(`{"verdict":"pass","findings":[]}`))
+		_ = state.MarkCompleted("review")
+
+		engine := &Engine{state: state, config: EngineConfig{}}
+		if fb := engine.extractReviewReworkFeedback(); fb != nil {
+			t.Error("expected nil when verdict is pass")
+		}
+	})
+
+	t.Run("returns_nil_when_verdict_is_pass_with_follow_ups", func(t *testing.T) {
+		stateDir := t.TempDir()
+		state, _ := LoadOrCreate(stateDir, "TEST-1")
+		_ = state.MarkRunning("review")
+		_ = state.WriteResult("review", json.RawMessage(`{"verdict":"pass-with-follow-ups","findings":[{"severity":"minor","issue":"style"}]}`))
+		_ = state.MarkCompleted("review")
+
+		engine := &Engine{state: state, config: EngineConfig{}}
+		if fb := engine.extractReviewReworkFeedback(); fb != nil {
+			t.Error("expected nil when verdict is pass-with-follow-ups")
+		}
+	})
+
+	t.Run("returns_feedback_when_verdict_is_rework", func(t *testing.T) {
+		stateDir := t.TempDir()
+		state, _ := LoadOrCreate(stateDir, "TEST-1")
+		_ = state.MarkRunning("review")
+		reviewResult := `{
+			"verdict": "rework",
+			"findings": [
+				{"source":"go-specialist","severity":"critical","file":"a.go","line":10,"issue":"nil deref","suggestion":"check nil"},
+				{"source":"ai-harness","severity":"major","file":"b.go","line":20,"issue":"missing guard","suggestion":"add guard"},
+				{"source":"go-specialist","severity":"minor","file":"c.go","line":30,"issue":"naming","suggestion":"rename"}
+			]
+		}`
+		_ = state.WriteResult("review", json.RawMessage(reviewResult))
+		_ = state.MarkCompleted("review")
+
+		engine := &Engine{state: state, config: EngineConfig{}}
+		fb := engine.extractReviewReworkFeedback()
+		if fb == nil {
+			t.Fatal("expected non-nil feedback for rework verdict")
+		}
+
+		if fb.Source != "review" {
+			t.Errorf("Source = %q, want %q", fb.Source, "review")
+		}
+		if fb.Verdict != "rework" {
+			t.Errorf("Verdict = %q, want %q", fb.Verdict, "rework")
+		}
+
+		// Only critical and major findings should be included (not minor).
+		if len(fb.ReviewFindings) != 2 {
+			t.Fatalf("ReviewFindings count = %d, want 2", len(fb.ReviewFindings))
+		}
+
+		if fb.ReviewFindings[0].Source != "go-specialist" || fb.ReviewFindings[0].Severity != "critical" {
+			t.Errorf("first finding = %+v, want go-specialist/critical", fb.ReviewFindings[0])
+		}
+		if fb.ReviewFindings[1].Source != "ai-harness" || fb.ReviewFindings[1].Severity != "major" {
+			t.Errorf("second finding = %+v, want ai-harness/major", fb.ReviewFindings[1])
+		}
+	})
+}

--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -2933,6 +2933,8 @@ func TestEngine_ParallelReview_HappyPath(t *testing.T) {
 }
 
 func TestEngine_ParallelReview_MergedFindings(t *testing.T) {
+	// When max rework cycles is reached (set to 0), review with
+	// critical/major findings should gate with a PhaseGateError.
 	phases := []PhaseConfig{
 		{
 			Name:  "review",
@@ -2973,11 +2975,15 @@ func TestEngine_ParallelReview_MergedFindings(t *testing.T) {
 		},
 	}
 
-	engine, state := setupReviewEngine(t, phases, mock)
+	engine, state := setupReviewEngine(t, phases, mock, func(cfg *EngineConfig) {
+		// Pre-exhaust rework cycles so the gate blocks immediately.
+		cfg.MaxReworkCycles = 1
+	})
+	state.Meta().ReworkCycles = 1
 
 	err := engine.Run(context.Background())
 	if err == nil {
-		t.Fatal("expected PhaseGateError for review with critical/major findings")
+		t.Fatal("expected PhaseGateError for review with critical/major findings at max cycles")
 	}
 
 	var gateErr *PhaseGateError
@@ -2989,6 +2995,9 @@ func TestEngine_ParallelReview_MergedFindings(t *testing.T) {
 	}
 	if !strings.Contains(gateErr.Reason, "rework") {
 		t.Errorf("gate error reason should contain 'rework', got: %q", gateErr.Reason)
+	}
+	if !strings.Contains(gateErr.Reason, "max cycles") {
+		t.Errorf("gate error reason should mention max cycles, got: %q", gateErr.Reason)
 	}
 
 	// Verify the merged result contains findings from both reviewers.

--- a/internal/pipeline/errors.go
+++ b/internal/pipeline/errors.go
@@ -1,6 +1,9 @@
 package pipeline
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // BudgetExceededError is returned when accumulated cost exceeds the configured limit.
 type BudgetExceededError struct {
@@ -33,4 +36,29 @@ type PhaseGateError struct {
 
 func (e *PhaseGateError) Error() string {
 	return fmt.Sprintf("pipeline: phase %s gated: %s", e.Phase, e.Reason)
+}
+
+// reviewReworkSignal is an internal sentinel error used by gatePhase to
+// signal the engine loop that the review phase produced a "rework" verdict
+// and the pipeline should route back to implement. This is NOT a terminal
+// error — the engine loop catches it and handles routing.
+type reviewReworkSignal struct {
+	findings []struct {
+		Severity string `json:"severity"`
+		Issue    string `json:"issue"`
+	}
+}
+
+func (e *reviewReworkSignal) Error() string {
+	var issues []string
+	for _, finding := range e.findings {
+		sev := strings.ToLower(finding.Severity)
+		if sev == "critical" || sev == "major" {
+			issues = append(issues, finding.Issue)
+		}
+	}
+	if len(issues) > 0 {
+		return "review rework signal: " + strings.Join(issues, "; ")
+	}
+	return "review rework signal"
 }

--- a/internal/pipeline/events.go
+++ b/internal/pipeline/events.go
@@ -50,6 +50,8 @@ const (
 	EventReviewerCompleted      = "reviewer_completed"
 	EventReviewerFailed         = "reviewer_failed"
 	EventReviewMerged           = "review_merged"
+	EventReviewReworkRouted     = "review_rework_routed"
+	EventReviewReworkMaxCycles  = "review_rework_max_cycles"
 )
 
 // logEvent appends an event to the events.jsonl file in dir.

--- a/internal/pipeline/meta.go
+++ b/internal/pipeline/meta.go
@@ -32,13 +32,14 @@ type PhaseState struct {
 
 // PipelineMeta is the top-level state stored in meta.json.
 type PipelineMeta struct {
-	Ticket    string                 `json:"ticket"`
-	Summary   string                 `json:"summary,omitempty"`
-	Branch    string                 `json:"branch,omitempty"`
-	Worktree  string                 `json:"worktree,omitempty"`
-	StartedAt time.Time              `json:"started_at"`
-	TotalCost float64                `json:"total_cost"`
-	Phases    map[string]*PhaseState `json:"phases"`
+	Ticket       string                 `json:"ticket"`
+	Summary      string                 `json:"summary,omitempty"`
+	Branch       string                 `json:"branch,omitempty"`
+	Worktree     string                 `json:"worktree,omitempty"`
+	StartedAt    time.Time              `json:"started_at"`
+	TotalCost    float64                `json:"total_cost"`
+	ReworkCycles int                    `json:"rework_cycles,omitempty"`
+	Phases       map[string]*PhaseState `json:"phases"`
 }
 
 // ReadMeta reads and unmarshals a meta.json file.

--- a/internal/pipeline/prompt.go
+++ b/internal/pipeline/prompt.go
@@ -25,14 +25,27 @@ type PromptData struct {
 	ReworkFeedback *ReworkFeedback
 }
 
-// ReworkFeedback holds selective feedback from a failed verify phase,
-// injected into implement's prompt on resume.
+// ReworkFeedback holds selective feedback from a failed verify phase
+// or a review-rework verdict, injected into implement's prompt on resume.
 type ReworkFeedback struct {
 	Verdict        string
+	Source         string // "verify" or "review"
 	FixesRequired  []string
 	FailedCriteria []FailedCriterion
 	CodeIssues     []ReworkCodeIssue
 	FailedCommands []FailedCommand
+	ReviewFindings []ReviewReworkFinding
+}
+
+// ReviewReworkFinding holds a critical or major finding from a specialist
+// reviewer, injected into the implement prompt for rework.
+type ReviewReworkFinding struct {
+	Source     string // reviewer name, e.g. "go-specialist"
+	Severity   string // "critical" or "major"
+	File       string
+	Line       int
+	Issue      string
+	Suggestion string
 }
 
 // FailedCriterion is a single acceptance criterion that failed verification.

--- a/phases.yaml
+++ b/phases.yaml
@@ -101,6 +101,10 @@ phases:
       - name: ai-harness
         prompt: prompts/review-harness.md
         focus: "prompt engineering, context budget, Claude CLI integration, sandbox, structured output"
+    # Routing: critical/major → rework (route back to implement),
+    # minor → follow-up (proceed to submit, queue follow-up phase),
+    # none → pass (proceed to submit).
+    # Max rework cycles is configured in EngineConfig (default: 2).
 
   - name: submit
     prompt: prompts/submit.md


### PR DESCRIPTION
## Summary

- Route pipeline after review verdict: rework loops back to implement, pass-with-follow-ups proceeds to submit
- Reuse ReworkFeedback pattern from #75 for review findings injection
- Add max rework cycles tracking

Closes #78

## Test plan

- [x] `go test ./...` passes
- [x] `go vet` clean
- [x] Verify phase completed

Assisted-by: SODA