### PR TITLE
refactor(pipeline): extract engine.now() helper (#100)

### DIFF
--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -1326,6 +1326,14 @@ func (e *Engine) runMonitorStub(phase PhaseConfig) error {
 	return nil
 }
 
+// now returns the current time, using NowFunc if configured for testability.
+func (e *Engine) now() time.Time {
+	if e.config.NowFunc != nil {
+		return e.config.NowFunc()
+	}
+	return time.Now()
+}
+
 // workDir returns the working directory for a phase, preferring the worktree
 // if one has been created.
 func (e *Engine) workDir(phase PhaseConfig) string {

--- a/internal/pipeline/monitor_poll.go
+++ b/internal/pipeline/monitor_poll.go
@@ -99,10 +99,7 @@ func (e *Engine) runMonitor(ctx context.Context, phase PhaseConfig) error {
 		return fmt.Errorf("engine: write initial monitor state: %w", err)
 	}
 
-	startTime := time.Now()
-	if e.config.NowFunc != nil {
-		startTime = e.config.NowFunc()
-	}
+	startTime := e.now()
 
 	// Polling loop.
 	for {
@@ -114,10 +111,7 @@ func (e *Engine) runMonitor(ctx context.Context, phase PhaseConfig) error {
 		}
 
 		// Check max duration timeout.
-		now := time.Now()
-		if e.config.NowFunc != nil {
-			now = e.config.NowFunc()
-		}
+		now := e.now()
 		if now.Sub(startTime) >= polling.MaxDuration.Duration {
 			monState.Status = MonitorFailed
 			_ = e.state.WriteMonitorState(monState)


### PR DESCRIPTION
## Summary
- Extracts a `func (e *Engine) now() time.Time` helper that centralizes the `NowFunc` nil-check fallback
- Replaces 2 instances of the 4-line pattern in `monitor_poll.go` with single-line `e.now()` calls

Closes #100

## Test plan
- [x] `go test ./internal/pipeline/...` passes
- [x] Existing `NowFunc`-based tests still work (monitor poll timeout test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)