### PR TITLE
fix(pipeline): classify sandbox ExitError as transient (#108)

### DIFF
--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -14,6 +14,7 @@ import (
 	"github.com/decko/soda/internal/claude"
 	"github.com/decko/soda/internal/git"
 	"github.com/decko/soda/internal/runner"
+	"github.com/decko/soda/internal/sandbox"
 )
 
 // Mode controls whether the engine pauses between phases.
@@ -506,6 +507,12 @@ func classifyError(err error) string {
 	var se *claude.SemanticError
 	if errors.As(err, &se) {
 		return "semantic"
+	}
+	var ee *sandbox.ExitError
+	if errors.As(err, &ee) {
+		if ee.OOMKill || ee.Signal != 0 {
+			return "transient"
+		}
 	}
 	return "unknown"
 }

--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/decko/soda/internal/claude"
 	"github.com/decko/soda/internal/runner"
+	"github.com/decko/soda/internal/sandbox"
 )
 
 // flexMockRunner returns per-call responses, allowing multi-call test scenarios
@@ -699,6 +700,10 @@ func TestClassifyError(t *testing.T) {
 		{"semantic", &claude.SemanticError{Message: "bad"}, "semantic"},
 		{"unknown", fmt.Errorf("something else"), "unknown"},
 		{"wrapped_transient", fmt.Errorf("wrap: %w", &claude.TransientError{Reason: "r", Err: fmt.Errorf("x")}), "transient"},
+		{"sandbox_oom", &sandbox.ExitError{OOMKill: true, Signal: 9}, "transient"},
+		{"sandbox_signal", &sandbox.ExitError{Signal: 15}, "transient"},
+		{"sandbox_exit_code", &sandbox.ExitError{Code: 1}, "unknown"},
+		{"wrapped_sandbox_oom", fmt.Errorf("wrap: %w", &sandbox.ExitError{OOMKill: true}), "transient"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Adds `sandbox.ExitError` handling to `classifyError`: OOM kills and signal kills map to `"transient"` (retriable)
- Plain exit-code failures remain `"unknown"` (not retriable)
- Adds 4 test cases: OOM, signal, exit-code-only, and wrapped OOM

Closes #108

## Test plan
- [x] `go test ./internal/pipeline/...` passes (CGO_ENABLED=0)
- [x] New test cases cover OOM → transient, signal → transient, exit-code → unknown, wrapped OOM → transient

🤖 Generated with [Claude Code](https://claude.com/claude-code)