### PR TITLE
refactor(pipeline): add PhaseSkipped constant and migrate os.IsNotExist (#117)

### DIFF
--- a/cmd/soda/clean.go
+++ b/cmd/soda/clean.go
@@ -47,7 +47,7 @@ func newCleanCmd() *cobra.Command {
 func cleanAll(stateDir string, dryRun bool) error {
 	entries, err := os.ReadDir(stateDir)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			fmt.Println("No pipelines found.")
 			return nil
 		}

--- a/cmd/soda/history.go
+++ b/cmd/soda/history.go
@@ -199,7 +199,7 @@ func statusSymbol(status pipeline.PhaseStatus, superseded bool) string {
 		return "✗"
 	case pipeline.PhaseRunning:
 		return "⧗"
-	case "skipped":
+	case pipeline.PhaseSkipped:
 		return "⏭"
 	default:
 		return string(status)

--- a/cmd/soda/history_test.go
+++ b/cmd/soda/history_test.go
@@ -15,7 +15,7 @@ func TestStatusSymbol(t *testing.T) {
 		{pipeline.PhaseCompleted, false, "✓"},
 		{pipeline.PhaseFailed, false, "✗"},
 		{pipeline.PhaseRunning, false, "⧗"},
-		{"skipped", false, "⏭"},
+		{pipeline.PhaseSkipped, false, "⏭"},
 		{pipeline.PhasePending, false, "pending"},
 
 		// Superseded variants.

--- a/cmd/soda/status.go
+++ b/cmd/soda/status.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -28,7 +29,7 @@ func newStatusCmd() *cobra.Command {
 func runStatus(stateDir string) error {
 	entries, err := os.ReadDir(stateDir)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			fmt.Println("No pipelines found.")
 			return nil
 		}

--- a/internal/pipeline/atomic_test.go
+++ b/internal/pipeline/atomic_test.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -25,7 +26,7 @@ func TestAtomicWrite(t *testing.T) {
 
 		// Verify no .tmp file left behind
 		tmpPath := path + ".tmp"
-		if _, err := os.Stat(tmpPath); !os.IsNotExist(err) {
+		if _, err := os.Stat(tmpPath); !errors.Is(err, os.ErrNotExist) {
 			t.Errorf("temp file should not exist, got err: %v", err)
 		}
 	})
@@ -94,7 +95,7 @@ func TestArchiveArtifact(t *testing.T) {
 		}
 
 		// Original should be gone
-		if _, err := os.Stat(path); !os.IsNotExist(err) {
+		if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
 			t.Error("original file should not exist after archive")
 		}
 

--- a/internal/pipeline/events.go
+++ b/internal/pipeline/events.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -66,7 +67,7 @@ func ReadEvents(dir string) ([]Event, error) {
 	path := filepath.Join(dir, "events.jsonl")
 	data, err := os.ReadFile(path)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("pipeline: read events %s: %w", path, err)

--- a/internal/pipeline/history.go
+++ b/internal/pipeline/history.go
@@ -104,7 +104,7 @@ func BuildHistory(events []Event, stateDir string) History {
 		case EventPhaseSkipped:
 			entry := PhaseGeneration{
 				Phase:  ev.Phase,
-				Status: "skipped",
+				Status: PhaseSkipped,
 			}
 			idx := len(h.Entries)
 			h.Entries = append(h.Entries, entry)

--- a/internal/pipeline/history_integration_test.go
+++ b/internal/pipeline/history_integration_test.go
@@ -151,10 +151,10 @@ func TestBuildHistory_MixedSkipAndRun(t *testing.T) {
 	}
 
 	// First two should be skipped.
-	if h.Entries[0].Status != "skipped" {
+	if h.Entries[0].Status != PhaseSkipped {
 		t.Errorf("triage status = %q, want skipped", h.Entries[0].Status)
 	}
-	if h.Entries[1].Status != "skipped" {
+	if h.Entries[1].Status != PhaseSkipped {
 		t.Errorf("plan status = %q, want skipped", h.Entries[1].Status)
 	}
 

--- a/internal/pipeline/history_test.go
+++ b/internal/pipeline/history_test.go
@@ -115,7 +115,7 @@ func TestBuildHistory_SkippedPhase(t *testing.T) {
 		t.Fatalf("expected 2 entries, got %d", len(h.Entries))
 	}
 
-	if h.Entries[1].Status != "skipped" {
+	if h.Entries[1].Status != PhaseSkipped {
 		t.Errorf("plan status=%q, want skipped", h.Entries[1].Status)
 	}
 }

--- a/internal/pipeline/meta.go
+++ b/internal/pipeline/meta.go
@@ -17,6 +17,7 @@ const (
 	PhaseFailed    PhaseStatus = "failed"
 	PhaseRetrying  PhaseStatus = "retrying"
 	PhasePaused    PhaseStatus = "paused"
+	PhaseSkipped   PhaseStatus = "skipped"
 )
 
 // PhaseState holds the status and metrics for a single phase.

--- a/internal/pipeline/monitor_test.go
+++ b/internal/pipeline/monitor_test.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -119,7 +120,7 @@ func TestReadMonitorState(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error for missing monitor.json")
 		}
-		if !os.IsNotExist(err) {
+		if !errors.Is(err, os.ErrNotExist) {
 			t.Errorf("expected os.ErrNotExist, got: %v", err)
 		}
 	})


### PR DESCRIPTION
## Summary
- Adds `PhaseSkipped PhaseStatus = "skipped"` constant to the enum
- Replaces string literal `"skipped"` with `PhaseSkipped` in history.go, history.go cmd, and tests
- Migrates `os.IsNotExist()` → `errors.Is(err, os.ErrNotExist)` across pipeline and cmd packages

Closes #117

## Test plan
- [x] `go test ./internal/pipeline/... ./cmd/soda/...` passes
- [x] All existing "skipped" comparisons use the typed constant

🤖 Generated with [Claude Code](https://claude.com/claude-code)