### PR TITLE
fix(cli): guard empty failedPhase and inline resumeFrom (#98, #99)

### DIFF
--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -689,16 +689,22 @@ func formatNextSteps(w io.Writer, meta *pipeline.PipelineMeta, phases []pipeline
 		fmt.Fprintf(w, "    soda run %s --from %s  (resume with higher budget)\n", ticket, be.Phase)
 
 	case isTransientError(runErr):
-		resumeFrom := failedPhase
 		fmt.Fprintf(w, "  A transient error occurred (network, rate-limit, or timeout).\n")
 		fmt.Fprintf(w, "  • Wait a moment and retry:\n")
-		fmt.Fprintf(w, "    soda run %s --from %s  (retry the failed phase)\n", ticket, resumeFrom)
+		if failedPhase != "" {
+			fmt.Fprintf(w, "    soda run %s --from %s  (retry the failed phase)\n", ticket, failedPhase)
+		} else {
+			fmt.Fprintf(w, "    soda run %s\n", ticket)
+		}
 
 	case isParseError(runErr):
-		resumeFrom := failedPhase
 		fmt.Fprintf(w, "  The model returned output that could not be parsed.\n")
 		fmt.Fprintf(w, "  • Retry (the model may produce valid output on the next attempt):\n")
-		fmt.Fprintf(w, "    soda run %s --from %s  (retry with a fresh attempt)\n", ticket, resumeFrom)
+		if failedPhase != "" {
+			fmt.Fprintf(w, "    soda run %s --from %s  (retry with a fresh attempt)\n", ticket, failedPhase)
+		} else {
+			fmt.Fprintf(w, "    soda run %s\n", ticket)
+		}
 
 	default:
 		// Generic fallback: suggest resuming from predecessor or failed phase.

--- a/cmd/soda/run_test.go
+++ b/cmd/soda/run_test.go
@@ -624,6 +624,50 @@ func TestPrintSummaryParseError(t *testing.T) {
 	}
 }
 
+func TestPrintSummaryTransientErrorEmptyPhase(t *testing.T) {
+	dir := t.TempDir()
+	state, _ := pipeline.LoadOrCreate(dir, "PROJ-31")
+	meta := state.Meta()
+	meta.Branch = "soda/PROJ-31"
+	meta.TotalCost = 0.10
+
+	// No phase has PhaseFailed, so failedPhase will be "".
+	transientErr := fmt.Errorf("engine: transient: %w",
+		&claude.TransientError{Reason: "timeout", Err: fmt.Errorf("connection reset")})
+	var buf bytes.Buffer
+	fprintSummary(&buf, state, testPhases(), "Transient empty phase", 30*time.Second, transientErr, nil)
+	output := buf.String()
+
+	if strings.Contains(output, "--from ") {
+		t.Error("should not suggest --from when failedPhase is empty")
+	}
+	if !strings.Contains(output, "soda run PROJ-31") {
+		t.Error("expected bare soda run suggestion")
+	}
+}
+
+func TestPrintSummaryParseErrorEmptyPhase(t *testing.T) {
+	dir := t.TempDir()
+	state, _ := pipeline.LoadOrCreate(dir, "PROJ-41")
+	meta := state.Meta()
+	meta.Branch = "soda/PROJ-41"
+	meta.TotalCost = 0.10
+
+	// No phase has PhaseFailed, so failedPhase will be "".
+	parseErr := fmt.Errorf("engine: parse: %w",
+		&claude.ParseError{Raw: []byte("bad"), Err: fmt.Errorf("invalid")})
+	var buf bytes.Buffer
+	fprintSummary(&buf, state, testPhases(), "Parse empty phase", 30*time.Second, parseErr, nil)
+	output := buf.String()
+
+	if strings.Contains(output, "--from ") {
+		t.Error("should not suggest --from when failedPhase is empty")
+	}
+	if !strings.Contains(output, "soda run PROJ-41") {
+		t.Error("expected bare soda run suggestion")
+	}
+}
+
 func TestPrintSummaryGenericError(t *testing.T) {
 	dir := t.TempDir()
 	state, _ := pipeline.LoadOrCreate(dir, "PROJ-60")


### PR DESCRIPTION
## Summary
- **#98**: Adds empty-string guard for `failedPhase` in transient and parse next-steps branches, falling back to `soda run TICKET` without `--from`
- **#99**: Inlines `resumeFrom := failedPhase` (used once, assigned once) by using `failedPhase` directly
- Adds 2 new tests: `TestPrintSummaryTransientErrorEmptyPhase` and `TestPrintSummaryParseErrorEmptyPhase`

Closes #98
Closes #99

## Test plan
- [x] `go test ./cmd/soda/...` passes
- [x] All 11 PrintSummary tests pass including 2 new empty-phase tests
- [x] Existing transient/parse tests still verify `--from` behavior when phase is known

🤖 Generated with [Claude Code](https://claude.com/claude-code)