### PR TITLE
fix(pipeline): fail-closed on review gate unmarshal error (#105, #104)

### DIFF
--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -874,7 +874,7 @@ func (e *Engine) gatePhase(phase PhaseConfig) error {
 			} `json:"findings"`
 		}
 		if err := json.Unmarshal(raw, &result); err != nil {
-			return nil
+			return fmt.Errorf("engine: review gate: failed to unmarshal result: %w", err)
 		}
 		if strings.EqualFold(result.Verdict, "rework") {
 			// Rework routing is handled by the engine loop, not the gate.
@@ -1164,7 +1164,13 @@ func (e *Engine) runReviewer(ctx context.Context, phase PhaseConfig, reviewer Re
 		var parsed struct {
 			Findings []reviewFinding `json:"findings"`
 		}
-		if parseErr := json.Unmarshal(result.Output, &parsed); parseErr == nil {
+		if parseErr := json.Unmarshal(result.Output, &parsed); parseErr != nil {
+			sendEvent(Event{
+				Phase: phase.Name,
+				Kind:  EventReviewerParseWarning,
+				Data:  map[string]any{"reviewer": reviewer.Name, "error": parseErr.Error()},
+			})
+		} else {
 			findings = parsed.Findings
 		}
 	}

--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -852,6 +852,38 @@ func TestEngine_GatePhase_TriageNotAutomatable(t *testing.T) {
 	}
 }
 
+func TestEngine_GatePhase_ReviewUnmarshalError(t *testing.T) {
+	phases := []PhaseConfig{
+		{
+			Name:   "review",
+			Prompt: "review.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"review": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`not valid json`),
+					RawText: "corrupt output",
+					CostUSD: 0.01,
+				},
+			}},
+		},
+	}
+
+	engine, _ := setupEngine(t, phases, mock)
+
+	err := engine.Run(context.Background())
+	if err == nil {
+		t.Fatal("expected error for corrupt review result, got nil")
+	}
+	if !strings.Contains(err.Error(), "review gate") {
+		t.Errorf("error should mention review gate, got: %v", err)
+	}
+}
+
 func TestEngineFullLifecycle(t *testing.T) {
 	// A realistic 4-phase pipeline: triage -> plan -> implement -> verify.
 	// Each phase depends on the previous one. Prompt templates reference

--- a/internal/pipeline/events.go
+++ b/internal/pipeline/events.go
@@ -57,6 +57,7 @@ const (
 	EventReviewMerged             = "review_merged"
 	EventReviewReworkRouted       = "review_rework_routed"
 	EventReviewReworkMaxCycles    = "review_rework_max_cycles"
+	EventReviewerParseWarning    = "reviewer_parse_warning"
 )
 
 // ReadEvents reads and parses all events from the events.jsonl file in dir.


### PR DESCRIPTION
## Summary
- **#105**: Review gate now returns an error on `json.Unmarshal` failure instead of silently passing (`return nil`)
- **#104**: Emits `EventReviewerParseWarning` when reviewer output fails to parse as structured findings (instead of silently swallowing)
- Adds `TestEngine_GatePhase_ReviewUnmarshalError` to verify corrupt review results fail the gate

Closes #105
Closes #104

## Test plan
- [x] `go test ./internal/pipeline/...` passes
- [x] New test verifies corrupt JSON triggers a gate error
- [x] Parse warning event emitted on malformed reviewer output

🤖 Generated with [Claude Code](https://claude.com/claude-code)