### PR TITLE
docs: require soda for all development

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,6 +217,8 @@ Atomic writes: always write to `.tmp` then rename. Archive on re-run (`verify.js
 
 ## Implementation workflow
 
+**All development must be done using soda itself.** Run `soda run <ticket>` to implement issues through the pipeline. Do not implement tickets manually outside of soda unless the pipeline is broken or the work is on soda's own pipeline infrastructure.
+
 Issues are fully specified with acceptance criteria.
 Do NOT write separate spec or plan documents.
 Read the issue, read the existing code, implement, test.


### PR DESCRIPTION
## Summary
- Adds instruction to AGENTS.md requiring all development to go through `soda run <ticket>`
- Exceptions: pipeline infrastructure work or when the pipeline itself is broken

## Test plan
- [x] Documentation-only change, no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)