### PR TITLE
#103 refactor: unify review finding types

### DIFF
--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -896,13 +896,7 @@ func (e *Engine) gatePhase(phase PhaseConfig) error {
 		}
 
 	case "review":
-		var result struct {
-			Verdict  string `json:"verdict"`
-			Findings []struct {
-				Severity string `json:"severity"`
-				Issue    string `json:"issue"`
-			} `json:"findings"`
-		}
+		var result schemas.ReviewOutput
 		if err := json.Unmarshal(raw, &result); err != nil {
 			return fmt.Errorf("engine: review gate: failed to unmarshal result: %w", err)
 		}

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -971,18 +971,9 @@ func (e *Engine) gatePhase(phase PhaseConfig) error {
 // reviewerResult holds the outcome of a single reviewer subagent.
 type reviewerResult struct {
 	Name     string
-	Findings []reviewFinding
+	Findings []schemas.ReviewFinding
 	Cost     float64
 	Err      error
-}
-
-// reviewFinding mirrors the structured output each reviewer returns.
-type reviewFinding struct {
-	Severity   string `json:"severity"`
-	File       string `json:"file"`
-	Line       int    `json:"line,omitempty"`
-	Issue      string `json:"issue"`
-	Suggestion string `json:"suggestion"`
 }
 
 // reviewerMsg is sent from reviewer goroutines to the parent via channel.
@@ -1206,10 +1197,10 @@ func (e *Engine) runReviewer(ctx context.Context, phase PhaseConfig, reviewer Re
 	}
 
 	// Parse findings from the structured output.
-	var findings []reviewFinding
+	var findings []schemas.ReviewFinding
 	if result.Output != nil {
 		var parsed struct {
-			Findings []reviewFinding `json:"findings"`
+			Findings []schemas.ReviewFinding `json:"findings"`
 		}
 		if parseErr := json.Unmarshal(result.Output, &parsed); parseErr != nil {
 			sendEvent(Event{
@@ -1245,14 +1236,8 @@ func (e *Engine) mergeReviewFindings(phase PhaseConfig, results []reviewerResult
 
 	for _, result := range results {
 		for _, finding := range result.Findings {
-			allFindings = append(allFindings, schemas.ReviewFinding{
-				Source:     result.Name,
-				Severity:   finding.Severity,
-				File:       finding.File,
-				Line:       finding.Line,
-				Issue:      finding.Issue,
-				Suggestion: finding.Suggestion,
-			})
+			finding.Source = result.Name
+			allFindings = append(allFindings, finding)
 		}
 	}
 

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -768,17 +768,7 @@ func (e *Engine) extractReviewReworkFeedback() *ReworkFeedback {
 		return nil
 	}
 
-	var result struct {
-		Verdict  string `json:"verdict"`
-		Findings []struct {
-			Source     string `json:"source"`
-			Severity   string `json:"severity"`
-			File       string `json:"file"`
-			Line       int    `json:"line,omitempty"`
-			Issue      string `json:"issue"`
-			Suggestion string `json:"suggestion"`
-		} `json:"findings"`
-	}
+	var result schemas.ReviewOutput
 	if err := json.Unmarshal(raw, &result); err != nil {
 		return nil
 	}
@@ -795,14 +785,7 @@ func (e *Engine) extractReviewReworkFeedback() *ReworkFeedback {
 	for _, finding := range result.Findings {
 		sev := strings.ToLower(finding.Severity)
 		if sev == "critical" || sev == "major" {
-			fb.ReviewFindings = append(fb.ReviewFindings, ReviewReworkFinding{
-				Source:     finding.Source,
-				Severity:   finding.Severity,
-				File:       finding.File,
-				Line:       finding.Line,
-				Issue:      finding.Issue,
-				Suggestion: finding.Suggestion,
-			})
+			fb.ReviewFindings = append(fb.ReviewFindings, finding)
 		}
 	}
 

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -15,6 +15,7 @@ import (
 	"github.com/decko/soda/internal/git"
 	"github.com/decko/soda/internal/runner"
 	"github.com/decko/soda/internal/sandbox"
+	"github.com/decko/soda/schemas"
 )
 
 // Mode controls whether the engine pauses between phases.
@@ -1238,30 +1239,13 @@ func (e *Engine) runReviewer(ctx context.Context, phase PhaseConfig, reviewer Re
 	})
 }
 
-// mergedReviewOutput is the combined output from all reviewers.
-type mergedReviewOutput struct {
-	TicketKey string                `json:"ticket_key"`
-	Findings  []mergedReviewFinding `json:"findings"`
-	Verdict   string                `json:"verdict"`
-}
-
-// mergedReviewFinding is a single finding with its source reviewer.
-type mergedReviewFinding struct {
-	Source     string `json:"source"`
-	Severity   string `json:"severity"`
-	File       string `json:"file"`
-	Line       int    `json:"line,omitempty"`
-	Issue      string `json:"issue"`
-	Suggestion string `json:"suggestion"`
-}
-
 // mergeReviewFindings combines findings from all reviewers and computes a verdict.
-func (e *Engine) mergeReviewFindings(phase PhaseConfig, results []reviewerResult) mergedReviewOutput {
-	var allFindings []mergedReviewFinding
+func (e *Engine) mergeReviewFindings(phase PhaseConfig, results []reviewerResult) schemas.ReviewOutput {
+	var allFindings []schemas.ReviewFinding
 
 	for _, result := range results {
 		for _, finding := range result.Findings {
-			allFindings = append(allFindings, mergedReviewFinding{
+			allFindings = append(allFindings, schemas.ReviewFinding{
 				Source:     result.Name,
 				Severity:   finding.Severity,
 				File:       finding.File,
@@ -1283,7 +1267,7 @@ func (e *Engine) mergeReviewFindings(phase PhaseConfig, results []reviewerResult
 		},
 	})
 
-	return mergedReviewOutput{
+	return schemas.ReviewOutput{
 		TicketKey: e.config.Ticket.Key,
 		Findings:  allFindings,
 		Verdict:   verdict,
@@ -1294,7 +1278,7 @@ func (e *Engine) mergeReviewFindings(phase PhaseConfig, results []reviewerResult
 // Any critical or major finding → "rework"
 // Only minor findings → "pass-with-follow-ups"
 // No findings → "pass"
-func computeReviewVerdict(findings []mergedReviewFinding) string {
+func computeReviewVerdict(findings []schemas.ReviewFinding) string {
 	hasCriticalOrMajor := false
 	hasMinor := false
 
@@ -1318,7 +1302,7 @@ func computeReviewVerdict(findings []mergedReviewFinding) string {
 }
 
 // buildReviewArtifact creates a human-readable markdown summary of the review.
-func (e *Engine) buildReviewArtifact(merged mergedReviewOutput) string {
+func (e *Engine) buildReviewArtifact(merged schemas.ReviewOutput) string {
 	var sb strings.Builder
 
 	sb.WriteString(fmt.Sprintf("# Review: %s\n\n", merged.Verdict))

--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/decko/soda/internal/claude"
 	"github.com/decko/soda/internal/runner"
 	"github.com/decko/soda/internal/sandbox"
+	"github.com/decko/soda/schemas"
 )
 
 // flexMockRunner returns per-call responses, allowing multi-call test scenarios
@@ -3452,7 +3453,7 @@ func TestEngine_ParallelReview_InPipeline(t *testing.T) {
 func TestComputeReviewVerdict(t *testing.T) {
 	tests := []struct {
 		name     string
-		findings []mergedReviewFinding
+		findings []schemas.ReviewFinding
 		want     string
 	}{
 		{
@@ -3462,33 +3463,33 @@ func TestComputeReviewVerdict(t *testing.T) {
 		},
 		{
 			name:     "empty_findings",
-			findings: []mergedReviewFinding{},
+			findings: []schemas.ReviewFinding{},
 			want:     "pass",
 		},
 		{
 			name: "minor_only",
-			findings: []mergedReviewFinding{
+			findings: []schemas.ReviewFinding{
 				{Severity: "minor", Issue: "style"},
 			},
 			want: "pass-with-follow-ups",
 		},
 		{
 			name: "major_triggers_rework",
-			findings: []mergedReviewFinding{
+			findings: []schemas.ReviewFinding{
 				{Severity: "major", Issue: "missing error check"},
 			},
 			want: "rework",
 		},
 		{
 			name: "critical_triggers_rework",
-			findings: []mergedReviewFinding{
+			findings: []schemas.ReviewFinding{
 				{Severity: "critical", Issue: "nil deref"},
 			},
 			want: "rework",
 		},
 		{
 			name: "mixed_severities",
-			findings: []mergedReviewFinding{
+			findings: []schemas.ReviewFinding{
 				{Severity: "minor", Issue: "style"},
 				{Severity: "major", Issue: "missing error check"},
 				{Severity: "minor", Issue: "naming"},
@@ -3497,7 +3498,7 @@ func TestComputeReviewVerdict(t *testing.T) {
 		},
 		{
 			name: "case_insensitive",
-			findings: []mergedReviewFinding{
+			findings: []schemas.ReviewFinding{
 				{Severity: "Critical", Issue: "nil deref"},
 			},
 			want: "rework",

--- a/internal/pipeline/errors.go
+++ b/internal/pipeline/errors.go
@@ -3,6 +3,8 @@ package pipeline
 import (
 	"fmt"
 	"strings"
+
+	"github.com/decko/soda/schemas"
 )
 
 // BudgetExceededError is returned when accumulated cost exceeds the configured limit.
@@ -43,10 +45,7 @@ func (e *PhaseGateError) Error() string {
 // and the pipeline should route back to implement. This is NOT a terminal
 // error — the engine loop catches it and handles routing.
 type reviewReworkSignal struct {
-	findings []struct {
-		Severity string `json:"severity"`
-		Issue    string `json:"issue"`
-	}
+	findings []schemas.ReviewFinding
 }
 
 func (e *reviewReworkSignal) Error() string {

--- a/internal/pipeline/prompt.go
+++ b/internal/pipeline/prompt.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"text/template"
+
+	"github.com/decko/soda/schemas"
 )
 
 // PromptData is the template context for phase prompts.
@@ -34,18 +36,7 @@ type ReworkFeedback struct {
 	FailedCriteria []FailedCriterion
 	CodeIssues     []ReworkCodeIssue
 	FailedCommands []FailedCommand
-	ReviewFindings []ReviewReworkFinding
-}
-
-// ReviewReworkFinding holds a critical or major finding from a specialist
-// reviewer, injected into the implement prompt for rework.
-type ReviewReworkFinding struct {
-	Source     string // reviewer name, e.g. "go-specialist"
-	Severity   string // "critical" or "major"
-	File       string
-	Line       int
-	Issue      string
-	Suggestion string
+	ReviewFindings []schemas.ReviewFinding
 }
 
 // FailedCriterion is a single acceptance criterion that failed verification.


### PR DESCRIPTION
## Summary
- Remove four duplicate type definitions (`reviewFinding`, `mergedReviewOutput`, `mergedReviewFinding`, `ReviewReworkFinding`) from `internal/pipeline/` and replace them with `schemas.ReviewOutput` and `schemas.ReviewFinding`
- Simplify `mergeReviewFindings` to set `finding.Source` directly instead of constructing a new struct
- Net reduction of ~63 lines of code with zero behavioral changes

## Changes
| Old Type (removed) | Replacement |
|---|---|
| `reviewFinding` | `schemas.ReviewFinding` |
| `mergedReviewOutput` | `schemas.ReviewOutput` |
| `mergedReviewFinding` | `schemas.ReviewFinding` |
| `ReviewReworkFinding` | `schemas.ReviewFinding` |

## Test plan
- [x] `go build ./...` — compiles cleanly
- [x] `go vet ./...` — no issues
- [x] All pipeline tests pass (`go test ./internal/pipeline/...`)
- [x] No remaining references to old type names in the codebase
- [x] Template field access (`.Source`, `.Severity`, `.File`, `.Line`, `.Issue`, `.Suggestion`) verified compatible with `schemas.ReviewFinding`
- [x] No circular dependency introduced — `schemas` is a pure leaf package with zero imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)