### PR TITLE
chore(pipeline): disable monitor phase until response execution is implemented

### DIFF
--- a/cmd/soda/embeds/phases.yaml
+++ b/cmd/soda/embeds/phases.yaml
@@ -120,27 +120,8 @@ phases:
       - verify
       - review
 
-  - name: monitor
-    prompt: prompts/monitor.md
-    schema: |
-      {"type":"object","properties":{"ticket_key":{"type":"string"},"pr_url":{"type":"string"},"comments_handled":{"type":"array","items":{"type":"object","properties":{"comment_id":{"type":"string"},"author":{"type":"string"},"content":{"type":"string"},"action":{"type":"string"},"response":{"type":"string"}},"required":["comment_id","author","content","action","response"]}},"files_changed":{"type":"array","items":{"type":"object","properties":{"path":{"type":"string"},"action":{"type":"string"}},"required":["path","action"]}},"commits":{"type":"array","items":{"type":"object","properties":{"hash":{"type":"string"},"message":{"type":"string"},"task_id":{"type":"string"}},"required":["hash","message","task_id"]}},"tests_passed":{"type":"boolean"}},"required":["ticket_key","pr_url","comments_handled","tests_passed"]}
-    type: polling     # not one-shot
-    tools:
-      - Read
-      - Write
-      - Edit
-      - Glob
-      - Grep
-      - Bash
-    polling:
-      initial_interval: 2m
-      max_interval: 5m
-      escalate_after: 30m
-      max_duration: 4h
-      max_response_rounds: 3
-    retry:
-      transient: 2
-      parse: 1
-      semantic: 0
-    depends_on:
-      - submit
+  # monitor phase disabled — response execution not yet implemented (#73)
+  # - name: monitor
+  #   type: polling
+  #   depends_on:
+  #     - submit


### PR DESCRIPTION
## Summary

- Disable the monitor phase in the default pipeline configuration
- The monitor phase polls for PR activity but cannot respond to comments or push fixes (#73)
- It consumes budget polling until timeout with no actionable output

## Test plan

- [x] All tests pass
- [x] Build succeeds
- [x] Pipeline completes at submit phase (no monitor timeout)

Generated with [Claude Code](https://claude.com/claude-code)
