### PR TITLE
feat(ticket): add comment fetching to GitHub ticket source (#132)

### DIFF
--- a/cmd/soda/render.go
+++ b/cmd/soda/render.go
@@ -83,6 +83,7 @@ func runRender(cmd *cobra.Command, cfg *config.Config, phaseName, ticketKey stri
 			Type:               t.Type,
 			Priority:           t.Priority,
 			AcceptanceCriteria: t.AcceptanceCriteria,
+			Comments:           mapTicketComments(t.Comments),
 		},
 	}
 
@@ -146,6 +147,21 @@ func createTicketSource(cfg *config.Config) (ticket.Source, error) {
 	default:
 		return nil, fmt.Errorf("unsupported ticket source: %q", cfg.TicketSource)
 	}
+}
+
+func mapTicketComments(comments []ticket.Comment) []pipeline.TicketComment {
+	if len(comments) == 0 {
+		return nil
+	}
+	out := make([]pipeline.TicketComment, len(comments))
+	for i, c := range comments {
+		out[i] = pipeline.TicketComment{
+			Author:    c.Author,
+			Body:      c.Body,
+			CreatedAt: c.CreatedAt,
+		}
+	}
+	return out
 }
 
 func loadArtifacts(state *pipeline.State, data *pipeline.PromptData) {

--- a/cmd/soda/render.go
+++ b/cmd/soda/render.go
@@ -139,8 +139,9 @@ func createTicketSource(cfg *config.Config) (ticket.Source, error) {
 		})
 	case "github":
 		return ticket.NewGitHubSource(ticket.GitHubConfig{
-			Owner: cfg.GitHub.Owner,
-			Repo:  cfg.GitHub.Repo,
+			Owner:         cfg.GitHub.Owner,
+			Repo:          cfg.GitHub.Repo,
+			FetchComments: cfg.GitHub.FetchComments,
 		})
 	default:
 		return nil, fmt.Errorf("unsupported ticket source: %q", cfg.TicketSource)

--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -69,6 +69,7 @@ func runPipeline(cmd *cobra.Command, cfg *config.Config, ticketKey string) error
 		Type:               t.Type,
 		Priority:           t.Priority,
 		AcceptanceCriteria: t.AcceptanceCriteria,
+		Comments:           mapTicketComments(t.Comments),
 	}
 
 	// Load pipeline config

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,8 +33,9 @@ type JiraConfig struct {
 
 // GitHubTicketConfig holds GitHub Issues ticket source settings.
 type GitHubTicketConfig struct {
-	Owner string `yaml:"owner"`
-	Repo  string `yaml:"repo"`
+	Owner         string `yaml:"owner"`
+	Repo          string `yaml:"repo"`
+	FetchComments bool   `yaml:"fetch_comments"`
 }
 
 // SandboxConfig holds sandbox execution settings.

--- a/internal/pipeline/prompt.go
+++ b/internal/pipeline/prompt.go
@@ -69,6 +69,15 @@ type TicketData struct {
 	Type               string
 	Priority           string
 	AcceptanceCriteria []string
+	Comments           []TicketComment
+}
+
+// TicketComment holds a single ticket comment for prompt templates.
+// Named TicketComment (not Comment) to avoid ambiguity with PR/review comments.
+type TicketComment struct {
+	Author    string
+	Body      string
+	CreatedAt string
 }
 
 // PromptConfigData holds config fields accessible from templates.

--- a/internal/ticket/github.go
+++ b/internal/ticket/github.go
@@ -11,9 +11,10 @@ import (
 
 // GitHubConfig holds configuration for the GitHub Issues ticket source.
 type GitHubConfig struct {
-	Owner   string
-	Repo    string
-	Command string // gh binary path; defaults to "gh"
+	Owner         string
+	Repo          string
+	Command       string // gh binary path; defaults to "gh"
+	FetchComments bool   // when true, Fetch includes issue comments
 }
 
 // GitHubSource fetches tickets from GitHub Issues via the gh CLI.

--- a/internal/ticket/github.go
+++ b/internal/ticket/github.go
@@ -39,10 +39,15 @@ func (s *GitHubSource) repo() string {
 
 // Fetch retrieves a single GitHub issue by number.
 func (s *GitHubSource) Fetch(ctx context.Context, key string) (*Ticket, error) {
+	jsonFields := "number,title,body,labels,state,assignees"
+	if s.config.FetchComments {
+		jsonFields += ",comments"
+	}
+
 	out, err := exec.CommandContext(ctx, s.config.Command,
 		"issue", "view", key,
 		"--repo", s.repo(),
-		"--json", "number,title,body,labels,state,assignees",
+		"--json", jsonFields,
 	).Output()
 	if err != nil {
 		return nil, fmt.Errorf("ticket: github fetch %s: %w%s", key, err, exitStderr(err))
@@ -90,12 +95,13 @@ func (s *GitHubSource) List(ctx context.Context, query string) ([]Ticket, error)
 // GitHub API response types
 
 type ghIssue struct {
-	Number    int       `json:"number"`
-	Title     string    `json:"title"`
-	Body      string    `json:"body"`
-	State     string    `json:"state"`
-	Labels    []ghLabel `json:"labels"`
-	Assignees []ghUser  `json:"assignees"`
+	Number    int         `json:"number"`
+	Title     string      `json:"title"`
+	Body      string      `json:"body"`
+	State     string      `json:"state"`
+	Labels    []ghLabel   `json:"labels"`
+	Assignees []ghUser    `json:"assignees"`
+	Comments  []ghComment `json:"comments"`
 }
 
 type ghLabel struct {
@@ -104,6 +110,12 @@ type ghLabel struct {
 
 type ghUser struct {
 	Login string `json:"login"`
+}
+
+type ghComment struct {
+	Author    ghUser `json:"author"`
+	Body      string `json:"body"`
+	CreatedAt string `json:"createdAt"`
 }
 
 func (issue *ghIssue) toTicket() *Ticket {
@@ -128,6 +140,15 @@ func (issue *ghIssue) toTicket() *Ticket {
 		status = strings.ToUpper(issue.State[:1]) + issue.State[1:]
 	}
 
+	var comments []Comment
+	for _, c := range issue.Comments {
+		comments = append(comments, Comment{
+			Author:    c.Author.Login,
+			Body:      c.Body,
+			CreatedAt: c.CreatedAt,
+		})
+	}
+
 	return &Ticket{
 		Key:                fmt.Sprintf("%d", issue.Number),
 		Summary:            issue.Title,
@@ -136,6 +157,7 @@ func (issue *ghIssue) toTicket() *Ticket {
 		Status:             status,
 		Labels:             labels,
 		AcceptanceCriteria: ExtractCriteria(issue.Body),
+		Comments:           comments,
 		RawFields:          rawFields,
 	}
 }

--- a/internal/ticket/github_test.go
+++ b/internal/ticket/github_test.go
@@ -197,5 +197,78 @@ func TestGitHubSource_Fetch_NotFound(t *testing.T) {
 	}
 }
 
+func TestGitHubSource_Fetch_WithComments(t *testing.T) {
+	t.Setenv("MOCK_GH_FIXTURE", "github_fetch_with_comments.json")
+
+	source, err := NewGitHubSource(GitHubConfig{
+		Owner:         "decko",
+		Repo:          "soda",
+		Command:       mockGHBinary(t),
+		FetchComments: true,
+	})
+	if err != nil {
+		t.Fatalf("NewGitHubSource: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	ticket, err := source.Fetch(ctx, "36")
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+
+	if ticket.Key != "36" {
+		t.Errorf("Key = %q, want %q", ticket.Key, "36")
+	}
+
+	// Comments should be populated
+	if len(ticket.Comments) != 2 {
+		t.Fatalf("Comments len = %d, want 2", len(ticket.Comments))
+	}
+	if ticket.Comments[0].Author != "reviewer1" {
+		t.Errorf("Comments[0].Author = %q, want %q", ticket.Comments[0].Author, "reviewer1")
+	}
+	if ticket.Comments[0].Body != "Looks good, but please add tests." {
+		t.Errorf("Comments[0].Body = %q, want %q", ticket.Comments[0].Body, "Looks good, but please add tests.")
+	}
+	if ticket.Comments[0].CreatedAt != "2025-07-01T10:00:00Z" {
+		t.Errorf("Comments[0].CreatedAt = %q, want %q", ticket.Comments[0].CreatedAt, "2025-07-01T10:00:00Z")
+	}
+	if ticket.Comments[1].Author != "ddebrito" {
+		t.Errorf("Comments[1].Author = %q, want %q", ticket.Comments[1].Author, "ddebrito")
+	}
+	if ticket.Comments[1].CreatedAt != "2025-07-01T12:30:00Z" {
+		t.Errorf("Comments[1].CreatedAt = %q, want %q", ticket.Comments[1].CreatedAt, "2025-07-01T12:30:00Z")
+	}
+}
+
+func TestGitHubSource_Fetch_DefaultNoComments(t *testing.T) {
+	t.Setenv("MOCK_GH_FIXTURE", "github_fetch.json")
+
+	source, err := NewGitHubSource(GitHubConfig{
+		Owner:   "decko",
+		Repo:    "soda",
+		Command: mockGHBinary(t),
+		// FetchComments defaults to false
+	})
+	if err != nil {
+		t.Fatalf("NewGitHubSource: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	ticket, err := source.Fetch(ctx, "36")
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+
+	// Comments should be nil/empty when FetchComments is false
+	if len(ticket.Comments) != 0 {
+		t.Errorf("Comments len = %d, want 0 when FetchComments is false", len(ticket.Comments))
+	}
+}
+
 // Verify GitHubSource satisfies Source interface at compile time.
 var _ Source = (*GitHubSource)(nil)

--- a/internal/ticket/testdata/github_fetch_with_comments.json
+++ b/internal/ticket/testdata/github_fetch_with_comments.json
@@ -1,0 +1,25 @@
+{
+  "number": 36,
+  "title": "Add GitHub Issues ticket source",
+  "body": "Implement a GitHub Issues source.\n\n## Acceptance Criteria\n- [ ] Fetch retrieves a single issue\n- [ ] List returns open issues\n- [ ] Labels are mapped correctly",
+  "state": "open",
+  "labels": [
+    {"name": "enhancement"},
+    {"name": "ticket"}
+  ],
+  "assignees": [
+    {"login": "ddebrito"}
+  ],
+  "comments": [
+    {
+      "author": {"login": "reviewer1"},
+      "body": "Looks good, but please add tests.",
+      "createdAt": "2025-07-01T10:00:00Z"
+    },
+    {
+      "author": {"login": "ddebrito"},
+      "body": "Done, tests added in the latest commit.",
+      "createdAt": "2025-07-01T12:30:00Z"
+    }
+  ]
+}

--- a/internal/ticket/ticket.go
+++ b/internal/ticket/ticket.go
@@ -12,5 +12,13 @@ type Ticket struct {
 	Status             string         `json:"status"`
 	Labels             []string       `json:"labels"`
 	AcceptanceCriteria []string       `json:"acceptance_criteria"`
+	Comments           []Comment      `json:"comments,omitempty"`
 	RawFields          map[string]any `json:"raw_fields,omitempty"`
+}
+
+// Comment holds a single comment from a ticket.
+type Comment struct {
+	Author    string `json:"author"`
+	Body      string `json:"body"`
+	CreatedAt string `json:"created_at"`
 }


### PR DESCRIPTION
## Summary

- Add `Comment` type with `Author`, `Body`, `CreatedAt` to `Ticket` struct
- Add `TicketComment` and `Comments` field to `TicketData` (accessible as `{{.Ticket.Comments}}` in templates)
- Add `FetchComments` option to GitHub config (opt-in, default false)
- Update `GitHubSource.Fetch` to include comments when enabled
- Wire `Ticket.Comments` → `TicketData.Comments` mapping in `run.go` and `render.go`
- Tests for comment fetching and parsing

## Test plan

- [x] All tests pass (`go test ./...`)
- [x] Existing behavior unchanged when `FetchComments` not set
- [ ] CI passes

Part of milestone: Configurable spec/plan extraction from ticket sources.
Unblocks: #133 (extraction strategies)

Fixes: #132

Generated with [Claude Code](https://claude.com/claude-code) via SODA
