### PR TITLE
feat(triage): route pipeline based on existing spec/plan (#134)

### DIFF
--- a/cmd/soda/embeds/phases.yaml
+++ b/cmd/soda/embeds/phases.yaml
@@ -7,7 +7,7 @@ phases:
   - name: triage
     prompt: prompts/triage.md
     schema: |
-      {"type":"object","properties":{"ticket_key":{"type":"string"},"repo":{"type":"string"},"code_area":{"type":"string"},"files":{"type":"array","items":{"type":"string"}},"complexity":{"type":"string"},"approach":{"type":"string"},"risks":{"type":"array","items":{"type":"string"}},"automatable":{"type":"boolean"},"block_reason":{"type":"string"}},"required":["ticket_key","repo","code_area","files","complexity","approach","risks","automatable"]}
+      {"type":"object","properties":{"ticket_key":{"type":"string"},"repo":{"type":"string"},"code_area":{"type":"string"},"files":{"type":"array","items":{"type":"string"}},"complexity":{"type":"string"},"approach":{"type":"string"},"risks":{"type":"array","items":{"type":"string"}},"automatable":{"type":"boolean"},"block_reason":{"type":"string"},"skip_plan":{"type":"boolean"},"extracted_plan":{"type":"string"}},"required":["ticket_key","repo","code_area","files","complexity","approach","risks","automatable"]}
     tools:
       - Read
       - Glob

--- a/cmd/soda/embeds/phases.yaml
+++ b/cmd/soda/embeds/phases.yaml
@@ -7,7 +7,7 @@ phases:
   - name: triage
     prompt: prompts/triage.md
     schema: |
-      {"type":"object","properties":{"ticket_key":{"type":"string"},"repo":{"type":"string"},"code_area":{"type":"string"},"files":{"type":"array","items":{"type":"string"}},"complexity":{"type":"string"},"approach":{"type":"string"},"risks":{"type":"array","items":{"type":"string"}},"automatable":{"type":"boolean"},"block_reason":{"type":"string"},"skip_plan":{"type":"boolean"},"extracted_plan":{"type":"string"}},"required":["ticket_key","repo","code_area","files","complexity","approach","risks","automatable"]}
+      {"type":"object","properties":{"ticket_key":{"type":"string"},"repo":{"type":"string"},"code_area":{"type":"string"},"files":{"type":"array","items":{"type":"string"}},"complexity":{"type":"string"},"approach":{"type":"string"},"risks":{"type":"array","items":{"type":"string"}},"automatable":{"type":"boolean"},"block_reason":{"type":"string"},"skip_plan":{"type":"boolean","default":false}},"required":["ticket_key","repo","code_area","files","complexity","approach","risks","automatable"]}
     tools:
       - Read
       - Glob

--- a/cmd/soda/embeds/prompts/triage.md
+++ b/cmd/soda/embeds/prompts/triage.md
@@ -24,6 +24,18 @@ Priority: {{.Ticket.Priority}}
 - **{{.Name}}** ({{.Forge}}) — {{.Description}}
 {{- end}}
 
+{{- if .Ticket.ExistingSpec}}
+
+## Existing Spec (from issue)
+{{.Ticket.ExistingSpec}}
+{{- end}}
+
+{{- if .Ticket.ExistingPlan}}
+
+## Existing Plan (from issue)
+{{.Ticket.ExistingPlan}}
+{{- end}}
+
 {{- if .Context.ProjectContext}}
 
 ## Project Context
@@ -46,3 +58,9 @@ Assess this ticket and produce a structured classification:
 7. **Decide if automatable** — can an agent implement this end-to-end, or does it need human decisions?
 
 Read the relevant codebase before answering. Do not guess file paths.
+
+## Plan routing
+
+If an existing plan is provided above and appears complete (has concrete tasks with files, acceptance criteria, and a verification strategy), set `skip_plan: true` and include the plan content verbatim in `extracted_plan`. This signals the engine to skip the plan phase and proceed directly to implementation.
+
+If no plan is provided, or the plan is incomplete or outdated relative to the codebase, leave `skip_plan` as false and `extracted_plan` empty.

--- a/cmd/soda/embeds/prompts/triage.md
+++ b/cmd/soda/embeds/prompts/triage.md
@@ -61,6 +61,6 @@ Read the relevant codebase before answering. Do not guess file paths.
 
 ## Plan routing
 
-If an existing plan is provided above and appears complete (has concrete tasks with files, acceptance criteria, and a verification strategy), set `skip_plan: true` and include the plan content verbatim in `extracted_plan`. This signals the engine to skip the plan phase and proceed directly to implementation.
+If an existing plan is provided above and appears complete (has concrete tasks with files, acceptance criteria, and a verification strategy), set `skip_plan: true`. The engine will use the existing plan directly and skip the plan phase.
 
-If no plan is provided, or the plan is incomplete or outdated relative to the codebase, leave `skip_plan` as false and `extracted_plan` empty.
+If no plan is provided, or the plan is incomplete or outdated relative to the codebase, leave `skip_plan` as false.

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -123,6 +123,56 @@ func (e *Engine) ensureWorktree(ctx context.Context) error {
 	return nil
 }
 
+// triageRequestsSkipPlan reads the triage result and returns true when the
+// LLM set skip_plan=true and the ticket carries a non-empty ExistingPlan.
+func (e *Engine) triageRequestsSkipPlan() bool {
+	raw, err := e.state.ReadResult("triage")
+	if err != nil {
+		return false
+	}
+	var result struct {
+		SkipPlan bool `json:"skip_plan"`
+	}
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return false
+	}
+	return result.SkipPlan && e.config.Ticket.ExistingPlan != ""
+}
+
+// skipPlanFromTriage writes the ticket's ExistingPlan as the plan artifact,
+// marks the plan phase as completed, and emits a skip event. This lets
+// downstream phases (implement, verify, review) see a populated plan
+// artifact without running the plan LLM call.
+func (e *Engine) skipPlanFromTriage() error {
+	plan := e.config.Ticket.ExistingPlan
+
+	// Mark running so the PhaseState entry is created/archived.
+	if err := e.state.MarkRunning("plan"); err != nil {
+		return fmt.Errorf("engine: skip plan: mark running: %w", err)
+	}
+
+	// Write the existing plan as the plan artifact.
+	if err := e.state.WriteArtifact("plan", []byte(plan)); err != nil {
+		return fmt.Errorf("engine: skip plan: write artifact: %w", err)
+	}
+
+	// Mark completed so downstream dependency checks pass.
+	if err := e.state.MarkCompleted("plan"); err != nil {
+		return fmt.Errorf("engine: skip plan: mark completed: %w", err)
+	}
+
+	e.emit(Event{
+		Phase: "plan",
+		Kind:  EventPlanSkippedByTriage,
+		Data: map[string]any{
+			"reason":    "triage set skip_plan=true; using ExistingPlan from ticket",
+			"plan_size": len(plan),
+		},
+	})
+
+	return nil
+}
+
 // shouldSkip returns true if a completed phase can be skipped because none
 // of its dependencies were re-run in this execution.
 func (e *Engine) shouldSkip(phase PhaseConfig) bool {
@@ -265,6 +315,26 @@ func (e *Engine) executePhases(ctx context.Context, phases []PhaseConfig, forceF
 					return err
 				}
 				e.emit(Event{Phase: phase.Name, Kind: EventPhaseSkipped})
+				continue
+			}
+
+			// Skip-plan routing: when triage set skip_plan=true and the
+			// ticket carries an ExistingPlan, write the plan artifact from
+			// ticket data and mark the phase completed — no LLM call needed.
+			if phase.Name == "plan" && e.triageRequestsSkipPlan() {
+				if err := e.skipPlanFromTriage(); err != nil {
+					return err
+				}
+				e.reranPhases[phase.Name] = true
+
+				if e.config.Mode == Checkpoint {
+					e.emit(Event{Phase: phase.Name, Kind: EventCheckpointPause})
+					select {
+					case <-e.confirmCh:
+					case <-ctx.Done():
+						return fmt.Errorf("engine: context cancelled during checkpoint: %w", ctx.Err())
+					}
+				}
 				continue
 			}
 

--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -858,6 +858,79 @@ func TestEngine_GatePhase_TriageNotAutomatable(t *testing.T) {
 	}
 }
 
+func TestEngine_GatePhase_TriageSkipPlanDoesNotAffectGate(t *testing.T) {
+	// Triage output with skip_plan=true and extracted_plan set should still
+	// pass the gate when automatable=true. The gate only checks automatable.
+	phases := []PhaseConfig{
+		{
+			Name:   "triage",
+			Prompt: "triage.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"triage": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"automatable":true,"skip_plan":true,"extracted_plan":"Task 1: do the thing"}`),
+					RawText: "Automatable with existing plan",
+					CostUSD: 0.05,
+				},
+			}},
+		},
+	}
+
+	engine, state := setupEngine(t, phases, mock)
+
+	err := engine.Run(context.Background())
+	if err != nil {
+		t.Fatalf("expected no error when automatable=true with skip_plan, got: %v", err)
+	}
+
+	if !state.IsCompleted("triage") {
+		t.Error("triage should be completed")
+	}
+}
+
+func TestEngine_GatePhase_TriageNotAutomatableWithSkipPlanStillBlocks(t *testing.T) {
+	// Even if skip_plan=true, automatable=false should still gate.
+	phases := []PhaseConfig{
+		{
+			Name:   "triage",
+			Prompt: "triage.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"triage": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"automatable":false,"block_reason":"complex refactor","skip_plan":true,"extracted_plan":"some plan"}`),
+					RawText: "Not automatable",
+					CostUSD: 0.05,
+				},
+			}},
+		},
+	}
+
+	engine, _ := setupEngine(t, phases, mock)
+
+	err := engine.Run(context.Background())
+	if err == nil {
+		t.Fatal("expected PhaseGateError when automatable=false, even with skip_plan=true")
+	}
+
+	var gateErr *PhaseGateError
+	if !errors.As(err, &gateErr) {
+		t.Fatalf("expected PhaseGateError, got: %v", err)
+	}
+	if gateErr.Phase != "triage" {
+		t.Errorf("gate error phase = %q, want %q", gateErr.Phase, "triage")
+	}
+}
+
 func TestEngine_GatePhase_ReviewUnmarshalError(t *testing.T) {
 	phases := []PhaseConfig{
 		{

--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -859,8 +859,8 @@ func TestEngine_GatePhase_TriageNotAutomatable(t *testing.T) {
 }
 
 func TestEngine_GatePhase_TriageSkipPlanDoesNotAffectGate(t *testing.T) {
-	// Triage output with skip_plan=true and extracted_plan set should still
-	// pass the gate when automatable=true. The gate only checks automatable.
+	// Triage output with skip_plan=true should still pass the gate when
+	// automatable=true. The gate only checks automatable.
 	phases := []PhaseConfig{
 		{
 			Name:   "triage",
@@ -873,7 +873,7 @@ func TestEngine_GatePhase_TriageSkipPlanDoesNotAffectGate(t *testing.T) {
 		responses: map[string][]flexResponse{
 			"triage": {{
 				result: &runner.RunResult{
-					Output:  json.RawMessage(`{"automatable":true,"skip_plan":true,"extracted_plan":"Task 1: do the thing"}`),
+					Output:  json.RawMessage(`{"automatable":true,"skip_plan":true}`),
 					RawText: "Automatable with existing plan",
 					CostUSD: 0.05,
 				},
@@ -907,7 +907,7 @@ func TestEngine_GatePhase_TriageNotAutomatableWithSkipPlanStillBlocks(t *testing
 		responses: map[string][]flexResponse{
 			"triage": {{
 				result: &runner.RunResult{
-					Output:  json.RawMessage(`{"automatable":false,"block_reason":"complex refactor","skip_plan":true,"extracted_plan":"some plan"}`),
+					Output:  json.RawMessage(`{"automatable":false,"block_reason":"complex refactor","skip_plan":true}`),
 					RawText: "Not automatable",
 					CostUSD: 0.05,
 				},
@@ -928,6 +928,327 @@ func TestEngine_GatePhase_TriageNotAutomatableWithSkipPlanStillBlocks(t *testing
 	}
 	if gateErr.Phase != "triage" {
 		t.Errorf("gate error phase = %q, want %q", gateErr.Phase, "triage")
+	}
+}
+
+func TestEngine_SkipPlanRouting_SkipsPlanPhaseWhenTriageSetSkipPlan(t *testing.T) {
+	// When triage sets skip_plan=true and the ticket has an ExistingPlan,
+	// the engine should skip the plan LLM call, write the ExistingPlan as
+	// the plan artifact, and proceed to implement.
+	phases := []PhaseConfig{
+		{
+			Name:   "triage",
+			Prompt: "triage.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+		{
+			Name:      "plan",
+			Prompt:    "plan.md",
+			Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			DependsOn: []string{"triage"},
+		},
+		{
+			Name:      "implement",
+			Prompt:    "implement.md",
+			Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			DependsOn: []string{"plan"},
+		},
+	}
+
+	existingPlan := "## Tasks\n\n1. Task one\n2. Task two\n\n## Verification\n\nRun tests."
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"triage": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"automatable":true,"skip_plan":true}`),
+					RawText: "Triage with skip_plan",
+					CostUSD: 0.05,
+				},
+			}},
+			// No "plan" response — plan phase should not run.
+			"implement": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"tests_passed":true}`),
+					RawText: "Implementation done",
+					CostUSD: 0.10,
+				},
+			}},
+		},
+	}
+
+	var events []Event
+	engine, state := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.Ticket.ExistingPlan = existingPlan
+		cfg.OnEvent = func(e Event) {
+			events = append(events, e)
+		}
+	})
+
+	err := engine.Run(context.Background())
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	// Plan phase should be completed.
+	if !state.IsCompleted("plan") {
+		t.Error("plan phase should be completed")
+	}
+
+	// Plan artifact should contain the ExistingPlan.
+	artifact, err := state.ReadArtifact("plan")
+	if err != nil {
+		t.Fatalf("reading plan artifact: %v", err)
+	}
+	if string(artifact) != existingPlan {
+		t.Errorf("plan artifact = %q, want %q", string(artifact), existingPlan)
+	}
+
+	// Runner should NOT have been called for "plan" phase.
+	for _, call := range mock.calls {
+		if call.Phase == "plan" {
+			t.Error("plan phase runner should not have been called when skip_plan=true")
+		}
+	}
+
+	// Implement should have been called and completed.
+	if !state.IsCompleted("implement") {
+		t.Error("implement should be completed")
+	}
+
+	// Check that plan_skipped_by_triage event was emitted.
+	foundSkipEvent := false
+	for _, ev := range events {
+		if ev.Kind == EventPlanSkippedByTriage {
+			foundSkipEvent = true
+			if ev.Phase != "plan" {
+				t.Errorf("skip event phase = %q, want %q", ev.Phase, "plan")
+			}
+			break
+		}
+	}
+	if !foundSkipEvent {
+		t.Error("expected plan_skipped_by_triage event")
+	}
+}
+
+func TestEngine_SkipPlanRouting_NoSkipWhenSkipPlanFalse(t *testing.T) {
+	// When triage does not set skip_plan (or sets it to false), the plan
+	// phase should run normally.
+	phases := []PhaseConfig{
+		{
+			Name:   "triage",
+			Prompt: "triage.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+		{
+			Name:      "plan",
+			Prompt:    "plan.md",
+			Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			DependsOn: []string{"triage"},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"triage": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"automatable":true}`),
+					RawText: "Triage without skip_plan",
+					CostUSD: 0.05,
+				},
+			}},
+			"plan": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"tasks":[{"id":"1","description":"do it"}]}`),
+					RawText: "Plan from LLM",
+					CostUSD: 0.08,
+				},
+			}},
+		},
+	}
+
+	engine, state := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.Ticket.ExistingPlan = "some plan content"
+	})
+
+	err := engine.Run(context.Background())
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	// Plan phase should have run via the runner.
+	planCalled := false
+	for _, call := range mock.calls {
+		if call.Phase == "plan" {
+			planCalled = true
+		}
+	}
+	if !planCalled {
+		t.Error("plan phase runner should have been called when skip_plan is not set")
+	}
+
+	if !state.IsCompleted("plan") {
+		t.Error("plan should be completed")
+	}
+}
+
+func TestEngine_SkipPlanRouting_NoSkipWhenExistingPlanEmpty(t *testing.T) {
+	// When triage sets skip_plan=true but the ticket has no ExistingPlan,
+	// the plan phase should run normally (skip_plan is ignored).
+	phases := []PhaseConfig{
+		{
+			Name:   "triage",
+			Prompt: "triage.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+		{
+			Name:      "plan",
+			Prompt:    "plan.md",
+			Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			DependsOn: []string{"triage"},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"triage": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"automatable":true,"skip_plan":true}`),
+					RawText: "Triage with skip_plan but no plan",
+					CostUSD: 0.05,
+				},
+			}},
+			"plan": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"tasks":[{"id":"1","description":"do it"}]}`),
+					RawText: "Plan from LLM",
+					CostUSD: 0.08,
+				},
+			}},
+		},
+	}
+
+	engine, state := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.Ticket.ExistingPlan = "" // empty plan
+	})
+
+	err := engine.Run(context.Background())
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	// Plan phase should have run via the runner since ExistingPlan is empty.
+	planCalled := false
+	for _, call := range mock.calls {
+		if call.Phase == "plan" {
+			planCalled = true
+		}
+	}
+	if !planCalled {
+		t.Error("plan phase runner should have been called when ExistingPlan is empty")
+	}
+
+	if !state.IsCompleted("plan") {
+		t.Error("plan should be completed")
+	}
+}
+
+func TestEngine_SkipPlanRouting_PlanArtifactAvailableToImplement(t *testing.T) {
+	// When skip_plan routes the plan, the implement phase should see the
+	// plan content in its prompt (via Artifacts.Plan).
+	phases := []PhaseConfig{
+		{
+			Name:   "triage",
+			Prompt: "triage.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+		{
+			Name:      "plan",
+			Prompt:    "plan.md",
+			Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			DependsOn: []string{"triage"},
+		},
+		{
+			Name:      "implement",
+			Prompt:    "implement.md",
+			Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			DependsOn: []string{"plan"},
+		},
+	}
+
+	existingPlan := "## Tasks\n\n1. Update engine.go\n2. Add tests"
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"triage": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"automatable":true,"skip_plan":true}`),
+					RawText: "Triage output",
+					CostUSD: 0.05,
+				},
+			}},
+			"implement": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"tests_passed":true}`),
+					RawText: "Implementation done",
+					CostUSD: 0.10,
+				},
+			}},
+		},
+	}
+
+	// Set up with custom implement template that renders {{.Artifacts.Plan}}.
+	stateDir := t.TempDir()
+	promptDir := t.TempDir()
+	workDir := t.TempDir()
+
+	templates := map[string]string{
+		"triage.md":    "Phase: triage\nTicket: {{.Ticket.Key}}\n",
+		"plan.md":      "Phase: plan\nTicket: {{.Ticket.Key}}\n",
+		"implement.md": "Phase: implement\nTicket: {{.Ticket.Key}}\nPlan:\n{{.Artifacts.Plan}}\n",
+	}
+	for name, content := range templates {
+		if err := os.WriteFile(filepath.Join(promptDir, name), []byte(content), 0644); err != nil {
+			t.Fatalf("write template %s: %v", name, err)
+		}
+	}
+
+	state, err := LoadOrCreate(stateDir, "TEST-1")
+	if err != nil {
+		t.Fatalf("LoadOrCreate: %v", err)
+	}
+
+	engine := NewEngine(mock, state, EngineConfig{
+		Pipeline:   &PhasePipeline{Phases: phases},
+		Loader:     NewPromptLoader(promptDir),
+		Ticket:     TicketData{Key: "TEST-1", Summary: "Test ticket", ExistingPlan: existingPlan},
+		Model:      "test-model",
+		WorkDir:    workDir,
+		MaxCostUSD: 0,
+		Mode:       Autonomous,
+		SleepFunc:  func(time.Duration) {},
+		JitterFunc: func(time.Duration) time.Duration { return 0 },
+	})
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	// The implement phase should have received a prompt containing the plan.
+	var implementOpts *runner.RunOpts
+	for i, call := range mock.calls {
+		if call.Phase == "implement" {
+			implementOpts = &mock.calls[i]
+			break
+		}
+	}
+	if implementOpts == nil {
+		t.Fatal("implement phase was not called")
+	}
+
+	if !strings.Contains(implementOpts.SystemPrompt, existingPlan) {
+		t.Errorf("implement prompt should contain the existing plan, got: %s", implementOpts.SystemPrompt[:min(200, len(implementOpts.SystemPrompt))])
 	}
 }
 

--- a/internal/pipeline/events.go
+++ b/internal/pipeline/events.go
@@ -49,6 +49,7 @@ const (
 	EventMonitorCommentSkipped    = "monitor_comment_skipped"
 	EventMonitorProfileApplied    = "monitor_profile_applied"
 	EventMonitorWarning           = "monitor_warning"
+	EventPlanSkippedByTriage      = "plan_skipped_by_triage"
 	EventReworkFeedbackInjected   = "rework_feedback_injected"
 	EventReworkFeedbackSkipped    = "rework_feedback_skipped"
 	EventPromptLoaded             = "prompt_loaded"

--- a/internal/pipeline/prompt_test.go
+++ b/internal/pipeline/prompt_test.go
@@ -311,6 +311,14 @@ func TestValidateTemplate(t *testing.T) {
 		}
 	})
 
+	t.Run("valid_template_with_existing_spec_and_plan", func(t *testing.T) {
+		tmpl := `{{- if .Ticket.ExistingSpec}}Spec: {{.Ticket.ExistingSpec}}{{- end}}
+{{- if .Ticket.ExistingPlan}}Plan: {{.Ticket.ExistingPlan}}{{- end}}`
+		if err := ValidateTemplate(tmpl); err != nil {
+			t.Fatalf("ValidateTemplate: %v", err)
+		}
+	})
+
 	t.Run("errors_on_syntax_error", func(t *testing.T) {
 		err := ValidateTemplate("{{.Invalid}")
 		if err == nil {
@@ -553,6 +561,155 @@ Verdict: {{.ReworkFeedback.Verdict}}
 		}
 		if !strings.Contains(result, "the feedback takes precedence") {
 			t.Error("implement prompt should say 'the feedback takes precedence' for verify rework feedback")
+		}
+	})
+
+	t.Run("renders_existing_spec_when_present", func(t *testing.T) {
+		tmpl := `{{- if .Ticket.ExistingSpec}}
+## Existing Spec
+{{.Ticket.ExistingSpec}}
+{{- end}}`
+		data := PromptData{
+			Ticket: TicketData{ExistingSpec: "The spec content here"},
+		}
+		result, err := RenderPrompt(tmpl, data)
+		if err != nil {
+			t.Fatalf("RenderPrompt: %v", err)
+		}
+		if !strings.Contains(result, "Existing Spec") {
+			t.Errorf("result should contain Existing Spec header, got: %s", result)
+		}
+		if !strings.Contains(result, "The spec content here") {
+			t.Errorf("result should contain spec content, got: %s", result)
+		}
+	})
+
+	t.Run("omits_existing_spec_when_empty", func(t *testing.T) {
+		tmpl := `{{- if .Ticket.ExistingSpec}}
+## Existing Spec
+{{.Ticket.ExistingSpec}}
+{{- end}}`
+		data := PromptData{}
+		result, err := RenderPrompt(tmpl, data)
+		if err != nil {
+			t.Fatalf("RenderPrompt: %v", err)
+		}
+		if strings.Contains(result, "Existing Spec") {
+			t.Errorf("result should not contain Existing Spec when empty, got: %s", result)
+		}
+	})
+
+	t.Run("renders_existing_plan_when_present", func(t *testing.T) {
+		tmpl := `{{- if .Ticket.ExistingPlan}}
+## Existing Plan
+{{.Ticket.ExistingPlan}}
+{{- end}}`
+		data := PromptData{
+			Ticket: TicketData{ExistingPlan: "Step 1: do stuff\nStep 2: more stuff"},
+		}
+		result, err := RenderPrompt(tmpl, data)
+		if err != nil {
+			t.Fatalf("RenderPrompt: %v", err)
+		}
+		if !strings.Contains(result, "Existing Plan") {
+			t.Errorf("result should contain Existing Plan header, got: %s", result)
+		}
+		if !strings.Contains(result, "Step 1: do stuff") {
+			t.Errorf("result should contain plan content, got: %s", result)
+		}
+	})
+
+	t.Run("omits_existing_plan_when_empty", func(t *testing.T) {
+		tmpl := `{{- if .Ticket.ExistingPlan}}
+## Existing Plan
+{{.Ticket.ExistingPlan}}
+{{- end}}`
+		data := PromptData{}
+		result, err := RenderPrompt(tmpl, data)
+		if err != nil {
+			t.Fatalf("RenderPrompt: %v", err)
+		}
+		if strings.Contains(result, "Existing Plan") {
+			t.Errorf("result should not contain Existing Plan when empty, got: %s", result)
+		}
+	})
+
+	t.Run("renders_triage_prompt_with_existing_spec_and_plan", func(t *testing.T) {
+		// Read the actual embedded triage.md template.
+		tmplBytes, err := os.ReadFile(filepath.Join("..", "..", "cmd", "soda", "embeds", "prompts", "triage.md"))
+		if err != nil {
+			t.Skipf("skipping: cannot read embedded triage.md: %v", err)
+		}
+		tmpl := string(tmplBytes)
+
+		data := PromptData{
+			Ticket: TicketData{
+				Key:          "TEST-134",
+				Summary:      "Test plan routing",
+				Type:         "feat",
+				Description:  "A test ticket with existing plan",
+				ExistingSpec: "The reviewed specification content",
+				ExistingPlan: "Task 1: update schema\nTask 2: update prompt",
+			},
+			Config: PromptConfigData{
+				Repos: []RepoConfig{{Name: "soda", Forge: "github", Description: "test repo"}},
+			},
+		}
+
+		result, err := RenderPrompt(tmpl, data)
+		if err != nil {
+			t.Fatalf("RenderPrompt: %v", err)
+		}
+		if !strings.Contains(result, "Existing Spec (from issue)") {
+			t.Errorf("triage prompt should contain Existing Spec section;\ngot: %s", result)
+		}
+		if !strings.Contains(result, "The reviewed specification content") {
+			t.Errorf("triage prompt should contain spec content;\ngot: %s", result)
+		}
+		if !strings.Contains(result, "Existing Plan (from issue)") {
+			t.Errorf("triage prompt should contain Existing Plan section;\ngot: %s", result)
+		}
+		if !strings.Contains(result, "Task 1: update schema") {
+			t.Errorf("triage prompt should contain plan content;\ngot: %s", result)
+		}
+		if !strings.Contains(result, "skip_plan") {
+			t.Errorf("triage prompt should contain plan routing instructions mentioning skip_plan;\ngot: %s", result)
+		}
+	})
+
+	t.Run("renders_triage_prompt_without_spec_plan_when_absent", func(t *testing.T) {
+		// Read the actual embedded triage.md template.
+		tmplBytes, err := os.ReadFile(filepath.Join("..", "..", "cmd", "soda", "embeds", "prompts", "triage.md"))
+		if err != nil {
+			t.Skipf("skipping: cannot read embedded triage.md: %v", err)
+		}
+		tmpl := string(tmplBytes)
+
+		data := PromptData{
+			Ticket: TicketData{
+				Key:         "TEST-134",
+				Summary:     "Test no spec/plan",
+				Type:        "feat",
+				Description: "A ticket without existing spec or plan",
+			},
+			Config: PromptConfigData{
+				Repos: []RepoConfig{{Name: "soda", Forge: "github", Description: "test repo"}},
+			},
+		}
+
+		result, err := RenderPrompt(tmpl, data)
+		if err != nil {
+			t.Fatalf("RenderPrompt: %v", err)
+		}
+		if strings.Contains(result, "Existing Spec (from issue)") {
+			t.Errorf("triage prompt should NOT contain Existing Spec section when empty;\ngot: %s", result)
+		}
+		if strings.Contains(result, "Existing Plan (from issue)") {
+			t.Errorf("triage prompt should NOT contain Existing Plan section when empty;\ngot: %s", result)
+		}
+		// Core triage content should still be present.
+		if !strings.Contains(result, "TEST-134") {
+			t.Errorf("triage prompt should still contain ticket key;\ngot: %s", result)
 		}
 	})
 

--- a/phases.yaml
+++ b/phases.yaml
@@ -7,7 +7,7 @@ phases:
   - name: triage
     prompt: prompts/triage.md
     schema: |
-      {"type":"object","properties":{"ticket_key":{"type":"string"},"repo":{"type":"string"},"code_area":{"type":"string"},"files":{"type":"array","items":{"type":"string"}},"complexity":{"type":"string"},"approach":{"type":"string"},"risks":{"type":"array","items":{"type":"string"}},"automatable":{"type":"boolean"},"block_reason":{"type":"string"}},"required":["ticket_key","repo","code_area","files","complexity","approach","risks","automatable"]}
+      {"type":"object","properties":{"ticket_key":{"type":"string"},"repo":{"type":"string"},"code_area":{"type":"string"},"files":{"type":"array","items":{"type":"string"}},"complexity":{"type":"string"},"approach":{"type":"string"},"risks":{"type":"array","items":{"type":"string"}},"automatable":{"type":"boolean"},"block_reason":{"type":"string"},"skip_plan":{"type":"boolean"},"extracted_plan":{"type":"string"}},"required":["ticket_key","repo","code_area","files","complexity","approach","risks","automatable"]}
     tools:
       - Read
       - Glob

--- a/phases.yaml
+++ b/phases.yaml
@@ -7,7 +7,7 @@ phases:
   - name: triage
     prompt: prompts/triage.md
     schema: |
-      {"type":"object","properties":{"ticket_key":{"type":"string"},"repo":{"type":"string"},"code_area":{"type":"string"},"files":{"type":"array","items":{"type":"string"}},"complexity":{"type":"string"},"approach":{"type":"string"},"risks":{"type":"array","items":{"type":"string"}},"automatable":{"type":"boolean"},"block_reason":{"type":"string"},"skip_plan":{"type":"boolean"},"extracted_plan":{"type":"string"}},"required":["ticket_key","repo","code_area","files","complexity","approach","risks","automatable"]}
+      {"type":"object","properties":{"ticket_key":{"type":"string"},"repo":{"type":"string"},"code_area":{"type":"string"},"files":{"type":"array","items":{"type":"string"}},"complexity":{"type":"string"},"approach":{"type":"string"},"risks":{"type":"array","items":{"type":"string"}},"automatable":{"type":"boolean"},"block_reason":{"type":"string"},"skip_plan":{"type":"boolean","default":false}},"required":["ticket_key","repo","code_area","files","complexity","approach","risks","automatable"]}
     tools:
       - Read
       - Glob

--- a/schemas/triage.go
+++ b/schemas/triage.go
@@ -3,13 +3,15 @@ package schemas
 // TriageOutput is the structured output for the triage phase.
 // Used to generate the JSON schema passed to --json-schema.
 type TriageOutput struct {
-	TicketKey   string   `json:"ticket_key"`
-	Repo        string   `json:"repo"`
-	CodeArea    string   `json:"code_area"`
-	Files       []string `json:"files"`
-	Complexity  string   `json:"complexity"` // small, medium, large
-	Approach    string   `json:"approach"`
-	Risks       []string `json:"risks"`
-	Automatable bool     `json:"automatable"`
-	BlockReason string   `json:"block_reason,omitempty"` // why not automatable
+	TicketKey     string   `json:"ticket_key"`
+	Repo          string   `json:"repo"`
+	CodeArea      string   `json:"code_area"`
+	Files         []string `json:"files"`
+	Complexity    string   `json:"complexity"` // small, medium, large
+	Approach      string   `json:"approach"`
+	Risks         []string `json:"risks"`
+	Automatable   bool     `json:"automatable"`
+	BlockReason   string   `json:"block_reason,omitempty"`   // why not automatable
+	SkipPlan      bool     `json:"skip_plan,omitempty"`      // true when an existing plan is complete and reviewed
+	ExtractedPlan string   `json:"extracted_plan,omitempty"` // plan content from the ticket, when skip_plan is true
 }

--- a/schemas/triage.go
+++ b/schemas/triage.go
@@ -3,15 +3,14 @@ package schemas
 // TriageOutput is the structured output for the triage phase.
 // Used to generate the JSON schema passed to --json-schema.
 type TriageOutput struct {
-	TicketKey     string   `json:"ticket_key"`
-	Repo          string   `json:"repo"`
-	CodeArea      string   `json:"code_area"`
-	Files         []string `json:"files"`
-	Complexity    string   `json:"complexity"` // small, medium, large
-	Approach      string   `json:"approach"`
-	Risks         []string `json:"risks"`
-	Automatable   bool     `json:"automatable"`
-	BlockReason   string   `json:"block_reason,omitempty"`   // why not automatable
-	SkipPlan      bool     `json:"skip_plan,omitempty"`      // true when an existing plan is complete and reviewed
-	ExtractedPlan string   `json:"extracted_plan,omitempty"` // plan content from the ticket, when skip_plan is true
+	TicketKey   string   `json:"ticket_key"`
+	Repo        string   `json:"repo"`
+	CodeArea    string   `json:"code_area"`
+	Files       []string `json:"files"`
+	Complexity  string   `json:"complexity"` // small, medium, large
+	Approach    string   `json:"approach"`
+	Risks       []string `json:"risks"`
+	Automatable bool     `json:"automatable"`
+	BlockReason string   `json:"block_reason,omitempty"` // why not automatable
+	SkipPlan    bool     `json:"skip_plan,omitempty"`    // true when an existing plan is complete; engine uses ExistingPlan from ticket
 }


### PR DESCRIPTION
## Summary

- **Triage prompt** now conditionally renders `ExistingSpec` and `ExistingPlan` sections, instructing the LLM to set `skip_plan=true` when a complete, reviewed plan is already present in the ticket
- **Schema updates** add `skip_plan` (boolean, default false) to the triage output JSON schema and Go struct; `extracted_plan` was intentionally removed to avoid wasteful LLM duplication
- **Engine routing** adds `triageRequestsSkipPlan()` (requires both `skip_plan=true` AND non-empty `ExistingPlan`) and `skipPlanFromTriage()` which writes the existing plan as the plan artifact, marks the phase completed, and emits an event — skipping the plan LLM call entirely
- **7 new tests** covering happy path, negative cases (`skip_plan=false`, empty plan), gate independence, and artifact propagation to downstream phases

## Acceptance Criteria

- [x] Triage prompt renders existing spec/plan sections conditionally
- [x] `skip_plan` field added to triage JSON schema and Go struct
- [x] Engine skips plan phase when `skip_plan=true` and `ExistingPlan` is non-empty
- [x] Plan artifact is written so downstream phases (implement, verify, review) see it
- [x] Gate logic (`gatePhase("triage")`) unchanged — only checks `automatable`
- [x] `extracted_plan` removed to avoid duplicate LLM output
- [x] All existing tests pass, no regressions

## Test Plan

- [x] `TestTriagePromptRendering` — verifies conditional spec/plan blocks in prompt
- [x] `TestSkipsPlanPhaseWhenTriageSetSkipPlan` — happy path: plan LLM skipped, artifact written
- [x] `TestNoSkipWhenSkipPlanFalse` — normal flow when `skip_plan` unset
- [x] `TestNoSkipWhenExistingPlanEmpty` — `skip_plan` ignored without plan content
- [x] `TestPlanArtifactAvailableToImplement` — downstream phase receives plan via `Artifacts.Plan`
- [x] Gate tests updated to remove `extracted_plan` from payloads
- [x] All 11 project packages pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)