### PR TITLE
fix(pipeline): bump phase timeouts and align SUBMITTED column (#144, #147)

### DIFF
--- a/cmd/soda/embeds/phases.yaml
+++ b/cmd/soda/embeds/phases.yaml
@@ -31,7 +31,7 @@ phases:
       - Grep
       - Bash(git:*)
       - Bash(ls:*)
-    timeout: 5m
+    timeout: 8m
     retry:
       transient: 2
       parse: 1
@@ -67,7 +67,7 @@ phases:
       - Glob
       - Grep
       - Bash
-    timeout: 5m
+    timeout: 8m
     retry:
       transient: 2
       parse: 1
@@ -85,7 +85,7 @@ phases:
       - Glob
       - Grep
       - Bash
-    timeout: 8m
+    timeout: 12m
     retry:
       transient: 2
       parse: 1

--- a/cmd/soda/status.go
+++ b/cmd/soda/status.go
@@ -262,7 +262,7 @@ func formatSubmitted(startedAt, now time.Time) string {
 	sy, sm, sd := startedAt.Date()
 	ny, nm, nd := now.Date()
 	if sy == ny && sm == nm && sd == nd {
-		return startedAt.Format("15:04")
+		return fmt.Sprintf("%12s", startedAt.Format("15:04"))
 	}
 	return startedAt.Format("Jan 02 15:04")
 }

--- a/cmd/soda/status_test.go
+++ b/cmd/soda/status_test.go
@@ -135,7 +135,7 @@ func TestFormatSubmitted(t *testing.T) {
 			name:      "same day → time only",
 			startedAt: time.Date(2025, 6, 15, 9, 5, 0, 0, time.UTC),
 			now:       now,
-			want:      "09:05",
+			want:      "       09:05",
 		},
 		{
 			name:      "yesterday → date + time",


### PR DESCRIPTION
## Summary

- Bump plan timeout: 5m → 8m
- Bump verify timeout: 5m → 8m
- Bump review timeout: 8m → 12m
- Right-pad time-only SUBMITTED values for consistent column alignment

## Test plan

- [x] All tests pass
- [ ] CI passes

Fixes: #144, #147

Generated with [Claude Code](https://claude.com/claude-code)
