### PR TITLE
feat(cli): enrich soda history with phase outcome details (#59)

### DIFF
--- a/cmd/soda/history.go
+++ b/cmd/soda/history.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,7 +14,7 @@ import (
 )
 
 func newHistoryCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "history <ticket>",
 		Short: "Show phase details for a ticket",
 		Args:  cobra.ExactArgs(1),
@@ -21,12 +23,19 @@ func newHistoryCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return runHistory(cfg.StateDir, args[0])
+			detail, _ := cmd.Flags().GetBool("detail")
+			phase, _ := cmd.Flags().GetString("phase")
+			return runHistory(cfg.StateDir, args[0], detail, phase)
 		},
 	}
+
+	cmd.Flags().Bool("detail", false, "show full structured output for all phases")
+	cmd.Flags().String("phase", "", "filter to a specific phase and show full details")
+
+	return cmd
 }
 
-func runHistory(stateDir, ticketKey string) error {
+func runHistory(stateDir, ticketKey string, detail bool, phaseFilter string) error {
 	ticketDir := filepath.Join(stateDir, ticketKey)
 	metaPath := filepath.Join(ticketDir, "meta.json")
 	meta, err := pipeline.ReadMeta(metaPath)
@@ -51,7 +60,7 @@ func runHistory(stateDir, ticketKey string) error {
 		fmt.Fprintf(os.Stderr, "warning: could not read events: %v\n", eventsErr)
 	}
 	if len(events) > 0 {
-		return renderEventsHistory(meta, events, ticketDir)
+		return renderEventsHistory(meta, events, ticketDir, detail, phaseFilter)
 	}
 
 	// Fallback: meta-only rendering for old state dirs without events.jsonl.
@@ -59,9 +68,31 @@ func runHistory(stateDir, ticketKey string) error {
 }
 
 // renderEventsHistory renders the full multi-generation history table
-// reconstructed from events.jsonl.
-func renderEventsHistory(meta *pipeline.PipelineMeta, events []pipeline.Event, stateDir string) error {
+// reconstructed from events.jsonl. When detail is true, the full structured
+// output JSON is printed after each phase row. When phaseFilter is non-empty,
+// only entries for that phase are shown with their full output.
+func renderEventsHistory(meta *pipeline.PipelineMeta, events []pipeline.Event, stateDir string, detail bool, phaseFilter string) error {
 	h := pipeline.BuildHistory(events, stateDir)
+
+	// When --detail or --phase is used, load full outputs.
+	if detail || phaseFilter != "" {
+		h.LoadFullOutputs(stateDir, phaseFilter)
+	}
+
+	// Filter entries when --phase is specified.
+	entries := h.Entries
+	if phaseFilter != "" {
+		var filtered []pipeline.PhaseGeneration
+		for _, e := range entries {
+			if e.Phase == phaseFilter {
+				filtered = append(filtered, e)
+			}
+		}
+		entries = filtered
+		if len(entries) == 0 {
+			return fmt.Errorf("history: no entries found for phase %q", phaseFilter)
+		}
+	}
 
 	tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
 	fmt.Fprintln(tw, "Phase\tGen\tStatus\tDuration\tCost\tDetails")
@@ -69,7 +100,16 @@ func renderEventsHistory(meta *pipeline.PipelineMeta, events []pipeline.Event, s
 	var lastFailPhase string
 	var lastFailError string
 
-	for _, entry := range h.Entries {
+	// Collect full outputs to print after the table (to avoid breaking
+	// tabwriter alignment).
+	type outputBlock struct {
+		phase      string
+		generation int
+		data       json.RawMessage
+	}
+	var outputs []outputBlock
+
+	for _, entry := range entries {
 		sym := statusSymbol(entry.Status, entry.Superseded)
 
 		gen := fmt.Sprintf("%d", entry.Generation)
@@ -92,6 +132,14 @@ func renderEventsHistory(meta *pipeline.PipelineMeta, events []pipeline.Event, s
 		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
 			entry.Phase, gen, sym, dur, cost, details)
 
+		if len(entry.FullOutput) > 0 {
+			outputs = append(outputs, outputBlock{
+				phase:      entry.Phase,
+				generation: entry.Generation,
+				data:       entry.FullOutput,
+			})
+		}
+
 		if entry.Status == pipeline.PhaseFailed && entry.Error != "" && !entry.Superseded {
 			lastFailPhase = entry.Phase
 			lastFailError = entry.Error
@@ -99,10 +147,12 @@ func renderEventsHistory(meta *pipeline.PipelineMeta, events []pipeline.Event, s
 	}
 
 	// Total line using meta.TotalCost as the authoritative total.
-	fmt.Fprintf(tw, "\t\t\t\t──────────\t\n")
-	fmt.Fprintf(tw, "\t\t\tTotal:\t$%.2f\t\n", meta.TotalCost)
-	if h.SupersededCost > 0 {
-		fmt.Fprintf(tw, "\t\t\tSuperseded:\t$%.2f\t\n", h.SupersededCost)
+	if phaseFilter == "" {
+		fmt.Fprintf(tw, "\t\t\t\t──────────\t\n")
+		fmt.Fprintf(tw, "\t\t\tTotal:\t$%.2f\t\n", meta.TotalCost)
+		if h.SupersededCost > 0 {
+			fmt.Fprintf(tw, "\t\t\tSuperseded:\t$%.2f\t\n", h.SupersededCost)
+		}
 	}
 	if err := tw.Flush(); err != nil {
 		return fmt.Errorf("history: flush output: %w", err)
@@ -112,7 +162,23 @@ func renderEventsHistory(meta *pipeline.PipelineMeta, events []pipeline.Event, s
 		fmt.Printf("\nLast failure (%s):\n  Error: %s\n", lastFailPhase, lastFailError)
 	}
 
+	// Print full structured outputs after the table.
+	for _, ob := range outputs {
+		fmt.Printf("\n--- %s (gen %d) ---\n", ob.phase, ob.generation)
+		fmt.Println(prettyJSON(ob.data))
+	}
+
 	return nil
+}
+
+// prettyJSON formats raw JSON with indentation. Falls back to the raw
+// content if the data cannot be parsed.
+func prettyJSON(data json.RawMessage) string {
+	var buf bytes.Buffer
+	if err := json.Indent(&buf, data, "", "  "); err != nil {
+		return string(data)
+	}
+	return buf.String()
 }
 
 // renderMetaHistory renders a simple history table from meta.json only.

--- a/cmd/soda/history.go
+++ b/cmd/soda/history.go
@@ -87,16 +87,7 @@ func renderEventsHistory(meta *pipeline.PipelineMeta, events []pipeline.Event, s
 			cost = fmt.Sprintf("$%.2f", entry.Cost)
 		}
 
-		details := entry.Details
-		if entry.Superseded {
-			details = "(superseded)"
-		}
-		if entry.Error != "" && !entry.Superseded {
-			details = entry.Error
-			if len(details) > 60 {
-				details = details[:57] + "..."
-			}
-		}
+		details := formatDetails(entry.Details, entry.Error, entry.Superseded)
 
 		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
 			entry.Phase, gen, sym, dur, cost, details)
@@ -178,6 +169,26 @@ func renderMetaHistory(meta *pipeline.PipelineMeta) error {
 	}
 
 	return nil
+}
+
+// formatDetails builds the details column text for a history entry.
+// When both outcome details and an error are present, they are joined
+// with " — " so the reader sees both at a glance.
+func formatDetails(details, errMsg string, superseded bool) string {
+	if superseded {
+		return "(superseded)"
+	}
+	if errMsg != "" {
+		errText := errMsg
+		if len(errText) > 60 {
+			errText = errText[:57] + "..."
+		}
+		if details != "" {
+			return details + " — " + errText
+		}
+		return errText
+	}
+	return details
 }
 
 // statusSymbol returns a status symbol for display.

--- a/cmd/soda/history_test.go
+++ b/cmd/soda/history_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/decko/soda/internal/pipeline"
@@ -60,6 +61,60 @@ func TestFormatDetails(t *testing.T) {
 				t.Errorf("formatDetails(%q, %q, %v) = %q, want %q", tc.details, tc.errMsg, tc.superseded, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestPrettyJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		data json.RawMessage
+		want string
+	}{
+		{
+			name: "simple object",
+			data: json.RawMessage(`{"key":"value"}`),
+			want: "{\n  \"key\": \"value\"\n}",
+		},
+		{
+			name: "nested object",
+			data: json.RawMessage(`{"a":{"b":1}}`),
+			want: "{\n  \"a\": {\n    \"b\": 1\n  }\n}",
+		},
+		{
+			name: "invalid json",
+			data: json.RawMessage(`not json`),
+			want: "not json",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := prettyJSON(tc.data)
+			if got != tc.want {
+				t.Errorf("prettyJSON(%q) =\n%s\nwant:\n%s", string(tc.data), got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNewHistoryCmd_Flags(t *testing.T) {
+	cmd := newHistoryCmd()
+
+	// Verify --detail flag exists and defaults to false.
+	detailFlag := cmd.Flags().Lookup("detail")
+	if detailFlag == nil {
+		t.Fatal("--detail flag not found")
+	}
+	if detailFlag.DefValue != "false" {
+		t.Errorf("--detail default = %q, want %q", detailFlag.DefValue, "false")
+	}
+
+	// Verify --phase flag exists and defaults to empty.
+	phaseFlag := cmd.Flags().Lookup("phase")
+	if phaseFlag == nil {
+		t.Fatal("--phase flag not found")
+	}
+	if phaseFlag.DefValue != "" {
+		t.Errorf("--phase default = %q, want empty", phaseFlag.DefValue)
 	}
 }
 

--- a/cmd/soda/history_test.go
+++ b/cmd/soda/history_test.go
@@ -6,6 +6,63 @@ import (
 	"github.com/decko/soda/internal/pipeline"
 )
 
+func TestFormatDetails(t *testing.T) {
+	tests := []struct {
+		name       string
+		details    string
+		errMsg     string
+		superseded bool
+		want       string
+	}{
+		{
+			name:    "details only",
+			details: "low",
+			want:    "low",
+		},
+		{
+			name:   "error only",
+			errMsg: "tests failed",
+			want:   "tests failed",
+		},
+		{
+			name:    "details and error",
+			details: "FAIL",
+			errMsg:  "verification failed",
+			want:    "FAIL — verification failed",
+		},
+		{
+			name:       "superseded overrides everything",
+			details:    "low",
+			errMsg:     "some error",
+			superseded: true,
+			want:       "(superseded)",
+		},
+		{
+			name: "empty",
+			want: "",
+		},
+		{
+			name:   "long error truncated",
+			errMsg: "this is a very long error message that definitely exceeds sixty characters in total length",
+			want:   "this is a very long error message that definitely exceeds...",
+		},
+		{
+			name:    "details with long error truncated",
+			details: "FAIL",
+			errMsg:  "this is a very long error message that definitely exceeds sixty characters in total length",
+			want:    "FAIL — this is a very long error message that definitely exceeds...",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := formatDetails(tc.details, tc.errMsg, tc.superseded)
+			if got != tc.want {
+				t.Errorf("formatDetails(%q, %q, %v) = %q, want %q", tc.details, tc.errMsg, tc.superseded, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestStatusSymbol(t *testing.T) {
 	tests := []struct {
 		status     pipeline.PhaseStatus

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/decko/soda/internal/claude"
 	"github.com/decko/soda/internal/git"
+	"github.com/decko/soda/internal/progress"
 	"github.com/decko/soda/internal/runner"
 	"github.com/decko/soda/internal/sandbox"
 	"github.com/decko/soda/schemas"
@@ -528,10 +529,19 @@ func (e *Engine) runPhase(ctx context.Context, phase PhaseConfig) error {
 	if err := e.state.MarkCompleted(phase.Name); err != nil {
 		return fmt.Errorf("engine: mark completed %s: %w", phase.Name, err)
 	}
+	completedData := map[string]any{
+		"duration_ms": e.state.Meta().Phases[phase.Name].DurationMs,
+		"cost":        e.state.Meta().Phases[phase.Name].Cost,
+	}
+	if result.Output != nil {
+		if summary := progress.PhaseSummary(phase.Name, result.Output); summary != "" {
+			completedData["summary"] = summary
+		}
+	}
 	e.emit(Event{
 		Phase: phase.Name,
 		Kind:  EventPhaseCompleted,
-		Data:  map[string]any{"duration_ms": e.state.Meta().Phases[phase.Name].DurationMs, "cost": e.state.Meta().Phases[phase.Name].Cost},
+		Data:  completedData,
 	})
 
 	// Domain gating.
@@ -1166,10 +1176,17 @@ func (e *Engine) runParallelReview(ctx context.Context, phase PhaseConfig) error
 	if err := e.state.MarkCompleted(phase.Name); err != nil {
 		return fmt.Errorf("engine: mark completed %s: %w", phase.Name, err)
 	}
+	reviewCompletedData := map[string]any{
+		"duration_ms": e.state.Meta().Phases[phase.Name].DurationMs,
+		"cost":        e.state.Meta().Phases[phase.Name].Cost,
+	}
+	if summary := progress.PhaseSummary(phase.Name, json.RawMessage(output)); summary != "" {
+		reviewCompletedData["summary"] = summary
+	}
 	e.emit(Event{
 		Phase: phase.Name,
 		Kind:  EventPhaseCompleted,
-		Data:  map[string]any{"duration_ms": e.state.Meta().Phases[phase.Name].DurationMs, "cost": e.state.Meta().Phases[phase.Name].Cost},
+		Data:  reviewCompletedData,
 	})
 
 	// Domain gating.

--- a/internal/pipeline/history.go
+++ b/internal/pipeline/history.go
@@ -18,8 +18,9 @@ type PhaseGeneration struct {
 	Cost       float64
 	DurationMs int64
 	Error      string
-	Details    string // one-line summary from result JSON
-	Superseded bool   // true if a later generation exists
+	Details    string          // one-line summary from result JSON
+	FullOutput json.RawMessage // full structured output JSON (populated by LoadFullOutputs)
+	Superseded bool            // true if a later generation exists
 }
 
 // History holds the reconstructed multi-generation history for a ticket.
@@ -161,6 +162,43 @@ func loadPhaseDetails(phase string, generation int, stateDir string) string {
 	}
 
 	return progress.PhaseSummary(phase, json.RawMessage(data))
+}
+
+// LoadPhaseResult reads the full structured output JSON for a phase generation.
+// It checks for an archived file (<phase>.json.<generation>) first, then
+// falls back to the current result file (<phase>.json). Returns nil if no
+// result file exists.
+func LoadPhaseResult(phase string, generation int, stateDir string) json.RawMessage {
+	if stateDir == "" {
+		return nil
+	}
+
+	path := filepath.Join(stateDir, phase+".json")
+	archivePath := fmt.Sprintf("%s.%d", path, generation)
+	data, err := os.ReadFile(archivePath)
+	if err != nil {
+		data, err = os.ReadFile(path)
+		if err != nil {
+			return nil
+		}
+	}
+	return json.RawMessage(data)
+}
+
+// LoadFullOutputs populates the FullOutput field on all history entries by
+// reading result JSON files from stateDir. If phaseFilter is non-empty, only
+// entries matching that phase name are loaded.
+func (h *History) LoadFullOutputs(stateDir, phaseFilter string) {
+	for i := range h.Entries {
+		if phaseFilter != "" && h.Entries[i].Phase != phaseFilter {
+			continue
+		}
+		h.Entries[i].FullOutput = LoadPhaseResult(
+			h.Entries[i].Phase,
+			h.Entries[i].Generation,
+			stateDir,
+		)
+	}
 }
 
 // FormatDuration formats a duration from milliseconds as "Xs" or "XmYYs".

--- a/internal/pipeline/history.go
+++ b/internal/pipeline/history.go
@@ -100,6 +100,9 @@ func BuildHistory(events []Event, stateDir string) History {
 			if v, ok := ev.Data["cost"]; ok {
 				h.Entries[idx].Cost = toFloat64(v)
 			}
+			// Load details from result JSON (may exist even for failed phases,
+			// e.g. verify with verdict=FAIL).
+			h.Entries[idx].Details = loadPhaseDetails(ev.Phase, h.Entries[idx].Generation, stateDir)
 
 		case EventPhaseSkipped:
 			entry := PhaseGeneration{

--- a/internal/pipeline/history.go
+++ b/internal/pipeline/history.go
@@ -80,8 +80,15 @@ func BuildHistory(events []Event, stateDir string) History {
 			if v, ok := ev.Data["duration_ms"]; ok {
 				h.Entries[idx].DurationMs = toInt64(v)
 			}
-			// Load details from result JSON.
+			// Load details from result JSON; fall back to event-embedded summary.
 			h.Entries[idx].Details = loadPhaseDetails(ev.Phase, h.Entries[idx].Generation, stateDir)
+			if h.Entries[idx].Details == "" {
+				if v, ok := ev.Data["summary"]; ok {
+					if s, ok := v.(string); ok {
+						h.Entries[idx].Details = s
+					}
+				}
+			}
 
 		case EventPhaseFailed:
 			idx, ok := currentIdx[ev.Phase]
@@ -101,8 +108,15 @@ func BuildHistory(events []Event, stateDir string) History {
 				h.Entries[idx].Cost = toFloat64(v)
 			}
 			// Load details from result JSON (may exist even for failed phases,
-			// e.g. verify with verdict=FAIL).
+			// e.g. verify with verdict=FAIL); fall back to event-embedded summary.
 			h.Entries[idx].Details = loadPhaseDetails(ev.Phase, h.Entries[idx].Generation, stateDir)
+			if h.Entries[idx].Details == "" {
+				if v, ok := ev.Data["summary"]; ok {
+					if s, ok := v.(string); ok {
+						h.Entries[idx].Details = s
+					}
+				}
+			}
 
 		case EventPhaseSkipped:
 			entry := PhaseGeneration{

--- a/internal/pipeline/history_test.go
+++ b/internal/pipeline/history_test.go
@@ -157,6 +157,36 @@ func TestBuildHistory_WithDetails(t *testing.T) {
 	}
 }
 
+func TestBuildHistory_FailedPhaseDetails(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write a verify result with verdict=FAIL (result file exists even though phase failed).
+	verifyResult := map[string]any{
+		"verdict": "FAIL",
+	}
+	data, _ := json.Marshal(verifyResult)
+	if err := os.WriteFile(filepath.Join(dir, "verify.json"), data, 0644); err != nil {
+		t.Fatalf("WriteFile verify.json: %v", err)
+	}
+
+	events := []Event{
+		{Phase: "verify", Kind: EventPhaseStarted, Data: map[string]any{"generation": float64(1)}},
+		{Phase: "verify", Kind: EventPhaseFailed, Data: map[string]any{"error": "verification failed", "duration_ms": float64(20000), "cost": 0.15}},
+	}
+
+	h := BuildHistory(events, dir)
+	if len(h.Entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(h.Entries))
+	}
+
+	if h.Entries[0].Details != "FAIL" {
+		t.Errorf("details = %q, want %q", h.Entries[0].Details, "FAIL")
+	}
+	if h.Entries[0].Error != "verification failed" {
+		t.Errorf("error = %q, want %q", h.Entries[0].Error, "verification failed")
+	}
+}
+
 func TestBuildHistory_ArchivedDetails(t *testing.T) {
 	dir := t.TempDir()
 

--- a/internal/pipeline/history_test.go
+++ b/internal/pipeline/history_test.go
@@ -187,6 +187,66 @@ func TestBuildHistory_FailedPhaseDetails(t *testing.T) {
 	}
 }
 
+func TestBuildHistory_EventEmbeddedSummary(t *testing.T) {
+	// No result files on disk — details should come from event data "summary" field.
+	events := []Event{
+		{Phase: "triage", Kind: EventPhaseStarted, Data: map[string]any{"generation": float64(1)}},
+		{Phase: "triage", Kind: EventPhaseCompleted, Data: map[string]any{"cost": 0.10, "duration_ms": float64(5000), "summary": "low"}},
+	}
+
+	h := BuildHistory(events, "") // empty stateDir — no files to read
+	if len(h.Entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(h.Entries))
+	}
+	if h.Entries[0].Details != "low" {
+		t.Errorf("details = %q, want %q (from event summary)", h.Entries[0].Details, "low")
+	}
+}
+
+func TestBuildHistory_EventEmbeddedSummaryFailed(t *testing.T) {
+	// Failed phase with event-embedded summary and no result file.
+	events := []Event{
+		{Phase: "verify", Kind: EventPhaseStarted, Data: map[string]any{"generation": float64(1)}},
+		{Phase: "verify", Kind: EventPhaseFailed, Data: map[string]any{"error": "verification failed", "duration_ms": float64(20000), "cost": 0.15, "summary": "FAIL"}},
+	}
+
+	h := BuildHistory(events, "")
+	if len(h.Entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(h.Entries))
+	}
+	if h.Entries[0].Details != "FAIL" {
+		t.Errorf("details = %q, want %q (from event summary)", h.Entries[0].Details, "FAIL")
+	}
+	if h.Entries[0].Error != "verification failed" {
+		t.Errorf("error = %q, want %q", h.Entries[0].Error, "verification failed")
+	}
+}
+
+func TestBuildHistory_ResultFileOverridesEventSummary(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write a triage result file.
+	triageResult := map[string]any{"complexity": "medium", "automatable": true}
+	data, _ := json.Marshal(triageResult)
+	if err := os.WriteFile(filepath.Join(dir, "triage.json"), data, 0644); err != nil {
+		t.Fatalf("WriteFile triage.json: %v", err)
+	}
+
+	// Event includes a stale summary — result file should take precedence.
+	events := []Event{
+		{Phase: "triage", Kind: EventPhaseStarted, Data: map[string]any{"generation": float64(1)}},
+		{Phase: "triage", Kind: EventPhaseCompleted, Data: map[string]any{"cost": 0.10, "duration_ms": float64(5000), "summary": "stale-summary"}},
+	}
+
+	h := BuildHistory(events, dir)
+	if len(h.Entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(h.Entries))
+	}
+	if h.Entries[0].Details != "medium" {
+		t.Errorf("details = %q, want %q (from result file, not event summary)", h.Entries[0].Details, "medium")
+	}
+}
+
 func TestBuildHistory_ArchivedDetails(t *testing.T) {
 	dir := t.TempDir()
 

--- a/internal/pipeline/history_test.go
+++ b/internal/pipeline/history_test.go
@@ -336,6 +336,99 @@ func TestToFloat64(t *testing.T) {
 	}
 }
 
+func TestLoadPhaseResult(t *testing.T) {
+	t.Run("empty stateDir", func(t *testing.T) {
+		got := LoadPhaseResult("triage", 1, "")
+		if got != nil {
+			t.Errorf("expected nil, got %s", string(got))
+		}
+	})
+
+	t.Run("no result file", func(t *testing.T) {
+		dir := t.TempDir()
+		got := LoadPhaseResult("triage", 1, dir)
+		if got != nil {
+			t.Errorf("expected nil, got %s", string(got))
+		}
+	})
+
+	t.Run("current result file", func(t *testing.T) {
+		dir := t.TempDir()
+		data := []byte(`{"complexity":"low","automatable":true}`)
+		if err := os.WriteFile(filepath.Join(dir, "triage.json"), data, 0644); err != nil {
+			t.Fatal(err)
+		}
+		got := LoadPhaseResult("triage", 1, dir)
+		if string(got) != string(data) {
+			t.Errorf("got %s, want %s", string(got), string(data))
+		}
+	})
+
+	t.Run("archived result file", func(t *testing.T) {
+		dir := t.TempDir()
+		archived := []byte(`{"complexity":"high"}`)
+		current := []byte(`{"complexity":"low"}`)
+		if err := os.WriteFile(filepath.Join(dir, "triage.json.1"), archived, 0644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "triage.json"), current, 0644); err != nil {
+			t.Fatal(err)
+		}
+		got := LoadPhaseResult("triage", 1, dir)
+		if string(got) != string(archived) {
+			t.Errorf("got %s, want %s (archived)", string(got), string(archived))
+		}
+	})
+}
+
+func TestLoadFullOutputs(t *testing.T) {
+	dir := t.TempDir()
+
+	triageData := []byte(`{"complexity":"low","automatable":true}`)
+	planData := []byte(`{"tasks":[{"id":"1"}]}`)
+	if err := os.WriteFile(filepath.Join(dir, "triage.json"), triageData, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "plan.json"), planData, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	events := []Event{
+		{Phase: "triage", Kind: EventPhaseStarted, Data: map[string]any{"generation": float64(1)}},
+		{Phase: "triage", Kind: EventPhaseCompleted, Data: map[string]any{"cost": 0.10, "duration_ms": float64(5000)}},
+		{Phase: "plan", Kind: EventPhaseStarted, Data: map[string]any{"generation": float64(1)}},
+		{Phase: "plan", Kind: EventPhaseCompleted, Data: map[string]any{"cost": 0.20, "duration_ms": float64(10000)}},
+	}
+
+	h := BuildHistory(events, dir)
+
+	t.Run("all phases", func(t *testing.T) {
+		h2 := h // copy
+		h2.Entries = make([]PhaseGeneration, len(h.Entries))
+		copy(h2.Entries, h.Entries)
+		h2.LoadFullOutputs(dir, "")
+		if string(h2.Entries[0].FullOutput) != string(triageData) {
+			t.Errorf("triage full output = %s, want %s", string(h2.Entries[0].FullOutput), string(triageData))
+		}
+		if string(h2.Entries[1].FullOutput) != string(planData) {
+			t.Errorf("plan full output = %s, want %s", string(h2.Entries[1].FullOutput), string(planData))
+		}
+	})
+
+	t.Run("filtered to triage", func(t *testing.T) {
+		h2 := h
+		h2.Entries = make([]PhaseGeneration, len(h.Entries))
+		copy(h2.Entries, h.Entries)
+		h2.LoadFullOutputs(dir, "triage")
+		if string(h2.Entries[0].FullOutput) != string(triageData) {
+			t.Errorf("triage full output = %s, want %s", string(h2.Entries[0].FullOutput), string(triageData))
+		}
+		if h2.Entries[1].FullOutput != nil {
+			t.Errorf("plan full output should be nil when filtered, got %s", string(h2.Entries[1].FullOutput))
+		}
+	})
+}
+
 // Ensure Event timestamp parsing works with BuildHistory.
 func TestBuildHistory_PreservesTimestamps(t *testing.T) {
 	ts := time.Date(2026, 4, 11, 10, 0, 0, 0, time.UTC)

--- a/internal/pipeline/state.go
+++ b/internal/pipeline/state.go
@@ -187,6 +187,7 @@ func (s *State) MarkFailed(phase string, phaseErr error) error {
 		Data: map[string]any{
 			"error":       ps.Error,
 			"duration_ms": ps.DurationMs,
+			"cost":        ps.Cost,
 		},
 	})
 }

--- a/internal/pipeline/state_test.go
+++ b/internal/pipeline/state_test.go
@@ -261,9 +261,44 @@ func TestMarkFailed(t *testing.T) {
 		}
 	})
 
+	t.Run("event_includes_cost", func(t *testing.T) {
+		dir := t.TempDir()
+		state, _ := LoadOrCreate(dir, "T-3")
+
+		state.MarkRunning("plan")
+		state.AccumulateCost("plan", 0.42)
+		if err := state.MarkFailed("plan", fmt.Errorf("budget exceeded")); err != nil {
+			t.Fatalf("MarkFailed: %v", err)
+		}
+
+		events, err := ReadEvents(filepath.Join(dir, "T-3"))
+		if err != nil {
+			t.Fatalf("ReadEvents: %v", err)
+		}
+
+		// Find the phase_failed event.
+		var found bool
+		for _, ev := range events {
+			if ev.Kind == EventPhaseFailed && ev.Phase == "plan" {
+				cost, ok := ev.Data["cost"]
+				if !ok {
+					t.Fatal("phase_failed event missing cost field")
+				}
+				if c := toFloat64(cost); !approxEqual(c, 0.42) {
+					t.Errorf("cost = %f, want 0.42", c)
+				}
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatal("phase_failed event not found in events.jsonl")
+		}
+	})
+
 	t.Run("error_on_unknown_phase", func(t *testing.T) {
 		dir := t.TempDir()
-		state, _ := LoadOrCreate(dir, "T-2")
+		state, _ := LoadOrCreate(dir, "T-4")
 
 		err := state.MarkFailed("nonexistent", fmt.Errorf("err"))
 		if err == nil {


### PR DESCRIPTION
## Summary

- Add DETAILS column to `soda history` with one-line phase summaries (complexity for triage, task count for plan, files changed for implement, PASS/FAIL for verify, PR# for submit)
- Add `--detail` flag for full structured JSON output per phase
- Add `--phase <name>` flag for single-phase drill-down
- Embed phase summary in events for self-contained history
- Show outcome details alongside errors for failed phases

## Test plan

- [x] All tests pass
- [ ] CI passes

Fixes: #59

Generated with [Claude Code](https://claude.com/claude-code) via SODA
