### PR TITLE
fix(pipeline): remove duplicate phase event logging in events.jsonl (#152)

### DIFF
--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -151,6 +151,7 @@ func (e *Engine) skipPlanFromTriage() error {
 	if err := e.state.MarkRunning("plan"); err != nil {
 		return fmt.Errorf("engine: skip plan: mark running: %w", err)
 	}
+	e.emit(Event{Phase: "plan", Kind: EventPhaseStarted, Data: map[string]any{"generation": e.state.Meta().Phases["plan"].Generation}})
 
 	// Write the existing plan as the plan artifact.
 	if err := e.state.WriteArtifact("plan", []byte(plan)); err != nil {
@@ -168,6 +169,15 @@ func (e *Engine) skipPlanFromTriage() error {
 		Data: map[string]any{
 			"reason":    "triage set skip_plan=true; using ExistingPlan from ticket",
 			"plan_size": len(plan),
+		},
+	})
+
+	e.emit(Event{
+		Phase: "plan",
+		Kind:  EventPhaseCompleted,
+		Data: map[string]any{
+			"duration_ms": e.state.Meta().Phases["plan"].DurationMs,
+			"cost":        e.state.Meta().Phases["plan"].Cost,
 		},
 	})
 
@@ -431,16 +441,16 @@ func (e *Engine) runPhase(ctx context.Context, phase PhaseConfig) error {
 	}
 
 	// Mark phase running and notify callback.
-	e.emit(Event{Phase: phase.Name, Kind: EventPhaseStarted})
 	if err := e.state.MarkRunning(phase.Name); err != nil {
 		return fmt.Errorf("engine: mark running %s: %w", phase.Name, err)
 	}
+	e.emit(Event{Phase: phase.Name, Kind: EventPhaseStarted, Data: map[string]any{"generation": e.state.Meta().Phases[phase.Name].Generation}})
 
 	// Build prompt data and render template.
 	promptData, err := e.buildPromptData(phase)
 	if err != nil {
 		_ = e.state.MarkFailed(phase.Name, err)
-		e.emit(Event{Phase: phase.Name, Kind: EventPhaseFailed, Data: map[string]any{"error": err.Error()}})
+		e.emitPhaseFailed(phase.Name, err)
 		return fmt.Errorf("engine: build prompt data for %s: %w", phase.Name, err)
 	}
 
@@ -457,7 +467,7 @@ func (e *Engine) runPhase(ctx context.Context, phase PhaseConfig) error {
 	loadResult, err := e.config.Loader.LoadWithSource(phase.Prompt)
 	if err != nil {
 		_ = e.state.MarkFailed(phase.Name, err)
-		e.emit(Event{Phase: phase.Name, Kind: EventPhaseFailed, Data: map[string]any{"error": err.Error()}})
+		e.emitPhaseFailed(phase.Name, err)
 		return fmt.Errorf("engine: load template for %s: %w", phase.Name, err)
 	}
 
@@ -479,7 +489,7 @@ func (e *Engine) runPhase(ctx context.Context, phase PhaseConfig) error {
 	rendered, err := RenderPrompt(loadResult.Content, promptData)
 	if err != nil {
 		_ = e.state.MarkFailed(phase.Name, err)
-		e.emit(Event{Phase: phase.Name, Kind: EventPhaseFailed, Data: map[string]any{"error": err.Error()}})
+		e.emitPhaseFailed(phase.Name, err)
 		return fmt.Errorf("engine: render prompt for %s: %w", phase.Name, err)
 	}
 
@@ -506,7 +516,7 @@ func (e *Engine) runPhase(ctx context.Context, phase PhaseConfig) error {
 	result, err := e.runWithRetry(ctx, phase, opts)
 	if err != nil {
 		_ = e.state.MarkFailed(phase.Name, err)
-		e.emit(Event{Phase: phase.Name, Kind: EventPhaseFailed, Data: map[string]any{"error": err.Error()}})
+		e.emitPhaseFailed(phase.Name, err)
 		return err
 	}
 
@@ -1069,16 +1079,16 @@ func (e *Engine) runParallelReview(ctx context.Context, phase PhaseConfig) error
 	}
 
 	// Mark phase running.
-	e.emit(Event{Phase: phase.Name, Kind: EventPhaseStarted})
 	if err := e.state.MarkRunning(phase.Name); err != nil {
 		return fmt.Errorf("engine: mark running %s: %w", phase.Name, err)
 	}
+	e.emit(Event{Phase: phase.Name, Kind: EventPhaseStarted, Data: map[string]any{"generation": e.state.Meta().Phases[phase.Name].Generation}})
 
 	// Build prompt data shared by all reviewers.
 	promptData, err := e.buildPromptData(phase)
 	if err != nil {
 		_ = e.state.MarkFailed(phase.Name, err)
-		e.emit(Event{Phase: phase.Name, Kind: EventPhaseFailed, Data: map[string]any{"error": err.Error()}})
+		e.emitPhaseFailed(phase.Name, err)
 		return fmt.Errorf("engine: build prompt data for %s: %w", phase.Name, err)
 	}
 
@@ -1125,7 +1135,7 @@ func (e *Engine) runParallelReview(ctx context.Context, phase PhaseConfig) error
 	// Check for context cancellation first.
 	if err := ctx.Err(); err != nil {
 		_ = e.state.MarkFailed(phase.Name, err)
-		e.emit(Event{Phase: phase.Name, Kind: EventPhaseFailed, Data: map[string]any{"error": err.Error()}})
+		e.emitPhaseFailed(phase.Name, err)
 		return fmt.Errorf("engine: context cancelled during %s: %w", phase.Name, err)
 	}
 
@@ -1139,7 +1149,7 @@ func (e *Engine) runParallelReview(ctx context.Context, phase PhaseConfig) error
 	if len(reviewErrors) > 0 {
 		combinedErr := fmt.Errorf("engine: reviewer failures in %s: %s", phase.Name, strings.Join(reviewErrors, "; "))
 		_ = e.state.MarkFailed(phase.Name, combinedErr)
-		e.emit(Event{Phase: phase.Name, Kind: EventPhaseFailed, Data: map[string]any{"error": combinedErr.Error()}})
+		e.emitPhaseFailed(phase.Name, combinedErr)
 		return combinedErr
 	}
 
@@ -1388,10 +1398,10 @@ func (e *Engine) buildReviewArtifact(merged schemas.ReviewOutput) string {
 func (e *Engine) runMonitorStub(phase PhaseConfig) error {
 	prURL := e.extractPRURL()
 
-	e.emit(Event{Phase: phase.Name, Kind: EventPhaseStarted})
 	if err := e.state.MarkRunning(phase.Name); err != nil {
 		return fmt.Errorf("engine: mark running %s: %w", phase.Name, err)
 	}
+	e.emit(Event{Phase: phase.Name, Kind: EventPhaseStarted, Data: map[string]any{"generation": e.state.Meta().Phases[phase.Name].Generation}})
 
 	e.emit(Event{
 		Phase: phase.Name,
@@ -1434,4 +1444,16 @@ func (e *Engine) emit(event Event) {
 	if e.config.OnEvent != nil {
 		e.config.OnEvent(event)
 	}
+}
+
+// emitPhaseFailed emits a phase_failed event with error, duration, and cost
+// data from the phase state. Must be called after MarkFailed so the phase
+// state contains the final duration and cost values.
+func (e *Engine) emitPhaseFailed(phase string, phaseErr error) {
+	data := map[string]any{"error": phaseErr.Error()}
+	if ps := e.state.Meta().Phases[phase]; ps != nil {
+		data["duration_ms"] = ps.DurationMs
+		data["cost"] = ps.Cost
+	}
+	e.emit(Event{Phase: phase, Kind: EventPhaseFailed, Data: data})
 }

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -1160,6 +1160,7 @@ func (e *Engine) runParallelReview(ctx context.Context, phase PhaseConfig) error
 	output, err := json.Marshal(merged)
 	if err != nil {
 		_ = e.state.MarkFailed(phase.Name, err)
+		e.emitPhaseFailed(phase.Name, err)
 		return fmt.Errorf("engine: marshal review output for %s: %w", phase.Name, err)
 	}
 

--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -4787,3 +4787,161 @@ func TestEngine_SkippedReviewPhaseReworkSignalRoutesToImplement(t *testing.T) {
 		}
 	}
 }
+
+// TestEngine_PhaseLifecycleEvents verifies that the engine emits exactly one
+// phase_started and one phase_completed (or phase_failed) event per phase, and
+// that those events carry the expected data fields. This is the core acceptance
+// criterion for ticket #152: the engine is the single source of phase lifecycle
+// event logging.
+func TestEngine_PhaseLifecycleEvents(t *testing.T) {
+	t.Run("completed_phase_emits_started_and_completed", func(t *testing.T) {
+		phases := []PhaseConfig{
+			{
+				Name:   "triage",
+				Prompt: "triage.md",
+				Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			},
+		}
+
+		mock := &flexMockRunner{
+			responses: map[string][]flexResponse{
+				"triage": {{
+					result: &runner.RunResult{
+						Output:  json.RawMessage(`{"automatable":true}`),
+						RawText: "Triage output",
+						CostUSD: 0.25,
+					},
+				}},
+			},
+		}
+
+		var events []Event
+		engine, _ := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+			cfg.OnEvent = func(e Event) {
+				events = append(events, e)
+			}
+		})
+
+		if err := engine.Run(context.Background()); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+
+		// Count phase lifecycle events for "triage".
+		var started, completed, failed int
+		var startedEv, completedEv Event
+		for _, ev := range events {
+			if ev.Phase != "triage" {
+				continue
+			}
+			switch ev.Kind {
+			case EventPhaseStarted:
+				started++
+				startedEv = ev
+			case EventPhaseCompleted:
+				completed++
+				completedEv = ev
+			case EventPhaseFailed:
+				failed++
+			}
+		}
+
+		if started != 1 {
+			t.Errorf("phase_started count = %d, want 1", started)
+		}
+		if completed != 1 {
+			t.Errorf("phase_completed count = %d, want 1", completed)
+		}
+		if failed != 0 {
+			t.Errorf("phase_failed count = %d, want 0", failed)
+		}
+
+		// phase_started must include generation.
+		if gen, ok := startedEv.Data["generation"]; !ok {
+			t.Error("phase_started missing 'generation' field")
+		} else if toFloat64(gen) != 1 {
+			t.Errorf("phase_started generation = %v, want 1", gen)
+		}
+
+		// phase_completed must include duration_ms and cost.
+		if _, ok := completedEv.Data["duration_ms"]; !ok {
+			t.Error("phase_completed missing 'duration_ms' field")
+		}
+		if cost, ok := completedEv.Data["cost"]; !ok {
+			t.Error("phase_completed missing 'cost' field")
+		} else if !approxEqual(toFloat64(cost), 0.25) {
+			t.Errorf("phase_completed cost = %v, want 0.25", cost)
+		}
+	})
+
+	t.Run("failed_phase_emits_started_and_failed", func(t *testing.T) {
+		phases := []PhaseConfig{
+			{
+				Name:   "plan",
+				Prompt: "plan.md",
+				Retry:  RetryConfig{Transient: 0, Parse: 0, Semantic: 0},
+			},
+		}
+
+		mock := &flexMockRunner{
+			responses: map[string][]flexResponse{
+				"plan": {{
+					err: fmt.Errorf("LLM call failed"),
+				}},
+			},
+		}
+
+		var events []Event
+		engine, _ := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+			cfg.OnEvent = func(e Event) {
+				events = append(events, e)
+			}
+		})
+
+		_ = engine.Run(context.Background()) // expected to fail
+
+		// Count phase lifecycle events for "plan".
+		var started, completed, failed int
+		var startedEv, failedEv Event
+		for _, ev := range events {
+			if ev.Phase != "plan" {
+				continue
+			}
+			switch ev.Kind {
+			case EventPhaseStarted:
+				started++
+				startedEv = ev
+			case EventPhaseCompleted:
+				completed++
+			case EventPhaseFailed:
+				failed++
+				failedEv = ev
+			}
+		}
+
+		if started != 1 {
+			t.Errorf("phase_started count = %d, want 1", started)
+		}
+		if completed != 0 {
+			t.Errorf("phase_completed count = %d, want 0", completed)
+		}
+		if failed != 1 {
+			t.Errorf("phase_failed count = %d, want 1", failed)
+		}
+
+		// phase_started must include generation.
+		if _, ok := startedEv.Data["generation"]; !ok {
+			t.Error("phase_started missing 'generation' field")
+		}
+
+		// phase_failed must include error, duration_ms, and cost.
+		if _, ok := failedEv.Data["error"]; !ok {
+			t.Error("phase_failed missing 'error' field")
+		}
+		if _, ok := failedEv.Data["duration_ms"]; !ok {
+			t.Error("phase_failed missing 'duration_ms' field")
+		}
+		if _, ok := failedEv.Data["cost"]; !ok {
+			t.Error("phase_failed missing 'cost' field")
+		}
+	})
+}

--- a/internal/pipeline/monitor_poll.go
+++ b/internal/pipeline/monitor_poll.go
@@ -147,8 +147,8 @@ func (e *Engine) runMonitor(ctx context.Context, phase PhaseConfig) error {
 		if err != nil {
 			e.emit(Event{
 				Phase: phase.Name,
-				Kind:  EventPhaseFailed,
-				Data:  map[string]any{"error": fmt.Sprintf("check PR status: %v", err)},
+				Kind:  EventMonitorWarning,
+				Data:  map[string]any{"warning": fmt.Sprintf("check PR status: %v", err)},
 			})
 			// Non-fatal — continue polling.
 		}

--- a/internal/pipeline/monitor_poll.go
+++ b/internal/pipeline/monitor_poll.go
@@ -78,10 +78,10 @@ func (e *Engine) runMonitor(ctx context.Context, phase PhaseConfig) error {
 		}
 	}
 
-	e.emit(Event{Phase: phase.Name, Kind: EventPhaseStarted})
 	if err := e.state.MarkRunning(phase.Name); err != nil {
 		return fmt.Errorf("engine: mark running %s: %w", phase.Name, err)
 	}
+	e.emit(Event{Phase: phase.Name, Kind: EventPhaseStarted, Data: map[string]any{"generation": e.state.Meta().Phases[phase.Name].Generation}})
 
 	// Initialize or resume monitor state.
 	monState, err := e.state.ReadMonitorState()
@@ -123,9 +123,11 @@ func (e *Engine) runMonitor(ctx context.Context, phase PhaseConfig) error {
 					"poll_count": monState.PollCount,
 				},
 			})
-			if err := e.state.MarkFailed(phase.Name, fmt.Errorf("monitor: max duration %s exceeded", polling.MaxDuration.Duration)); err != nil {
+			timeoutErr := fmt.Errorf("monitor: max duration %s exceeded", polling.MaxDuration.Duration)
+			if err := e.state.MarkFailed(phase.Name, timeoutErr); err != nil {
 				return fmt.Errorf("engine: mark failed %s: %w", phase.Name, err)
 			}
+			e.emitPhaseFailed(phase.Name, timeoutErr)
 			return nil
 		}
 
@@ -162,9 +164,11 @@ func (e *Engine) runMonitor(ctx context.Context, phase PhaseConfig) error {
 					Data:  map[string]any{"duration_ms": e.state.Meta().Phases[phase.Name].DurationMs},
 				})
 			} else {
-				if err := e.state.MarkFailed(phase.Name, fmt.Errorf("monitor: PR %s", monState.Status)); err != nil {
+				failErr := fmt.Errorf("monitor: PR %s", monState.Status)
+				if err := e.state.MarkFailed(phase.Name, failErr); err != nil {
 					return fmt.Errorf("engine: mark failed %s: %w", phase.Name, err)
 				}
+				e.emitPhaseFailed(phase.Name, failErr)
 			}
 			return nil
 		}

--- a/internal/pipeline/state.go
+++ b/internal/pipeline/state.go
@@ -127,15 +127,7 @@ func (s *State) MarkRunning(phase string) error {
 	ps.PlanHash = ""
 	ps.startedAt = time.Now()
 
-	if err := s.flushMeta(); err != nil {
-		return err
-	}
-
-	return s.LogEvent(Event{
-		Phase: phase,
-		Kind:  "phase_started",
-		Data:  map[string]any{"generation": ps.Generation},
-	})
+	return s.flushMeta()
 }
 
 // MarkCompleted marks a phase as completed with its duration.
@@ -150,18 +142,7 @@ func (s *State) MarkCompleted(phase string) error {
 		ps.DurationMs = time.Since(ps.startedAt).Milliseconds()
 	}
 
-	if err := s.flushMeta(); err != nil {
-		return err
-	}
-
-	return s.LogEvent(Event{
-		Phase: phase,
-		Kind:  "phase_completed",
-		Data: map[string]any{
-			"duration_ms": ps.DurationMs,
-			"cost":        ps.Cost,
-		},
-	})
+	return s.flushMeta()
 }
 
 // MarkFailed marks a phase as failed with the error and duration.
@@ -177,19 +158,7 @@ func (s *State) MarkFailed(phase string, phaseErr error) error {
 		ps.DurationMs = time.Since(ps.startedAt).Milliseconds()
 	}
 
-	if err := s.flushMeta(); err != nil {
-		return err
-	}
-
-	return s.LogEvent(Event{
-		Phase: phase,
-		Kind:  "phase_failed",
-		Data: map[string]any{
-			"error":       ps.Error,
-			"duration_ms": ps.DurationMs,
-			"cost":        ps.Cost,
-		},
-	})
+	return s.flushMeta()
 }
 
 // AccumulateCost adds cost to the phase and total. Phase must exist (via MarkRunning).

--- a/internal/pipeline/state_test.go
+++ b/internal/pipeline/state_test.go
@@ -7,7 +7,6 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 )
 
@@ -261,7 +260,7 @@ func TestMarkFailed(t *testing.T) {
 		}
 	})
 
-	t.Run("event_includes_cost", func(t *testing.T) {
+	t.Run("no_duplicate_events", func(t *testing.T) {
 		dir := t.TempDir()
 		state, _ := LoadOrCreate(dir, "T-3")
 
@@ -276,23 +275,13 @@ func TestMarkFailed(t *testing.T) {
 			t.Fatalf("ReadEvents: %v", err)
 		}
 
-		// Find the phase_failed event.
-		var found bool
+		// State methods no longer emit events to events.jsonl; the engine
+		// is the single source of event logging via emit(). Verify that
+		// MarkRunning/MarkFailed do not write phase events.
 		for _, ev := range events {
-			if ev.Kind == EventPhaseFailed && ev.Phase == "plan" {
-				cost, ok := ev.Data["cost"]
-				if !ok {
-					t.Fatal("phase_failed event missing cost field")
-				}
-				if c := toFloat64(cost); !approxEqual(c, 0.42) {
-					t.Errorf("cost = %f, want 0.42", c)
-				}
-				found = true
-				break
+			if ev.Kind == EventPhaseStarted || ev.Kind == EventPhaseFailed || ev.Kind == EventPhaseCompleted {
+				t.Errorf("unexpected phase event %q in events.jsonl from state method", ev.Kind)
 			}
-		}
-		if !found {
-			t.Fatal("phase_failed event not found in events.jsonl")
 		}
 	})
 
@@ -598,11 +587,12 @@ func TestFullLifecycle(t *testing.T) {
 		t.Errorf("final TotalCost = %v, want 3.78", state2.Meta().TotalCost)
 	}
 
-	// Verify events.jsonl has entries
+	// State methods no longer write phase events to events.jsonl (the engine
+	// handles event logging via emit to avoid duplicates). Verify the file
+	// is either absent or empty.
 	eventsData, _ := os.ReadFile(filepath.Join(dir, "PROJ-100", "events.jsonl"))
-	eventLines := strings.Split(strings.TrimSpace(string(eventsData)), "\n")
-	if len(eventLines) < 8 {
-		t.Errorf("expected >= 8 events, got %d", len(eventLines))
+	if len(eventsData) > 0 {
+		t.Errorf("events.jsonl should be empty when using raw state methods, got %d bytes", len(eventsData))
 	}
 
 	// Verify log files exist


### PR DESCRIPTION
## Summary

- Remove duplicate `LogEvent` calls from `MarkRunning`, `MarkCompleted`, `MarkFailed` in state.go
- Reorder engine emit to happen AFTER Mark calls (so generation is correct)
- Enrich `EventPhaseFailed` emits with `duration_ms` and `cost`
- Add explicit emit calls in `skipPlanFromTriage` and monitor failure paths
- Add `TestNoDuplicatePhaseEvents` asserting exactly 1 started + 1 completed per phase

## Test plan

- [x] All tests pass
- [x] Verify passed (all criteria met)
- [ ] CI passes

Fixes: #152

Generated with [Claude Code](https://claude.com/claude-code) via SODA
