### PR TITLE
feat(cli): list previous pipeline sessions (#69)

### DIFF
--- a/cmd/soda/main.go
+++ b/cmd/soda/main.go
@@ -41,6 +41,7 @@ func newRootCmd() *cobra.Command {
 	cmd.AddCommand(
 		newRunCmd(),
 		newStatusCmd(),
+		newSessionsCmd(),
 		newHistoryCmd(),
 		newCleanCmd(),
 		newRenderCmd(),

--- a/cmd/soda/sessions.go
+++ b/cmd/soda/sessions.go
@@ -20,9 +20,11 @@ import (
 // sessionEntry holds data for one row in the sessions listing.
 type sessionEntry struct {
 	ticket     string
+	dirName    string // filesystem directory name (may differ from ticket)
 	summary    string
 	status     string
 	cost       string
+	costRaw    float64 // raw cost for sorting/computation; avoids re-parsing the display string
 	elapsed    string
 	lastRun    string
 	startedAt  time.Time
@@ -144,9 +146,11 @@ func collectSessions(stateDir string, now time.Time) ([]sessionEntry, error) {
 
 		rows = append(rows, sessionEntry{
 			ticket:     meta.Ticket,
+			dirName:    entry.Name(),
 			summary:    meta.Summary,
 			status:     status,
 			cost:       cost,
+			costRaw:    meta.TotalCost,
 			elapsed:    elapsed,
 			lastRun:    lastRun,
 			startedAt:  meta.StartedAt,
@@ -173,10 +177,7 @@ func sortSessions(rows []sessionEntry, sortBy string) {
 	switch sortBy {
 	case "cost":
 		sort.SliceStable(rows, func(i, j int) bool {
-			// Parse cost strings for comparison.
-			ci := parseCost(rows[i].cost)
-			cj := parseCost(rows[j].cost)
-			return ci > cj // highest cost first
+			return rows[i].costRaw > rows[j].costRaw // highest cost first
 		})
 	case "elapsed":
 		sort.SliceStable(rows, func(i, j int) bool {
@@ -187,13 +188,6 @@ func sortSessions(rows []sessionEntry, sortBy string) {
 			return rows[i].startedAt.After(rows[j].startedAt) // newest first
 		})
 	}
-}
-
-// parseCost extracts a float from a "$X.XX" string.
-func parseCost(s string) float64 {
-	var cost float64
-	fmt.Sscanf(s, "$%f", &cost)
-	return cost
 }
 
 // computeElapsed returns the actual elapsed duration for a pipeline session.
@@ -291,10 +285,16 @@ func runSessionsTUI(stateDir, statusFilter, sortBy string, limit int, now time.T
 		return nil
 	}
 
+	// Use DirName for path-based lookups; fall back to Ticket for display.
+	dirKey := result.DirName
+	if dirKey == "" {
+		dirKey = result.Ticket
+	}
+
 	switch result.Action {
 	case tui.SessionActionView:
-		// Drill into session history.
-		return runHistory(stateDir, result.Ticket, false, "")
+		// Drill into session history using the directory name for correct path.
+		return runHistory(stateDir, dirKey, false, "")
 	case tui.SessionActionResume:
 		fmt.Printf("To resume: soda run %s --from last\n", result.Ticket)
 	case tui.SessionActionDelete:
@@ -310,9 +310,10 @@ func sessionsToTUI(rows []sessionEntry) []tui.SessionInfo {
 	for idx, row := range rows {
 		sessions[idx] = tui.SessionInfo{
 			Ticket:    row.ticket,
+			DirName:   row.dirName,
 			Summary:   row.summary,
 			Status:    row.status,
-			Cost:      parseCost(row.cost),
+			Cost:      row.costRaw,
 			Elapsed:   row.elapsed,
 			StartedAt: row.startedAt,
 		}

--- a/cmd/soda/sessions.go
+++ b/cmd/soda/sessions.go
@@ -10,7 +10,9 @@ import (
 	"text/tabwriter"
 	"time"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/decko/soda/internal/pipeline"
+	"github.com/decko/soda/internal/tui"
 	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 )
@@ -38,9 +40,13 @@ func newSessionsCmd() *cobra.Command {
 			statusFilter, _ := cmd.Flags().GetString("status")
 			sortBy, _ := cmd.Flags().GetString("sort")
 			all, _ := cmd.Flags().GetBool("all")
+			interactive, _ := cmd.Flags().GetBool("tui")
 			limit := 20
 			if all {
 				limit = 0
+			}
+			if interactive {
+				return runSessionsTUI(cfg.StateDir, statusFilter, sortBy, limit, time.Now())
 			}
 			return runSessions(cfg.StateDir, statusFilter, sortBy, limit, time.Now())
 		},
@@ -49,6 +55,7 @@ func newSessionsCmd() *cobra.Command {
 	cmd.Flags().String("status", "", "filter by status (completed, failed, running, stale)")
 	cmd.Flags().String("sort", "date", "sort order: date, cost, elapsed")
 	cmd.Flags().Bool("all", false, "list all sessions (default: most recent 20)")
+	cmd.Flags().Bool("tui", false, "launch interactive session browser")
 
 	return cmd
 }
@@ -227,6 +234,66 @@ func truncate(s string, maxLen int) string {
 		return s[:maxLen]
 	}
 	return s[:maxLen-3] + "..."
+}
+
+// runSessionsTUI launches the interactive TUI session browser. When the user
+// selects a session, it drills into the history for that ticket.
+func runSessionsTUI(stateDir, statusFilter, sortBy string, limit int, now time.Time) error {
+	rows, err := collectSessions(stateDir, now)
+	if err != nil {
+		return err
+	}
+
+	if statusFilter != "" {
+		rows = filterSessionsByStatus(rows, statusFilter)
+	}
+	sortSessions(rows, sortBy)
+	if limit > 0 && len(rows) > limit {
+		rows = rows[:limit]
+	}
+
+	// Convert to TUI session infos.
+	sessions := sessionsToTUI(rows)
+
+	model := tui.NewSessionsModel(sessions)
+	program := tea.NewProgram(model, tea.WithAltScreen())
+	finalModel, err := program.Run()
+	if err != nil {
+		return fmt.Errorf("sessions tui: %w", err)
+	}
+
+	result := finalModel.(tui.SessionsModel).Result()
+	if result == nil {
+		return nil
+	}
+
+	switch result.Action {
+	case tui.SessionActionView:
+		// Drill into session history.
+		return runHistory(stateDir, result.Ticket, false, "")
+	case tui.SessionActionResume:
+		fmt.Printf("To resume: soda run %s --from last\n", result.Ticket)
+	case tui.SessionActionDelete:
+		fmt.Printf("To clean: soda clean %s\n", result.Ticket)
+	}
+
+	return nil
+}
+
+// sessionsToTUI converts sessionEntry rows to tui.SessionInfo for the TUI model.
+func sessionsToTUI(rows []sessionEntry) []tui.SessionInfo {
+	sessions := make([]tui.SessionInfo, len(rows))
+	for idx, row := range rows {
+		sessions[idx] = tui.SessionInfo{
+			Ticket:    row.ticket,
+			Summary:   row.summary,
+			Status:    row.status,
+			Cost:      parseCost(row.cost),
+			Elapsed:   row.elapsed,
+			StartedAt: row.startedAt,
+		}
+	}
+	return sessions
 }
 
 // sessionsSummaryLine returns a summary like "4 sessions (3 completed, 1 running)".

--- a/cmd/soda/sessions.go
+++ b/cmd/soda/sessions.go
@@ -19,13 +19,14 @@ import (
 
 // sessionEntry holds data for one row in the sessions listing.
 type sessionEntry struct {
-	ticket    string
-	summary   string
-	status    string
-	cost      string
-	elapsed   string
-	lastRun   string
-	startedAt time.Time
+	ticket     string
+	summary    string
+	status     string
+	cost       string
+	elapsed    string
+	lastRun    string
+	startedAt  time.Time
+	elapsedDur time.Duration
 }
 
 func newSessionsCmd() *cobra.Command {
@@ -136,18 +137,20 @@ func collectSessions(stateDir string, now time.Time) ([]sessionEntry, error) {
 		lockInfo, _ := pipeline.ReadLockInfo(lockPath)
 		status := pipelineStatus(meta, lockInfo)
 
-		elapsed := formatElapsed(meta)
+		elapsedDur := computeElapsed(meta, now)
+		elapsed := elapsedDur.Truncate(time.Second).String()
 		cost := fmt.Sprintf("$%.2f", meta.TotalCost)
 		lastRun := formatLastRun(meta.StartedAt, now)
 
 		rows = append(rows, sessionEntry{
-			ticket:    meta.Ticket,
-			summary:   meta.Summary,
-			status:    status,
-			cost:      cost,
-			elapsed:   elapsed,
-			lastRun:   lastRun,
-			startedAt: meta.StartedAt,
+			ticket:     meta.Ticket,
+			summary:    meta.Summary,
+			status:     status,
+			cost:       cost,
+			elapsed:    elapsed,
+			lastRun:    lastRun,
+			startedAt:  meta.StartedAt,
+			elapsedDur: elapsedDur,
 		})
 	}
 
@@ -177,9 +180,7 @@ func sortSessions(rows []sessionEntry, sortBy string) {
 		})
 	case "elapsed":
 		sort.SliceStable(rows, func(i, j int) bool {
-			// Use startedAt as a proxy — sessions that started earlier
-			// have been running longer.
-			return rows[i].startedAt.Before(rows[j].startedAt)
+			return rows[i].elapsedDur > rows[j].elapsedDur // longest elapsed first
 		})
 	default: // "date" or unrecognized
 		sort.SliceStable(rows, func(i, j int) bool {
@@ -193,6 +194,24 @@ func parseCost(s string) float64 {
 	var cost float64
 	fmt.Sscanf(s, "$%f", &cost)
 	return cost
+}
+
+// computeElapsed returns the actual elapsed duration for a pipeline session.
+// For running sessions it uses wall-clock time since start; for completed
+// sessions it sums the DurationMs of individual phases.
+func computeElapsed(meta *pipeline.PipelineMeta, now time.Time) time.Duration {
+	var totalMs int64
+	hasRunning := false
+	for _, ps := range meta.Phases {
+		if ps.Status == pipeline.PhaseRunning {
+			hasRunning = true
+		}
+		totalMs += ps.DurationMs
+	}
+	if hasRunning {
+		return now.Sub(meta.StartedAt)
+	}
+	return time.Duration(totalMs) * time.Millisecond
 }
 
 // formatLastRun returns a human-friendly relative time string.

--- a/cmd/soda/sessions.go
+++ b/cmd/soda/sessions.go
@@ -262,7 +262,11 @@ func runSessionsTUI(stateDir, statusFilter, sortBy string, limit int, now time.T
 		return fmt.Errorf("sessions tui: %w", err)
 	}
 
-	result := finalModel.(tui.SessionsModel).Result()
+	sm, ok := finalModel.(tui.SessionsModel)
+	if !ok {
+		return fmt.Errorf("sessions tui: unexpected model type %T", finalModel)
+	}
+	result := sm.Result()
 	if result == nil {
 		return nil
 	}

--- a/cmd/soda/sessions.go
+++ b/cmd/soda/sessions.go
@@ -1,0 +1,257 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/decko/soda/internal/pipeline"
+	"github.com/mattn/go-isatty"
+	"github.com/spf13/cobra"
+)
+
+// sessionEntry holds data for one row in the sessions listing.
+type sessionEntry struct {
+	ticket    string
+	summary   string
+	status    string
+	cost      string
+	elapsed   string
+	lastRun   string
+	startedAt time.Time
+}
+
+func newSessionsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "sessions",
+		Short: "List previous and active pipeline sessions",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := loadConfig(cmd)
+			if err != nil {
+				return err
+			}
+			statusFilter, _ := cmd.Flags().GetString("status")
+			sortBy, _ := cmd.Flags().GetString("sort")
+			all, _ := cmd.Flags().GetBool("all")
+			limit := 20
+			if all {
+				limit = 0
+			}
+			return runSessions(cfg.StateDir, statusFilter, sortBy, limit, time.Now())
+		},
+	}
+
+	cmd.Flags().String("status", "", "filter by status (completed, failed, running, stale)")
+	cmd.Flags().String("sort", "date", "sort order: date, cost, elapsed")
+	cmd.Flags().Bool("all", false, "list all sessions (default: most recent 20)")
+
+	return cmd
+}
+
+func runSessions(stateDir, statusFilter, sortBy string, limit int, now time.Time) error {
+	rows, err := collectSessions(stateDir, now)
+	if err != nil {
+		return err
+	}
+
+	if len(rows) == 0 {
+		fmt.Println("No sessions found.")
+		return nil
+	}
+
+	// Filter by status.
+	if statusFilter != "" {
+		rows = filterSessionsByStatus(rows, statusFilter)
+		if len(rows) == 0 {
+			fmt.Printf("No sessions with status %q.\n", statusFilter)
+			return nil
+		}
+	}
+
+	// Sort.
+	sortSessions(rows, sortBy)
+
+	// Apply limit.
+	if limit > 0 && len(rows) > limit {
+		rows = rows[:limit]
+	}
+
+	// Render.
+	isTTY := isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd())
+	tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(tw, "TICKET\tSUMMARY\tSTATUS\tCOST\tELAPSED\tLAST RUN")
+	for _, row := range rows {
+		status := colorizeStatus(row.status, isTTY)
+		summary := truncate(row.summary, 40)
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			row.ticket, summary, status, row.cost, row.elapsed, row.lastRun)
+	}
+	if err := tw.Flush(); err != nil {
+		return fmt.Errorf("sessions: flush output: %w", err)
+	}
+
+	// Summary footer.
+	fmt.Println()
+	fmt.Println(sessionsSummaryLine(rows))
+
+	return nil
+}
+
+// collectSessions reads all meta.json files from stateDir and builds session entries.
+func collectSessions(stateDir string, now time.Time) ([]sessionEntry, error) {
+	entries, err := os.ReadDir(stateDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("sessions: read state dir: %w", err)
+	}
+
+	var rows []sessionEntry
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		ticketDir := filepath.Join(stateDir, entry.Name())
+		metaPath := filepath.Join(ticketDir, "meta.json")
+
+		meta, metaErr := pipeline.ReadMeta(metaPath)
+		if metaErr != nil {
+			continue
+		}
+
+		lockPath := filepath.Join(ticketDir, "lock")
+		lockInfo, _ := pipeline.ReadLockInfo(lockPath)
+		status := pipelineStatus(meta, lockInfo)
+
+		elapsed := formatElapsed(meta)
+		cost := fmt.Sprintf("$%.2f", meta.TotalCost)
+		lastRun := formatLastRun(meta.StartedAt, now)
+
+		rows = append(rows, sessionEntry{
+			ticket:    meta.Ticket,
+			summary:   meta.Summary,
+			status:    status,
+			cost:      cost,
+			elapsed:   elapsed,
+			lastRun:   lastRun,
+			startedAt: meta.StartedAt,
+		})
+	}
+
+	return rows, nil
+}
+
+// filterSessionsByStatus returns only rows matching the given status.
+func filterSessionsByStatus(rows []sessionEntry, status string) []sessionEntry {
+	var filtered []sessionEntry
+	for _, row := range rows {
+		if row.status == status {
+			filtered = append(filtered, row)
+		}
+	}
+	return filtered
+}
+
+// sortSessions sorts session entries by the specified field.
+func sortSessions(rows []sessionEntry, sortBy string) {
+	switch sortBy {
+	case "cost":
+		sort.SliceStable(rows, func(i, j int) bool {
+			// Parse cost strings for comparison.
+			ci := parseCost(rows[i].cost)
+			cj := parseCost(rows[j].cost)
+			return ci > cj // highest cost first
+		})
+	case "elapsed":
+		sort.SliceStable(rows, func(i, j int) bool {
+			// Use startedAt as a proxy — sessions that started earlier
+			// have been running longer.
+			return rows[i].startedAt.Before(rows[j].startedAt)
+		})
+	default: // "date" or unrecognized
+		sort.SliceStable(rows, func(i, j int) bool {
+			return rows[i].startedAt.After(rows[j].startedAt) // newest first
+		})
+	}
+}
+
+// parseCost extracts a float from a "$X.XX" string.
+func parseCost(s string) float64 {
+	var cost float64
+	fmt.Sscanf(s, "$%f", &cost)
+	return cost
+}
+
+// formatLastRun returns a human-friendly relative time string.
+func formatLastRun(startedAt, now time.Time) string {
+	diff := now.Sub(startedAt)
+	if diff < 0 {
+		return "now"
+	}
+	if diff < time.Minute {
+		return "now"
+	}
+	if diff < time.Hour {
+		mins := int(diff.Minutes())
+		if mins == 1 {
+			return "1m ago"
+		}
+		return fmt.Sprintf("%dm ago", mins)
+	}
+	if diff < 24*time.Hour {
+		hours := int(diff.Hours())
+		if hours == 1 {
+			return "1h ago"
+		}
+		return fmt.Sprintf("%dh ago", hours)
+	}
+	days := int(diff.Hours() / 24)
+	if days == 1 {
+		return "1d ago"
+	}
+	return fmt.Sprintf("%dd ago", days)
+}
+
+// truncate shortens a string to maxLen, adding "..." if truncated.
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	if maxLen <= 3 {
+		return s[:maxLen]
+	}
+	return s[:maxLen-3] + "..."
+}
+
+// sessionsSummaryLine returns a summary like "4 sessions (3 completed, 1 running)".
+func sessionsSummaryLine(rows []sessionEntry) string {
+	counts := map[string]int{}
+	for _, row := range rows {
+		counts[row.status]++
+	}
+
+	total := len(rows)
+	var parts []string
+	// Render in a deterministic order.
+	for _, status := range []string{"running", "stale", "completed", "failed", "pending", "retrying"} {
+		if count, ok := counts[status]; ok {
+			parts = append(parts, fmt.Sprintf("%d %s", count, status))
+		}
+	}
+
+	if len(parts) == 0 {
+		return fmt.Sprintf("%d sessions", total)
+	}
+
+	noun := "sessions"
+	if total == 1 {
+		noun = "session"
+	}
+	return fmt.Sprintf("%d %s (%s)", total, noun, strings.Join(parts, ", "))
+}

--- a/cmd/soda/sessions.go
+++ b/cmd/soda/sessions.go
@@ -244,15 +244,16 @@ func formatLastRun(startedAt, now time.Time) string {
 	return fmt.Sprintf("%dd ago", days)
 }
 
-// truncate shortens a string to maxLen, adding "..." if truncated.
+// truncate shortens a string to maxLen runes, adding "..." if truncated.
 func truncate(s string, maxLen int) string {
-	if len(s) <= maxLen {
+	runes := []rune(s)
+	if len(runes) <= maxLen {
 		return s
 	}
 	if maxLen <= 3 {
-		return s[:maxLen]
+		return string(runes[:maxLen])
 	}
-	return s[:maxLen-3] + "..."
+	return string(runes[:maxLen-3]) + "..."
 }
 
 // runSessionsTUI launches the interactive TUI session browser. When the user

--- a/cmd/soda/sessions_test.go
+++ b/cmd/soda/sessions_test.go
@@ -90,6 +90,39 @@ func TestCollectSessions_ReadsMeta(t *testing.T) {
 	}
 }
 
+func TestCollectSessions_DirNameDiffersFromTicket(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2025, 6, 15, 14, 0, 0, 0, time.UTC)
+
+	// Directory name is slugified, but meta.Ticket has the original key.
+	writeMeta(t, filepath.Join(dir, "proj-42-slugified"), &pipeline.PipelineMeta{
+		Ticket:    "PROJ-42",
+		Summary:   "Slugified dir test",
+		StartedAt: now.Add(-1 * time.Hour),
+		TotalCost: 2.50,
+		Phases: map[string]*pipeline.PhaseState{
+			"triage": {Status: pipeline.PhaseCompleted},
+		},
+	})
+
+	rows, err := collectSessions(dir, now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	if rows[0].ticket != "PROJ-42" {
+		t.Errorf("ticket = %q, want %q", rows[0].ticket, "PROJ-42")
+	}
+	if rows[0].dirName != "proj-42-slugified" {
+		t.Errorf("dirName = %q, want %q", rows[0].dirName, "proj-42-slugified")
+	}
+	if rows[0].costRaw != 2.50 {
+		t.Errorf("costRaw = %f, want %f", rows[0].costRaw, 2.50)
+	}
+}
+
 func TestFilterSessionsByStatus(t *testing.T) {
 	rows := []sessionEntry{
 		{ticket: "A", status: "completed"},
@@ -123,9 +156,9 @@ func TestSortSessions(t *testing.T) {
 	now := time.Date(2025, 6, 15, 14, 0, 0, 0, time.UTC)
 
 	rows := []sessionEntry{
-		{ticket: "A", cost: "$1.00", startedAt: now.Add(-3 * time.Hour), elapsedDur: 10 * time.Minute},
-		{ticket: "B", cost: "$5.00", startedAt: now.Add(-1 * time.Hour), elapsedDur: 30 * time.Minute},
-		{ticket: "C", cost: "$0.50", startedAt: now.Add(-2 * time.Hour), elapsedDur: 2 * time.Minute},
+		{ticket: "A", cost: "$1.00", costRaw: 1.00, startedAt: now.Add(-3 * time.Hour), elapsedDur: 10 * time.Minute},
+		{ticket: "B", cost: "$5.00", costRaw: 5.00, startedAt: now.Add(-1 * time.Hour), elapsedDur: 30 * time.Minute},
+		{ticket: "C", cost: "$0.50", costRaw: 0.50, startedAt: now.Add(-2 * time.Hour), elapsedDur: 2 * time.Minute},
 	}
 
 	t.Run("sort by date (default)", func(t *testing.T) {
@@ -297,23 +330,6 @@ func TestComputeElapsed_RunningPhase(t *testing.T) {
 	}
 }
 
-func TestParseCost(t *testing.T) {
-	tests := []struct {
-		input string
-		want  float64
-	}{
-		{"$1.23", 1.23},
-		{"$0.00", 0.00},
-		{"$10.50", 10.50},
-	}
-	for _, tc := range tests {
-		got := parseCost(tc.input)
-		if got != tc.want {
-			t.Errorf("parseCost(%q) = %f, want %f", tc.input, got, tc.want)
-		}
-	}
-}
-
 func TestNewSessionsCmd_Flags(t *testing.T) {
 	cmd := newSessionsCmd()
 
@@ -354,8 +370,8 @@ func TestSessionsToTUI(t *testing.T) {
 	now := time.Date(2025, 6, 15, 14, 0, 0, 0, time.UTC)
 
 	rows := []sessionEntry{
-		{ticket: "A", summary: "First", status: "completed", cost: "$1.23", elapsed: "5m", startedAt: now.Add(-2 * time.Hour)},
-		{ticket: "B", summary: "Second", status: "failed", cost: "$5.58", elapsed: "12m", startedAt: now.Add(-30 * time.Minute)},
+		{ticket: "A", dirName: "dir-a", summary: "First", status: "completed", cost: "$1.23", costRaw: 1.23, elapsed: "5m", startedAt: now.Add(-2 * time.Hour)},
+		{ticket: "B", dirName: "dir-b", summary: "Second", status: "failed", cost: "$5.58", costRaw: 5.58, elapsed: "12m", startedAt: now.Add(-30 * time.Minute)},
 	}
 
 	sessions := sessionsToTUI(rows)
@@ -365,6 +381,9 @@ func TestSessionsToTUI(t *testing.T) {
 
 	if sessions[0].Ticket != "A" {
 		t.Errorf("session 0 ticket = %q, want %q", sessions[0].Ticket, "A")
+	}
+	if sessions[0].DirName != "dir-a" {
+		t.Errorf("session 0 dirName = %q, want %q", sessions[0].DirName, "dir-a")
 	}
 	if sessions[0].Summary != "First" {
 		t.Errorf("session 0 summary = %q, want %q", sessions[0].Summary, "First")
@@ -378,6 +397,9 @@ func TestSessionsToTUI(t *testing.T) {
 
 	if sessions[1].Ticket != "B" {
 		t.Errorf("session 1 ticket = %q, want %q", sessions[1].Ticket, "B")
+	}
+	if sessions[1].DirName != "dir-b" {
+		t.Errorf("session 1 dirName = %q, want %q", sessions[1].DirName, "dir-b")
 	}
 	if sessions[1].Cost != 5.58 {
 		t.Errorf("session 1 cost = %f, want %f", sessions[1].Cost, 5.58)

--- a/cmd/soda/sessions_test.go
+++ b/cmd/soda/sessions_test.go
@@ -123,9 +123,9 @@ func TestSortSessions(t *testing.T) {
 	now := time.Date(2025, 6, 15, 14, 0, 0, 0, time.UTC)
 
 	rows := []sessionEntry{
-		{ticket: "A", cost: "$1.00", startedAt: now.Add(-3 * time.Hour)},
-		{ticket: "B", cost: "$5.00", startedAt: now.Add(-1 * time.Hour)},
-		{ticket: "C", cost: "$0.50", startedAt: now.Add(-2 * time.Hour)},
+		{ticket: "A", cost: "$1.00", startedAt: now.Add(-3 * time.Hour), elapsedDur: 10 * time.Minute},
+		{ticket: "B", cost: "$5.00", startedAt: now.Add(-1 * time.Hour), elapsedDur: 30 * time.Minute},
+		{ticket: "C", cost: "$0.50", startedAt: now.Add(-2 * time.Hour), elapsedDur: 2 * time.Minute},
 	}
 
 	t.Run("sort by date (default)", func(t *testing.T) {
@@ -156,7 +156,9 @@ func TestSortSessions(t *testing.T) {
 		r := make([]sessionEntry, len(rows))
 		copy(r, rows)
 		sortSessions(r, "elapsed")
-		wantOrder := []string{"A", "C", "B"} // longest running first
+		// B (30m) > A (10m) > C (2m) — sorted by actual elapsed duration,
+		// NOT by startedAt. A was started earliest but has only 10m elapsed.
+		wantOrder := []string{"B", "A", "C"} // longest elapsed first
 		for i, want := range wantOrder {
 			if r[i].ticket != want {
 				t.Errorf("rows[%d].ticket = %q, want %q", i, r[i].ticket, want)
@@ -251,6 +253,42 @@ func TestSessionsSummaryLine(t *testing.T) {
 				t.Errorf("sessionsSummaryLine() = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestComputeElapsed_CompletedPhases(t *testing.T) {
+	now := time.Date(2025, 6, 15, 14, 0, 0, 0, time.UTC)
+
+	meta := &pipeline.PipelineMeta{
+		StartedAt: now.Add(-10 * time.Hour), // started long ago
+		Phases: map[string]*pipeline.PhaseState{
+			"triage":    {Status: pipeline.PhaseCompleted, DurationMs: 120000}, // 2m
+			"implement": {Status: pipeline.PhaseCompleted, DurationMs: 300000}, // 5m
+		},
+	}
+
+	got := computeElapsed(meta, now)
+	want := 7 * time.Minute
+	if got != want {
+		t.Errorf("computeElapsed() = %v, want %v (should sum DurationMs, not wall-clock)", got, want)
+	}
+}
+
+func TestComputeElapsed_RunningPhase(t *testing.T) {
+	now := time.Date(2025, 6, 15, 14, 0, 0, 0, time.UTC)
+
+	meta := &pipeline.PipelineMeta{
+		StartedAt: now.Add(-5 * time.Minute),
+		Phases: map[string]*pipeline.PhaseState{
+			"triage":    {Status: pipeline.PhaseCompleted, DurationMs: 60000},
+			"implement": {Status: pipeline.PhaseRunning},
+		},
+	}
+
+	got := computeElapsed(meta, now)
+	want := 5 * time.Minute
+	if got != want {
+		t.Errorf("computeElapsed() = %v, want %v (should use wall-clock for running)", got, want)
 	}
 }
 

--- a/cmd/soda/sessions_test.go
+++ b/cmd/soda/sessions_test.go
@@ -205,6 +205,11 @@ func TestTruncate(t *testing.T) {
 		{"this is a long string", 10, "this is..."},
 		{"ab", 3, "ab"},
 		{"abcd", 3, "abc"},
+		// Multi-byte UTF-8: each CJK character is 3 bytes but 1 rune.
+		{"日本語テスト", 5, "日本..."},
+		{"日本語テスト", 6, "日本語テスト"}, // exactly fits (6 runes)
+		{"日本語テスト", 3, "日本語"},    // maxLen<=3, no ellipsis
+		{"café résumé done", 10, "café ré..."},
 	}
 	for _, tc := range tests {
 		got := truncate(tc.input, tc.maxLen)

--- a/cmd/soda/sessions_test.go
+++ b/cmd/soda/sessions_test.go
@@ -1,0 +1,300 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/decko/soda/internal/pipeline"
+)
+
+func writeMeta(t *testing.T, dir string, meta *pipeline.PipelineMeta) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	data, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		t.Fatalf("MarshalIndent: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "meta.json"), data, 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}
+
+func TestCollectSessions_Empty(t *testing.T) {
+	dir := t.TempDir()
+	rows, err := collectSessions(dir, time.Now())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("expected 0 rows, got %d", len(rows))
+	}
+}
+
+func TestCollectSessions_NonexistentDir(t *testing.T) {
+	rows, err := collectSessions("/tmp/nonexistent-soda-sessions-test", time.Now())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("expected 0 rows, got %d", len(rows))
+	}
+}
+
+func TestCollectSessions_ReadsMeta(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2025, 6, 15, 14, 0, 0, 0, time.UTC)
+
+	writeMeta(t, filepath.Join(dir, "TICKET-1"), &pipeline.PipelineMeta{
+		Ticket:    "TICKET-1",
+		Summary:   "First ticket",
+		StartedAt: now.Add(-2 * time.Hour),
+		TotalCost: 1.23,
+		Phases: map[string]*pipeline.PhaseState{
+			"triage":    {Status: pipeline.PhaseCompleted},
+			"implement": {Status: pipeline.PhaseCompleted},
+		},
+	})
+	writeMeta(t, filepath.Join(dir, "TICKET-2"), &pipeline.PipelineMeta{
+		Ticket:    "TICKET-2",
+		Summary:   "Second ticket",
+		StartedAt: now.Add(-30 * time.Minute),
+		TotalCost: 5.58,
+		Phases: map[string]*pipeline.PhaseState{
+			"triage": {Status: pipeline.PhaseFailed, Error: "timeout"},
+		},
+	})
+
+	rows, err := collectSessions(dir, now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(rows))
+	}
+
+	// Verify fields populated
+	found := map[string]bool{}
+	for _, row := range rows {
+		found[row.ticket] = true
+		if row.cost == "" || row.elapsed == "" || row.status == "" {
+			t.Errorf("row %s: missing fields (cost=%q, elapsed=%q, status=%q)", row.ticket, row.cost, row.elapsed, row.status)
+		}
+	}
+	if !found["TICKET-1"] || !found["TICKET-2"] {
+		t.Errorf("expected both tickets, found: %v", found)
+	}
+}
+
+func TestFilterSessionsByStatus(t *testing.T) {
+	rows := []sessionEntry{
+		{ticket: "A", status: "completed"},
+		{ticket: "B", status: "failed"},
+		{ticket: "C", status: "completed"},
+		{ticket: "D", status: "running"},
+	}
+
+	completed := filterSessionsByStatus(rows, "completed")
+	if len(completed) != 2 {
+		t.Errorf("expected 2 completed, got %d", len(completed))
+	}
+	for _, row := range completed {
+		if row.status != "completed" {
+			t.Errorf("expected completed, got %q", row.status)
+		}
+	}
+
+	running := filterSessionsByStatus(rows, "running")
+	if len(running) != 1 {
+		t.Errorf("expected 1 running, got %d", len(running))
+	}
+
+	none := filterSessionsByStatus(rows, "stale")
+	if len(none) != 0 {
+		t.Errorf("expected 0 stale, got %d", len(none))
+	}
+}
+
+func TestSortSessions(t *testing.T) {
+	now := time.Date(2025, 6, 15, 14, 0, 0, 0, time.UTC)
+
+	rows := []sessionEntry{
+		{ticket: "A", cost: "$1.00", startedAt: now.Add(-3 * time.Hour)},
+		{ticket: "B", cost: "$5.00", startedAt: now.Add(-1 * time.Hour)},
+		{ticket: "C", cost: "$0.50", startedAt: now.Add(-2 * time.Hour)},
+	}
+
+	t.Run("sort by date (default)", func(t *testing.T) {
+		r := make([]sessionEntry, len(rows))
+		copy(r, rows)
+		sortSessions(r, "date")
+		wantOrder := []string{"B", "C", "A"} // newest first
+		for i, want := range wantOrder {
+			if r[i].ticket != want {
+				t.Errorf("rows[%d].ticket = %q, want %q", i, r[i].ticket, want)
+			}
+		}
+	})
+
+	t.Run("sort by cost", func(t *testing.T) {
+		r := make([]sessionEntry, len(rows))
+		copy(r, rows)
+		sortSessions(r, "cost")
+		wantOrder := []string{"B", "A", "C"} // highest cost first
+		for i, want := range wantOrder {
+			if r[i].ticket != want {
+				t.Errorf("rows[%d].ticket = %q, want %q", i, r[i].ticket, want)
+			}
+		}
+	})
+
+	t.Run("sort by elapsed", func(t *testing.T) {
+		r := make([]sessionEntry, len(rows))
+		copy(r, rows)
+		sortSessions(r, "elapsed")
+		wantOrder := []string{"A", "C", "B"} // longest running first
+		for i, want := range wantOrder {
+			if r[i].ticket != want {
+				t.Errorf("rows[%d].ticket = %q, want %q", i, r[i].ticket, want)
+			}
+		}
+	})
+}
+
+func TestFormatLastRun(t *testing.T) {
+	now := time.Date(2025, 6, 15, 14, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name      string
+		startedAt time.Time
+		want      string
+	}{
+		{"just now", now, "now"},
+		{"30 seconds ago", now.Add(-30 * time.Second), "now"},
+		{"1 minute ago", now.Add(-90 * time.Second), "1m ago"},
+		{"5 minutes ago", now.Add(-5 * time.Minute), "5m ago"},
+		{"1 hour ago", now.Add(-time.Hour), "1h ago"},
+		{"3 hours ago", now.Add(-3 * time.Hour), "3h ago"},
+		{"1 day ago", now.Add(-24 * time.Hour), "1d ago"},
+		{"3 days ago", now.Add(-72 * time.Hour), "3d ago"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := formatLastRun(tc.startedAt, now)
+			if got != tc.want {
+				t.Errorf("formatLastRun() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	tests := []struct {
+		input  string
+		maxLen int
+		want   string
+	}{
+		{"short", 10, "short"},
+		{"exactly ten", 11, "exactly ten"},
+		{"this is a long string", 10, "this is..."},
+		{"ab", 3, "ab"},
+		{"abcd", 3, "abc"},
+	}
+	for _, tc := range tests {
+		got := truncate(tc.input, tc.maxLen)
+		if got != tc.want {
+			t.Errorf("truncate(%q, %d) = %q, want %q", tc.input, tc.maxLen, got, tc.want)
+		}
+	}
+}
+
+func TestSessionsSummaryLine(t *testing.T) {
+	tests := []struct {
+		name string
+		rows []sessionEntry
+		want string
+	}{
+		{
+			name: "mixed statuses",
+			rows: []sessionEntry{
+				{status: "completed"},
+				{status: "completed"},
+				{status: "running"},
+				{status: "failed"},
+			},
+			want: "4 sessions (1 running, 2 completed, 1 failed)",
+		},
+		{
+			name: "all completed",
+			rows: []sessionEntry{
+				{status: "completed"},
+				{status: "completed"},
+			},
+			want: "2 sessions (2 completed)",
+		},
+		{
+			name: "single session",
+			rows: []sessionEntry{
+				{status: "running"},
+			},
+			want: "1 session (1 running)",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sessionsSummaryLine(tc.rows)
+			if got != tc.want {
+				t.Errorf("sessionsSummaryLine() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseCost(t *testing.T) {
+	tests := []struct {
+		input string
+		want  float64
+	}{
+		{"$1.23", 1.23},
+		{"$0.00", 0.00},
+		{"$10.50", 10.50},
+	}
+	for _, tc := range tests {
+		got := parseCost(tc.input)
+		if got != tc.want {
+			t.Errorf("parseCost(%q) = %f, want %f", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestNewSessionsCmd_Flags(t *testing.T) {
+	cmd := newSessionsCmd()
+
+	statusFlag := cmd.Flags().Lookup("status")
+	if statusFlag == nil {
+		t.Fatal("--status flag not found")
+	}
+	if statusFlag.DefValue != "" {
+		t.Errorf("--status default = %q, want empty", statusFlag.DefValue)
+	}
+
+	sortFlag := cmd.Flags().Lookup("sort")
+	if sortFlag == nil {
+		t.Fatal("--sort flag not found")
+	}
+	if sortFlag.DefValue != "date" {
+		t.Errorf("--sort default = %q, want %q", sortFlag.DefValue, "date")
+	}
+
+	allFlag := cmd.Flags().Lookup("all")
+	if allFlag == nil {
+		t.Fatal("--all flag not found")
+	}
+	if allFlag.DefValue != "false" {
+		t.Errorf("--all default = %q, want %q", allFlag.DefValue, "false")
+	}
+}

--- a/cmd/soda/sessions_test.go
+++ b/cmd/soda/sessions_test.go
@@ -297,4 +297,46 @@ func TestNewSessionsCmd_Flags(t *testing.T) {
 	if allFlag.DefValue != "false" {
 		t.Errorf("--all default = %q, want %q", allFlag.DefValue, "false")
 	}
+
+	tuiFlag := cmd.Flags().Lookup("tui")
+	if tuiFlag == nil {
+		t.Fatal("--tui flag not found")
+	}
+	if tuiFlag.DefValue != "false" {
+		t.Errorf("--tui default = %q, want %q", tuiFlag.DefValue, "false")
+	}
+}
+
+func TestSessionsToTUI(t *testing.T) {
+	now := time.Date(2025, 6, 15, 14, 0, 0, 0, time.UTC)
+
+	rows := []sessionEntry{
+		{ticket: "A", summary: "First", status: "completed", cost: "$1.23", elapsed: "5m", startedAt: now.Add(-2 * time.Hour)},
+		{ticket: "B", summary: "Second", status: "failed", cost: "$5.58", elapsed: "12m", startedAt: now.Add(-30 * time.Minute)},
+	}
+
+	sessions := sessionsToTUI(rows)
+	if len(sessions) != 2 {
+		t.Fatalf("expected 2 sessions, got %d", len(sessions))
+	}
+
+	if sessions[0].Ticket != "A" {
+		t.Errorf("session 0 ticket = %q, want %q", sessions[0].Ticket, "A")
+	}
+	if sessions[0].Summary != "First" {
+		t.Errorf("session 0 summary = %q, want %q", sessions[0].Summary, "First")
+	}
+	if sessions[0].Status != "completed" {
+		t.Errorf("session 0 status = %q, want %q", sessions[0].Status, "completed")
+	}
+	if sessions[0].Cost != 1.23 {
+		t.Errorf("session 0 cost = %f, want %f", sessions[0].Cost, 1.23)
+	}
+
+	if sessions[1].Ticket != "B" {
+		t.Errorf("session 1 ticket = %q, want %q", sessions[1].Ticket, "B")
+	}
+	if sessions[1].Cost != 5.58 {
+		t.Errorf("session 1 cost = %f, want %f", sessions[1].Cost, 5.58)
+	}
 }

--- a/internal/tui/sessions.go
+++ b/internal/tui/sessions.go
@@ -13,6 +13,7 @@ import (
 // in the TUI session browser.
 type SessionInfo struct {
 	Ticket    string
+	DirName   string // filesystem directory name; used for path lookups (may differ from Ticket)
 	Summary   string
 	Status    string
 	Cost      float64
@@ -36,8 +37,9 @@ const (
 
 // SessionResult is returned when the user selects an action on a session.
 type SessionResult struct {
-	Ticket string
-	Action SessionAction
+	Ticket  string
+	DirName string // filesystem directory name for path construction
+	Action  SessionAction
 }
 
 // SessionsModel is a bubbletea model for browsing pipeline sessions.
@@ -110,9 +112,11 @@ func (m SessionsModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case "enter":
+		s := m.sessions[m.cursor]
 		m.result = &SessionResult{
-			Ticket: m.sessions[m.cursor].Ticket,
-			Action: SessionActionView,
+			Ticket:  s.Ticket,
+			DirName: s.DirName,
+			Action:  SessionActionView,
 		}
 		return m, tea.Quit
 
@@ -120,8 +124,9 @@ func (m SessionsModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		s := m.sessions[m.cursor]
 		if s.Status == "failed" || s.Status == "stale" {
 			m.result = &SessionResult{
-				Ticket: s.Ticket,
-				Action: SessionActionResume,
+				Ticket:  s.Ticket,
+				DirName: s.DirName,
+				Action:  SessionActionResume,
 			}
 			return m, tea.Quit
 		}
@@ -131,8 +136,9 @@ func (m SessionsModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		s := m.sessions[m.cursor]
 		if s.Status == "completed" || s.Status == "failed" {
 			m.result = &SessionResult{
-				Ticket: s.Ticket,
-				Action: SessionActionDelete,
+				Ticket:  s.Ticket,
+				DirName: s.DirName,
+				Action:  SessionActionDelete,
 			}
 			return m, tea.Quit
 		}

--- a/internal/tui/sessions.go
+++ b/internal/tui/sessions.go
@@ -173,8 +173,9 @@ func renderSessionRow(session SessionInfo, selected bool) string {
 	cost := fmt.Sprintf("$%.2f", session.Cost)
 
 	summary := session.Summary
-	if len(summary) > 36 {
-		summary = summary[:33] + "..."
+	summaryRunes := []rune(summary)
+	if len(summaryRunes) > 36 {
+		summary = string(summaryRunes[:33]) + "..."
 	}
 
 	line := fmt.Sprintf("%s%-36s  %s  %s",

--- a/internal/tui/sessions.go
+++ b/internal/tui/sessions.go
@@ -1,0 +1,241 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// SessionInfo holds the data needed to render a single session row
+// in the TUI session browser.
+type SessionInfo struct {
+	Ticket    string
+	Summary   string
+	Status    string
+	Cost      float64
+	Elapsed   string
+	StartedAt time.Time
+}
+
+// SessionAction represents an action the user selected on a session.
+type SessionAction int
+
+const (
+	// SessionActionNone means no action was taken.
+	SessionActionNone SessionAction = iota
+	// SessionActionView means the user pressed Enter to view history.
+	SessionActionView
+	// SessionActionResume means the user pressed r to resume.
+	SessionActionResume
+	// SessionActionDelete means the user pressed d to delete/clean.
+	SessionActionDelete
+)
+
+// SessionResult is returned when the user selects an action on a session.
+type SessionResult struct {
+	Ticket string
+	Action SessionAction
+}
+
+// SessionsModel is a bubbletea model for browsing pipeline sessions.
+type SessionsModel struct {
+	sessions []SessionInfo
+	cursor   int
+	width    int
+	height   int
+	result   *SessionResult
+	quitting bool
+}
+
+// NewSessionsModel creates a new session browser model.
+func NewSessionsModel(sessions []SessionInfo) SessionsModel {
+	return SessionsModel{
+		sessions: sessions,
+	}
+}
+
+// Result returns the selected session action, or nil if the user quit.
+func (m SessionsModel) Result() *SessionResult {
+	return m.result
+}
+
+// Init implements tea.Model.
+func (m SessionsModel) Init() tea.Cmd {
+	return nil
+}
+
+// Update implements tea.Model.
+func (m SessionsModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		return m, nil
+
+	case tea.KeyMsg:
+		return m.handleKey(msg)
+	}
+
+	return m, nil
+}
+
+func (m SessionsModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if len(m.sessions) == 0 {
+		switch msg.String() {
+		case "q", "ctrl+c", "esc":
+			m.quitting = true
+			return m, tea.Quit
+		}
+		return m, nil
+	}
+
+	switch msg.String() {
+	case "q", "ctrl+c", "esc":
+		m.quitting = true
+		return m, tea.Quit
+
+	case "up", "k":
+		if m.cursor > 0 {
+			m.cursor--
+		}
+		return m, nil
+
+	case "down", "j":
+		if m.cursor < len(m.sessions)-1 {
+			m.cursor++
+		}
+		return m, nil
+
+	case "enter":
+		m.result = &SessionResult{
+			Ticket: m.sessions[m.cursor].Ticket,
+			Action: SessionActionView,
+		}
+		return m, tea.Quit
+
+	case "r":
+		s := m.sessions[m.cursor]
+		if s.Status == "failed" || s.Status == "stale" {
+			m.result = &SessionResult{
+				Ticket: s.Ticket,
+				Action: SessionActionResume,
+			}
+			return m, tea.Quit
+		}
+		return m, nil
+
+	case "d":
+		s := m.sessions[m.cursor]
+		if s.Status == "completed" || s.Status == "failed" {
+			m.result = &SessionResult{
+				Ticket: s.Ticket,
+				Action: SessionActionDelete,
+			}
+			return m, tea.Quit
+		}
+		return m, nil
+	}
+
+	return m, nil
+}
+
+// View implements tea.Model.
+func (m SessionsModel) View() string {
+	if m.quitting {
+		return ""
+	}
+
+	if len(m.sessions) == 0 {
+		return renderSessionsFrame("No sessions found.\n\n"+m.helpBar(), m.width)
+	}
+
+	var lines []string
+	for idx, session := range m.sessions {
+		lines = append(lines, renderSessionRow(session, idx == m.cursor))
+	}
+
+	content := strings.Join(lines, "\n")
+	content += "\n\n" + m.helpBar()
+
+	return renderSessionsFrame(content, m.width)
+}
+
+func renderSessionRow(session SessionInfo, selected bool) string {
+	cursor := "  "
+	if selected {
+		cursor = "> "
+	}
+
+	statusIcon := sessionStatusIcon(session.Status)
+	cost := fmt.Sprintf("$%.2f", session.Cost)
+
+	summary := session.Summary
+	if len(summary) > 36 {
+		summary = summary[:33] + "..."
+	}
+
+	line := fmt.Sprintf("%s%-36s  %s  %s",
+		stylePending.Render(session.Ticket),
+		"  "+summary,
+		statusIcon,
+		styleStatsValue.Render(cost),
+	)
+
+	if selected {
+		return styleRunning.Render(cursor) + line
+	}
+	return stylePending.Render(cursor) + line
+}
+
+func sessionStatusIcon(status string) string {
+	switch status {
+	case "completed":
+		return styleCompleted.Render("✓")
+	case "running":
+		return styleRunning.Render("●")
+	case "failed":
+		return styleFailed.Render("✗")
+	case "stale":
+		return styleRetrying.Render("⏸")
+	default:
+		return stylePending.Render("○")
+	}
+}
+
+func (m SessionsModel) helpBar() string {
+	bindings := []struct{ key, label string }{
+		{"↑/↓", "navigate"},
+		{"Enter", "view history"},
+		{"r", "resume"},
+		{"d", "delete"},
+		{"q", "quit"},
+	}
+	var parts []string
+	for _, b := range bindings {
+		parts = append(parts, fmt.Sprintf("%s %s",
+			styleKey.Render(b.key),
+			stylePending.Render(b.label),
+		))
+	}
+	return strings.Join(parts, "  ")
+}
+
+func renderSessionsFrame(content string, width int) string {
+	title := styleHeader.Render("Sessions")
+	body := title + "\n\n" + content
+
+	if width < 1 {
+		return body
+	}
+
+	w := width - 2
+	if w < 1 {
+		w = 1
+	}
+	return styleBorder.
+		Width(w).
+		Render(lipgloss.NewStyle().Padding(0, 1).Render(body))
+}

--- a/internal/tui/sessions.go
+++ b/internal/tui/sessions.go
@@ -172,23 +172,34 @@ func renderSessionRow(session SessionInfo, selected bool) string {
 	statusIcon := sessionStatusIcon(session.Status)
 	cost := fmt.Sprintf("$%.2f", session.Cost)
 
+	// Pad plain text to fixed column widths before applying styles so that
+	// ANSI escape sequences don't break alignment.
+	ticket := padRight(session.Ticket, 12)
 	summary := session.Summary
 	summaryRunes := []rune(summary)
 	if len(summaryRunes) > 36 {
 		summary = string(summaryRunes[:33]) + "..."
 	}
+	summary = padRight(summary, 36)
 
-	line := fmt.Sprintf("%s%-36s  %s  %s",
-		stylePending.Render(session.Ticket),
-		"  "+summary,
-		statusIcon,
-		styleStatsValue.Render(cost),
-	)
+	line := stylePending.Render(ticket) + "  " +
+		stylePending.Render(summary) + "  " +
+		statusIcon + "  " +
+		styleStatsValue.Render(cost)
 
 	if selected {
 		return styleRunning.Render(cursor) + line
 	}
 	return stylePending.Render(cursor) + line
+}
+
+// padRight pads s with spaces to the given width (measured in runes).
+func padRight(s string, width int) string {
+	r := []rune(s)
+	if len(r) >= width {
+		return s
+	}
+	return s + strings.Repeat(" ", width-len(r))
 }
 
 func sessionStatusIcon(status string) string {

--- a/internal/tui/sessions_test.go
+++ b/internal/tui/sessions_test.go
@@ -1,0 +1,313 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func testSessions() []SessionInfo {
+	return []SessionInfo{
+		{Ticket: "36", Summary: "Add version command to CLI", Status: "completed", Cost: 0.98, Elapsed: "5m49s", StartedAt: time.Now().Add(-2 * time.Hour)},
+		{Ticket: "58", Summary: "Show detailed pipeline outcome", Status: "completed", Cost: 5.58, Elapsed: "12m47s", StartedAt: time.Now().Add(-30 * time.Minute)},
+		{Ticket: "64", Summary: "Delete branch when cleaning", Status: "running", Cost: 0.45, Elapsed: "2m12s", StartedAt: time.Now()},
+		{Ticket: "50", Summary: "Resume gate check bug", Status: "failed", Cost: 1.23, Elapsed: "4m30s", StartedAt: time.Now().Add(-5 * time.Hour)},
+	}
+}
+
+func TestSessionsModel_InitialState(t *testing.T) {
+	sessions := testSessions()
+	model := NewSessionsModel(sessions)
+
+	if model.cursor != 0 {
+		t.Errorf("expected cursor at 0, got %d", model.cursor)
+	}
+	if model.result != nil {
+		t.Error("expected nil result initially")
+	}
+}
+
+func TestSessionsModel_NavigateDown(t *testing.T) {
+	model := NewSessionsModel(testSessions())
+
+	model2, _ := model.handleKey(tea.KeyMsg{Type: tea.KeyDown})
+	m := model2.(SessionsModel)
+	if m.cursor != 1 {
+		t.Errorf("expected cursor at 1 after down, got %d", m.cursor)
+	}
+
+	// Navigate to last
+	m2, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyDown})
+	m3, _ := m2.(SessionsModel).handleKey(tea.KeyMsg{Type: tea.KeyDown})
+	mm := m3.(SessionsModel)
+	if mm.cursor != 3 {
+		t.Errorf("expected cursor at 3, got %d", mm.cursor)
+	}
+
+	// Cannot go past last
+	m4, _ := mm.handleKey(tea.KeyMsg{Type: tea.KeyDown})
+	if m4.(SessionsModel).cursor != 3 {
+		t.Errorf("expected cursor still at 3, got %d", m4.(SessionsModel).cursor)
+	}
+}
+
+func TestSessionsModel_NavigateUp(t *testing.T) {
+	model := NewSessionsModel(testSessions())
+	model.cursor = 2
+
+	model2, _ := model.handleKey(tea.KeyMsg{Type: tea.KeyUp})
+	m := model2.(SessionsModel)
+	if m.cursor != 1 {
+		t.Errorf("expected cursor at 1 after up, got %d", m.cursor)
+	}
+
+	// Navigate to first
+	m2, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyUp})
+	if m2.(SessionsModel).cursor != 0 {
+		t.Errorf("expected cursor at 0, got %d", m2.(SessionsModel).cursor)
+	}
+
+	// Cannot go past first
+	m3, _ := m2.(SessionsModel).handleKey(tea.KeyMsg{Type: tea.KeyUp})
+	if m3.(SessionsModel).cursor != 0 {
+		t.Errorf("expected cursor still at 0, got %d", m3.(SessionsModel).cursor)
+	}
+}
+
+func TestSessionsModel_NavigateWithKJ(t *testing.T) {
+	model := NewSessionsModel(testSessions())
+
+	// j moves down
+	model2, _ := model.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	if model2.(SessionsModel).cursor != 1 {
+		t.Errorf("expected cursor at 1 after j, got %d", model2.(SessionsModel).cursor)
+	}
+
+	// k moves up
+	model3, _ := model2.(SessionsModel).handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("k")})
+	if model3.(SessionsModel).cursor != 0 {
+		t.Errorf("expected cursor at 0 after k, got %d", model3.(SessionsModel).cursor)
+	}
+}
+
+func TestSessionsModel_EnterViewsHistory(t *testing.T) {
+	model := NewSessionsModel(testSessions())
+	model.cursor = 1
+
+	model2, cmd := model.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	m := model2.(SessionsModel)
+
+	if m.result == nil {
+		t.Fatal("expected result after Enter")
+	}
+	if m.result.Ticket != "58" {
+		t.Errorf("expected ticket 58, got %q", m.result.Ticket)
+	}
+	if m.result.Action != SessionActionView {
+		t.Errorf("expected SessionActionView, got %d", m.result.Action)
+	}
+	if cmd == nil {
+		t.Error("expected quit command after Enter")
+	}
+}
+
+func TestSessionsModel_ResumeFailedSession(t *testing.T) {
+	model := NewSessionsModel(testSessions())
+	model.cursor = 3 // failed session
+
+	model2, cmd := model.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("r")})
+	m := model2.(SessionsModel)
+
+	if m.result == nil {
+		t.Fatal("expected result after r on failed session")
+	}
+	if m.result.Action != SessionActionResume {
+		t.Errorf("expected SessionActionResume, got %d", m.result.Action)
+	}
+	if cmd == nil {
+		t.Error("expected quit command after resume")
+	}
+}
+
+func TestSessionsModel_ResumeIgnoredOnCompleted(t *testing.T) {
+	model := NewSessionsModel(testSessions())
+	model.cursor = 0 // completed session
+
+	model2, _ := model.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("r")})
+	m := model2.(SessionsModel)
+
+	if m.result != nil {
+		t.Error("expected no result on r for completed session")
+	}
+}
+
+func TestSessionsModel_ResumeIgnoredOnRunning(t *testing.T) {
+	model := NewSessionsModel(testSessions())
+	model.cursor = 2 // running session
+
+	model2, _ := model.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("r")})
+	m := model2.(SessionsModel)
+
+	if m.result != nil {
+		t.Error("expected no result on r for running session")
+	}
+}
+
+func TestSessionsModel_DeleteCompletedSession(t *testing.T) {
+	model := NewSessionsModel(testSessions())
+	model.cursor = 0 // completed session
+
+	model2, cmd := model.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")})
+	m := model2.(SessionsModel)
+
+	if m.result == nil {
+		t.Fatal("expected result after d on completed session")
+	}
+	if m.result.Action != SessionActionDelete {
+		t.Errorf("expected SessionActionDelete, got %d", m.result.Action)
+	}
+	if cmd == nil {
+		t.Error("expected quit command after delete")
+	}
+}
+
+func TestSessionsModel_DeleteIgnoredOnRunning(t *testing.T) {
+	model := NewSessionsModel(testSessions())
+	model.cursor = 2 // running session
+
+	model2, _ := model.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")})
+	m := model2.(SessionsModel)
+
+	if m.result != nil {
+		t.Error("expected no result on d for running session")
+	}
+}
+
+func TestSessionsModel_Quit(t *testing.T) {
+	model := NewSessionsModel(testSessions())
+
+	model2, cmd := model.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	m := model2.(SessionsModel)
+
+	if !m.quitting {
+		t.Error("expected quitting true after q")
+	}
+	if m.result != nil {
+		t.Error("expected nil result on quit")
+	}
+	if cmd == nil {
+		t.Error("expected quit command")
+	}
+}
+
+func TestSessionsModel_ViewContent(t *testing.T) {
+	model := NewSessionsModel(testSessions())
+	model.width = 80
+	model.height = 24
+
+	view := model.View()
+
+	// Should show session browser title
+	if !strings.Contains(view, "Sessions") {
+		t.Error("view missing Sessions title")
+	}
+
+	// Should show ticket keys
+	for _, ticket := range []string{"36", "58", "64", "50"} {
+		if !strings.Contains(view, ticket) {
+			t.Errorf("view missing ticket %q", ticket)
+		}
+	}
+
+	// Should show status icons
+	if !strings.Contains(view, "✓") {
+		t.Error("view missing completed icon ✓")
+	}
+	if !strings.Contains(view, "●") {
+		t.Error("view missing running icon ●")
+	}
+	if !strings.Contains(view, "✗") {
+		t.Error("view missing failed icon ✗")
+	}
+
+	// Should show help bar
+	if !strings.Contains(view, "navigate") {
+		t.Error("view missing help bar")
+	}
+	if !strings.Contains(view, "view history") {
+		t.Error("view missing 'view history' in help bar")
+	}
+
+	// Should show cursor on first item
+	if !strings.Contains(view, ">") {
+		t.Error("view missing cursor '>'")
+	}
+}
+
+func TestSessionsModel_ViewEmpty(t *testing.T) {
+	model := NewSessionsModel(nil)
+	model.width = 80
+
+	view := model.View()
+	if !strings.Contains(view, "No sessions found") {
+		t.Error("empty view should show 'No sessions found'")
+	}
+}
+
+func TestSessionsModel_EmptyListQuit(t *testing.T) {
+	model := NewSessionsModel(nil)
+
+	model2, cmd := model.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	m := model2.(SessionsModel)
+
+	if !m.quitting {
+		t.Error("expected quitting true after q on empty list")
+	}
+	if cmd == nil {
+		t.Error("expected quit command")
+	}
+}
+
+func TestSessionsModel_ViewQuitting(t *testing.T) {
+	model := NewSessionsModel(testSessions())
+	model.quitting = true
+
+	view := model.View()
+	if view != "" {
+		t.Errorf("expected empty view when quitting, got %q", view)
+	}
+}
+
+func TestSessionStatusIcon(t *testing.T) {
+	tests := []struct {
+		status string
+		icon   string
+	}{
+		{"completed", "✓"},
+		{"running", "●"},
+		{"failed", "✗"},
+		{"stale", "⏸"},
+		{"pending", "○"},
+	}
+	for _, tc := range tests {
+		got := sessionStatusIcon(tc.status)
+		if !strings.Contains(got, tc.icon) {
+			t.Errorf("sessionStatusIcon(%q) = %q, want to contain %q", tc.status, got, tc.icon)
+		}
+	}
+}
+
+func TestSessionsModel_CostDisplay(t *testing.T) {
+	model := NewSessionsModel(testSessions())
+	model.width = 80
+
+	view := model.View()
+	if !strings.Contains(view, "$0.98") {
+		t.Error("view missing cost $0.98")
+	}
+	if !strings.Contains(view, "$5.58") {
+		t.Error("view missing cost $5.58")
+	}
+}

--- a/internal/tui/sessions_test.go
+++ b/internal/tui/sessions_test.go
@@ -10,10 +10,10 @@ import (
 
 func testSessions() []SessionInfo {
 	return []SessionInfo{
-		{Ticket: "36", Summary: "Add version command to CLI", Status: "completed", Cost: 0.98, Elapsed: "5m49s", StartedAt: time.Now().Add(-2 * time.Hour)},
-		{Ticket: "58", Summary: "Show detailed pipeline outcome", Status: "completed", Cost: 5.58, Elapsed: "12m47s", StartedAt: time.Now().Add(-30 * time.Minute)},
-		{Ticket: "64", Summary: "Delete branch when cleaning", Status: "running", Cost: 0.45, Elapsed: "2m12s", StartedAt: time.Now()},
-		{Ticket: "50", Summary: "Resume gate check bug", Status: "failed", Cost: 1.23, Elapsed: "4m30s", StartedAt: time.Now().Add(-5 * time.Hour)},
+		{Ticket: "36", DirName: "36", Summary: "Add version command to CLI", Status: "completed", Cost: 0.98, Elapsed: "5m49s", StartedAt: time.Now().Add(-2 * time.Hour)},
+		{Ticket: "58", DirName: "58", Summary: "Show detailed pipeline outcome", Status: "completed", Cost: 5.58, Elapsed: "12m47s", StartedAt: time.Now().Add(-30 * time.Minute)},
+		{Ticket: "64", DirName: "64", Summary: "Delete branch when cleaning", Status: "running", Cost: 0.45, Elapsed: "2m12s", StartedAt: time.Now()},
+		{Ticket: "50", DirName: "50", Summary: "Resume gate check bug", Status: "failed", Cost: 1.23, Elapsed: "4m30s", StartedAt: time.Now().Add(-5 * time.Hour)},
 	}
 }
 
@@ -105,11 +105,34 @@ func TestSessionsModel_EnterViewsHistory(t *testing.T) {
 	if m.result.Ticket != "58" {
 		t.Errorf("expected ticket 58, got %q", m.result.Ticket)
 	}
+	if m.result.DirName != "58" {
+		t.Errorf("expected dirName 58, got %q", m.result.DirName)
+	}
 	if m.result.Action != SessionActionView {
 		t.Errorf("expected SessionActionView, got %d", m.result.Action)
 	}
 	if cmd == nil {
 		t.Error("expected quit command after Enter")
+	}
+}
+
+func TestSessionsModel_EnterPropagatesDirName(t *testing.T) {
+	sessions := []SessionInfo{
+		{Ticket: "PROJ-42", DirName: "proj-42-slugified", Summary: "Test", Status: "completed", Cost: 1.0},
+	}
+	model := NewSessionsModel(sessions)
+
+	model2, _ := model.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	m := model2.(SessionsModel)
+
+	if m.result == nil {
+		t.Fatal("expected result after Enter")
+	}
+	if m.result.Ticket != "PROJ-42" {
+		t.Errorf("expected ticket PROJ-42, got %q", m.result.Ticket)
+	}
+	if m.result.DirName != "proj-42-slugified" {
+		t.Errorf("expected dirName proj-42-slugified, got %q", m.result.DirName)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `soda sessions` command listing all previous and active pipeline runs
- Table with ticket, summary, status, cost, elapsed, submitted time
- `--all`, `--status <filter>`, `--sort <field>` flags
- TUI session browser with `--tui` flag: keyboard nav, Enter to view history
- UTF-8 safe truncation, proper column alignment

## Test plan

- [x] All tests pass
- [ ] CI passes

Fixes: #69

Generated with [Claude Code](https://claude.com/claude-code) via SODA
