### PR TITLE
fix(cli): resolve WorkDir to git repo root to prevent nested worktrees (#156)

### DIFF
--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -115,8 +115,22 @@ func runPipeline(cmd *cobra.Command, cfg *config.Config, ticketKey string) error
 		return runDryRun(cfg, pl, loader, ticketData)
 	}
 
+	// Resolve working directory to the main repo root so worktrees,
+	// state, and all paths are always relative to the root, even when
+	// soda is invoked from inside an existing worktree.
+	workDir, err := git.RepoRoot(".")
+	if err != nil {
+		return fmt.Errorf("run: resolve repo root: %w", err)
+	}
+
+	// Resolve StateDir relative to repo root.
+	stateDir := cfg.StateDir
+	if !filepath.IsAbs(stateDir) {
+		stateDir = filepath.Join(workDir, stateDir)
+	}
+
 	// Load or create state
-	state, err := pipeline.LoadOrCreate(cfg.StateDir, ticketKey)
+	state, err := pipeline.LoadOrCreate(stateDir, ticketKey)
 	if err != nil {
 		return fmt.Errorf("run: %w", err)
 	}
@@ -134,14 +148,6 @@ func runPipeline(cmd *cobra.Command, cfg *config.Config, ticketKey string) error
 		// default
 	default:
 		return fmt.Errorf("run: unknown mode %q (expected 'checkpoint' or 'autonomous')", modeStr)
-	}
-
-	// Resolve working directory to the git repo toplevel so worktrees are
-	// always created from the root, even when soda is invoked from a subdirectory
-	// or from inside an existing worktree.
-	workDir, err := git.Toplevel(".")
-	if err != nil {
-		return fmt.Errorf("run: resolve git toplevel: %w", err)
 	}
 
 	// Build runner
@@ -182,7 +188,7 @@ func runPipeline(cmd *cobra.Command, cfg *config.Config, ticketKey string) error
 		PromptContext: promptContext,
 		Model:         cfg.Model,
 		WorkDir:       workDir,
-		WorktreeBase:  cfg.WorktreeDir,
+		WorktreeBase:  filepath.Join(workDir, cfg.WorktreeDir),
 		BaseBranch:    "main",
 		MaxCostUSD:    cfg.Limits.MaxCostPerTicket,
 		Mode:          mode,

--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/decko/soda/internal/claude"
 	"github.com/decko/soda/internal/config"
+	"github.com/decko/soda/internal/git"
 	"github.com/decko/soda/internal/pipeline"
 	"github.com/decko/soda/internal/progress"
 	"github.com/decko/soda/internal/runner"
@@ -135,16 +136,20 @@ func runPipeline(cmd *cobra.Command, cfg *config.Config, ticketKey string) error
 		return fmt.Errorf("run: unknown mode %q (expected 'checkpoint' or 'autonomous')", modeStr)
 	}
 
+	// Resolve working directory to the git repo toplevel so worktrees are
+	// always created from the root, even when soda is invoked from a subdirectory
+	// or from inside an existing worktree.
+	workDir, err := git.Toplevel(".")
+	if err != nil {
+		return fmt.Errorf("run: resolve git toplevel: %w", err)
+	}
+
 	// Build runner
 	var r runner.Runner
 	useMock, _ := cmd.Flags().GetBool("mock")
 	if useMock {
 		r = buildMockRunner()
 	} else {
-		workDir, err := filepath.Abs(".")
-		if err != nil {
-			return fmt.Errorf("run: resolve workdir: %w", err)
-		}
 		claudeRunner, err := runner.NewClaudeRunner("claude", cfg.Model, workDir)
 		if err != nil {
 			return fmt.Errorf("run: create claude runner: %w", err)
@@ -176,7 +181,7 @@ func runPipeline(cmd *cobra.Command, cfg *config.Config, ticketKey string) error
 		PromptConfig:  promptConfig,
 		PromptContext: promptContext,
 		Model:         cfg.Model,
-		WorkDir:       ".",
+		WorkDir:       workDir,
 		WorktreeBase:  cfg.WorktreeDir,
 		BaseBranch:    "main",
 		MaxCostUSD:    cfg.Limits.MaxCostPerTicket,

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -10,6 +10,20 @@ import (
 	"strings"
 )
 
+// Toplevel returns the absolute path of the top-level directory of the git
+// repository that contains dir. It runs "git rev-parse --show-toplevel".
+// This resolves through worktrees, so calling it from inside a worktree
+// returns the worktree root (not the main repo).
+func Toplevel(dir string) (string, error) {
+	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("git: rev-parse --show-toplevel in %s: %w", dir, err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
 // CreateWorktree creates a git worktree for a new branch based on baseBranch.
 // Returns the absolute path to the worktree directory.
 // If the worktree already exists at the expected path, returns that path.

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -10,18 +10,21 @@ import (
 	"strings"
 )
 
-// Toplevel returns the absolute path of the top-level directory of the git
-// repository that contains dir. It runs "git rev-parse --show-toplevel".
-// This resolves through worktrees, so calling it from inside a worktree
-// returns the worktree root (not the main repo).
-func Toplevel(dir string) (string, error) {
-	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+// RepoRoot returns the absolute path of the main repository root,
+// even when called from inside a worktree. Uses --git-common-dir
+// which always points to the shared .git directory.
+func RepoRoot(dir string) (string, error) {
+	cmd := exec.Command("git", "rev-parse", "--git-common-dir")
 	cmd.Dir = dir
 	out, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("git: rev-parse --show-toplevel in %s: %w", dir, err)
+		return "", fmt.Errorf("git: rev-parse --git-common-dir in %s: %w", dir, err)
 	}
-	return strings.TrimSpace(string(out)), nil
+	gitDir := strings.TrimSpace(string(out))
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(dir, gitDir)
+	}
+	return filepath.Dir(gitDir), nil
 }
 
 // CreateWorktree creates a git worktree for a new branch based on baseBranch.

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -29,6 +29,65 @@ func initGitRepo(t *testing.T) string {
 	return dir
 }
 
+func TestToplevel(t *testing.T) {
+	t.Run("returns_repo_root", func(t *testing.T) {
+		repoDir := initGitRepo(t)
+
+		got, err := Toplevel(repoDir)
+		if err != nil {
+			t.Fatalf("Toplevel: %v", err)
+		}
+		if got != repoDir {
+			t.Errorf("Toplevel = %q, want %q", got, repoDir)
+		}
+	})
+
+	t.Run("resolves_from_subdirectory", func(t *testing.T) {
+		repoDir := initGitRepo(t)
+
+		subDir := filepath.Join(repoDir, "sub", "deep")
+		if err := os.MkdirAll(subDir, 0755); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+
+		got, err := Toplevel(subDir)
+		if err != nil {
+			t.Fatalf("Toplevel: %v", err)
+		}
+		if got != repoDir {
+			t.Errorf("Toplevel = %q, want %q", got, repoDir)
+		}
+	})
+
+	t.Run("resolves_from_worktree", func(t *testing.T) {
+		repoDir := initGitRepo(t)
+		worktreeBase := filepath.Join(repoDir, ".worktrees")
+
+		wtPath, err := CreateWorktree(context.Background(), repoDir, worktreeBase, "feat/toplevel-test", "main")
+		if err != nil {
+			t.Fatalf("CreateWorktree: %v", err)
+		}
+
+		got, err := Toplevel(wtPath)
+		if err != nil {
+			t.Fatalf("Toplevel: %v", err)
+		}
+		// Inside a worktree, git rev-parse --show-toplevel returns
+		// the worktree root, not the main repository.
+		if got != wtPath {
+			t.Errorf("Toplevel = %q, want %q (worktree root)", got, wtPath)
+		}
+	})
+
+	t.Run("errors_outside_git_repo", func(t *testing.T) {
+		dir := t.TempDir()
+		_, err := Toplevel(dir)
+		if err == nil {
+			t.Fatal("expected error outside git repo")
+		}
+	})
+}
+
 func TestCreateWorktree(t *testing.T) {
 	t.Run("creates_worktree_and_branch", func(t *testing.T) {
 		repoDir := initGitRepo(t)

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -29,16 +29,16 @@ func initGitRepo(t *testing.T) string {
 	return dir
 }
 
-func TestToplevel(t *testing.T) {
+func TestRepoRoot(t *testing.T) {
 	t.Run("returns_repo_root", func(t *testing.T) {
 		repoDir := initGitRepo(t)
 
-		got, err := Toplevel(repoDir)
+		got, err := RepoRoot(repoDir)
 		if err != nil {
-			t.Fatalf("Toplevel: %v", err)
+			t.Fatalf("RepoRoot: %v", err)
 		}
 		if got != repoDir {
-			t.Errorf("Toplevel = %q, want %q", got, repoDir)
+			t.Errorf("RepoRoot = %q, want %q", got, repoDir)
 		}
 	})
 
@@ -50,38 +50,37 @@ func TestToplevel(t *testing.T) {
 			t.Fatalf("MkdirAll: %v", err)
 		}
 
-		got, err := Toplevel(subDir)
+		got, err := RepoRoot(subDir)
 		if err != nil {
-			t.Fatalf("Toplevel: %v", err)
+			t.Fatalf("RepoRoot: %v", err)
 		}
 		if got != repoDir {
-			t.Errorf("Toplevel = %q, want %q", got, repoDir)
+			t.Errorf("RepoRoot = %q, want %q", got, repoDir)
 		}
 	})
 
-	t.Run("resolves_from_worktree", func(t *testing.T) {
+	t.Run("returns_main_repo_from_worktree", func(t *testing.T) {
 		repoDir := initGitRepo(t)
 		worktreeBase := filepath.Join(repoDir, ".worktrees")
 
-		wtPath, err := CreateWorktree(context.Background(), repoDir, worktreeBase, "feat/toplevel-test", "main")
+		wtPath, err := CreateWorktree(context.Background(), repoDir, worktreeBase, "feat/reporoot-test", "main")
 		if err != nil {
 			t.Fatalf("CreateWorktree: %v", err)
 		}
 
-		got, err := Toplevel(wtPath)
+		got, err := RepoRoot(wtPath)
 		if err != nil {
-			t.Fatalf("Toplevel: %v", err)
+			t.Fatalf("RepoRoot: %v", err)
 		}
-		// Inside a worktree, git rev-parse --show-toplevel returns
-		// the worktree root, not the main repository.
-		if got != wtPath {
-			t.Errorf("Toplevel = %q, want %q (worktree root)", got, wtPath)
+		// RepoRoot must return the MAIN repo root, not the worktree.
+		if got != repoDir {
+			t.Errorf("RepoRoot from worktree = %q, want %q (main repo)", got, repoDir)
 		}
 	})
 
 	t.Run("errors_outside_git_repo", func(t *testing.T) {
 		dir := t.TempDir()
-		_, err := Toplevel(dir)
+		_, err := RepoRoot(dir)
 		if err == nil {
 			t.Fatal("expected error outside git repo")
 		}


### PR DESCRIPTION
## Summary

- Replace `git.Toplevel` (`--show-toplevel`, returns worktree root) with `git.RepoRoot` (`--git-common-dir`, returns main repo root)
- Resolve `StateDir` and `WorktreeBase` relative to repo root in `run.go`
- Prevents nested worktree creation when `soda run` is invoked from inside an existing worktree

## Root cause

`git rev-parse --show-toplevel` returns the worktree root when called from a worktree, not the main repo. All relative paths (`WorkDir`, `StateDir`, `WorktreeBase`) resolved against this, creating nested directories.

## Test plan

- [x] `TestRepoRoot/returns_main_repo_from_worktree` — verifies correct behavior
- [x] All tests pass
- [ ] CI passes

Fixes: #156

Generated with [Claude Code](https://claude.com/claude-code)
