### PR TITLE
fix(cli): resolve RepoRoot to absolute path and print errors to stderr

### DIFF
--- a/cmd/soda/main.go
+++ b/cmd/soda/main.go
@@ -22,6 +22,7 @@ var version = "dev"
 func main() {
 	rootCmd := newRootCmd()
 	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
 }

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -24,7 +24,11 @@ func RepoRoot(dir string) (string, error) {
 	if !filepath.IsAbs(gitDir) {
 		gitDir = filepath.Join(dir, gitDir)
 	}
-	return filepath.Dir(gitDir), nil
+	absPath, err := filepath.Abs(filepath.Dir(gitDir))
+	if err != nil {
+		return "", fmt.Errorf("git: resolve absolute path: %w", err)
+	}
+	return absPath, nil
 }
 
 // CreateWorktree creates a git worktree for a new branch based on baseBranch.

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -78,6 +78,32 @@ func TestRepoRoot(t *testing.T) {
 		}
 	})
 
+	t.Run("returns_absolute_path_from_dot", func(t *testing.T) {
+		repoDir := initGitRepo(t)
+
+		// Simulate calling RepoRoot(".") from inside the repo root
+		// by changing to the repo directory.
+		origDir, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("Getwd: %v", err)
+		}
+		t.Cleanup(func() { os.Chdir(origDir) })
+		if err := os.Chdir(repoDir); err != nil {
+			t.Fatalf("Chdir: %v", err)
+		}
+
+		got, err := RepoRoot(".")
+		if err != nil {
+			t.Fatalf("RepoRoot: %v", err)
+		}
+		if !filepath.IsAbs(got) {
+			t.Errorf("RepoRoot(\".\") = %q, want absolute path", got)
+		}
+		if got != repoDir {
+			t.Errorf("RepoRoot(\".\") = %q, want %q", got, repoDir)
+		}
+	})
+
 	t.Run("errors_outside_git_repo", func(t *testing.T) {
 		dir := t.TempDir()
 		_, err := RepoRoot(dir)


### PR DESCRIPTION
## Summary
- `RepoRoot(".")` returned `"."` instead of an absolute path when called from the repo root, causing `NewClaudeRunner` to reject the workDir and silently kill every `soda run` invocation
- Cobra's `SilenceErrors: true` + bare `os.Exit(1)` swallowed the error completely — no stdout, no stderr, just exit code 1
- Now `RepoRoot` always returns an absolute path via `filepath.Abs()`, and `main()` prints errors to stderr before exiting

## Test plan
- [x] Added test `TestRepoRoot/returns_absolute_path_from_dot` that verifies `RepoRoot(".")` returns an absolute path
- [x] All existing `TestRepoRoot` subtests pass
- [x] Full test suite passes (except pre-existing sandbox linker issue)
- [x] Verified `soda run` no longer silently fails — errors print to stderr


🤖 Generated with [Claude Code](https://claude.com/claude-code)