### PR TITLE
feat(pipeline): add per-reviewer model selection (#81)

### DIFF
--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -1359,6 +1359,12 @@ func (e *Engine) runReviewer(ctx context.Context, phase PhaseConfig, reviewer Re
 	}
 
 	// Use the parent phase's schema for the reviewer findings.
+	// Prefer per-reviewer model if set, otherwise use the global model.
+	model := e.config.Model
+	if reviewer.Model != "" {
+		model = reviewer.Model
+	}
+
 	opts := runner.RunOpts{
 		Phase:        phase.Name + "/" + reviewer.Name,
 		SystemPrompt: rendered,
@@ -1367,7 +1373,7 @@ func (e *Engine) runReviewer(ctx context.Context, phase PhaseConfig, reviewer Re
 		AllowedTools: phase.Tools,
 		MaxBudgetUSD: budgetRemaining,
 		WorkDir:      e.workDir(phase),
-		Model:        e.config.Model,
+		Model:        model,
 		Timeout:      phase.Timeout.Duration,
 		OnChunk:      onChunk,
 	}

--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -3365,6 +3365,63 @@ func TestEngine_ParallelReview_HappyPath(t *testing.T) {
 	}
 }
 
+func TestEngine_ParallelReview_PerReviewerModel(t *testing.T) {
+	phases := []PhaseConfig{
+		{
+			Name:  "review",
+			Type:  "parallel-review",
+			Retry: RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			Reviewers: []ReviewerConfig{
+				{Name: "go-specialist", Prompt: "prompts/review-go.md", Focus: "Go idioms", Model: "claude-sonnet-4-6"},
+				{Name: "ai-harness", Prompt: "prompts/review-harness.md", Focus: "AI harness"}, // no model — should use global
+			},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"review/go-specialist": {{
+				result: &runner.RunResult{
+					Output: json.RawMessage(`{"findings":[],"verdict":"pass"}`),
+				},
+			}},
+			"review/ai-harness": {{
+				result: &runner.RunResult{
+					Output: json.RawMessage(`{"findings":[],"verdict":"pass"}`),
+				},
+			}},
+		},
+	}
+
+	engine, _ := setupReviewEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.Model = "claude-opus-4-6"
+	})
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+
+	if len(mock.calls) != 2 {
+		t.Fatalf("runner called %d times, want 2", len(mock.calls))
+	}
+
+	// Find each reviewer's call by phase name.
+	models := map[string]string{}
+	for _, c := range mock.calls {
+		models[c.Phase] = c.Model
+	}
+
+	if models["review/go-specialist"] != "claude-sonnet-4-6" {
+		t.Errorf("go-specialist model = %q, want %q", models["review/go-specialist"], "claude-sonnet-4-6")
+	}
+	if models["review/ai-harness"] != "claude-opus-4-6" {
+		t.Errorf("ai-harness model = %q, want %q (global fallback)", models["review/ai-harness"], "claude-opus-4-6")
+	}
+}
+
 func TestEngine_ParallelReview_MergedFindings(t *testing.T) {
 	// When max rework cycles is reached (set to 0), review with
 	// critical/major findings should gate with a PhaseGateError.

--- a/internal/pipeline/phase.go
+++ b/internal/pipeline/phase.go
@@ -35,6 +35,7 @@ type ReviewerConfig struct {
 	Name   string `yaml:"name"`
 	Prompt string `yaml:"prompt"`
 	Focus  string `yaml:"focus"`
+	Model  string `yaml:"model,omitempty"`
 }
 
 // RetryConfig holds per-category retry limits.


### PR DESCRIPTION
## Summary
- Add optional `Model` field to `ReviewerConfig` for per-reviewer model selection
- `runReviewer` prefers reviewer-specific model, falls back to global engine model
- Enables using cheaper models (Sonnet) for routine reviews, Opus for complex ones

## Test plan
- [x] `TestEngine_ParallelReview_PerReviewerModel` — verifies per-reviewer model used when set, global model used when unset
- [x] All existing parallel review tests pass unchanged

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)