### PR TITLE
feat(pipeline): patch regression detection and exhaustion handling (#168)

### DIFF
--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -501,9 +501,14 @@ func handleEvent(ctx context.Context, cancel context.CancelFunc, engine *pipelin
 		prog.PhaseSkipped(event.Phase)
 
 	case pipeline.EventPatchExhausted:
-		patchCycles, _ := event.Data["patch_cycles"].(float64)
+		patchCycles, _ := event.Data["patch_cycles"].(int)
+		if patchCycles == 0 {
+			if pf, ok := event.Data["patch_cycles"].(float64); ok {
+				patchCycles = int(pf)
+			}
+		}
 		onExhausted, _ := event.Data["on_exhausted"].(string)
-		prog.Message(fmt.Sprintf("  ⏹  Patch exhausted after %d cycles (policy: %s)", int(patchCycles), onExhausted))
+		prog.Message(fmt.Sprintf("  ⏹  Patch exhausted after %d cycles (policy: %s)", patchCycles, onExhausted))
 
 	case pipeline.EventPatchEscalated:
 		escalatingTo, _ := event.Data["escalating_to"].(string)

--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -496,6 +496,29 @@ func handleEvent(ctx context.Context, cancel context.CancelFunc, engine *pipelin
 	case pipeline.EventMonitorTimeout:
 		duration, _ := event.Data["duration"].(string)
 		prog.Message(fmt.Sprintf("  ⏹  Monitor timeout after %s", duration))
+
+	case pipeline.EventCorrectiveSkipped:
+		prog.PhaseSkipped(event.Phase)
+
+	case pipeline.EventPatchExhausted:
+		patchCycles, _ := event.Data["patch_cycles"].(float64)
+		onExhausted, _ := event.Data["on_exhausted"].(string)
+		prog.Message(fmt.Sprintf("  ⏹  Patch exhausted after %d cycles (policy: %s)", int(patchCycles), onExhausted))
+
+	case pipeline.EventPatchEscalated:
+		escalatingTo, _ := event.Data["escalating_to"].(string)
+		prog.Message(fmt.Sprintf("  ⬆️  Escalating to %s", escalatingTo))
+
+	case pipeline.EventPatchRegression:
+		prog.Message("  ⚠️  Regression detected: previously-passing criteria now fail")
+
+	case pipeline.EventPatchTooComplex:
+		reason, _ := event.Data["reason"].(string)
+		prog.Message(fmt.Sprintf("  ⚠️  Patch too complex: %s", reason))
+
+	case pipeline.EventPatchEscalationSkipped:
+		reason, _ := event.Data["reason"].(string)
+		prog.Message(fmt.Sprintf("  ⏭  Escalation skipped: %s", reason))
 	}
 }
 
@@ -647,6 +670,26 @@ func formatPhaseDetails(state *pipeline.State, phase string) string {
 			return out.Verdict
 		}
 		return fmt.Sprintf("%s — %d findings", out.Verdict, len(out.Findings))
+
+	case "patch":
+		var out schemas.PatchOutput
+		if json.Unmarshal(raw, &out) != nil {
+			return ""
+		}
+		if out.TooComplex {
+			return "too complex"
+		}
+		fixed := 0
+		for _, fr := range out.FixResults {
+			if fr.Status == "fixed" {
+				fixed++
+			}
+		}
+		total := len(out.FixResults)
+		if total == 0 {
+			return ""
+		}
+		return fmt.Sprintf("%d/%d fixed", fixed, total)
 
 	case "submit":
 		var out schemas.SubmitOutput

--- a/cmd/soda/run_test.go
+++ b/cmd/soda/run_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -817,7 +818,7 @@ func TestHandleEventPatchExhaustedCycles(t *testing.T) {
 				Kind: pipeline.EventPatchExhausted,
 				Data: tt.data,
 			}
-			handleEvent(nil, nil, nil, state, prog, event)
+			handleEvent(context.Background(), nil, nil, state, prog, event)
 
 			output := buf.String()
 			if !strings.Contains(output, tt.wantCycles) {

--- a/cmd/soda/run_test.go
+++ b/cmd/soda/run_test.go
@@ -248,6 +248,44 @@ func TestFormatPhaseDetails(t *testing.T) {
 		}
 	})
 
+	t.Run("patch_fixed", func(t *testing.T) {
+		dir := t.TempDir()
+		state, _ := pipeline.LoadOrCreate(dir, "T-1")
+		state.WriteResult("patch", json.RawMessage(`{
+			"ticket_key": "T-1",
+			"fix_results": [
+				{"fix_index": 0, "status": "fixed", "description": "fixed test"},
+				{"fix_index": 1, "status": "cannot_fix", "description": "too complex"}
+			],
+			"files_changed": [],
+			"tests_passed": true,
+			"too_complex": false
+		}`))
+
+		got := formatPhaseDetails(state, "patch")
+		if got != "1/2 fixed" {
+			t.Errorf("expected '1/2 fixed', got %q", got)
+		}
+	})
+
+	t.Run("patch_too_complex", func(t *testing.T) {
+		dir := t.TempDir()
+		state, _ := pipeline.LoadOrCreate(dir, "T-1")
+		state.WriteResult("patch", json.RawMessage(`{
+			"ticket_key": "T-1",
+			"fix_results": [],
+			"files_changed": [],
+			"tests_passed": false,
+			"too_complex": true,
+			"too_complex_reason": "needs refactoring"
+		}`))
+
+		got := formatPhaseDetails(state, "patch")
+		if got != "too complex" {
+			t.Errorf("expected 'too complex', got %q", got)
+		}
+	})
+
 	t.Run("missing_result_returns_empty", func(t *testing.T) {
 		dir := t.TempDir()
 		state, _ := pipeline.LoadOrCreate(dir, "T-1")

--- a/cmd/soda/run_test.go
+++ b/cmd/soda/run_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/decko/soda/internal/claude"
 	"github.com/decko/soda/internal/pipeline"
+	"github.com/decko/soda/internal/progress"
 )
 
 func TestResolveLastPhase(t *testing.T) {
@@ -776,5 +777,52 @@ func TestPrintSummaryGenericError(t *testing.T) {
 	}
 	if !strings.Contains(output, "cd /tmp/worktrees/PROJ-60") {
 		t.Error("expected cd to worktree path")
+	}
+}
+
+func TestHandleEventPatchExhaustedCycles(t *testing.T) {
+	// Verify that handleEvent correctly extracts patch_cycles as int
+	// (native Go type from the engine) and falls back to float64 (JSON).
+	tests := []struct {
+		name       string
+		data       map[string]any
+		wantCycles string
+	}{
+		{
+			name:       "int value from engine",
+			data:       map[string]any{"patch_cycles": 3, "on_exhausted": "stop"},
+			wantCycles: "3 cycles",
+		},
+		{
+			name:       "float64 value from JSON",
+			data:       map[string]any{"patch_cycles": float64(5), "on_exhausted": "escalate"},
+			wantCycles: "5 cycles",
+		},
+		{
+			name:       "zero value",
+			data:       map[string]any{"patch_cycles": 0, "on_exhausted": "stop"},
+			wantCycles: "0 cycles",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			state, _ := pipeline.LoadOrCreate(dir, "T-1")
+
+			var buf bytes.Buffer
+			prog := progress.New(&buf, false)
+
+			event := pipeline.Event{
+				Kind: pipeline.EventPatchExhausted,
+				Data: tt.data,
+			}
+			handleEvent(nil, nil, nil, state, prog, event)
+
+			output := buf.String()
+			if !strings.Contains(output, tt.wantCycles) {
+				t.Errorf("expected output to contain %q, got %q", tt.wantCycles, output)
+			}
+		})
 	}
 }

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -1423,8 +1423,10 @@ func (e *Engine) gateVerifyFail(phase PhaseConfig, fixesRequired []string) error
 }
 
 // handlePatchExhausted applies the on_exhausted policy when patch attempts
-// are depleted. "stop" returns a PhaseGateError; "escalate" routes to
-// the escalation target (e.g., implement) with a budget check.
+// are depleted.
+//   - "stop" returns a PhaseGateError.
+//   - "escalate" routes to the escalation target (e.g., implement) with a budget check.
+//   - "retry" allows one extra patch cycle by resetting PatchCycles, then stops.
 func (e *Engine) handlePatchExhausted(phase PhaseConfig, cc *CorrectiveConfig, reason string) error {
 	switch cc.OnExhausted {
 	case "escalate":
@@ -1465,6 +1467,16 @@ func (e *Engine) handlePatchExhausted(phase PhaseConfig, cc *CorrectiveConfig, r
 		})
 
 		return &reworkSignal{target: cc.EscalateTo}
+
+	case "retry":
+		// Allow one extra patch cycle. If already used, stop.
+		if e.state.Meta().PatchRetryUsed {
+			return &PhaseGateError{Phase: phase.Name, Reason: reason + " (patch retry exhausted)"}
+		}
+		e.state.Meta().PatchRetryUsed = true
+		e.state.Meta().PatchCycles = 0
+		e.state.Meta().PreviousFailures = nil
+		return &reworkSignal{target: cc.Phase}
 
 	default: // "stop" or unrecognized
 		return &PhaseGateError{Phase: phase.Name, Reason: reason + " (patch attempts exhausted)"}

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -1296,10 +1296,68 @@ func (e *Engine) gateRework(phase PhaseConfig, raw json.RawMessage) error {
 	return &reworkSignal{target: phase.Rework.Target, findings: findings}
 }
 
+// regressionResult holds the outcome of a regression check between two
+// sets of failing criteria.
+type regressionResult struct {
+	Regressions []string // criteria that were previously passing but now fail
+	HasProgress bool     // true if there are strictly fewer failures now
+}
+
+// detectRegression compares the previous set of failing criteria against the
+// current set. A "regression" is a criterion that was NOT in the previous
+// failures (i.e., it was passing) but IS in the current failures.
+// "Progress" means strictly fewer total failures than before.
+func detectRegression(previous, current []string) regressionResult {
+	prevSet := make(map[string]bool, len(previous))
+	for _, f := range previous {
+		prevSet[f] = true
+	}
+
+	var regressions []string
+	for _, c := range current {
+		if !prevSet[c] {
+			regressions = append(regressions, c)
+		}
+	}
+
+	return regressionResult{
+		Regressions: regressions,
+		HasProgress: len(current) < len(previous),
+	}
+}
+
+// extractFailingCriteria reads the verify result from state and returns
+// the criterion text for each failing criterion. Returns nil if the result
+// cannot be read or parsed.
+func (e *Engine) extractFailingCriteria() []string {
+	raw, err := e.state.ReadResult("verify")
+	if err != nil {
+		return nil
+	}
+
+	var result struct {
+		CriteriaResults []struct {
+			Criterion string `json:"criterion"`
+			Passed    bool   `json:"passed"`
+		} `json:"criteria_results"`
+	}
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil
+	}
+
+	var failures []string
+	for _, cr := range result.CriteriaResults {
+		if !cr.Passed {
+			failures = append(failures, cr.Criterion)
+		}
+	}
+	return failures
+}
+
 // gateVerifyFail handles a verify FAIL verdict. When the phase has a
 // CorrectiveConfig, it routes to the corrective phase (e.g., patch) instead
 // of stopping with a PhaseGateError. Respects max_attempts, on_exhausted
-// policy, and the EscalatedFromPatch one-shot flag.
+// policy, the EscalatedFromPatch one-shot flag, and regression detection.
 func (e *Engine) gateVerifyFail(phase PhaseConfig, fixesRequired []string) error {
 	reason := "verification failed"
 	if len(fixesRequired) > 0 {
@@ -1314,6 +1372,30 @@ func (e *Engine) gateVerifyFail(phase PhaseConfig, fixesRequired []string) error
 	// One-shot escalation flag: once set, subsequent verify FAILs stop.
 	if e.state.Meta().EscalatedFromPatch {
 		return &PhaseGateError{Phase: phase.Name, Reason: reason + " (escalated from patch, no re-entry)"}
+	}
+
+	// Regression detection: when PatchCycles > 0, compare current failures
+	// against PreviousFailures. A regression (previously-passing criterion
+	// now fails) triggers immediate escalation. Note: criterion text from
+	// the ticket's acceptance criteria should be stable across runs; if
+	// criteria are rephrased, this may cause false negatives.
+	currentFailures := e.extractFailingCriteria()
+	if e.state.Meta().PatchCycles > 0 && len(e.state.Meta().PreviousFailures) > 0 {
+		regResult := detectRegression(e.state.Meta().PreviousFailures, currentFailures)
+		if len(regResult.Regressions) > 0 {
+			e.emit(Event{
+				Phase: phase.Name,
+				Kind:  EventPatchRegression,
+				Data: map[string]any{
+					"previously_passed": regResult.Regressions,
+					"now_failed":        currentFailures,
+				},
+			})
+			return &PhaseGateError{
+				Phase:  phase.Name,
+				Reason: reason + " (regression: previously-passing criteria now fail: " + strings.Join(regResult.Regressions, "; ") + ")",
+			}
+		}
 	}
 
 	// Check max_attempts.
@@ -1332,6 +1414,9 @@ func (e *Engine) gateVerifyFail(phase PhaseConfig, fixesRequired []string) error
 		})
 		return e.handlePatchExhausted(phase, cc, reason)
 	}
+
+	// Snapshot current failures for the next regression check.
+	e.state.Meta().PreviousFailures = currentFailures
 
 	// Route to the corrective phase.
 	return &reworkSignal{target: cc.Phase}

--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -7175,3 +7175,402 @@ func TestEngine_PatchExhaustedRetry(t *testing.T) {
 		t.Errorf("runner called %d times, want 6", len(mock.calls))
 	}
 }
+
+func TestEngine_PatchRegressionStopsImmediately(t *testing.T) {
+	// When verify fails again after patch but a previously-passing criterion
+	// now fails (regression), the engine should stop immediately with a
+	// PhaseGateError and emit patch_regression.
+	phases := []PhaseConfig{
+		{
+			Name:   "implement",
+			Prompt: "implement.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+		{
+			Name:         "patch",
+			Type:         "corrective",
+			Prompt:       "patch.md",
+			DependsOn:    []string{"implement"},
+			FeedbackFrom: []string{"verify"},
+			Retry:        RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+		{
+			Name:      "verify",
+			Prompt:    "verify.md",
+			DependsOn: []string{"implement"},
+			Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			Corrective: &CorrectiveConfig{
+				Phase:       "patch",
+				MaxAttempts: 3,
+				OnExhausted: "stop",
+			},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"implement": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"tests_passed":true}`),
+					RawText: "impl",
+					CostUSD: 0.10,
+				},
+			}},
+			"verify": {
+				// First verify: FAIL with criterion A failing.
+				{
+					result: &runner.RunResult{
+						Output: json.RawMessage(`{
+							"verdict":"FAIL",
+							"fixes_required":["fix A"],
+							"criteria_results":[
+								{"criterion":"A","passed":false,"evidence":"fails"},
+								{"criterion":"B","passed":true,"evidence":"ok"},
+								{"criterion":"C","passed":true,"evidence":"ok"}
+							],
+							"command_results":[]
+						}`),
+						RawText: "fail1",
+						CostUSD: 0.05,
+					},
+				},
+				// Second verify (after patch): A still fails, but B now fails too (regression).
+				{
+					result: &runner.RunResult{
+						Output: json.RawMessage(`{
+							"verdict":"FAIL",
+							"fixes_required":["fix A","fix B"],
+							"criteria_results":[
+								{"criterion":"A","passed":false,"evidence":"still fails"},
+								{"criterion":"B","passed":false,"evidence":"now fails"},
+								{"criterion":"C","passed":true,"evidence":"ok"}
+							],
+							"command_results":[]
+						}`),
+						RawText: "fail2",
+						CostUSD: 0.05,
+					},
+				},
+			},
+			"patch": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"ticket_key":"TEST-1","fix_results":[{"fix_index":0,"status":"fixed","description":"attempted fix"}],"files_changed":[],"tests_passed":false,"too_complex":false}`),
+					RawText: "patched",
+					CostUSD: 0.20,
+				},
+			}},
+		},
+	}
+
+	var events []Event
+	engine, state := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.OnEvent = func(ev Event) { events = append(events, ev) }
+	})
+
+	err := engine.Run(context.Background())
+	var gateErr *PhaseGateError
+	if !errors.As(err, &gateErr) {
+		t.Fatalf("expected PhaseGateError, got: %v", err)
+	}
+	if !strings.Contains(gateErr.Reason, "regression") {
+		t.Errorf("gate error reason should mention regression, got: %q", gateErr.Reason)
+	}
+	if !strings.Contains(gateErr.Reason, "B") {
+		t.Errorf("gate error reason should mention criterion B, got: %q", gateErr.Reason)
+	}
+
+	// Should have patch_regression event.
+	hasRegression := false
+	for _, ev := range events {
+		if ev.Kind == EventPatchRegression {
+			hasRegression = true
+			// Verify event data contains the regressed criteria.
+			prevPassed, _ := ev.Data["previously_passed"].([]string)
+			if len(prevPassed) == 0 {
+				// Try interface{} slice (JSON roundtrip)
+				if prevArr, ok := ev.Data["previously_passed"].([]interface{}); ok {
+					for _, item := range prevArr {
+						if s, ok := item.(string); ok {
+							prevPassed = append(prevPassed, s)
+						}
+					}
+				}
+			}
+			found := false
+			for _, p := range prevPassed {
+				if p == "B" {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("patch_regression event should list B in previously_passed, got: %v", ev.Data["previously_passed"])
+			}
+		}
+	}
+	if !hasRegression {
+		t.Error("patch_regression event not emitted")
+	}
+
+	// PatchCycles should be 1 (only one patch ran before regression).
+	if state.Meta().PatchCycles != 1 {
+		t.Errorf("PatchCycles = %d, want 1", state.Meta().PatchCycles)
+	}
+
+	// PreviousFailures should have been set before regression detected.
+	// After routing to patch, PreviousFailures = ["A"].
+	if len(state.Meta().PreviousFailures) != 1 || state.Meta().PreviousFailures[0] != "A" {
+		t.Errorf("PreviousFailures = %v, want [A]", state.Meta().PreviousFailures)
+	}
+
+	// Runner should have been called: implement, verify(fail), patch, verify(regression) = 4.
+	if len(mock.calls) != 4 {
+		t.Errorf("runner called %d times, want 4", len(mock.calls))
+	}
+}
+
+func TestEngine_PatchNoProgressRetry(t *testing.T) {
+	// When verify fails with the same criteria (no progress, no regression),
+	// the engine should still route to patch, respecting the cycle limit.
+	// With on_exhausted=retry, this allows one extra attempt.
+	phases := []PhaseConfig{
+		{
+			Name:   "implement",
+			Prompt: "implement.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+		{
+			Name:         "patch",
+			Type:         "corrective",
+			Prompt:       "patch.md",
+			DependsOn:    []string{"implement"},
+			FeedbackFrom: []string{"verify"},
+			Retry:        RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+		{
+			Name:      "verify",
+			Prompt:    "verify.md",
+			DependsOn: []string{"implement"},
+			Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			Corrective: &CorrectiveConfig{
+				Phase:       "patch",
+				MaxAttempts: 1,
+				OnExhausted: "retry",
+			},
+		},
+	}
+
+	// All verifies fail with the same criterion A.
+	verifyFail := func() *runner.RunResult {
+		return &runner.RunResult{
+			Output: json.RawMessage(`{
+				"verdict":"FAIL",
+				"fixes_required":["fix A"],
+				"criteria_results":[{"criterion":"A","passed":false,"evidence":"still fails"}],
+				"command_results":[]
+			}`),
+			RawText: "fail",
+			CostUSD: 0.05,
+		}
+	}
+
+	patchResult := func() *runner.RunResult {
+		return &runner.RunResult{
+			Output:  json.RawMessage(`{"ticket_key":"TEST-1","fix_results":[],"files_changed":[],"tests_passed":false,"too_complex":false}`),
+			RawText: "patched",
+			CostUSD: 0.20,
+		}
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"implement": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"tests_passed":true}`),
+					RawText: "impl",
+					CostUSD: 0.10,
+				},
+			}},
+			"verify": {
+				{result: verifyFail()},
+				{result: verifyFail()},
+				{result: verifyFail()},
+			},
+			"patch": {
+				{result: patchResult()},
+				{result: patchResult()},
+			},
+		},
+	}
+
+	engine, state := setupEngine(t, phases, mock)
+	err := engine.Run(context.Background())
+
+	var gateErr *PhaseGateError
+	if !errors.As(err, &gateErr) {
+		t.Fatalf("expected PhaseGateError, got: %v", err)
+	}
+	if !strings.Contains(gateErr.Reason, "patch retry exhausted") {
+		t.Errorf("gate error should mention retry exhausted, got: %q", gateErr.Reason)
+	}
+
+	if !state.Meta().PatchRetryUsed {
+		t.Error("PatchRetryUsed should be true")
+	}
+
+	// 6 calls: implement, verify, patch, verify, patch(retry), verify
+	if len(mock.calls) != 6 {
+		t.Errorf("runner called %d times, want 6", len(mock.calls))
+	}
+}
+
+func TestEngine_ReviewReworkAndPatchIndependent(t *testing.T) {
+	// Both review rework and patch cycles should work independently in the
+	// same pipeline run. Review rework increments ReworkCycles, patch
+	// increments PatchCycles — they don't interfere with each other.
+	phases := []PhaseConfig{
+		{
+			Name:   "implement",
+			Prompt: "implement.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+		{
+			Name:         "patch",
+			Type:         "corrective",
+			Prompt:       "patch.md",
+			DependsOn:    []string{"implement"},
+			FeedbackFrom: []string{"verify"},
+			Retry:        RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+		{
+			Name:      "verify",
+			Prompt:    "verify.md",
+			DependsOn: []string{"implement"},
+			Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			Corrective: &CorrectiveConfig{
+				Phase:       "patch",
+				MaxAttempts: 2,
+				OnExhausted: "stop",
+			},
+		},
+		{
+			Name:      "review",
+			Prompt:    "review.md",
+			DependsOn: []string{"implement", "verify"},
+			Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			Rework: &ReworkConfig{
+				Target: "implement",
+			},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"implement": {
+				// First implement.
+				{
+					result: &runner.RunResult{
+						Output:  json.RawMessage(`{"tests_passed":true}`),
+						RawText: "impl1",
+						CostUSD: 0.10,
+					},
+				},
+				// Second implement (after review rework).
+				{
+					result: &runner.RunResult{
+						Output:  json.RawMessage(`{"tests_passed":true}`),
+						RawText: "impl2",
+						CostUSD: 0.10,
+					},
+				},
+			},
+			"patch": {
+				// First patch (after first verify FAIL).
+				{
+					result: &runner.RunResult{
+						Output:  json.RawMessage(`{"ticket_key":"TEST-1","fix_results":[{"fix_index":0,"status":"fixed","description":"fixed"}],"files_changed":[],"tests_passed":true,"too_complex":false}`),
+						RawText: "patched",
+						CostUSD: 0.20,
+					},
+				},
+			},
+			"verify": {
+				// First verify: FAIL → routes to patch.
+				{
+					result: &runner.RunResult{
+						Output: json.RawMessage(`{
+							"verdict":"FAIL",
+							"fixes_required":["fix test"],
+							"criteria_results":[{"criterion":"tests pass","passed":false,"evidence":"1 failure"}],
+							"command_results":[]
+						}`),
+						RawText: "fail",
+						CostUSD: 0.05,
+					},
+				},
+				// Second verify (after patch): PASS → continues to review.
+				{
+					result: &runner.RunResult{
+						Output:  json.RawMessage(`{"verdict":"PASS","criteria_results":[],"command_results":[]}`),
+						RawText: "pass",
+						CostUSD: 0.05,
+					},
+				},
+				// Third verify (after review rework → implement): PASS.
+				{
+					result: &runner.RunResult{
+						Output:  json.RawMessage(`{"verdict":"PASS","criteria_results":[],"command_results":[]}`),
+						RawText: "pass2",
+						CostUSD: 0.05,
+					},
+				},
+			},
+			"review": {
+				// First review: rework verdict → routes back to implement.
+				{
+					result: &runner.RunResult{
+						Output:  json.RawMessage(`{"verdict":"rework","findings":[{"severity":"major","issue":"needs refactor"}],"ticket_key":"TEST-1"}`),
+						RawText: "rework",
+						CostUSD: 0.15,
+					},
+				},
+				// Second review: pass → pipeline completes.
+				{
+					result: &runner.RunResult{
+						Output:  json.RawMessage(`{"verdict":"pass","findings":[],"ticket_key":"TEST-1"}`),
+						RawText: "pass",
+						CostUSD: 0.15,
+					},
+				},
+			},
+		},
+	}
+
+	engine, state := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.MaxReworkCycles = 2
+	})
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// PatchCycles and ReworkCycles should be independent.
+	if state.Meta().PatchCycles != 1 {
+		t.Errorf("PatchCycles = %d, want 1", state.Meta().PatchCycles)
+	}
+	if state.Meta().ReworkCycles != 1 {
+		t.Errorf("ReworkCycles = %d, want 1", state.Meta().ReworkCycles)
+	}
+
+	// All phases should be completed.
+	for _, name := range []string{"implement", "patch", "verify", "review"} {
+		if !state.IsCompleted(name) {
+			t.Errorf("%s should be completed", name)
+		}
+	}
+
+	// Flow: implement, verify(fail), patch, verify(pass), review(rework),
+	// implement, verify(pass), review(pass) = 8 calls
+	if len(mock.calls) != 8 {
+		t.Errorf("runner called %d times, want 8", len(mock.calls))
+	}
+}

--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -6962,3 +6962,93 @@ func TestEngine_ResumePatchRerunsVerify(t *testing.T) {
 		t.Error("verify should be completed after Resume")
 	}
 }
+
+func TestDetectRegression(t *testing.T) {
+	tests := []struct {
+		name            string
+		previous        []string
+		current         []string
+		wantRegressions []string
+		wantProgress    bool
+	}{
+		{
+			name:            "no_regressions_same_failures",
+			previous:        []string{"criterion A", "criterion B"},
+			current:         []string{"criterion A", "criterion B"},
+			wantRegressions: nil,
+			wantProgress:    false,
+		},
+		{
+			name:            "progress_fewer_failures",
+			previous:        []string{"criterion A", "criterion B", "criterion C"},
+			current:         []string{"criterion A"},
+			wantRegressions: nil,
+			wantProgress:    true,
+		},
+		{
+			name:            "regression_new_failure",
+			previous:        []string{"criterion A"},
+			current:         []string{"criterion A", "criterion B"},
+			wantRegressions: []string{"criterion B"},
+			wantProgress:    false,
+		},
+		{
+			name:            "regression_different_failure",
+			previous:        []string{"criterion A"},
+			current:         []string{"criterion B"},
+			wantRegressions: []string{"criterion B"},
+			wantProgress:    false,
+		},
+		{
+			name:            "regression_with_progress",
+			previous:        []string{"criterion A", "criterion B", "criterion C"},
+			current:         []string{"criterion A", "criterion D"},
+			wantRegressions: []string{"criterion D"},
+			wantProgress:    true,
+		},
+		{
+			name:            "empty_previous",
+			previous:        nil,
+			current:         []string{"criterion A"},
+			wantRegressions: []string{"criterion A"},
+			wantProgress:    false,
+		},
+		{
+			name:            "empty_current",
+			previous:        []string{"criterion A"},
+			current:         nil,
+			wantRegressions: nil,
+			wantProgress:    true,
+		},
+		{
+			name:            "both_empty",
+			previous:        nil,
+			current:         nil,
+			wantRegressions: nil,
+			wantProgress:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := detectRegression(tt.previous, tt.current)
+
+			if tt.wantProgress != result.HasProgress {
+				t.Errorf("HasProgress = %v, want %v", result.HasProgress, tt.wantProgress)
+			}
+
+			if len(tt.wantRegressions) == 0 && len(result.Regressions) == 0 {
+				return // both empty/nil, OK
+			}
+
+			if len(result.Regressions) != len(tt.wantRegressions) {
+				t.Fatalf("Regressions = %v, want %v", result.Regressions, tt.wantRegressions)
+			}
+			for idx, got := range result.Regressions {
+				if got != tt.wantRegressions[idx] {
+					t.Errorf("Regressions[%d] = %q, want %q", idx, got, tt.wantRegressions[idx])
+				}
+			}
+		})
+	}
+}

--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -7052,3 +7052,126 @@ func TestDetectRegression(t *testing.T) {
 		})
 	}
 }
+
+func TestEngine_PatchExhaustedRetry(t *testing.T) {
+	// When on_exhausted is "retry", the engine should allow one extra patch
+	// cycle by resetting PatchCycles. After the retry, if still failing, stop.
+	phases := []PhaseConfig{
+		{
+			Name:   "implement",
+			Prompt: "implement.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+		{
+			Name:         "patch",
+			Type:         "corrective",
+			Prompt:       "patch.md",
+			DependsOn:    []string{"implement"},
+			FeedbackFrom: []string{"verify"},
+			Retry:        RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+		{
+			Name:      "verify",
+			Prompt:    "verify.md",
+			DependsOn: []string{"implement"},
+			Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			Corrective: &CorrectiveConfig{
+				Phase:       "patch",
+				MaxAttempts: 1,
+				OnExhausted: "retry",
+			},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"implement": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"tests_passed":true}`),
+					RawText: "impl",
+					CostUSD: 0.10,
+				},
+			}},
+			"verify": {
+				// First verify: FAIL → routes to patch (cycle 1).
+				{
+					result: &runner.RunResult{
+						Output:  json.RawMessage(`{"verdict":"FAIL","fixes_required":["fix1"],"criteria_results":[{"criterion":"A","passed":false,"evidence":"e"}],"command_results":[]}`),
+						RawText: "fail1",
+						CostUSD: 0.05,
+					},
+				},
+				// Second verify (after first patch): FAIL → exhausted → retry resets cycles.
+				{
+					result: &runner.RunResult{
+						Output:  json.RawMessage(`{"verdict":"FAIL","fixes_required":["fix2"],"criteria_results":[{"criterion":"A","passed":false,"evidence":"e"}],"command_results":[]}`),
+						RawText: "fail2",
+						CostUSD: 0.05,
+					},
+				},
+				// Third verify (after retry patch): FAIL → retry already used → stop.
+				{
+					result: &runner.RunResult{
+						Output:  json.RawMessage(`{"verdict":"FAIL","fixes_required":["fix3"],"criteria_results":[{"criterion":"A","passed":false,"evidence":"e"}],"command_results":[]}`),
+						RawText: "fail3",
+						CostUSD: 0.05,
+					},
+				},
+			},
+			"patch": {
+				// First patch (cycle 1).
+				{
+					result: &runner.RunResult{
+						Output:  json.RawMessage(`{"ticket_key":"TEST-1","fix_results":[],"files_changed":[],"tests_passed":false,"too_complex":false}`),
+						RawText: "patched1",
+						CostUSD: 0.20,
+					},
+				},
+				// Second patch (retry cycle).
+				{
+					result: &runner.RunResult{
+						Output:  json.RawMessage(`{"ticket_key":"TEST-1","fix_results":[],"files_changed":[],"tests_passed":false,"too_complex":false}`),
+						RawText: "patched2",
+						CostUSD: 0.20,
+					},
+				},
+			},
+		},
+	}
+
+	var events []Event
+	engine, state := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.OnEvent = func(ev Event) { events = append(events, ev) }
+	})
+
+	err := engine.Run(context.Background())
+	var gateErr *PhaseGateError
+	if !errors.As(err, &gateErr) {
+		t.Fatalf("expected PhaseGateError, got: %v", err)
+	}
+	if !strings.Contains(gateErr.Reason, "patch retry exhausted") {
+		t.Errorf("gate error reason should mention retry exhausted, got: %q", gateErr.Reason)
+	}
+
+	// PatchRetryUsed should be set.
+	if !state.Meta().PatchRetryUsed {
+		t.Error("PatchRetryUsed should be true after retry")
+	}
+
+	// Should have patch_exhausted event (emitted when first exhausted).
+	hasExhausted := false
+	for _, ev := range events {
+		if ev.Kind == EventPatchExhausted {
+			hasExhausted = true
+		}
+	}
+	if !hasExhausted {
+		t.Error("patch_exhausted event not emitted")
+	}
+
+	// Runner should have been called:
+	// implement, verify(fail), patch, verify(fail), patch(retry), verify(fail) = 6 calls
+	if len(mock.calls) != 6 {
+		t.Errorf("runner called %d times, want 6", len(mock.calls))
+	}
+}

--- a/internal/pipeline/events.go
+++ b/internal/pipeline/events.go
@@ -74,6 +74,7 @@ const (
 	EventPatchEscalated           = "patch_escalated"
 	EventPatchTooComplex          = "patch_too_complex"
 	EventPatchEscalationSkipped   = "patch_escalation_skipped"
+	EventPatchRegression          = "patch_regression"
 )
 
 // ReadEvents reads and parses all events from the events.jsonl file in dir.

--- a/internal/pipeline/meta.go
+++ b/internal/pipeline/meta.go
@@ -42,6 +42,7 @@ type PipelineMeta struct {
 	ReworkCycles       int                    `json:"rework_cycles,omitempty"`
 	PatchCycles        int                    `json:"patch_cycles,omitempty"`
 	EscalatedFromPatch bool                   `json:"escalated_from_patch,omitempty"`
+	PreviousFailures   []string               `json:"previous_failures,omitempty"`
 	Phases             map[string]*PhaseState `json:"phases"`
 }
 

--- a/internal/pipeline/meta.go
+++ b/internal/pipeline/meta.go
@@ -42,6 +42,7 @@ type PipelineMeta struct {
 	ReworkCycles       int                    `json:"rework_cycles,omitempty"`
 	PatchCycles        int                    `json:"patch_cycles,omitempty"`
 	EscalatedFromPatch bool                   `json:"escalated_from_patch,omitempty"`
+	PatchRetryUsed     bool                   `json:"patch_retry_used,omitempty"`
 	PreviousFailures   []string               `json:"previous_failures,omitempty"`
 	Phases             map[string]*PhaseState `json:"phases"`
 }


### PR DESCRIPTION
## Summary
- **Regression detection**: Track failing criteria across patch cycles via `PreviousFailures` in `PipelineMeta`; if a previously-passing criterion starts failing after a patch, abort immediately with `EventPatchRegression` instead of wasting remaining cycles
- **Exhaustion policies**: When `max_cycles` is reached, handle via `on_exhausted` policy — `stop` (default), `escalate` (promote to rework with budget guard), or `retry` (one-shot reset of patch counter with `PatchRetryUsed` flag to prevent infinite loops)
- **CLI event display**: Surface all patch-related events (`patch_regression`, `patch_exhausted`, `patch_escalated`, `patch_too_complex`, `patch_escalation_skipped`, `corrective_skipped`) in the TUI with formatted phase details
- **Comprehensive test coverage**: 11 dedicated tests covering regression detection (8 unit cases), retry exhaustion, escalation with low-budget guard, independent rework/patch counters, and crash recovery

## Acceptance Criteria
- [x] `detectRegression()` pure function compares previous vs current failure sets
- [x] `gateVerifyFail()` orders: regression check → exhaustion check → snapshot → route
- [x] `handlePatchExhausted()` handles stop/escalate/retry policies with state management
- [x] `PatchRetryUsed` one-shot flag prevents infinite retry loops
- [x] `EscalatedFromPatch` one-shot flag prevents re-entering patch loop after escalation
- [x] Budget check ($5 threshold) before escalation prevents wasting budget
- [x] All tests pass (race-clean, `go vet` clean)
- [x] CLI event handlers display patch events with correct type assertions

## Test plan
- [x] `go test ./internal/pipeline/... -race` — all pass including 11 new tests
- [x] `go test ./cmd/soda/... -race` — event handler tests pass
- [x] `go test ./schemas/... ./internal/progress/...` — related package tests pass
- [x] `go vet ./...` — clean
- [x] Verify `detectRegression` unit tests cover: no regression, regression found, empty previous, disjoint sets, subset, superset, single-element, and overlap cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)