### PR TITLE
fix(pipeline): validate target before mutating state in routeRework

### DIFF
--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -360,18 +360,26 @@ type reworkRoute struct {
 	forceFirst bool
 }
 
-// routeRework handles a reworkSignal by incrementing the rework cycle counter,
-// emitting a routed event, flushing meta, and re-slicing the pipeline phases
-// to start from the rework target. Returns the new route or an error.
+// routeRework handles a reworkSignal by validating the target phase exists,
+// incrementing the rework cycle counter, emitting a routed event, flushing
+// meta, and re-slicing the pipeline phases to start from the rework target.
+// Returns the new route or an error.
 //
-// When the rework target re-runs (e.g. implement), its downstream
-// dependents (verify, review) also re-run because they detect a re-ran
-// dependency via reranPhases. Those re-runs overwrite the previous
-// verify.json / review.json result files. Consequently, on the NEXT
-// rework cycle the ReworkFeedback extracted for implement will reflect
-// only the latest failures — previous failures are implicitly reset.
-// See ReworkFeedback doc comment for the full reset lifecycle.
+// The target phase is validated before any state mutation so that an invalid
+// target does not leave behind an incremented counter or a spurious event.
 func (e *Engine) routeRework(phaseName string, sig *reworkSignal) (*reworkRoute, error) {
+	// Validate the target phase exists before mutating any state.
+	targetIdx := -1
+	for i, p := range e.config.Pipeline.Phases {
+		if p.Name == sig.target {
+			targetIdx = i
+			break
+		}
+	}
+	if targetIdx < 0 {
+		return nil, fmt.Errorf("engine: rework routing requires phase %q in the pipeline", sig.target)
+	}
+
 	// Increment the appropriate counter based on whether the target is
 	// a corrective phase (patch) or a full rework (implement).
 	isPatch := e.isCorrectivePhase(sig.target)
@@ -380,7 +388,6 @@ func (e *Engine) routeRework(phaseName string, sig *reworkSignal) (*reworkRoute,
 	} else {
 		e.state.Meta().ReworkCycles++
 	}
-
 	cycle := e.state.Meta().ReworkCycles
 	if isPatch {
 		cycle = e.state.Meta().PatchCycles
@@ -398,17 +405,6 @@ func (e *Engine) routeRework(phaseName string, sig *reworkSignal) (*reworkRoute,
 
 	if err := e.state.flushMeta(); err != nil {
 		return nil, fmt.Errorf("engine: flush meta after rework routing: %w", err)
-	}
-
-	targetIdx := -1
-	for i, p := range e.config.Pipeline.Phases {
-		if p.Name == sig.target {
-			targetIdx = i
-			break
-		}
-	}
-	if targetIdx < 0 {
-		return nil, fmt.Errorf("engine: rework routing requires phase %q in the pipeline", sig.target)
 	}
 
 	return &reworkRoute{

--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -4503,6 +4503,75 @@ func TestEngine_ReviewReworkRouting(t *testing.T) {
 			t.Errorf("ReworkCycles = %d, want 0", state.Meta().ReworkCycles)
 		}
 	})
+
+	t.Run("invalid_target_does_not_mutate_state", func(t *testing.T) {
+		// When the rework target refers to a phase that doesn't exist in
+		// the pipeline, routeRework should return an error WITHOUT
+		// incrementing ReworkCycles or emitting a routed event.
+		phases := []PhaseConfig{
+			{
+				Name:   "implement",
+				Prompt: "implement.md",
+				Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			},
+			{
+				Name:      "review",
+				Type:      "parallel-review",
+				DependsOn: []string{"implement"},
+				Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+				Rework:    &ReworkConfig{Target: "nonexistent-phase"},
+				Reviewers: []ReviewerConfig{
+					{Name: "go-specialist", Prompt: "prompts/review-go.md", Focus: "Go idioms"},
+				},
+			},
+		}
+
+		mock := &flexMockRunner{
+			responses: map[string][]flexResponse{
+				"implement": {{
+					result: &runner.RunResult{
+						Output:  json.RawMessage(`{"tests_passed":true,"commits":1}`),
+						RawText: "Impl v1",
+						CostUSD: 0.50,
+					},
+				}},
+				"review/go-specialist": {{
+					result: &runner.RunResult{
+						Output:  json.RawMessage(`{"findings":[{"severity":"critical","file":"x.go","line":1,"issue":"bug","suggestion":"fix it"}]}`),
+						RawText: "Critical issue",
+						CostUSD: 0.15,
+					},
+				}},
+			},
+		}
+
+		var events []Event
+		engine, state := setupReviewEngine(t, phases, mock, func(cfg *EngineConfig) {
+			cfg.OnEvent = func(e Event) {
+				events = append(events, e)
+			}
+		})
+
+		err := engine.Run(context.Background())
+		if err == nil {
+			t.Fatal("expected error for invalid rework target")
+		}
+		if !strings.Contains(err.Error(), "nonexistent-phase") {
+			t.Errorf("error should mention invalid target, got: %v", err)
+		}
+
+		// ReworkCycles must NOT have been incremented.
+		if state.Meta().ReworkCycles != 0 {
+			t.Errorf("ReworkCycles = %d, want 0 (state mutated before validation)", state.Meta().ReworkCycles)
+		}
+
+		// No review_rework_routed event should have been emitted.
+		for _, ev := range events {
+			if ev.Kind == EventReworkRouted {
+				t.Error("review_rework_routed event should not be emitted for invalid target")
+			}
+		}
+	})
 }
 
 func TestEngine_ReviewReworkFeedbackInjected(t *testing.T) {


### PR DESCRIPTION
## Summary
- **Bug**: `routeRework` mutated state (`ReworkCycles++`, emitted `review_rework_routed` event, flushed meta) before validating that the target phase existed. An invalid target left corrupted state behind.
- **Fix**: Moved the target-phase lookup to the very beginning of `routeRework`, before any state mutation, so an invalid target returns an error immediately with zero side effects.
- **Test**: Added `invalid_target_does_not_mutate_state` subtest that asserts `ReworkCycles == 0` and no routed event after routing to a nonexistent phase.

## Test plan
- [x] New test `invalid_target_does_not_mutate_state` passes
- [x] All 4 pre-existing rework routing subtests pass
- [x] Full test suite passes
- [x] `go vet` clean

## Acceptance criteria
- [x] An invalid rework target does not increment `ReworkCycles`
- [x] An invalid rework target does not emit a `review_rework_routed` event
- [x] An invalid rework target does not flush meta to disk
- [x] Existing valid rework routing behaviour is unchanged

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)