### PR TITLE
fix(pipeline): update OnExhausted comment to include retry (#181)

### DIFF
--- a/internal/pipeline/phase.go
+++ b/internal/pipeline/phase.go
@@ -44,7 +44,7 @@ type ReworkConfig struct {
 type CorrectiveConfig struct {
 	Phase       string `yaml:"phase"`        // corrective phase to route to on failure
 	MaxAttempts int    `yaml:"max_attempts"` // max corrective cycles before exhaustion
-	OnExhausted string `yaml:"on_exhausted"` // "stop" | "escalate"
+	OnExhausted string `yaml:"on_exhausted"` // "stop" | "escalate" | "retry"
 	EscalateTo  string `yaml:"escalate_to"`  // target for "escalate" policy
 }
 


### PR DESCRIPTION
## Summary
- Updated the `CorrectiveConfig.OnExhausted` struct field comment to include the `"retry"` option alongside the existing `"stop"` and `"escalate"` options.
- The `"retry"` exhaustion policy was added in #168 but the comment was not updated to reflect it, making the field documentation incomplete.

## Acceptance Criteria
- [x] `OnExhausted` comment reads `// "stop" | "escalate" | "retry"`

## Test plan
- [x] Verified the change is a comment-only update with no functional impact
- [x] Confirmed the `"retry"` policy exists in the codebase (added in #168)

🤖 Generated with [Claude Code](https://claude.com/claude-code)