### PR TITLE
fix(pipeline): remove unused HasProgress field #183

### DIFF
--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -1300,13 +1300,11 @@ func (e *Engine) gateRework(phase PhaseConfig, raw json.RawMessage) error {
 // sets of failing criteria.
 type regressionResult struct {
 	Regressions []string // criteria that were previously passing but now fail
-	HasProgress bool     // true if there are strictly fewer failures now
 }
 
 // detectRegression compares the previous set of failing criteria against the
 // current set. A "regression" is a criterion that was NOT in the previous
 // failures (i.e., it was passing) but IS in the current failures.
-// "Progress" means strictly fewer total failures than before.
 func detectRegression(previous, current []string) regressionResult {
 	prevSet := make(map[string]bool, len(previous))
 	for _, f := range previous {
@@ -1322,7 +1320,6 @@ func detectRegression(previous, current []string) regressionResult {
 
 	return regressionResult{
 		Regressions: regressions,
-		HasProgress: len(current) < len(previous),
 	}
 }
 

--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -6969,73 +6969,60 @@ func TestDetectRegression(t *testing.T) {
 		previous        []string
 		current         []string
 		wantRegressions []string
-		wantProgress    bool
 	}{
 		{
 			name:            "no_regressions_same_failures",
 			previous:        []string{"criterion A", "criterion B"},
 			current:         []string{"criterion A", "criterion B"},
 			wantRegressions: nil,
-			wantProgress:    false,
 		},
 		{
 			name:            "progress_fewer_failures",
 			previous:        []string{"criterion A", "criterion B", "criterion C"},
 			current:         []string{"criterion A"},
 			wantRegressions: nil,
-			wantProgress:    true,
 		},
 		{
 			name:            "regression_new_failure",
 			previous:        []string{"criterion A"},
 			current:         []string{"criterion A", "criterion B"},
 			wantRegressions: []string{"criterion B"},
-			wantProgress:    false,
 		},
 		{
 			name:            "regression_different_failure",
 			previous:        []string{"criterion A"},
 			current:         []string{"criterion B"},
 			wantRegressions: []string{"criterion B"},
-			wantProgress:    false,
 		},
 		{
 			name:            "regression_with_progress",
 			previous:        []string{"criterion A", "criterion B", "criterion C"},
 			current:         []string{"criterion A", "criterion D"},
 			wantRegressions: []string{"criterion D"},
-			wantProgress:    true,
 		},
 		{
 			name:            "empty_previous",
 			previous:        nil,
 			current:         []string{"criterion A"},
 			wantRegressions: []string{"criterion A"},
-			wantProgress:    false,
 		},
 		{
 			name:            "empty_current",
 			previous:        []string{"criterion A"},
 			current:         nil,
 			wantRegressions: nil,
-			wantProgress:    true,
 		},
 		{
 			name:            "both_empty",
 			previous:        nil,
 			current:         nil,
 			wantRegressions: nil,
-			wantProgress:    false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := detectRegression(tt.previous, tt.current)
-
-			if tt.wantProgress != result.HasProgress {
-				t.Errorf("HasProgress = %v, want %v", result.HasProgress, tt.wantProgress)
-			}
 
 			if len(tt.wantRegressions) == 0 && len(result.Regressions) == 0 {
 				return // both empty/nil, OK


### PR DESCRIPTION
## Summary
- Removed the unused `HasProgress` field from the `regressionResult` struct in `internal/pipeline/engine.go`
- Removed the corresponding computation (`len(current) < len(previous)`) in `detectRegression`
- Removed related test assertions in `internal/pipeline/engine_test.go` while preserving all 8 test scenarios

## Acceptance Criteria
- [x] `HasProgress` field removed from `regressionResult` struct
- [x] `HasProgress` computation removed from `detectRegression` function
- [x] Test assertions for `HasProgress` removed
- [x] All existing tests pass
- [x] `go vet` clean, build succeeds
- [x] No remaining references to `HasProgress` in codebase

## Test plan
- [x] `go test ./internal/pipeline/...` — all 8 regression detection test cases pass
- [x] `go vet ./...` — no issues
- [x] `go build ./...` — compiles cleanly
- [x] `grep -r HasProgress` — zero matches confirms complete removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)