### PR TITLE
fix(pipeline): add nil guard for phase.Rework in gateRework (#175)

### DIFF
--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -1172,6 +1172,10 @@ type reworkVerdict struct {
 // a verdict field can use config-driven rework. On unmarshal failure, the
 // gate silently skips (returns nil), consistent with all other gating cases.
 func (e *Engine) gateRework(phase PhaseConfig, raw json.RawMessage) error {
+	if phase.Rework == nil {
+		return nil
+	}
+
 	var result reworkVerdict
 	if err := json.Unmarshal(raw, &result); err != nil {
 		return nil // gracefully skip — consistent with other gating cases

--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -1286,39 +1286,25 @@ func TestEngine_GatePhase_ReviewUnmarshalError(t *testing.T) {
 	}
 }
 
-func TestEngine_GateRework_NilReworkConfig(t *testing.T) {
-	// When gateRework is called on a phase with nil Rework config, it should
-	// return nil immediately without panicking, even if the result contains
-	// a "rework" verdict.
+func TestEngine_gateRework_nilReworkConfig(t *testing.T) {
+	// Call gateRework directly with a PhaseConfig where Rework is nil.
+	// This exercises the nil guard inside gateRework itself, bypassing
+	// the caller guard in gatePhase (engine.go:1144).
 	phases := []PhaseConfig{
 		{
-			Name:   "review",
-			Prompt: "review.md",
+			Name:   "x",
+			Prompt: "x.md",
 			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
-			// Rework is intentionally nil — no rework config.
 		},
 	}
 
-	mock := &flexMockRunner{
-		responses: map[string][]flexResponse{
-			"review": {{
-				result: &runner.RunResult{
-					Output:  json.RawMessage(`{"verdict":"rework","findings":[{"severity":"critical","issue":"missing tests"}]}`),
-					RawText: "review output",
-					CostUSD: 0.01,
-				},
-			}},
-		},
-	}
+	engine, _ := setupEngine(t, phases, &flexMockRunner{})
 
-	engine, state := setupEngine(t, phases, mock)
+	phase := PhaseConfig{Name: "review"} // Rework is nil
+	raw := json.RawMessage(`{"verdict":"rework","findings":[{"severity":"critical","issue":"missing tests"}]}`)
 
-	err := engine.Run(context.Background())
-	if err != nil {
-		t.Fatalf("expected nil error when Rework config is nil, got: %v", err)
-	}
-	if !state.IsCompleted("review") {
-		t.Error("review phase should be completed despite rework verdict when Rework config is nil")
+	if err := engine.gateRework(phase, raw); err != nil {
+		t.Fatalf("expected nil when Rework config is nil, got: %v", err)
 	}
 }
 

--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -1286,6 +1286,42 @@ func TestEngine_GatePhase_ReviewUnmarshalError(t *testing.T) {
 	}
 }
 
+func TestEngine_GateRework_NilReworkConfig(t *testing.T) {
+	// When gateRework is called on a phase with nil Rework config, it should
+	// return nil immediately without panicking, even if the result contains
+	// a "rework" verdict.
+	phases := []PhaseConfig{
+		{
+			Name:   "review",
+			Prompt: "review.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			// Rework is intentionally nil — no rework config.
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"review": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"verdict":"rework","findings":[{"severity":"critical","issue":"missing tests"}]}`),
+					RawText: "review output",
+					CostUSD: 0.01,
+				},
+			}},
+		},
+	}
+
+	engine, state := setupEngine(t, phases, mock)
+
+	err := engine.Run(context.Background())
+	if err != nil {
+		t.Fatalf("expected nil error when Rework config is nil, got: %v", err)
+	}
+	if !state.IsCompleted("review") {
+		t.Error("review phase should be completed despite rework verdict when Rework config is nil")
+	}
+}
+
 func TestEngineFullLifecycle(t *testing.T) {
 	// A realistic 4-phase pipeline: triage -> plan -> implement -> verify.
 	// Each phase depends on the previous one. Prompt templates reference


### PR DESCRIPTION
## Summary
- Adds a nil guard (`if phase.Rework == nil { return nil }`) at the top of `gateRework()` in `engine.go` to prevent a nil pointer dereference when called with a phase that has no Rework config
- Adds a direct unit test (`TestEngine_gateRework_nilReworkConfig`) that exercises the nil guard by calling `gateRework` directly, bypassing the existing caller-side check in `gatePhase`
- Defense-in-depth fix: while `gatePhase` already guards for nil, this protects against future callers

## Test plan
- [x] New test `TestEngine_gateRework_nilReworkConfig` calls `gateRework` directly with nil Rework config and verifies it returns nil without panicking
- [x] All existing pipeline tests pass
- [x] Build and vet are clean

## Acceptance criteria
- [x] `gateRework` returns nil early when `phase.Rework` is nil
- [x] No nil pointer dereference possible in `gateRework`
- [x] Test covers the nil guard path

🤖 Generated with [Claude Code](https://claude.com/claude-code)