### PR TITLE
refactor(pipeline): inline feedbackSourcesFor #172

### DIFF
--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -911,7 +911,7 @@ func (e *Engine) buildPromptData(phase PhaseConfig) (PromptData, error) {
 	// so after verify/review re-run and overwrite their results, the
 	// next rework cycle sees only the new failures. See ReworkFeedback
 	// doc comment for the full reset lifecycle.
-	if sources := e.feedbackSourcesFor(phase); len(sources) > 0 {
+	if sources := phase.FeedbackFrom; len(sources) > 0 {
 		for _, source := range sources {
 			if fb := e.extractFeedbackFrom(source); fb != nil {
 				data.ReworkFeedback = fb

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -941,12 +941,6 @@ func (e *Engine) buildPromptData(phase PhaseConfig) (PromptData, error) {
 	return data, nil
 }
 
-// feedbackSourcesFor returns the ordered list of feedback sources for a phase.
-// Sources are read from the phase's own FeedbackFrom config.
-func (e *Engine) feedbackSourcesFor(phase PhaseConfig) []string {
-	return phase.FeedbackFrom
-}
-
 // extractFeedbackFrom dispatches to the appropriate source-specific feedback
 // extractor. Returns nil for unknown sources.
 func (e *Engine) extractFeedbackFrom(source string) *ReworkFeedback {

--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -4861,40 +4861,6 @@ func TestExtractReviewFeedback(t *testing.T) {
 	})
 }
 
-func TestFeedbackSourcesFor(t *testing.T) {
-	t.Run("returns_sources_from_phase_config", func(t *testing.T) {
-		pipeline := &PhasePipeline{
-			Phases: []PhaseConfig{
-				{Name: "implement", FeedbackFrom: []string{"review", "verify"}},
-				{Name: "review", Rework: &ReworkConfig{Target: "implement"}},
-			},
-		}
-		engine := &Engine{config: EngineConfig{Pipeline: pipeline}}
-
-		sources := engine.feedbackSourcesFor(pipeline.Phases[0])
-		if len(sources) != 2 {
-			t.Fatalf("sources = %v, want [review verify]", sources)
-		}
-		if sources[0] != "review" || sources[1] != "verify" {
-			t.Errorf("sources = %v, want [review verify]", sources)
-		}
-	})
-
-	t.Run("returns_nil_for_phase_without_config", func(t *testing.T) {
-		pipeline := &PhasePipeline{
-			Phases: []PhaseConfig{
-				{Name: "triage"},
-			},
-		}
-		engine := &Engine{config: EngineConfig{Pipeline: pipeline}}
-
-		sources := engine.feedbackSourcesFor(pipeline.Phases[0])
-		if sources != nil {
-			t.Errorf("sources = %v, want nil", sources)
-		}
-	})
-}
-
 func TestExtractFeedbackFrom(t *testing.T) {
 	t.Run("review_source", func(t *testing.T) {
 		stateDir := t.TempDir()


### PR DESCRIPTION
## Summary
- Inlines the trivial `feedbackSourcesFor` method, replacing `e.feedbackSourcesFor(phase)` with direct `phase.FeedbackFrom` field access in `buildPromptData`
- Removes the now-unnecessary `TestFeedbackSourcesFor` tests that only verified direct field access
- Aligns with how other `PhaseConfig` fields are accessed in the same function

## Acceptance Criteria
- [x] `feedbackSourcesFor` method is removed from `engine.go`
- [x] Call site in `buildPromptData` uses `phase.FeedbackFrom` directly
- [x] Associated tests (`TestFeedbackSourcesFor`) are removed
- [x] No behavioral change — existing feedback routing logic is preserved

## Test Plan
- [x] Existing `TestExtractFeedbackFrom` and integration tests continue to pass
- [x] `go build ./...` succeeds
- [x] `go test ./internal/pipeline/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)