### PR TITLE
fix(pipeline): stop hardcoding 'origin' as remote name (#187)

### DIFF
--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -64,6 +64,15 @@ func (c *EngineConfig) maxReworkCycles() int {
 	return DefaultMaxReworkCycles
 }
 
+// remoteName returns the configured git remote name from PromptConfig.Repo.PushTo,
+// defaulting to "origin" when not set.
+func (e *Engine) remoteName() string {
+	if r := e.config.PromptConfig.Repo.PushTo; r != "" {
+		return r
+	}
+	return "origin"
+}
+
 // Engine orchestrates a pipeline run, tying together the runner,
 // state management, prompt rendering, and retry logic.
 type Engine struct {
@@ -1118,7 +1127,7 @@ func (e *Engine) computeDiffContext(ctx context.Context) string {
 		baseBranch = "main"
 	}
 
-	diffCtx, err := git.Diff(ctx, workDir, "origin/"+baseBranch, 50000)
+	diffCtx, err := git.Diff(ctx, workDir, e.remoteName()+"/"+baseBranch, 50000)
 	if err != nil {
 		return ""
 	}

--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -4758,6 +4758,41 @@ func TestEngine_ReviewReworkDefaultMaxCycles(t *testing.T) {
 	}
 }
 
+func TestEngine_remoteName(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		// When PushTo is empty, remoteName() should return "origin".
+		stateDir := t.TempDir()
+		state, err := LoadOrCreate(stateDir, "REMOTE-1")
+		if err != nil {
+			t.Fatalf("LoadOrCreate: %v", err)
+		}
+		e := &Engine{config: EngineConfig{}, state: state}
+		if got := e.remoteName(); got != "origin" {
+			t.Errorf("remoteName() = %q, want %q", got, "origin")
+		}
+	})
+
+	t.Run("configured", func(t *testing.T) {
+		// When PushTo is set, remoteName() should return the configured value.
+		stateDir := t.TempDir()
+		state, err := LoadOrCreate(stateDir, "REMOTE-2")
+		if err != nil {
+			t.Fatalf("LoadOrCreate: %v", err)
+		}
+		e := &Engine{
+			config: EngineConfig{
+				PromptConfig: PromptConfigData{
+					Repo: RepoConfig{PushTo: "upstream"},
+				},
+			},
+			state: state,
+		}
+		if got := e.remoteName(); got != "upstream" {
+			t.Errorf("remoteName() = %q, want %q", got, "upstream")
+		}
+	})
+}
+
 func TestEngine_ReviewReworkCyclesPersisted(t *testing.T) {
 	// Verify rework cycles are persisted to meta.json across engine restarts.
 	stateDir := t.TempDir()

--- a/internal/pipeline/monitor_poll.go
+++ b/internal/pipeline/monitor_poll.go
@@ -485,9 +485,10 @@ func (e *Engine) checkMergeConflicts(ctx context.Context, phaseName string, monS
 	}
 
 	// Fetch latest base branch before checking.
-	_ = git.FetchBranch(ctx, workDir, "origin", baseBranch)
+	remote := e.remoteName()
+	_ = git.FetchBranch(ctx, workDir, remote, baseBranch)
 
-	hasConflicts, err := git.NeedsMergeWithBase(ctx, workDir, "origin/"+baseBranch)
+	hasConflicts, err := git.NeedsMergeWithBase(ctx, workDir, remote+"/"+baseBranch)
 	if err != nil {
 		// Non-fatal: some setups may not have origin configured.
 		return
@@ -508,7 +509,7 @@ func (e *Engine) checkMergeConflicts(ctx context.Context, phaseName string, monS
 	}
 
 	// Attempt auto-rebase.
-	if err := git.Rebase(ctx, workDir, "origin/"+baseBranch); err != nil {
+	if err := git.Rebase(ctx, workDir, remote+"/"+baseBranch); err != nil {
 		e.emit(Event{
 			Phase: phaseName,
 			Kind:  EventMonitorRebaseFailed,
@@ -521,7 +522,7 @@ func (e *Engine) checkMergeConflicts(ctx context.Context, phaseName string, monS
 	}
 
 	// Push the rebased branch.
-	if err := git.ForcePush(ctx, workDir, "origin"); err != nil {
+	if err := git.ForcePush(ctx, workDir, remote); err != nil {
 		e.emit(Event{
 			Phase: phaseName,
 			Kind:  EventMonitorRebaseFailed,
@@ -584,7 +585,8 @@ func (e *Engine) respondToComments(ctx context.Context, phase PhaseConfig, class
 
 	// Fetch latest base branch before computing diff so the comparison
 	// is against the current remote state, not a stale local ref.
-	if fetchErr := git.FetchBranch(ctx, workDir, "origin", baseBranch); fetchErr != nil {
+	remote := e.remoteName()
+	if fetchErr := git.FetchBranch(ctx, workDir, remote, baseBranch); fetchErr != nil {
 		// Non-fatal: proceed with potentially stale ref.
 		e.emit(Event{
 			Phase: phase.Name,
@@ -595,7 +597,7 @@ func (e *Engine) respondToComments(ctx context.Context, phase PhaseConfig, class
 		})
 	}
 
-	diffCtx, err := git.Diff(ctx, workDir, "origin/"+baseBranch, 50000)
+	diffCtx, err := git.Diff(ctx, workDir, remote+"/"+baseBranch, 50000)
 	if err != nil {
 		// Non-fatal: the session can still read files.
 		diffCtx = "(diff unavailable: " + err.Error() + ")"


### PR DESCRIPTION
## Summary
- Adds a `remoteName()` helper on `*Engine` that reads from `PromptConfig.Repo.PushTo`, defaulting to `"origin"` when not configured.
- Replaces all 7 hardcoded `"origin"` references across `engine.go` (1) and `monitor_poll.go` (6) with calls to `remoteName()`.
- Adds `TestEngine_remoteName` covering both the default and configured cases.

## Acceptance Criteria
- [x] No hardcoded `"origin"` remains in `computeDiffContext`, `checkMergeConflicts`, or `respondToComments`
- [x] When `Repo.PushTo` is empty, behaviour is unchanged (defaults to `"origin"`)
- [x] When `Repo.PushTo` is set (e.g. `"upstream"`), all git operations use the configured remote
- [x] All existing tests pass with no regressions

## Test Plan
- Run `go test ./internal/pipeline/... -run TestEngine_remoteName` to verify the new unit tests
- Run full `go test ./internal/pipeline/...` to confirm no regressions
- Manual: configure `PushTo: "upstream"` in a prompt config and verify diff/fetch/push use `upstream`

🤖 Generated with [Claude Code](https://claude.com/claude-code)