### PR TITLE
fix(pipeline): validate rework/corrective cross-refs at load time (#171)

### DIFF
--- a/internal/pipeline/phase.go
+++ b/internal/pipeline/phase.go
@@ -115,8 +115,9 @@ func LoadPipeline(path string) (*PhasePipeline, error) {
 		phaseNames[p.Name] = struct{}{}
 	}
 
-	// Validate cross-references: ReworkConfig.Target and FeedbackFrom
-	// must refer to phases that exist in the pipeline.
+	// Validate cross-references: ReworkConfig.Target, FeedbackFrom,
+	// CorrectiveConfig.Phase, and CorrectiveConfig.EscalateTo must
+	// refer to phases that exist in the pipeline.
 	for _, phase := range pipeline.Phases {
 		if phase.Rework != nil {
 			if _, ok := phaseNames[phase.Rework.Target]; !ok {
@@ -126,6 +127,16 @@ func LoadPipeline(path string) (*PhasePipeline, error) {
 		for _, src := range phase.FeedbackFrom {
 			if _, ok := phaseNames[src]; !ok {
 				return nil, fmt.Errorf("pipeline: phase %q feedback_from references unknown phase %q", phase.Name, src)
+			}
+		}
+		if phase.Corrective != nil {
+			if _, ok := phaseNames[phase.Corrective.Phase]; !ok {
+				return nil, fmt.Errorf("pipeline: phase %q corrective.phase %q not found", phase.Name, phase.Corrective.Phase)
+			}
+			if phase.Corrective.EscalateTo != "" {
+				if _, ok := phaseNames[phase.Corrective.EscalateTo]; !ok {
+					return nil, fmt.Errorf("pipeline: phase %q corrective.escalate_to %q not found", phase.Name, phase.Corrective.EscalateTo)
+				}
 			}
 		}
 	}

--- a/internal/pipeline/phase.go
+++ b/internal/pipeline/phase.go
@@ -109,6 +109,27 @@ func LoadPipeline(path string) (*PhasePipeline, error) {
 		return nil, fmt.Errorf("pipeline: no phases defined in %s", path)
 	}
 
+	// Build a set of known phase names for cross-reference validation.
+	phaseNames := make(map[string]struct{}, len(pipeline.Phases))
+	for _, p := range pipeline.Phases {
+		phaseNames[p.Name] = struct{}{}
+	}
+
+	// Validate cross-references: ReworkConfig.Target and FeedbackFrom
+	// must refer to phases that exist in the pipeline.
+	for _, phase := range pipeline.Phases {
+		if phase.Rework != nil {
+			if _, ok := phaseNames[phase.Rework.Target]; !ok {
+				return nil, fmt.Errorf("pipeline: phase %q rework target %q not found in pipeline", phase.Name, phase.Rework.Target)
+			}
+		}
+		for _, src := range phase.FeedbackFrom {
+			if _, ok := phaseNames[src]; !ok {
+				return nil, fmt.Errorf("pipeline: phase %q feedback_from references unknown phase %q", phase.Name, src)
+			}
+		}
+	}
+
 	// Resolve schemas: if a phase has no inline schema, look up the
 	// generated schema by phase name from the schemas package.
 	for idx := range pipeline.Phases {

--- a/internal/pipeline/phase_test.go
+++ b/internal/pipeline/phase_test.go
@@ -340,4 +340,96 @@ func TestLoadPipeline(t *testing.T) {
 			t.Errorf("got %d phases, want 2", len(pipeline.Phases))
 		}
 	})
+
+	t.Run("errors_on_invalid_corrective_phase", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "phases.yaml")
+		content := `phases:
+  - name: verify
+    prompt: prompts/verify.md
+    timeout: 5m
+    corrective:
+      phase: nonexistent
+      max_attempts: 2
+      on_exhausted: stop
+`
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+
+		_, err := LoadPipeline(path)
+		if err == nil {
+			t.Fatal("expected error for invalid corrective.phase")
+		}
+		if !strings.Contains(err.Error(), "corrective.phase") {
+			t.Errorf("error = %q, want mention of corrective.phase", err)
+		}
+		if !strings.Contains(err.Error(), "nonexistent") {
+			t.Errorf("error = %q, want mention of %q", err, "nonexistent")
+		}
+	})
+
+	t.Run("errors_on_invalid_corrective_escalate_to", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "phases.yaml")
+		content := `phases:
+  - name: patch
+    prompt: prompts/patch.md
+    timeout: 5m
+  - name: verify
+    prompt: prompts/verify.md
+    timeout: 5m
+    corrective:
+      phase: patch
+      max_attempts: 2
+      on_exhausted: escalate
+      escalate_to: nonexistent
+`
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+
+		_, err := LoadPipeline(path)
+		if err == nil {
+			t.Fatal("expected error for invalid corrective.escalate_to")
+		}
+		if !strings.Contains(err.Error(), "corrective.escalate_to") {
+			t.Errorf("error = %q, want mention of corrective.escalate_to", err)
+		}
+		if !strings.Contains(err.Error(), "nonexistent") {
+			t.Errorf("error = %q, want mention of %q", err, "nonexistent")
+		}
+	})
+
+	t.Run("valid_corrective_config", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "phases.yaml")
+		content := `phases:
+  - name: implement
+    prompt: prompts/implement.md
+    timeout: 5m
+  - name: patch
+    prompt: prompts/patch.md
+    timeout: 5m
+  - name: verify
+    prompt: prompts/verify.md
+    timeout: 5m
+    corrective:
+      phase: patch
+      max_attempts: 2
+      on_exhausted: escalate
+      escalate_to: implement
+`
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+
+		pipeline, err := LoadPipeline(path)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(pipeline.Phases) != 3 {
+			t.Errorf("got %d phases, want 3", len(pipeline.Phases))
+		}
+	})
 }

--- a/internal/pipeline/phase_test.go
+++ b/internal/pipeline/phase_test.go
@@ -257,4 +257,87 @@ func TestLoadPipeline(t *testing.T) {
 			t.Fatal("expected error for invalid yaml")
 		}
 	})
+
+	t.Run("errors_on_invalid_rework_target", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "phases.yaml")
+		content := `phases:
+  - name: implement
+    prompt: prompts/implement.md
+    timeout: 5m
+  - name: review
+    prompt: prompts/review.md
+    timeout: 5m
+    rework:
+      target: nonexistent
+`
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+
+		_, err := LoadPipeline(path)
+		if err == nil {
+			t.Fatal("expected error for invalid rework target")
+		}
+		if !strings.Contains(err.Error(), "rework target") {
+			t.Errorf("error = %q, want mention of rework target", err)
+		}
+		if !strings.Contains(err.Error(), "nonexistent") {
+			t.Errorf("error = %q, want mention of %q", err, "nonexistent")
+		}
+	})
+
+	t.Run("errors_on_invalid_feedback_from", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "phases.yaml")
+		content := `phases:
+  - name: implement
+    prompt: prompts/implement.md
+    timeout: 5m
+    feedback_from:
+      - nonexistent
+`
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+
+		_, err := LoadPipeline(path)
+		if err == nil {
+			t.Fatal("expected error for invalid feedback_from")
+		}
+		if !strings.Contains(err.Error(), "feedback_from") {
+			t.Errorf("error = %q, want mention of feedback_from", err)
+		}
+		if !strings.Contains(err.Error(), "nonexistent") {
+			t.Errorf("error = %q, want mention of %q", err, "nonexistent")
+		}
+	})
+
+	t.Run("valid_rework_target_and_feedback_from", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "phases.yaml")
+		content := `phases:
+  - name: implement
+    prompt: prompts/implement.md
+    timeout: 5m
+    feedback_from:
+      - review
+  - name: review
+    prompt: prompts/review.md
+    timeout: 5m
+    rework:
+      target: implement
+`
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+
+		pipeline, err := LoadPipeline(path)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(pipeline.Phases) != 2 {
+			t.Errorf("got %d phases, want 2", len(pipeline.Phases))
+		}
+	})
 }


### PR DESCRIPTION
## Summary
- Validate `ReworkConfig.Target` and `FeedbackFrom` references in `LoadPipeline`, catching invalid phase names at config load time instead of runtime
- Extend cross-reference validation to also cover `CorrectiveConfig.Phase` and `CorrectiveConfig.EscalateTo`
- Add 6 new test cases covering all validation paths (invalid rework target, invalid feedback_from, invalid corrective.phase, invalid corrective.escalate_to, and two valid-config positive tests)

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] New tests verify invalid rework target produces descriptive error
- [x] New tests verify invalid feedback_from produces descriptive error
- [x] New tests verify invalid corrective.phase produces descriptive error
- [x] New tests verify invalid corrective.escalate_to produces descriptive error
- [x] New tests verify valid configs load without error
- [x] Real `phases.yaml` continues to pass validation
- [x] `go vet ./...` clean

## Acceptance criteria
- [x] `LoadPipeline` returns an error when `ReworkConfig.Target` references a non-existent phase
- [x] `LoadPipeline` returns an error when `FeedbackFrom` references a non-existent phase
- [x] `LoadPipeline` returns an error when `CorrectiveConfig.Phase` references a non-existent phase
- [x] `LoadPipeline` returns an error when `CorrectiveConfig.EscalateTo` references a non-existent phase
- [x] Error messages include both the source phase name and the invalid target name
- [x] Runtime validation in `routeRework` retained as defense-in-depth

🤖 Generated with [Claude Code](https://claude.com/claude-code)