### PR TITLE
refactor(pipeline): decouple reworkSignal from schemas.ReviewFinding

### DIFF
--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -1318,9 +1318,9 @@ func (e *Engine) gateRework(phase PhaseConfig, raw json.RawMessage) error {
 	}
 
 	// Build findings for the rework signal from the minimal verdict struct.
-	var findings []schemas.ReviewFinding
+	var findings []reworkFinding
 	for _, f := range result.Findings {
-		findings = append(findings, schemas.ReviewFinding{
+		findings = append(findings, reworkFinding{
 			Severity: f.Severity,
 			Issue:    f.Issue,
 		})

--- a/internal/pipeline/errors.go
+++ b/internal/pipeline/errors.go
@@ -3,8 +3,6 @@ package pipeline
 import (
 	"fmt"
 	"strings"
-
-	"github.com/decko/soda/schemas"
 )
 
 // BudgetExceededError is returned when accumulated cost exceeds the configured limit.
@@ -40,13 +38,22 @@ func (e *PhaseGateError) Error() string {
 	return fmt.Sprintf("pipeline: phase %s gated: %s", e.Phase, e.Reason)
 }
 
+// reworkFinding is a minimal finding type used by reworkSignal for error
+// message context. It carries only the fields needed to describe rework
+// issues (severity + issue text), decoupled from schemas.ReviewFinding
+// which carries additional review-specific fields (file, line, source, etc.).
+type reworkFinding struct {
+	Severity string
+	Issue    string
+}
+
 // reworkSignal is an internal sentinel error used by gatePhase to signal the
 // engine loop that a phase produced a "rework" verdict and the pipeline should
 // route back to the configured target phase. This is NOT a terminal error —
 // the engine loop catches it and handles routing.
 type reworkSignal struct {
-	target   string                  // phase to route back to
-	findings []schemas.ReviewFinding // findings for error message context
+	target   string          // phase to route back to
+	findings []reworkFinding // findings for error message context
 }
 
 func (e *reworkSignal) Error() string {

--- a/internal/pipeline/errors_test.go
+++ b/internal/pipeline/errors_test.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"strings"
 	"testing"
-
-	"github.com/decko/soda/schemas"
 )
 
 func TestBudgetExceededError(t *testing.T) {
@@ -54,7 +52,7 @@ func TestReworkSignal(t *testing.T) {
 	t.Run("with_findings", func(t *testing.T) {
 		err := &reworkSignal{
 			target: "implement",
-			findings: []schemas.ReviewFinding{
+			findings: []reworkFinding{
 				{Severity: "critical", Issue: "nil deref"},
 				{Severity: "minor", Issue: "naming"},
 				{Severity: "major", Issue: "missing error check"},


### PR DESCRIPTION
## Summary
- Introduce a minimal `reworkFinding` struct with only `Severity` and `Issue` fields, replacing the `schemas.ReviewFinding` dependency in `reworkSignal`
- Update `gateRework` in `engine.go` to construct `[]reworkFinding` instead of `[]schemas.ReviewFinding`
- Remove unused `schemas` import from `errors.go` and `errors_test.go`

## Acceptance Criteria
- [x] `reworkSignal` no longer depends on `schemas.ReviewFinding`
- [x] `reworkFinding` carries only the two fields actually used (`Severity`, `Issue`)
- [x] `schemas.ReviewFinding` remains used for review-domain concerns (reviewer results, verdict computation, artifact building)
- [x] All existing tests pass with no behavioral changes

## Test plan
- [x] All 60+ pipeline tests pass, including rework-specific integration tests
- [x] `TestReworkSignal` updated to use `reworkFinding` and passes
- [x] Pure refactor — no behavioral changes, verified by unchanged test assertions

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)