### PR TITLE
feat(pipeline): downgrade minors to follow-ups at max rework (#178)

### DIFF
--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -1316,7 +1316,7 @@ func (e *Engine) gateRework(phase PhaseConfig, raw json.RawMessage) error {
 		// "pass-with-follow-ups" so the pipeline proceeds to submit and
 		// the remaining minors are handled by the follow-up phase.
 		if len(issues) == 0 {
-			if err := e.downgradeToFollowUps(phase, raw); err != nil {
+			if err := e.downgradeToFollowUps(phase, raw, result.Findings); err != nil {
 				return err
 			}
 			return nil
@@ -1345,16 +1345,24 @@ func (e *Engine) gateRework(phase PhaseConfig, raw json.RawMessage) error {
 // max rework cycles are exhausted but the remaining findings are all
 // minor — the pipeline can proceed to submit and handle them as follow-ups
 // instead of blocking.
-func (e *Engine) downgradeToFollowUps(phase PhaseConfig, raw json.RawMessage) error {
-	// Parse the full review output so we preserve all fields.
-	var review schemas.ReviewOutput
-	if err := json.Unmarshal(raw, &review); err != nil {
+//
+// The raw JSON is round-tripped through map[string]any (rather than a
+// typed struct like schemas.ReviewOutput) so that fields belonging to
+// non-review phases are preserved. The minor count is derived from the
+// already-parsed reworkVerdict findings, keeping this function
+// phase-agnostic — consistent with gateRework.
+func (e *Engine) downgradeToFollowUps(phase PhaseConfig, raw json.RawMessage, findings []struct {
+	Severity string `json:"severity"`
+	Issue    string `json:"issue"`
+}) error {
+	var doc map[string]any
+	if err := json.Unmarshal(raw, &doc); err != nil {
 		return fmt.Errorf("engine: downgrade to follow-ups: unmarshal %s result: %w", phase.Name, err)
 	}
 
-	review.Verdict = "pass-with-follow-ups"
+	doc["verdict"] = "pass-with-follow-ups"
 
-	updated, err := json.Marshal(review)
+	updated, err := json.Marshal(doc)
 	if err != nil {
 		return fmt.Errorf("engine: downgrade to follow-ups: marshal %s result: %w", phase.Name, err)
 	}
@@ -1363,7 +1371,7 @@ func (e *Engine) downgradeToFollowUps(phase PhaseConfig, raw json.RawMessage) er
 	}
 
 	minorCount := 0
-	for _, f := range review.Findings {
+	for _, f := range findings {
 		if strings.EqualFold(f.Severity, "minor") {
 			minorCount++
 		}

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -1302,10 +1302,7 @@ func (e *Engine) gateRework(phase PhaseConfig, raw json.RawMessage) error {
 				issues = append(issues, finding.Issue)
 			}
 		}
-		reason := fmt.Sprintf("%s requires rework but max cycles (%d) reached", phase.Name, maxCycles)
-		if len(issues) > 0 {
-			reason += ": " + strings.Join(issues, "; ")
-		}
+
 		e.emit(Event{
 			Phase: phase.Name,
 			Kind:  EventReworkMaxCycles,
@@ -1314,6 +1311,19 @@ func (e *Engine) gateRework(phase PhaseConfig, raw json.RawMessage) error {
 				"max_rework_cycles": maxCycles,
 			},
 		})
+
+		// When no critical/major issues remain, downgrade the verdict to
+		// "pass-with-follow-ups" so the pipeline proceeds to submit and
+		// the remaining minors are handled by the follow-up phase.
+		if len(issues) == 0 {
+			if err := e.downgradeToFollowUps(phase, raw); err != nil {
+				return err
+			}
+			return nil
+		}
+
+		reason := fmt.Sprintf("%s requires rework but max cycles (%d) reached: %s",
+			phase.Name, maxCycles, strings.Join(issues, "; "))
 		return &PhaseGateError{Phase: phase.Name, Reason: reason}
 	}
 
@@ -1328,6 +1338,50 @@ func (e *Engine) gateRework(phase PhaseConfig, raw json.RawMessage) error {
 
 	// Signal rework needed — the engine loop will handle routing.
 	return &reworkSignal{target: phase.Rework.Target, findings: findings}
+}
+
+// downgradeToFollowUps rewrites the phase result on disk, changing the
+// verdict from "rework" to "pass-with-follow-ups". This is called when
+// max rework cycles are exhausted but the remaining findings are all
+// minor — the pipeline can proceed to submit and handle them as follow-ups
+// instead of blocking.
+func (e *Engine) downgradeToFollowUps(phase PhaseConfig, raw json.RawMessage) error {
+	// Parse the full review output so we preserve all fields.
+	var review schemas.ReviewOutput
+	if err := json.Unmarshal(raw, &review); err != nil {
+		return fmt.Errorf("engine: downgrade to follow-ups: unmarshal %s result: %w", phase.Name, err)
+	}
+
+	review.Verdict = "pass-with-follow-ups"
+
+	updated, err := json.Marshal(review)
+	if err != nil {
+		return fmt.Errorf("engine: downgrade to follow-ups: marshal %s result: %w", phase.Name, err)
+	}
+	if err := e.state.WriteResult(phase.Name, json.RawMessage(updated)); err != nil {
+		return fmt.Errorf("engine: downgrade to follow-ups: write %s result: %w", phase.Name, err)
+	}
+
+	minorCount := 0
+	for _, f := range review.Findings {
+		if strings.EqualFold(f.Severity, "minor") {
+			minorCount++
+		}
+	}
+
+	e.emit(Event{
+		Phase: phase.Name,
+		Kind:  EventReworkMinorsDowngraded,
+		Data: map[string]any{
+			"original_verdict":  "rework",
+			"new_verdict":       "pass-with-follow-ups",
+			"minor_count":       minorCount,
+			"rework_cycles":     e.state.Meta().ReworkCycles,
+			"max_rework_cycles": e.config.maxReworkCycles(),
+		},
+	})
+
+	return nil
 }
 
 // regressionResult holds the outcome of a regression check between two

--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -1308,6 +1308,155 @@ func TestEngine_gateRework_nilReworkConfig(t *testing.T) {
 	}
 }
 
+func TestEngine_downgradeToFollowUps(t *testing.T) {
+	// Direct unit test for downgradeToFollowUps: verify it rewrites the
+	// verdict on disk and emits the correct event.
+	phases := []PhaseConfig{
+		{
+			Name:   "review",
+			Prompt: "review.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			Rework: &ReworkConfig{Target: "implement"},
+		},
+	}
+
+	var events []Event
+	engine, state := setupEngine(t, phases, &flexMockRunner{}, func(cfg *EngineConfig) {
+		cfg.MaxReworkCycles = 1
+		cfg.OnEvent = func(e Event) {
+			events = append(events, e)
+		}
+	})
+	state.Meta().ReworkCycles = 1
+
+	// Write a review result with rework verdict and minor findings.
+	raw := json.RawMessage(`{"ticket_key":"TEST-1","findings":[{"severity":"minor","file":"a.go","issue":"naming","suggestion":"rename"},{"severity":"minor","file":"b.go","issue":"style","suggestion":"fix"}],"verdict":"rework"}`)
+	if err := state.WriteResult("review", raw); err != nil {
+		t.Fatalf("WriteResult: %v", err)
+	}
+
+	phase := PhaseConfig{
+		Name:   "review",
+		Rework: &ReworkConfig{Target: "implement"},
+	}
+	if err := engine.downgradeToFollowUps(phase, raw); err != nil {
+		t.Fatalf("downgradeToFollowUps: %v", err)
+	}
+
+	// Verify the result on disk was rewritten.
+	updated, err := state.ReadResult("review")
+	if err != nil {
+		t.Fatalf("ReadResult: %v", err)
+	}
+	var reviewOutput schemas.ReviewOutput
+	if err := json.Unmarshal(updated, &reviewOutput); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if reviewOutput.Verdict != "pass-with-follow-ups" {
+		t.Errorf("verdict = %q, want %q", reviewOutput.Verdict, "pass-with-follow-ups")
+	}
+	if len(reviewOutput.Findings) != 2 {
+		t.Errorf("findings count = %d, want 2", len(reviewOutput.Findings))
+	}
+
+	// Verify event was emitted.
+	hasDowngraded := false
+	for _, e := range events {
+		if e.Kind == EventReworkMinorsDowngraded {
+			hasDowngraded = true
+			if mc, _ := e.Data["minor_count"].(int); mc != 2 {
+				t.Errorf("minor_count = %d, want 2", mc)
+			}
+		}
+	}
+	if !hasDowngraded {
+		t.Error("rework_minors_downgraded event not emitted")
+	}
+}
+
+func TestEngine_gateRework_maxCyclesMinorsOnly(t *testing.T) {
+	// When max rework cycles exhausted with only minor findings,
+	// gateRework should downgrade to pass-with-follow-ups (return nil).
+	phases := []PhaseConfig{
+		{
+			Name:   "review",
+			Prompt: "review.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			Rework: &ReworkConfig{Target: "implement"},
+		},
+	}
+
+	engine, state := setupEngine(t, phases, &flexMockRunner{}, func(cfg *EngineConfig) {
+		cfg.MaxReworkCycles = 1
+	})
+	state.Meta().ReworkCycles = 1
+
+	// Write the result to disk so downgradeToFollowUps can rewrite it.
+	raw := json.RawMessage(`{"ticket_key":"TEST-1","findings":[{"severity":"minor","file":"x.go","issue":"naming","suggestion":"rename"}],"verdict":"rework"}`)
+	if err := state.WriteResult("review", raw); err != nil {
+		t.Fatalf("WriteResult: %v", err)
+	}
+
+	phase := PhaseConfig{
+		Name:   "review",
+		Rework: &ReworkConfig{Target: "implement"},
+	}
+	err := engine.gateRework(phase, raw)
+	if err != nil {
+		t.Fatalf("expected nil (downgrade), got: %v", err)
+	}
+
+	// Verify the result was rewritten.
+	updated, err := state.ReadResult("review")
+	if err != nil {
+		t.Fatalf("ReadResult: %v", err)
+	}
+	var output schemas.ReviewOutput
+	if err := json.Unmarshal(updated, &output); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if output.Verdict != "pass-with-follow-ups" {
+		t.Errorf("verdict = %q, want %q", output.Verdict, "pass-with-follow-ups")
+	}
+}
+
+func TestEngine_gateRework_maxCyclesCriticalBlocks(t *testing.T) {
+	// When max rework cycles exhausted with critical findings,
+	// gateRework should still return PhaseGateError.
+	phases := []PhaseConfig{
+		{
+			Name:   "review",
+			Prompt: "review.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			Rework: &ReworkConfig{Target: "implement"},
+		},
+	}
+
+	engine, state := setupEngine(t, phases, &flexMockRunner{}, func(cfg *EngineConfig) {
+		cfg.MaxReworkCycles = 1
+	})
+	state.Meta().ReworkCycles = 1
+
+	phase := PhaseConfig{
+		Name:   "review",
+		Rework: &ReworkConfig{Target: "implement"},
+	}
+	raw := json.RawMessage(`{"verdict":"rework","findings":[{"severity":"critical","issue":"SQL injection"}]}`)
+
+	err := engine.gateRework(phase, raw)
+	if err == nil {
+		t.Fatal("expected PhaseGateError when critical findings remain")
+	}
+
+	var gateErr *PhaseGateError
+	if !errors.As(err, &gateErr) {
+		t.Fatalf("expected PhaseGateError, got: %T: %v", err, err)
+	}
+	if !strings.Contains(gateErr.Reason, "SQL injection") {
+		t.Errorf("reason should mention the critical issue, got: %q", gateErr.Reason)
+	}
+}
+
 func TestEngineFullLifecycle(t *testing.T) {
 	// A realistic 4-phase pipeline: triage -> plan -> implement -> verify.
 	// Each phase depends on the previous one. Prompt templates reference
@@ -4346,6 +4495,228 @@ func TestEngine_ReviewReworkRouting(t *testing.T) {
 		}
 		if !hasMaxCycles {
 			t.Error("rework_max_cycles event not emitted")
+		}
+	})
+
+	t.Run("max_rework_cycles_downgrades_minors", func(t *testing.T) {
+		// Pipeline: implement → review → submit
+		// Uses a regular (non-parallel) review phase where the runner
+		// controls the verdict directly. First review returns "rework" with
+		// major findings, second review returns "rework" with only minor
+		// findings. After max cycles, the engine should downgrade the
+		// verdict to "pass-with-follow-ups" and proceed to submit.
+		phases := []PhaseConfig{
+			{
+				Name:         "implement",
+				Prompt:       "implement.md",
+				Retry:        RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+				FeedbackFrom: []string{"review"},
+			},
+			{
+				Name:      "review",
+				Prompt:    "review.md",
+				DependsOn: []string{"implement"},
+				Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+				Rework:    &ReworkConfig{Target: "implement"},
+			},
+			{
+				Name:      "submit",
+				Prompt:    "submit.md",
+				DependsOn: []string{"implement", "review"},
+				Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			},
+		}
+
+		mock := &flexMockRunner{
+			responses: map[string][]flexResponse{
+				"implement": {
+					{result: &runner.RunResult{
+						Output:  json.RawMessage(`{"tests_passed":true,"commits":1}`),
+						RawText: "Impl v1",
+						CostUSD: 0.50,
+					}},
+					{result: &runner.RunResult{
+						Output:  json.RawMessage(`{"tests_passed":true,"commits":2}`),
+						RawText: "Impl v2",
+						CostUSD: 0.50,
+					}},
+				},
+				"review": {
+					// First review: rework with major finding → triggers rework.
+					{result: &runner.RunResult{
+						Output:  json.RawMessage(`{"ticket_key":"TEST-1","findings":[{"severity":"major","file":"x.go","line":1,"issue":"error not wrapped","suggestion":"use fmt.Errorf"}],"verdict":"rework"}`),
+						RawText: "Major issues found",
+						CostUSD: 0.15,
+					}},
+					// Second review: rework with only minor findings → downgraded.
+					{result: &runner.RunResult{
+						Output:  json.RawMessage(`{"ticket_key":"TEST-1","findings":[{"severity":"minor","file":"x.go","line":5,"issue":"naming style","suggestion":"use camelCase"}],"verdict":"rework"}`),
+						RawText: "Minor issue only",
+						CostUSD: 0.15,
+					}},
+				},
+				"submit": {{
+					result: &runner.RunResult{
+						Output:  json.RawMessage(`{"pr_url":"https://github.com/org/repo/pull/42"}`),
+						RawText: "PR created",
+						CostUSD: 0.05,
+					},
+				}},
+			},
+		}
+
+		var events []Event
+		engine, state := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+			cfg.MaxReworkCycles = 1
+			cfg.OnEvent = func(e Event) {
+				events = append(events, e)
+			}
+		})
+
+		err := engine.Run(context.Background())
+		if err != nil {
+			t.Fatalf("expected pipeline to proceed after downgrade, got: %v", err)
+		}
+
+		// All phases should be completed.
+		for _, name := range []string{"implement", "review", "submit"} {
+			if !state.IsCompleted(name) {
+				t.Errorf("phase %q should be completed", name)
+			}
+		}
+
+		// Should have 1 rework cycle.
+		if state.Meta().ReworkCycles != 1 {
+			t.Errorf("ReworkCycles = %d, want 1", state.Meta().ReworkCycles)
+		}
+
+		// Review result should have been rewritten with pass-with-follow-ups.
+		result, err := state.ReadResult("review")
+		if err != nil {
+			t.Fatalf("ReadResult: %v", err)
+		}
+		var reviewOutput schemas.ReviewOutput
+		if err := json.Unmarshal(result, &reviewOutput); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if reviewOutput.Verdict != "pass-with-follow-ups" {
+			t.Errorf("verdict = %q, want %q", reviewOutput.Verdict, "pass-with-follow-ups")
+		}
+		// Findings should still be present.
+		if len(reviewOutput.Findings) != 1 {
+			t.Errorf("findings count = %d, want 1", len(reviewOutput.Findings))
+		}
+
+		// Should have rework_routed, rework_max_cycles, and rework_minors_downgraded events.
+		hasRouted := false
+		hasDowngraded := false
+		hasMaxCycles := false
+		for _, e := range events {
+			if e.Kind == EventReworkRouted {
+				hasRouted = true
+			}
+			if e.Kind == EventReworkMinorsDowngraded {
+				hasDowngraded = true
+				if orig, _ := e.Data["original_verdict"].(string); orig != "rework" {
+					t.Errorf("original_verdict = %q, want %q", orig, "rework")
+				}
+				if newV, _ := e.Data["new_verdict"].(string); newV != "pass-with-follow-ups" {
+					t.Errorf("new_verdict = %q, want %q", newV, "pass-with-follow-ups")
+				}
+			}
+			if e.Kind == EventReworkMaxCycles {
+				hasMaxCycles = true
+			}
+		}
+		if !hasRouted {
+			t.Error("rework_routed event not emitted")
+		}
+		if !hasDowngraded {
+			t.Error("rework_minors_downgraded event not emitted")
+		}
+		if !hasMaxCycles {
+			t.Error("rework_max_cycles event not emitted")
+		}
+	})
+
+	t.Run("max_rework_cycles_blocks_with_mixed_findings", func(t *testing.T) {
+		// Pipeline: implement → review
+		// Uses a regular (non-parallel) review where the runner controls
+		// the verdict. Both reviews return "rework" with major+minor findings.
+		// The engine should block because critical/major findings remain.
+		phases := []PhaseConfig{
+			{
+				Name:         "implement",
+				Prompt:       "implement.md",
+				Retry:        RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+				FeedbackFrom: []string{"review"},
+			},
+			{
+				Name:      "review",
+				Prompt:    "review.md",
+				DependsOn: []string{"implement"},
+				Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+				Rework:    &ReworkConfig{Target: "implement"},
+			},
+		}
+
+		mixedFindings := `{"ticket_key":"TEST-1","findings":[{"severity":"major","file":"x.go","line":1,"issue":"error not wrapped","suggestion":"use fmt.Errorf"},{"severity":"minor","file":"y.go","line":10,"issue":"naming style","suggestion":"rename"}],"verdict":"rework"}`
+
+		mock := &flexMockRunner{
+			responses: map[string][]flexResponse{
+				"implement": {
+					{result: &runner.RunResult{
+						Output:  json.RawMessage(`{"tests_passed":true,"commits":1}`),
+						RawText: "Impl v1",
+						CostUSD: 0.50,
+					}},
+					{result: &runner.RunResult{
+						Output:  json.RawMessage(`{"tests_passed":true,"commits":2}`),
+						RawText: "Impl v2",
+						CostUSD: 0.50,
+					}},
+				},
+				"review": {
+					{result: &runner.RunResult{
+						Output:  json.RawMessage(mixedFindings),
+						RawText: "Mixed issues",
+						CostUSD: 0.15,
+					}},
+					{result: &runner.RunResult{
+						Output:  json.RawMessage(mixedFindings),
+						RawText: "Still mixed issues",
+						CostUSD: 0.15,
+					}},
+				},
+			},
+		}
+
+		engine, state := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+			cfg.MaxReworkCycles = 1
+		})
+
+		err := engine.Run(context.Background())
+		if err == nil {
+			t.Fatal("expected PhaseGateError after max rework cycles with major findings")
+		}
+
+		var gateErr *PhaseGateError
+		if !errors.As(err, &gateErr) {
+			t.Fatalf("expected PhaseGateError, got: %T: %v", err, err)
+		}
+		if gateErr.Phase != "review" {
+			t.Errorf("gate error phase = %q, want %q", gateErr.Phase, "review")
+		}
+		if !strings.Contains(gateErr.Reason, "max cycles") {
+			t.Errorf("gate error should mention max cycles, got: %q", gateErr.Reason)
+		}
+		if !strings.Contains(gateErr.Reason, "error not wrapped") {
+			t.Errorf("gate error should mention the major issue, got: %q", gateErr.Reason)
+		}
+
+		// Should have 1 rework cycle.
+		if state.Meta().ReworkCycles != 1 {
+			t.Errorf("ReworkCycles = %d, want 1", state.Meta().ReworkCycles)
 		}
 	})
 

--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -1310,7 +1310,7 @@ func TestEngine_gateRework_nilReworkConfig(t *testing.T) {
 
 func TestEngine_downgradeToFollowUps(t *testing.T) {
 	// Direct unit test for downgradeToFollowUps: verify it rewrites the
-	// verdict on disk and emits the correct event.
+	// verdict on disk, preserves unknown fields, and emits the correct event.
 	phases := []PhaseConfig{
 		{
 			Name:   "review",
@@ -1329,8 +1329,10 @@ func TestEngine_downgradeToFollowUps(t *testing.T) {
 	})
 	state.Meta().ReworkCycles = 1
 
-	// Write a review result with rework verdict and minor findings.
-	raw := json.RawMessage(`{"ticket_key":"TEST-1","findings":[{"severity":"minor","file":"a.go","issue":"naming","suggestion":"rename"},{"severity":"minor","file":"b.go","issue":"style","suggestion":"fix"}],"verdict":"rework"}`)
+	// Write a result with rework verdict, minor findings, and an extra
+	// field ("custom_metric") that is not part of schemas.ReviewOutput.
+	// downgradeToFollowUps must preserve it through the roundtrip.
+	raw := json.RawMessage(`{"ticket_key":"TEST-1","custom_metric":42,"findings":[{"severity":"minor","file":"a.go","issue":"naming","suggestion":"rename"},{"severity":"minor","file":"b.go","issue":"style","suggestion":"fix"}],"verdict":"rework"}`)
 	if err := state.WriteResult("review", raw); err != nil {
 		t.Fatalf("WriteResult: %v", err)
 	}
@@ -1339,7 +1341,14 @@ func TestEngine_downgradeToFollowUps(t *testing.T) {
 		Name:   "review",
 		Rework: &ReworkConfig{Target: "implement"},
 	}
-	if err := engine.downgradeToFollowUps(phase, raw); err != nil {
+	findings := []struct {
+		Severity string `json:"severity"`
+		Issue    string `json:"issue"`
+	}{
+		{Severity: "minor", Issue: "naming"},
+		{Severity: "minor", Issue: "style"},
+	}
+	if err := engine.downgradeToFollowUps(phase, raw, findings); err != nil {
 		t.Fatalf("downgradeToFollowUps: %v", err)
 	}
 
@@ -1348,15 +1357,22 @@ func TestEngine_downgradeToFollowUps(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadResult: %v", err)
 	}
-	var reviewOutput schemas.ReviewOutput
-	if err := json.Unmarshal(updated, &reviewOutput); err != nil {
+
+	// Parse as map to check all fields including extras.
+	var doc map[string]any
+	if err := json.Unmarshal(updated, &doc); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if reviewOutput.Verdict != "pass-with-follow-ups" {
-		t.Errorf("verdict = %q, want %q", reviewOutput.Verdict, "pass-with-follow-ups")
+	if v, _ := doc["verdict"].(string); v != "pass-with-follow-ups" {
+		t.Errorf("verdict = %q, want %q", v, "pass-with-follow-ups")
 	}
-	if len(reviewOutput.Findings) != 2 {
-		t.Errorf("findings count = %d, want 2", len(reviewOutput.Findings))
+	findingsSlice, _ := doc["findings"].([]any)
+	if len(findingsSlice) != 2 {
+		t.Errorf("findings count = %d, want 2", len(findingsSlice))
+	}
+	// Extra field must survive the roundtrip.
+	if cm, _ := doc["custom_metric"].(float64); cm != 42 {
+		t.Errorf("custom_metric = %v, want 42 (extra fields must be preserved)", cm)
 	}
 
 	// Verify event was emitted.

--- a/internal/pipeline/events.go
+++ b/internal/pipeline/events.go
@@ -75,6 +75,7 @@ const (
 	EventPatchTooComplex          = "patch_too_complex"
 	EventPatchEscalationSkipped   = "patch_escalation_skipped"
 	EventPatchRegression          = "patch_regression"
+	EventReworkMinorsDowngraded   = "rework_minors_downgraded"
 )
 
 // ReadEvents reads and parses all events from the events.jsonl file in dir.


### PR DESCRIPTION
## Summary
- When max rework cycles are exhausted and only minor findings remain, downgrade the verdict from `"rework"` to `"pass-with-follow-ups"` so the pipeline proceeds to submit instead of blocking indefinitely.
- Emit a new `rework_minors_downgraded` event with `minor_count` for observability.
- If critical/major findings remain at max cycles, the pipeline continues to block as before.

## Acceptance Criteria
- [x] Minors-only at max cycles → downgraded to `pass-with-follow-ups`
- [x] Pipeline proceeds to submit with findings preserved
- [x] Critical/major at max cycles → pipeline blocks (unchanged behavior)
- [x] `rework_minors_downgraded` event emitted with `minor_count`
- [x] Test: mixed findings with critical fixed, minors remain → proceeds
- [x] Test: critical remaining → stops

## Changed Files
- `internal/pipeline/engine.go` — `gateRework` checks for minor-only findings at max cycles; new `downgradeToFollowUps` method rewrites verdict on disk via `map[string]any` roundtrip
- `internal/pipeline/events.go` — new `EventReworkMinorsDowngraded` constant
- `internal/pipeline/engine_test.go` — 5 new tests (3 unit, 2 integration)

## Test Plan
- [x] All existing tests pass (`go test ./internal/pipeline/...`)
- [x] New unit tests: minors-only downgrade, critical blocks, mixed findings
- [x] New integration tests: full pipeline run with minors downgrade, full pipeline with critical remaining
- [x] Race detector passes (`go test -race`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)