### PR TITLE
feat(detect): auto-detect project stack from repo (#210)

### DIFF
--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -17,6 +17,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/decko/soda/internal/claude"
 	"github.com/decko/soda/internal/config"
+	"github.com/decko/soda/internal/detect"
 	"github.com/decko/soda/internal/git"
 	"github.com/decko/soda/internal/pipeline"
 	"github.com/decko/soda/internal/progress"
@@ -127,6 +128,23 @@ func runPipeline(cmd *cobra.Command, cfg *config.Config, ticketKey string) error
 		return fmt.Errorf("run: resolve repo root: %w", err)
 	}
 
+	// Auto-detect project stack from the repo. Detection is best-effort:
+	// errors are logged but do not block the pipeline.
+	var detectedStack pipeline.DetectedStackData
+	projectInfo, detectErr := detect.Detect(ctx, workDir)
+	if detectErr != nil {
+		fmt.Fprintf(os.Stderr, "Warning: project detection failed: %v\n", detectErr)
+	}
+	if projectInfo != nil {
+		detectedStack = pipeline.DetectedStackData{
+			Language:     projectInfo.Language,
+			Forge:        projectInfo.Forge,
+			Owner:        projectInfo.Owner,
+			Repo:         projectInfo.Repo,
+			ContextFiles: projectInfo.ContextFiles,
+		}
+	}
+
 	// Resolve StateDir relative to repo root.
 	stateDir := cfg.StateDir
 	if !filepath.IsAbs(stateDir) {
@@ -167,8 +185,17 @@ func runPipeline(cmd *cobra.Command, cfg *config.Config, ticketKey string) error
 		r = claudeRunner
 	}
 
-	// Build prompt config from repos
+	// Build prompt config from repos, using detected values as defaults
+	// when the user's config does not specify them explicitly.
 	promptConfig := buildPromptConfig(cfg)
+	if projectInfo != nil {
+		if promptConfig.Formatter == "" {
+			promptConfig.Formatter = projectInfo.Formatter
+		}
+		if promptConfig.TestCommand == "" {
+			promptConfig.TestCommand = projectInfo.TestCommand
+		}
+	}
 
 	// Load project context files
 	promptContext := buildPromptContext(cfg)
@@ -204,6 +231,7 @@ func runPipeline(cmd *cobra.Command, cfg *config.Config, ticketKey string) error
 		Ticket:          ticketData,
 		PromptConfig:    promptConfig,
 		PromptContext:   promptContext,
+		DetectedStack:   detectedStack,
 		Model:           cfg.Model,
 		WorkDir:         workDir,
 		WorktreeBase:    filepath.Join(workDir, cfg.WorktreeDir),

--- a/cmd/soda/run_test.go
+++ b/cmd/soda/run_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/decko/soda/internal/claude"
+	"github.com/decko/soda/internal/config"
 	"github.com/decko/soda/internal/pipeline"
 	"github.com/decko/soda/internal/progress"
 )
@@ -779,6 +780,81 @@ func TestPrintSummaryGenericError(t *testing.T) {
 	if !strings.Contains(output, "cd /tmp/worktrees/PROJ-60") {
 		t.Error("expected cd to worktree path")
 	}
+}
+
+func TestBuildPromptConfigDetectDefaults(t *testing.T) {
+	t.Run("detected_values_fill_empty_fields", func(t *testing.T) {
+		cfg := &config.Config{
+			Repos: []config.RepoConfig{
+				{Name: "myrepo", Forge: "github"},
+				// Formatter and TestCommand are empty.
+			},
+		}
+		promptConfig := buildPromptConfig(cfg)
+
+		// Simulate what runPipeline does after detect.
+		if promptConfig.Formatter == "" {
+			promptConfig.Formatter = "gofmt -w ."
+		}
+		if promptConfig.TestCommand == "" {
+			promptConfig.TestCommand = "go test ./..."
+		}
+
+		if promptConfig.Formatter != "gofmt -w ." {
+			t.Errorf("Formatter = %q, want %q", promptConfig.Formatter, "gofmt -w .")
+		}
+		if promptConfig.TestCommand != "go test ./..." {
+			t.Errorf("TestCommand = %q, want %q", promptConfig.TestCommand, "go test ./...")
+		}
+	})
+
+	t.Run("explicit_config_takes_precedence", func(t *testing.T) {
+		cfg := &config.Config{
+			Repos: []config.RepoConfig{
+				{
+					Name:        "myrepo",
+					Forge:       "github",
+					Formatter:   "custom-fmt",
+					TestCommand: "custom-test",
+				},
+			},
+		}
+		promptConfig := buildPromptConfig(cfg)
+
+		// Simulate detection filling — should NOT overwrite.
+		if promptConfig.Formatter == "" {
+			promptConfig.Formatter = "gofmt -w ."
+		}
+		if promptConfig.TestCommand == "" {
+			promptConfig.TestCommand = "go test ./..."
+		}
+
+		if promptConfig.Formatter != "custom-fmt" {
+			t.Errorf("Formatter = %q, want %q (explicit config should take precedence)", promptConfig.Formatter, "custom-fmt")
+		}
+		if promptConfig.TestCommand != "custom-test" {
+			t.Errorf("TestCommand = %q, want %q (explicit config should take precedence)", promptConfig.TestCommand, "custom-test")
+		}
+	})
+
+	t.Run("no_repos_uses_detected_values", func(t *testing.T) {
+		cfg := &config.Config{}
+		promptConfig := buildPromptConfig(cfg)
+
+		if promptConfig.Formatter == "" {
+			promptConfig.Formatter = "cargo fmt"
+		}
+		if promptConfig.TestCommand == "" {
+			promptConfig.TestCommand = "cargo test"
+		}
+
+		if promptConfig.Formatter != "cargo fmt" {
+			t.Errorf("Formatter = %q, want %q", promptConfig.Formatter, "cargo fmt")
+		}
+		if promptConfig.TestCommand != "cargo test" {
+			t.Errorf("TestCommand = %q, want %q", promptConfig.TestCommand, "cargo test")
+		}
+	})
 }
 
 func TestHandleEventPatchExhaustedCycles(t *testing.T) {

--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -4,19 +4,14 @@
 // remote URL to identify the forge, owner, and repo name. It also
 // checks for well-known context files (AGENTS.md, CLAUDE.md).
 //
-// # Pipeline integration (TODO)
+// # Pipeline integration
 //
-// This package is currently standalone. The planned integration points are:
-//
-//  1. Call Detect(ctx, workDir) in runPipeline() (cmd/soda/run.go) after
-//     resolving the worktree via git.RepoRoot.
-//  2. Populate PromptConfigData.Formatter and PromptConfigData.TestCommand
-//     from ProjectInfo when they are not already set in the user's
-//     config.yaml (i.e. detected values act as defaults, explicit config
-//     takes precedence).
-//  3. Optionally add a DetectedStack field to pipeline.PromptData so that
-//     prompt templates can reference the detected language, forge, and
-//     context files directly.
+// Detect is called by runPipeline (cmd/soda/run.go) after resolving
+// the worktree via git.RepoRoot. Detected Formatter and TestCommand
+// values are used as defaults when the user's config.yaml does not
+// set them (explicit config takes precedence). The full detection
+// result is available in prompt templates via the DetectedStack field
+// on pipeline.PromptData (e.g. {{.DetectedStack.Language}}).
 package detect
 
 import (

--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -6,6 +6,7 @@
 package detect
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -53,8 +54,9 @@ var contextFileNames = []string{
 
 // Detect scans repoDir and returns a ProjectInfo describing the project.
 // It is safe to call on directories that are not git repositories; forge
-// information will simply be empty in that case.
-func Detect(repoDir string) (*ProjectInfo, error) {
+// information will simply be empty in that case. The context is used for
+// subprocess cancellation (e.g. git remote lookup).
+func Detect(ctx context.Context, repoDir string) (*ProjectInfo, error) {
 	if _, err := os.Stat(repoDir); err != nil {
 		return nil, fmt.Errorf("detect: stat %s: %w", repoDir, err)
 	}
@@ -64,7 +66,7 @@ func Detect(repoDir string) (*ProjectInfo, error) {
 	}
 
 	detectLanguage(repoDir, info)
-	detectForge(repoDir, info)
+	detectForge(ctx, repoDir, info)
 	detectContextFiles(repoDir, info)
 	inferTooling(info)
 
@@ -92,8 +94,11 @@ func detectLanguage(repoDir string, info *ProjectInfo) {
 }
 
 // detectForge runs "git remote get-url origin" and parses the result.
-func detectForge(repoDir string, info *ProjectInfo) {
-	cmd := exec.Command("git", "remote", "get-url", "origin")
+// Uses exec.CommandContext so the call respects pipeline-level timeouts
+// and cancellation, consistent with other subprocess invocations in the
+// codebase.
+func detectForge(ctx context.Context, repoDir string, info *ProjectInfo) {
+	cmd := exec.CommandContext(ctx, "git", "remote", "get-url", "origin")
 	cmd.Dir = repoDir
 	out, err := cmd.Output()
 	if err != nil {

--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -1,0 +1,253 @@
+// Package detect provides auto-detection of project stack information
+// from a repository directory. It inspects marker files (go.mod,
+// package.json, etc.) to determine the language, and parses the git
+// remote URL to identify the forge, owner, and repo name. It also
+// checks for well-known context files (AGENTS.md, CLAUDE.md).
+package detect
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// ProjectInfo holds detected information about a project repository.
+type ProjectInfo struct {
+	Language     string   // e.g. "go", "python", "typescript", "javascript", "rust", "java", "unknown"
+	Forge        string   // e.g. "github", "gitlab", or "" if unrecognised
+	Owner        string   // repository owner/org extracted from remote URL
+	Repo         string   // repository name extracted from remote URL
+	Formatter    string   // suggested formatter command, or "" if unknown
+	TestCommand  string   // suggested test command, or "" if unknown
+	ContextFiles []string // detected context files (e.g. "AGENTS.md", "CLAUDE.md")
+
+	// markerFile is the file that triggered language detection (internal use).
+	markerFile string
+}
+
+// languageMarker maps a filename to the language it indicates.
+type languageMarker struct {
+	file     string
+	language string
+}
+
+// languageMarkers is checked in priority order; the first match wins.
+var languageMarkers = []languageMarker{
+	{"go.mod", "go"},
+	{"Cargo.toml", "rust"},
+	{"pyproject.toml", "python"},
+	{"pom.xml", "java"},
+	{"build.gradle", "java"},
+	// package.json is checked last because it can indicate either
+	// JavaScript or TypeScript depending on the presence of tsconfig.json.
+	{"package.json", "javascript"},
+}
+
+// contextFileNames lists well-known context files to look for in the repo root.
+var contextFileNames = []string{
+	"AGENTS.md",
+	"CLAUDE.md",
+}
+
+// Detect scans repoDir and returns a ProjectInfo describing the project.
+// It is safe to call on directories that are not git repositories; forge
+// information will simply be empty in that case.
+func Detect(repoDir string) (*ProjectInfo, error) {
+	if _, err := os.Stat(repoDir); err != nil {
+		return nil, fmt.Errorf("detect: stat %s: %w", repoDir, err)
+	}
+
+	info := &ProjectInfo{
+		Language: "unknown",
+	}
+
+	detectLanguage(repoDir, info)
+	detectForge(repoDir, info)
+	detectContextFiles(repoDir, info)
+	inferTooling(info)
+
+	return info, nil
+}
+
+// detectLanguage checks for marker files and sets info.Language.
+func detectLanguage(repoDir string, info *ProjectInfo) {
+	for _, marker := range languageMarkers {
+		path := filepath.Join(repoDir, marker.file)
+		if _, err := os.Stat(path); err == nil {
+			lang := marker.language
+			// TypeScript is a JavaScript project with a tsconfig.json.
+			if lang == "javascript" {
+				tsconfig := filepath.Join(repoDir, "tsconfig.json")
+				if _, tsErr := os.Stat(tsconfig); tsErr == nil {
+					lang = "typescript"
+				}
+			}
+			info.Language = lang
+			info.markerFile = marker.file
+			return
+		}
+	}
+}
+
+// detectForge runs "git remote get-url origin" and parses the result.
+func detectForge(repoDir string, info *ProjectInfo) {
+	cmd := exec.Command("git", "remote", "get-url", "origin")
+	cmd.Dir = repoDir
+	out, err := cmd.Output()
+	if err != nil {
+		return // no remote or not a git repo — leave fields empty
+	}
+	url := strings.TrimSpace(string(out))
+	info.Forge, info.Owner, info.Repo = parseRemoteURL(url)
+}
+
+// detectContextFiles looks for well-known context files in the repo root.
+func detectContextFiles(repoDir string, info *ProjectInfo) {
+	for _, name := range contextFileNames {
+		path := filepath.Join(repoDir, name)
+		if _, err := os.Stat(path); err == nil {
+			info.ContextFiles = append(info.ContextFiles, name)
+		}
+	}
+}
+
+// inferTooling sets Formatter and TestCommand based on the detected language.
+func inferTooling(info *ProjectInfo) {
+	switch info.Language {
+	case "go":
+		info.Formatter = "gofmt -w ."
+		info.TestCommand = "go test ./..."
+	case "python":
+		info.Formatter = "black ."
+		info.TestCommand = "pytest"
+	case "typescript", "javascript":
+		info.Formatter = "npx prettier --write ."
+		info.TestCommand = "npm test"
+	case "rust":
+		info.Formatter = "cargo fmt"
+		info.TestCommand = "cargo test"
+	case "java":
+		info.Formatter = ""
+		switch info.markerFile {
+		case "build.gradle":
+			info.TestCommand = "gradle test"
+		default:
+			info.TestCommand = "mvn test"
+		}
+	}
+}
+
+// parseRemoteURL extracts forge, owner, and repo from a git remote URL.
+// Supports SSH (git@github.com:owner/repo.git), SSH URL
+// (ssh://git@github.com/owner/repo.git), and HTTPS
+// (https://github.com/owner/repo.git) formats for GitHub and GitLab.
+// Returns empty strings for unrecognised URLs.
+func parseRemoteURL(url string) (forge, owner, repo string) {
+	if url == "" {
+		return "", "", ""
+	}
+
+	// SSH URL format: ssh://git@github.com/owner/repo.git
+	// Git may rewrite HTTPS URLs to this format via url.<base>.insteadOf.
+	if strings.HasPrefix(url, "ssh://") {
+		return parseSSHURLRemote(url)
+	}
+
+	// SCP-style SSH format: git@github.com:owner/repo.git
+	if strings.HasPrefix(url, "git@") {
+		return parseSSHRemote(url)
+	}
+
+	// HTTPS format: https://github.com/owner/repo.git
+	if strings.HasPrefix(url, "https://") || strings.HasPrefix(url, "http://") {
+		return parseHTTPSRemote(url)
+	}
+
+	return "", "", ""
+}
+
+// parseSSHURLRemote handles ssh://git@<host>/<owner>/<repo>.git URLs.
+// Git may produce these when url.<base>.insteadOf rewrites are active.
+func parseSSHURLRemote(url string) (forge, owner, repo string) {
+	// Strip "ssh://git@" prefix
+	stripped := strings.TrimPrefix(url, "ssh://git@")
+
+	// Split: host / owner / repo
+	parts := strings.SplitN(stripped, "/", 3)
+	if len(parts) < 3 {
+		return "", "", ""
+	}
+
+	forge = forgeFromHost(parts[0])
+	if forge == "" {
+		return "", "", ""
+	}
+
+	owner = parts[1]
+	repo = strings.TrimSuffix(parts[2], ".git")
+	repo = strings.TrimRight(repo, "/")
+	return forge, owner, repo
+}
+
+// parseSSHRemote handles git@<host>:<owner>/<repo>.git URLs.
+func parseSSHRemote(url string) (forge, owner, repo string) {
+	// Split on ":"  →  "git@github.com" and "owner/repo.git"
+	parts := strings.SplitN(url, ":", 2)
+	if len(parts) != 2 {
+		return "", "", ""
+	}
+
+	host := strings.TrimPrefix(parts[0], "git@")
+	forge = forgeFromHost(host)
+	if forge == "" {
+		return "", "", ""
+	}
+
+	pathParts := strings.SplitN(parts[1], "/", 2)
+	if len(pathParts) != 2 {
+		return "", "", ""
+	}
+
+	owner = pathParts[0]
+	repo = strings.TrimSuffix(pathParts[1], ".git")
+	return forge, owner, repo
+}
+
+// parseHTTPSRemote handles https://<host>/<owner>/<repo>.git URLs.
+func parseHTTPSRemote(url string) (forge, owner, repo string) {
+	// Strip scheme
+	stripped := url
+	stripped = strings.TrimPrefix(stripped, "https://")
+	stripped = strings.TrimPrefix(stripped, "http://")
+
+	// Split: host / owner / repo
+	parts := strings.SplitN(stripped, "/", 3)
+	if len(parts) < 3 {
+		return "", "", ""
+	}
+
+	forge = forgeFromHost(parts[0])
+	if forge == "" {
+		return "", "", ""
+	}
+
+	owner = parts[1]
+	repo = strings.TrimSuffix(parts[2], ".git")
+	// Remove trailing slashes if any.
+	repo = strings.TrimRight(repo, "/")
+	return forge, owner, repo
+}
+
+// forgeFromHost maps a hostname to a forge name.
+func forgeFromHost(host string) string {
+	switch host {
+	case "github.com":
+		return "github"
+	case "gitlab.com":
+		return "gitlab"
+	default:
+		return ""
+	}
+}

--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -3,6 +3,20 @@
 // package.json, etc.) to determine the language, and parses the git
 // remote URL to identify the forge, owner, and repo name. It also
 // checks for well-known context files (AGENTS.md, CLAUDE.md).
+//
+// # Pipeline integration (TODO)
+//
+// This package is currently standalone. The planned integration points are:
+//
+//  1. Call Detect(ctx, workDir) in runPipeline() (cmd/soda/run.go) after
+//     resolving the worktree via git.RepoRoot.
+//  2. Populate PromptConfigData.Formatter and PromptConfigData.TestCommand
+//     from ProjectInfo when they are not already set in the user's
+//     config.yaml (i.e. detected values act as defaults, explicit config
+//     takes precedence).
+//  3. Optionally add a DetectedStack field to pipeline.PromptData so that
+//     prompt templates can reference the detected language, forge, and
+//     context files directly.
 package detect
 
 import (

--- a/internal/detect/detect_test.go
+++ b/internal/detect/detect_test.go
@@ -12,6 +12,10 @@ import (
 // pointing at the given URL. If url is empty the remote is skipped.
 func initGitRepo(t *testing.T, dir, url string) {
 	t.Helper()
+	// Isolate from host git config to prevent url.*.insteadOf rewrites
+	// on CI runners. t.Setenv restores on cleanup.
+	t.Setenv("GIT_CONFIG_GLOBAL", "/dev/null")
+	t.Setenv("GIT_CONFIG_SYSTEM", "/dev/null")
 	run(t, dir, "git", "init")
 	run(t, dir, "git", "config", "user.email", "test@test.com")
 	run(t, dir, "git", "config", "user.name", "Test")

--- a/internal/detect/detect_test.go
+++ b/internal/detect/detect_test.go
@@ -25,6 +25,9 @@ func run(t *testing.T, dir string, name string, args ...string) {
 	t.Helper()
 	cmd := exec.Command(name, args...)
 	cmd.Dir = dir
+	// Isolate from host git config to prevent url.*.insteadOf rewrites
+	// that can change HTTPS remotes to SSH on CI.
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("%s %v failed: %s: %v", name, args, out, err)

--- a/internal/detect/detect_test.go
+++ b/internal/detect/detect_test.go
@@ -13,6 +13,8 @@ import (
 func initGitRepo(t *testing.T, dir, url string) {
 	t.Helper()
 	run(t, dir, "git", "init")
+	run(t, dir, "git", "config", "user.email", "test@test.com")
+	run(t, dir, "git", "config", "user.name", "Test")
 	run(t, dir, "git", "commit", "--allow-empty", "-m", "init")
 	if url != "" {
 		run(t, dir, "git", "remote", "add", "origin", url)

--- a/internal/detect/detect_test.go
+++ b/internal/detect/detect_test.go
@@ -1,0 +1,398 @@
+package detect
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// initGitRepo initialises a bare git repo in dir with an "origin" remote
+// pointing at the given URL. If url is empty the remote is skipped.
+func initGitRepo(t *testing.T, dir, url string) {
+	t.Helper()
+	run(t, dir, "git", "init")
+	run(t, dir, "git", "commit", "--allow-empty", "-m", "init")
+	if url != "" {
+		run(t, dir, "git", "remote", "add", "origin", url)
+	}
+}
+
+func run(t *testing.T, dir string, name string, args ...string) {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %v failed: %s: %v", name, args, out, err)
+	}
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func TestDetect(t *testing.T) {
+	tests := []struct {
+		name            string
+		remoteURL       string
+		files           map[string]string // relative path -> content
+		wantLanguage    string
+		wantForge       string
+		wantOwner       string
+		wantRepo        string
+		wantFormatter   string
+		wantTestCommand string
+		wantContext     []string
+	}{
+		{
+			name:            "Go project with GitHub SSH remote",
+			remoteURL:       "git@github.com:decko/soda.git",
+			files:           map[string]string{"go.mod": "module github.com/decko/soda\n\ngo 1.25.0\n"},
+			wantLanguage:    "go",
+			wantForge:       "github",
+			wantOwner:       "decko",
+			wantRepo:        "soda",
+			wantFormatter:   "gofmt -w .",
+			wantTestCommand: "go test ./...",
+		},
+		{
+			name:            "Go project with HTTPS remote",
+			remoteURL:       "https://github.com/decko/soda.git",
+			files:           map[string]string{"go.mod": "module github.com/decko/soda\n\ngo 1.25.0\n"},
+			wantLanguage:    "go",
+			wantForge:       "github",
+			wantOwner:       "decko",
+			wantRepo:        "soda",
+			wantFormatter:   "gofmt -w .",
+			wantTestCommand: "go test ./...",
+		},
+		{
+			name:            "Python project with pyproject.toml",
+			remoteURL:       "git@github.com:acme/myapp.git",
+			files:           map[string]string{"pyproject.toml": "[project]\nname = \"myapp\"\n"},
+			wantLanguage:    "python",
+			wantForge:       "github",
+			wantOwner:       "acme",
+			wantRepo:        "myapp",
+			wantFormatter:   "black .",
+			wantTestCommand: "pytest",
+		},
+		{
+			name:            "TypeScript project",
+			remoteURL:       "git@github.com:acme/frontend.git",
+			files:           map[string]string{"package.json": `{"name":"frontend"}`, "tsconfig.json": "{}"},
+			wantLanguage:    "typescript",
+			wantForge:       "github",
+			wantOwner:       "acme",
+			wantRepo:        "frontend",
+			wantFormatter:   "npx prettier --write .",
+			wantTestCommand: "npm test",
+		},
+		{
+			name:            "JavaScript project without tsconfig",
+			remoteURL:       "git@github.com:acme/scripts.git",
+			files:           map[string]string{"package.json": `{"name":"scripts"}`},
+			wantLanguage:    "javascript",
+			wantForge:       "github",
+			wantOwner:       "acme",
+			wantRepo:        "scripts",
+			wantFormatter:   "npx prettier --write .",
+			wantTestCommand: "npm test",
+		},
+		{
+			name:            "Rust project",
+			remoteURL:       "git@github.com:acme/oxide.git",
+			files:           map[string]string{"Cargo.toml": "[package]\nname = \"oxide\"\n"},
+			wantLanguage:    "rust",
+			wantForge:       "github",
+			wantOwner:       "acme",
+			wantRepo:        "oxide",
+			wantFormatter:   "cargo fmt",
+			wantTestCommand: "cargo test",
+		},
+		{
+			name:            "Java project with Maven",
+			remoteURL:       "git@github.com:acme/service.git",
+			files:           map[string]string{"pom.xml": "<project></project>"},
+			wantLanguage:    "java",
+			wantForge:       "github",
+			wantOwner:       "acme",
+			wantRepo:        "service",
+			wantFormatter:   "",
+			wantTestCommand: "mvn test",
+		},
+		{
+			name:            "Java project with Gradle",
+			remoteURL:       "git@github.com:acme/service.git",
+			files:           map[string]string{"build.gradle": "plugins { id 'java' }"},
+			wantLanguage:    "java",
+			wantForge:       "github",
+			wantOwner:       "acme",
+			wantRepo:        "service",
+			wantFormatter:   "",
+			wantTestCommand: "gradle test",
+		},
+		{
+			name:            "GitLab SSH remote",
+			remoteURL:       "git@gitlab.com:team/backend.git",
+			files:           map[string]string{"go.mod": "module gitlab.com/team/backend\n\ngo 1.22\n"},
+			wantLanguage:    "go",
+			wantForge:       "gitlab",
+			wantOwner:       "team",
+			wantRepo:        "backend",
+			wantFormatter:   "gofmt -w .",
+			wantTestCommand: "go test ./...",
+		},
+		{
+			name:            "GitLab HTTPS remote",
+			remoteURL:       "https://gitlab.com/team/backend.git",
+			files:           map[string]string{"go.mod": "module gitlab.com/team/backend\n\ngo 1.22\n"},
+			wantLanguage:    "go",
+			wantForge:       "gitlab",
+			wantOwner:       "team",
+			wantRepo:        "backend",
+			wantFormatter:   "gofmt -w .",
+			wantTestCommand: "go test ./...",
+		},
+		{
+			name:            "unknown language",
+			remoteURL:       "git@github.com:acme/docs.git",
+			files:           map[string]string{"README.md": "# Docs"},
+			wantLanguage:    "unknown",
+			wantForge:       "github",
+			wantOwner:       "acme",
+			wantRepo:        "docs",
+			wantFormatter:   "",
+			wantTestCommand: "",
+		},
+		{
+			name:            "no remote",
+			remoteURL:       "",
+			files:           map[string]string{"go.mod": "module local\n\ngo 1.22\n"},
+			wantLanguage:    "go",
+			wantForge:       "",
+			wantOwner:       "",
+			wantRepo:        "",
+			wantFormatter:   "gofmt -w .",
+			wantTestCommand: "go test ./...",
+		},
+		{
+			name:         "AGENTS.md detected",
+			remoteURL:    "git@github.com:acme/proj.git",
+			files:        map[string]string{"go.mod": "module m\n\ngo 1.22\n", "AGENTS.md": "# Agents"},
+			wantLanguage: "go",
+			wantForge:    "github",
+			wantOwner:    "acme",
+			wantRepo:     "proj",
+			wantContext:  []string{"AGENTS.md"},
+		},
+		{
+			name:         "CLAUDE.md detected",
+			remoteURL:    "git@github.com:acme/proj.git",
+			files:        map[string]string{"go.mod": "module m\n\ngo 1.22\n", "CLAUDE.md": "# Claude"},
+			wantLanguage: "go",
+			wantForge:    "github",
+			wantOwner:    "acme",
+			wantRepo:     "proj",
+			wantContext:  []string{"CLAUDE.md"},
+		},
+		{
+			name:         "both AGENTS.md and CLAUDE.md detected",
+			remoteURL:    "git@github.com:acme/proj.git",
+			files:        map[string]string{"go.mod": "module m\n\ngo 1.22\n", "AGENTS.md": "# Agents", "CLAUDE.md": "# Claude"},
+			wantLanguage: "go",
+			wantForge:    "github",
+			wantOwner:    "acme",
+			wantRepo:     "proj",
+			wantContext:  []string{"AGENTS.md", "CLAUDE.md"},
+		},
+		{
+			name:            "GitHub HTTPS remote without .git suffix",
+			remoteURL:       "https://github.com/acme/myrepo",
+			files:           map[string]string{"go.mod": "module m\n\ngo 1.22\n"},
+			wantLanguage:    "go",
+			wantForge:       "github",
+			wantOwner:       "acme",
+			wantRepo:        "myrepo",
+			wantFormatter:   "gofmt -w .",
+			wantTestCommand: "go test ./...",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			initGitRepo(t, dir, tt.remoteURL)
+
+			for path, content := range tt.files {
+				writeFile(t, filepath.Join(dir, path), content)
+			}
+
+			info, err := Detect(dir)
+			if err != nil {
+				t.Fatalf("Detect() error: %v", err)
+			}
+
+			if info.Language != tt.wantLanguage {
+				t.Errorf("Language = %q, want %q", info.Language, tt.wantLanguage)
+			}
+			if info.Forge != tt.wantForge {
+				t.Errorf("Forge = %q, want %q", info.Forge, tt.wantForge)
+			}
+			if info.Owner != tt.wantOwner {
+				t.Errorf("Owner = %q, want %q", info.Owner, tt.wantOwner)
+			}
+			if info.Repo != tt.wantRepo {
+				t.Errorf("Repo = %q, want %q", info.Repo, tt.wantRepo)
+			}
+			if tt.wantFormatter != "" && info.Formatter != tt.wantFormatter {
+				t.Errorf("Formatter = %q, want %q", info.Formatter, tt.wantFormatter)
+			}
+			if tt.wantTestCommand != "" && info.TestCommand != tt.wantTestCommand {
+				t.Errorf("TestCommand = %q, want %q", info.TestCommand, tt.wantTestCommand)
+			}
+			if tt.wantContext != nil {
+				if len(info.ContextFiles) != len(tt.wantContext) {
+					t.Errorf("ContextFiles = %v, want %v", info.ContextFiles, tt.wantContext)
+				} else {
+					for idx, want := range tt.wantContext {
+						if info.ContextFiles[idx] != want {
+							t.Errorf("ContextFiles[%d] = %q, want %q", idx, info.ContextFiles[idx], want)
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestDetect_InvalidDir(t *testing.T) {
+	_, err := Detect("/nonexistent/path/that/does/not/exist")
+	if err == nil {
+		t.Fatal("expected error for nonexistent directory, got nil")
+	}
+}
+
+func TestDetect_NotAGitRepo(t *testing.T) {
+	dir := t.TempDir()
+	// No git init -- just a plain directory with a go.mod.
+	writeFile(t, filepath.Join(dir, "go.mod"), "module m\n\ngo 1.22\n")
+
+	info, err := Detect(dir)
+	if err != nil {
+		t.Fatalf("Detect() error: %v", err)
+	}
+
+	// Language detection should still work even without a git repo.
+	if info.Language != "go" {
+		t.Errorf("Language = %q, want %q", info.Language, "go")
+	}
+	// Forge info should be empty since there is no git remote.
+	if info.Forge != "" {
+		t.Errorf("Forge = %q, want empty", info.Forge)
+	}
+}
+
+func TestParseRemoteURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		url       string
+		wantForge string
+		wantOwner string
+		wantRepo  string
+	}{
+		{
+			name:      "GitHub SSH",
+			url:       "git@github.com:decko/soda.git",
+			wantForge: "github",
+			wantOwner: "decko",
+			wantRepo:  "soda",
+		},
+		{
+			name:      "GitHub HTTPS",
+			url:       "https://github.com/decko/soda.git",
+			wantForge: "github",
+			wantOwner: "decko",
+			wantRepo:  "soda",
+		},
+		{
+			name:      "GitHub HTTPS no .git",
+			url:       "https://github.com/decko/soda",
+			wantForge: "github",
+			wantOwner: "decko",
+			wantRepo:  "soda",
+		},
+		{
+			name:      "GitLab SSH",
+			url:       "git@gitlab.com:team/project.git",
+			wantForge: "gitlab",
+			wantOwner: "team",
+			wantRepo:  "project",
+		},
+		{
+			name:      "GitLab HTTPS",
+			url:       "https://gitlab.com/team/project.git",
+			wantForge: "gitlab",
+			wantOwner: "team",
+			wantRepo:  "project",
+		},
+		{
+			name:      "GitHub SSH URL",
+			url:       "ssh://git@github.com/decko/soda.git",
+			wantForge: "github",
+			wantOwner: "decko",
+			wantRepo:  "soda",
+		},
+		{
+			name:      "GitLab SSH URL",
+			url:       "ssh://git@gitlab.com/team/project.git",
+			wantForge: "gitlab",
+			wantOwner: "team",
+			wantRepo:  "project",
+		},
+		{
+			name:      "unknown forge",
+			url:       "git@bitbucket.org:team/project.git",
+			wantForge: "",
+			wantOwner: "",
+			wantRepo:  "",
+		},
+		{
+			name:      "empty URL",
+			url:       "",
+			wantForge: "",
+			wantOwner: "",
+			wantRepo:  "",
+		},
+		{
+			name:      "malformed URL",
+			url:       "not-a-url",
+			wantForge: "",
+			wantOwner: "",
+			wantRepo:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			forge, owner, repo := parseRemoteURL(tt.url)
+			if forge != tt.wantForge {
+				t.Errorf("forge = %q, want %q", forge, tt.wantForge)
+			}
+			if owner != tt.wantOwner {
+				t.Errorf("owner = %q, want %q", owner, tt.wantOwner)
+			}
+			if repo != tt.wantRepo {
+				t.Errorf("repo = %q, want %q", repo, tt.wantRepo)
+			}
+		})
+	}
+}

--- a/internal/detect/detect_test.go
+++ b/internal/detect/detect_test.go
@@ -1,6 +1,7 @@
 package detect
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -242,7 +243,7 @@ func TestDetect(t *testing.T) {
 				writeFile(t, filepath.Join(dir, path), content)
 			}
 
-			info, err := Detect(dir)
+			info, err := Detect(context.Background(), dir)
 			if err != nil {
 				t.Fatalf("Detect() error: %v", err)
 			}
@@ -281,7 +282,7 @@ func TestDetect(t *testing.T) {
 }
 
 func TestDetect_InvalidDir(t *testing.T) {
-	_, err := Detect("/nonexistent/path/that/does/not/exist")
+	_, err := Detect(context.Background(), "/nonexistent/path/that/does/not/exist")
 	if err == nil {
 		t.Fatal("expected error for nonexistent directory, got nil")
 	}
@@ -292,7 +293,7 @@ func TestDetect_NotAGitRepo(t *testing.T) {
 	// No git init -- just a plain directory with a go.mod.
 	writeFile(t, filepath.Join(dir, "go.mod"), "module m\n\ngo 1.22\n")
 
-	info, err := Detect(dir)
+	info, err := Detect(context.Background(), dir)
 	if err != nil {
 		t.Fatalf("Detect() error: %v", err)
 	}

--- a/internal/detect/detect_test.go
+++ b/internal/detect/detect_test.go
@@ -185,34 +185,40 @@ func TestDetect(t *testing.T) {
 			wantTestCommand: "go test ./...",
 		},
 		{
-			name:         "AGENTS.md detected",
-			remoteURL:    "git@github.com:acme/proj.git",
-			files:        map[string]string{"go.mod": "module m\n\ngo 1.22\n", "AGENTS.md": "# Agents"},
-			wantLanguage: "go",
-			wantForge:    "github",
-			wantOwner:    "acme",
-			wantRepo:     "proj",
-			wantContext:  []string{"AGENTS.md"},
+			name:            "AGENTS.md detected",
+			remoteURL:       "git@github.com:acme/proj.git",
+			files:           map[string]string{"go.mod": "module m\n\ngo 1.22\n", "AGENTS.md": "# Agents"},
+			wantLanguage:    "go",
+			wantForge:       "github",
+			wantOwner:       "acme",
+			wantRepo:        "proj",
+			wantFormatter:   "gofmt -w .",
+			wantTestCommand: "go test ./...",
+			wantContext:     []string{"AGENTS.md"},
 		},
 		{
-			name:         "CLAUDE.md detected",
-			remoteURL:    "git@github.com:acme/proj.git",
-			files:        map[string]string{"go.mod": "module m\n\ngo 1.22\n", "CLAUDE.md": "# Claude"},
-			wantLanguage: "go",
-			wantForge:    "github",
-			wantOwner:    "acme",
-			wantRepo:     "proj",
-			wantContext:  []string{"CLAUDE.md"},
+			name:            "CLAUDE.md detected",
+			remoteURL:       "git@github.com:acme/proj.git",
+			files:           map[string]string{"go.mod": "module m\n\ngo 1.22\n", "CLAUDE.md": "# Claude"},
+			wantLanguage:    "go",
+			wantForge:       "github",
+			wantOwner:       "acme",
+			wantRepo:        "proj",
+			wantFormatter:   "gofmt -w .",
+			wantTestCommand: "go test ./...",
+			wantContext:     []string{"CLAUDE.md"},
 		},
 		{
-			name:         "both AGENTS.md and CLAUDE.md detected",
-			remoteURL:    "git@github.com:acme/proj.git",
-			files:        map[string]string{"go.mod": "module m\n\ngo 1.22\n", "AGENTS.md": "# Agents", "CLAUDE.md": "# Claude"},
-			wantLanguage: "go",
-			wantForge:    "github",
-			wantOwner:    "acme",
-			wantRepo:     "proj",
-			wantContext:  []string{"AGENTS.md", "CLAUDE.md"},
+			name:            "both AGENTS.md and CLAUDE.md detected",
+			remoteURL:       "git@github.com:acme/proj.git",
+			files:           map[string]string{"go.mod": "module m\n\ngo 1.22\n", "AGENTS.md": "# Agents", "CLAUDE.md": "# Claude"},
+			wantLanguage:    "go",
+			wantForge:       "github",
+			wantOwner:       "acme",
+			wantRepo:        "proj",
+			wantFormatter:   "gofmt -w .",
+			wantTestCommand: "go test ./...",
+			wantContext:     []string{"AGENTS.md", "CLAUDE.md"},
 		},
 		{
 			name:            "GitHub HTTPS remote without .git suffix",
@@ -253,10 +259,10 @@ func TestDetect(t *testing.T) {
 			if info.Repo != tt.wantRepo {
 				t.Errorf("Repo = %q, want %q", info.Repo, tt.wantRepo)
 			}
-			if tt.wantFormatter != "" && info.Formatter != tt.wantFormatter {
+			if info.Formatter != tt.wantFormatter {
 				t.Errorf("Formatter = %q, want %q", info.Formatter, tt.wantFormatter)
 			}
-			if tt.wantTestCommand != "" && info.TestCommand != tt.wantTestCommand {
+			if info.TestCommand != tt.wantTestCommand {
 				t.Errorf("TestCommand = %q, want %q", info.TestCommand, tt.wantTestCommand)
 			}
 			if tt.wantContext != nil {

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -37,6 +37,7 @@ type EngineConfig struct {
 	Ticket            TicketData
 	PromptConfig      PromptConfigData
 	PromptContext     ContextData
+	DetectedStack     DetectedStackData // auto-detected project stack info; zero value if detection was skipped
 	Model             string
 	WorkDir           string
 	WorktreeBase      string
@@ -934,12 +935,13 @@ func (e *Engine) checkPhaseBudget(phase PhaseConfig) error {
 // buildPromptData constructs the PromptData for a phase from its dependencies.
 func (e *Engine) buildPromptData(phase PhaseConfig) (PromptData, error) {
 	data := PromptData{
-		Ticket:       e.config.Ticket,
-		Config:       e.config.PromptConfig,
-		Context:      e.config.PromptContext,
-		WorktreePath: e.state.Meta().Worktree,
-		Branch:       e.state.Meta().Branch,
-		BaseBranch:   e.config.BaseBranch,
+		Ticket:        e.config.Ticket,
+		Config:        e.config.PromptConfig,
+		Context:       e.config.PromptContext,
+		DetectedStack: e.config.DetectedStack,
+		WorktreePath:  e.state.Meta().Worktree,
+		Branch:        e.state.Meta().Branch,
+		BaseBranch:    e.config.BaseBranch,
 	}
 
 	for _, dep := range phase.DependsOn {

--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -2298,6 +2298,154 @@ RepoConventions: {{.Context.RepoConventions}}
 	}
 }
 
+func TestEngine_BuildPromptDataIncludesDetectedStack(t *testing.T) {
+	phases := []PhaseConfig{
+		{
+			Name:   "triage",
+			Prompt: "triage.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"triage": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"automatable":true}`),
+					RawText: "Triage done",
+					CostUSD: 0.05,
+				},
+			}},
+		},
+	}
+
+	// Write a prompt template that renders DetectedStack fields.
+	stateDir := t.TempDir()
+	promptDir := t.TempDir()
+	workDir := t.TempDir()
+
+	tmpl := `Language: {{.DetectedStack.Language}}
+Forge: {{.DetectedStack.Forge}}
+Owner: {{.DetectedStack.Owner}}
+Repo: {{.DetectedStack.Repo}}
+{{range .DetectedStack.ContextFiles}}Context: {{.}}
+{{end}}`
+	if err := os.WriteFile(filepath.Join(promptDir, "triage.md"), []byte(tmpl), 0644); err != nil {
+		t.Fatalf("write prompt: %v", err)
+	}
+
+	state, err := LoadOrCreate(stateDir, "DETECT-1")
+	if err != nil {
+		t.Fatalf("LoadOrCreate: %v", err)
+	}
+
+	cfg := EngineConfig{
+		Pipeline: &PhasePipeline{Phases: phases},
+		Loader:   NewPromptLoader(promptDir),
+		Ticket:   TicketData{Key: "DETECT-1", Summary: "Detect stack test"},
+		DetectedStack: DetectedStackData{
+			Language:     "go",
+			Forge:        "github",
+			Owner:        "decko",
+			Repo:         "soda",
+			ContextFiles: []string{"AGENTS.md"},
+		},
+		Model:      "test-model",
+		WorkDir:    workDir,
+		MaxCostUSD: 0,
+		Mode:       Autonomous,
+		SleepFunc:  func(time.Duration) {},
+		JitterFunc: func(time.Duration) time.Duration { return 0 },
+	}
+
+	engine := NewEngine(mock, state, cfg)
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if len(mock.calls) != 1 {
+		t.Fatalf("runner called %d times, want 1", len(mock.calls))
+	}
+
+	rendered := mock.calls[0].SystemPrompt
+
+	for _, want := range []string{
+		"Language: go",
+		"Forge: github",
+		"Owner: decko",
+		"Repo: soda",
+		"Context: AGENTS.md",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("rendered prompt missing %q;\ngot: %s", want, rendered)
+		}
+	}
+}
+
+func TestEngine_BuildPromptDataOmitsDetectedStackWhenEmpty(t *testing.T) {
+	phases := []PhaseConfig{
+		{
+			Name:   "triage",
+			Prompt: "triage.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"triage": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"automatable":true}`),
+					RawText: "Triage done",
+					CostUSD: 0.05,
+				},
+			}},
+		},
+	}
+
+	stateDir := t.TempDir()
+	promptDir := t.TempDir()
+	workDir := t.TempDir()
+
+	tmpl := `{{- if .DetectedStack.Language}}HAS_LANG{{- end}}REST`
+	if err := os.WriteFile(filepath.Join(promptDir, "triage.md"), []byte(tmpl), 0644); err != nil {
+		t.Fatalf("write prompt: %v", err)
+	}
+
+	state, err := LoadOrCreate(stateDir, "DETECT-2")
+	if err != nil {
+		t.Fatalf("LoadOrCreate: %v", err)
+	}
+
+	cfg := EngineConfig{
+		Pipeline: &PhasePipeline{Phases: phases},
+		Loader:   NewPromptLoader(promptDir),
+		Ticket:   TicketData{Key: "DETECT-2", Summary: "No detect test"},
+		// DetectedStack intentionally left as zero value
+		Model:      "test-model",
+		WorkDir:    workDir,
+		MaxCostUSD: 0,
+		Mode:       Autonomous,
+		SleepFunc:  func(time.Duration) {},
+		JitterFunc: func(time.Duration) time.Duration { return 0 },
+	}
+
+	engine := NewEngine(mock, state, cfg)
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	rendered := mock.calls[0].SystemPrompt
+	if strings.Contains(rendered, "HAS_LANG") {
+		t.Errorf("rendered prompt should not contain HAS_LANG when DetectedStack is empty;\ngot: %s", rendered)
+	}
+	if !strings.Contains(rendered, "REST") {
+		t.Errorf("rendered prompt should contain REST;\ngot: %s", rendered)
+	}
+}
+
 func TestEngine_ResumeInvalidatesDownstreamPhases(t *testing.T) {
 	// Pipeline: implement -> verify -> submit (linear dependency chain).
 	// Bug: --from implement re-runs implement but skips verify/submit

--- a/internal/pipeline/prompt.go
+++ b/internal/pipeline/prompt.go
@@ -20,12 +20,25 @@ type PromptData struct {
 	Config         PromptConfigData
 	Artifacts      ArtifactData
 	Context        ContextData
+	DetectedStack  DetectedStackData
 	WorktreePath   string
 	Branch         string
 	BaseBranch     string
 	ReviewComments string
 	ReworkFeedback *ReworkFeedback
 	DiffContext    string // git diff of current branch vs base, injected for monitor and corrective phases
+}
+
+// DetectedStackData holds auto-detected project stack information from the
+// repository. Populated by detect.Detect and injected into prompts so
+// templates can adapt behaviour based on the detected language, forge, and
+// context files. Use {{if .DetectedStack.Language}} guards in templates.
+type DetectedStackData struct {
+	Language     string   // e.g. "go", "python", "typescript", "unknown"
+	Forge        string   // e.g. "github", "gitlab", or ""
+	Owner        string   // repository owner/org
+	Repo         string   // repository name
+	ContextFiles []string // well-known files found (e.g. "AGENTS.md", "CLAUDE.md")
 }
 
 // ReworkFeedback holds selective feedback from a failed verify phase

--- a/internal/pipeline/prompt_test.go
+++ b/internal/pipeline/prompt_test.go
@@ -319,6 +319,13 @@ func TestValidateTemplate(t *testing.T) {
 		}
 	})
 
+	t.Run("valid_template_with_detected_stack", func(t *testing.T) {
+		tmpl := `{{- if .DetectedStack.Language}}Language: {{.DetectedStack.Language}}{{- end}}`
+		if err := ValidateTemplate(tmpl); err != nil {
+			t.Fatalf("ValidateTemplate: %v", err)
+		}
+	})
+
 	t.Run("errors_on_syntax_error", func(t *testing.T) {
 		err := ValidateTemplate("{{.Invalid}")
 		if err == nil {
@@ -710,6 +717,60 @@ Verdict: {{.ReworkFeedback.Verdict}}
 		// Core triage content should still be present.
 		if !strings.Contains(result, "TEST-134") {
 			t.Errorf("triage prompt should still contain ticket key;\ngot: %s", result)
+		}
+	})
+
+	t.Run("renders_detected_stack_when_present", func(t *testing.T) {
+		tmpl := `{{- if .DetectedStack.Language}}Language: {{.DetectedStack.Language}}
+Forge: {{.DetectedStack.Forge}}
+Owner: {{.DetectedStack.Owner}}
+Repo: {{.DetectedStack.Repo}}
+{{- range .DetectedStack.ContextFiles}}
+Context: {{.}}
+{{- end}}
+{{- end}}`
+		data := PromptData{
+			DetectedStack: DetectedStackData{
+				Language:     "go",
+				Forge:        "github",
+				Owner:        "decko",
+				Repo:         "soda",
+				ContextFiles: []string{"AGENTS.md", "CLAUDE.md"},
+			},
+		}
+		result, err := RenderPrompt(tmpl, data)
+		if err != nil {
+			t.Fatalf("RenderPrompt: %v", err)
+		}
+		if !strings.Contains(result, "Language: go") {
+			t.Errorf("result should contain language, got: %s", result)
+		}
+		if !strings.Contains(result, "Forge: github") {
+			t.Errorf("result should contain forge, got: %s", result)
+		}
+		if !strings.Contains(result, "Owner: decko") {
+			t.Errorf("result should contain owner, got: %s", result)
+		}
+		if !strings.Contains(result, "Repo: soda") {
+			t.Errorf("result should contain repo, got: %s", result)
+		}
+		if !strings.Contains(result, "Context: AGENTS.md") {
+			t.Errorf("result should contain AGENTS.md, got: %s", result)
+		}
+		if !strings.Contains(result, "Context: CLAUDE.md") {
+			t.Errorf("result should contain CLAUDE.md, got: %s", result)
+		}
+	})
+
+	t.Run("omits_detected_stack_when_empty", func(t *testing.T) {
+		tmpl := `{{- if .DetectedStack.Language}}Language: {{.DetectedStack.Language}}{{- end}}`
+		data := PromptData{} // zero-value DetectedStack
+		result, err := RenderPrompt(tmpl, data)
+		if err != nil {
+			t.Fatalf("RenderPrompt: %v", err)
+		}
+		if strings.Contains(result, "Language") {
+			t.Errorf("result should not contain Language when DetectedStack is zero-value, got: %s", result)
 		}
 	})
 


### PR DESCRIPTION
## Summary
- New `internal/detect` package with `Detect(ctx, repoDir)` returning `ProjectInfo`
- Detects language (Go/Python/TS/JS/Rust/Java), forge (GitHub/GitLab), formatter, test command
- Detects context files (AGENTS.md, CLAUDE.md)
- Wired into pipeline engine via `DetectedStack` in `PromptData`
- Table-driven tests covering all languages and edge cases

## Test plan
- [x] Verify PASSED
- [x] Review completed
- [x] Tests for all detection rules

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)