### PR TITLE
feat(cli): soda init command — config generation and file writing (#211)

### DIFF
--- a/cmd/soda/init.go
+++ b/cmd/soda/init.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/decko/soda/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func newInitCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "init",
+		Short: "Generate a starter config file",
+		Long: `Generate a starter soda config file with sensible defaults.
+
+By default the config is written to the standard location
+(~/.config/soda/config.yaml). Use --output to choose a
+different path. The command refuses to overwrite an existing
+file unless --force is given.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			output, _ := cmd.Flags().GetString("output")
+			force, _ := cmd.Flags().GetBool("force")
+			return runInit(output, force)
+		},
+	}
+
+	cmd.Flags().StringP("output", "o", "", "output path (default: ~/.config/soda/config.yaml)")
+	cmd.Flags().Bool("force", false, "overwrite existing config file")
+
+	return cmd
+}
+
+// runInit generates a default config and writes it to disk.
+// Extracted for testability.
+func runInit(output string, force bool) error {
+	// Resolve output path.
+	destPath, err := resolveInitPath(output)
+	if err != nil {
+		return err
+	}
+
+	// Check for existing file unless --force.
+	if !force {
+		if _, err := os.Stat(destPath); err == nil {
+			return fmt.Errorf("config file already exists: %s (use --force to overwrite)", destPath)
+		}
+	}
+
+	// Generate default config.
+	cfg := config.DefaultConfig()
+	data, err := config.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("init: %w", err)
+	}
+
+	// Ensure parent directory exists.
+	dir := filepath.Dir(destPath)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("init: create directory %s: %w", dir, err)
+	}
+
+	// Write the file.
+	if err := os.WriteFile(destPath, data, 0644); err != nil {
+		return fmt.Errorf("init: write config: %w", err)
+	}
+
+	fmt.Printf("Config written to %s\n", destPath)
+	return nil
+}
+
+// resolveInitPath returns the destination path for the generated config.
+// If output is empty, the default config path is used.
+func resolveInitPath(output string) (string, error) {
+	if output != "" {
+		abs, err := filepath.Abs(output)
+		if err != nil {
+			return "", fmt.Errorf("init: resolve path: %w", err)
+		}
+		return abs, nil
+	}
+	p, err := config.DefaultPath()
+	if err != nil {
+		return "", fmt.Errorf("init: %w", err)
+	}
+	return p, nil
+}

--- a/cmd/soda/init_test.go
+++ b/cmd/soda/init_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/decko/soda/internal/config"
+)
+
+func TestRunInit_WritesDefaultConfig(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "config.yaml")
+
+	if err := runInit(dest, false); err != nil {
+		t.Fatalf("runInit() error: %v", err)
+	}
+
+	// File must exist.
+	info, err := os.Stat(dest)
+	if err != nil {
+		t.Fatalf("stat config: %v", err)
+	}
+	if info.Size() == 0 {
+		t.Fatal("config file is empty")
+	}
+
+	// File must be valid YAML that round-trips.
+	cfg, err := config.Load(dest)
+	if err != nil {
+		t.Fatalf("Load() written config: %v", err)
+	}
+	if cfg.TicketSource == "" {
+		t.Error("loaded config has empty TicketSource")
+	}
+	if cfg.Mode == "" {
+		t.Error("loaded config has empty Mode")
+	}
+}
+
+func TestRunInit_CreatesParentDirs(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "deep", "nested", "config.yaml")
+
+	if err := runInit(dest, false); err != nil {
+		t.Fatalf("runInit() error: %v", err)
+	}
+
+	if _, err := os.Stat(dest); err != nil {
+		t.Fatalf("config not created at nested path: %v", err)
+	}
+}
+
+func TestRunInit_RefusesOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "config.yaml")
+
+	// Write a dummy file.
+	if err := os.WriteFile(dest, []byte("existing"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runInit(dest, false)
+	if err == nil {
+		t.Fatal("expected error when file exists, got nil")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("error = %q, want to contain %q", err.Error(), "already exists")
+	}
+
+	// Original content must be preserved.
+	data, _ := os.ReadFile(dest)
+	if string(data) != "existing" {
+		t.Errorf("file was modified: got %q", string(data))
+	}
+}
+
+func TestRunInit_ForceOverwrites(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "config.yaml")
+
+	// Write a dummy file.
+	if err := os.WriteFile(dest, []byte("old"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runInit(dest, true); err != nil {
+		t.Fatalf("runInit(force=true) error: %v", err)
+	}
+
+	// Content must be replaced with valid config.
+	cfg, err := config.Load(dest)
+	if err != nil {
+		t.Fatalf("Load() after force overwrite: %v", err)
+	}
+	if cfg.TicketSource == "" {
+		t.Error("overwritten config has empty TicketSource")
+	}
+}
+
+func TestResolveInitPath_DefaultPath(t *testing.T) {
+	p, err := resolveInitPath("")
+	if err != nil {
+		t.Fatalf("resolveInitPath(\"\") error: %v", err)
+	}
+	if !filepath.IsAbs(p) {
+		t.Errorf("path %q is not absolute", p)
+	}
+	if filepath.Base(p) != "config.yaml" {
+		t.Errorf("base = %q, want config.yaml", filepath.Base(p))
+	}
+}
+
+func TestResolveInitPath_CustomPath(t *testing.T) {
+	p, err := resolveInitPath("my-config.yaml")
+	if err != nil {
+		t.Fatalf("resolveInitPath() error: %v", err)
+	}
+	if !filepath.IsAbs(p) {
+		t.Errorf("path %q is not absolute", p)
+	}
+	if filepath.Base(p) != "my-config.yaml" {
+		t.Errorf("base = %q, want my-config.yaml", filepath.Base(p))
+	}
+}

--- a/cmd/soda/main.go
+++ b/cmd/soda/main.go
@@ -40,6 +40,7 @@ func newRootCmd() *cobra.Command {
 	cmd.PersistentFlags().String("config", defaultPath, "config file path")
 
 	cmd.AddCommand(
+		newInitCmd(),
 		newRunCmd(),
 		newStatusCmd(),
 		newSessionsCmd(),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -95,6 +95,57 @@ type RepoConfig struct {
 	Trailers    []string `yaml:"trailers"`
 }
 
+// DefaultConfig returns a Config populated with sensible starter defaults.
+// The caller can modify the returned value before marshalling it to disk.
+func DefaultConfig() *Config {
+	return &Config{
+		TicketSource: "github",
+		GitHub: GitHubTicketConfig{
+			Owner:         "your-org",
+			Repo:          "your-repo",
+			FetchComments: true,
+			Spec: ExtractionStrategy{
+				StartMarker: "<!-- spec:start -->",
+				EndMarker:   "<!-- spec:end -->",
+			},
+			Plan: ExtractionStrategy{
+				StartMarker: "<!-- plan:start -->",
+				EndMarker:   "<!-- plan:end -->",
+			},
+		},
+		Mode:        "autonomous",
+		Model:       "claude-sonnet-4-20250514",
+		WorktreeDir: ".worktrees",
+		StateDir:    ".soda",
+		Limits: LimitsConfig{
+			MaxCostPerTicket: 15.00,
+			MaxCostPerPhase:  8.00,
+		},
+		Context: []string{"AGENTS.md"},
+		Repos: []RepoConfig{
+			{
+				Name:        "your-repo",
+				Forge:       "github",
+				PushTo:      "your-user/your-repo",
+				Target:      "your-org/your-repo",
+				Description: "Main repository",
+				Formatter:   "gofmt -w .",
+				TestCommand: "go test ./...",
+				Labels:      []string{"ai-assisted"},
+			},
+		},
+	}
+}
+
+// Marshal serialises a Config to YAML bytes.
+func Marshal(cfg *Config) ([]byte, error) {
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("config: marshal: %w", err)
+	}
+	return data, nil
+}
+
 // Load reads and parses a YAML config file.
 func Load(path string) (*Config, error) {
 	data, err := os.ReadFile(path)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/decko/soda/internal/pipeline"
+	"gopkg.in/yaml.v3"
 )
 
 func TestLoad(t *testing.T) {
@@ -160,6 +161,77 @@ func TestDefaultPath(t *testing.T) {
 	}
 	if filepath.Base(path) != "config.yaml" {
 		t.Errorf("DefaultPath() base = %q, want config.yaml", filepath.Base(path))
+	}
+}
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+
+	if cfg.TicketSource != "github" {
+		t.Errorf("TicketSource = %q, want %q", cfg.TicketSource, "github")
+	}
+	if cfg.Mode != "autonomous" {
+		t.Errorf("Mode = %q, want %q", cfg.Mode, "autonomous")
+	}
+	if cfg.Model == "" {
+		t.Error("Model is empty")
+	}
+	if cfg.StateDir != ".soda" {
+		t.Errorf("StateDir = %q, want %q", cfg.StateDir, ".soda")
+	}
+	if cfg.WorktreeDir != ".worktrees" {
+		t.Errorf("WorktreeDir = %q, want %q", cfg.WorktreeDir, ".worktrees")
+	}
+	if cfg.Limits.MaxCostPerTicket <= 0 {
+		t.Errorf("MaxCostPerTicket = %f, want > 0", cfg.Limits.MaxCostPerTicket)
+	}
+	if cfg.Limits.MaxCostPerPhase <= 0 {
+		t.Errorf("MaxCostPerPhase = %f, want > 0", cfg.Limits.MaxCostPerPhase)
+	}
+	if len(cfg.Repos) != 1 {
+		t.Fatalf("len(Repos) = %d, want 1", len(cfg.Repos))
+	}
+	if cfg.Repos[0].Forge != "github" {
+		t.Errorf("Repos[0].Forge = %q, want %q", cfg.Repos[0].Forge, "github")
+	}
+	if cfg.GitHub.Owner != "your-org" {
+		t.Errorf("GitHub.Owner = %q, want %q", cfg.GitHub.Owner, "your-org")
+	}
+}
+
+func TestMarshalRoundTrip(t *testing.T) {
+	original := DefaultConfig()
+
+	data, err := Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal() error: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("Marshal() returned empty data")
+	}
+
+	var roundTripped Config
+	if err := yaml.Unmarshal(data, &roundTripped); err != nil {
+		t.Fatalf("Unmarshal round-tripped data: %v", err)
+	}
+
+	if roundTripped.TicketSource != original.TicketSource {
+		t.Errorf("TicketSource = %q, want %q", roundTripped.TicketSource, original.TicketSource)
+	}
+	if roundTripped.Mode != original.Mode {
+		t.Errorf("Mode = %q, want %q", roundTripped.Mode, original.Mode)
+	}
+	if roundTripped.Model != original.Model {
+		t.Errorf("Model = %q, want %q", roundTripped.Model, original.Model)
+	}
+	if roundTripped.StateDir != original.StateDir {
+		t.Errorf("StateDir = %q, want %q", roundTripped.StateDir, original.StateDir)
+	}
+	if len(roundTripped.Repos) != len(original.Repos) {
+		t.Fatalf("len(Repos) = %d, want %d", len(roundTripped.Repos), len(original.Repos))
+	}
+	if roundTripped.Repos[0].Name != original.Repos[0].Name {
+		t.Errorf("Repos[0].Name = %q, want %q", roundTripped.Repos[0].Name, original.Repos[0].Name)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `DefaultConfig()` and `Marshal()` helpers in `internal/config` to produce a starter configuration with sensible defaults
- Implement `soda init` CLI command that generates and writes a `config.yaml` to `~/.config/soda/config.yaml` (or a custom `--output` path)
- Refuse to overwrite existing config unless `--force` is given; auto-create parent directories
- Register the new `init` subcommand in the root cobra command

## Test plan

- [x] `TestDefaultConfig` — verifies all expected fields are populated
- [x] `TestMarshalRoundTrip` — marshals DefaultConfig to YAML and unmarshals back, asserting field equality
- [x] `TestRunInit_WritesDefaultConfig` — writes config to temp dir, verifies non-empty and round-trips through `config.Load`
- [x] `TestRunInit_CreatesParentDirs` — writes to deeply nested path, verifies file creation
- [x] `TestRunInit_RefusesOverwrite` — existing file is preserved, error contains "already exists"
- [x] `TestRunInit_ForceOverwrites` — `--force` replaces existing file with valid config
- [x] `TestResolveInitPath_DefaultPath` — empty input resolves to absolute path ending in `config.yaml`
- [x] `TestResolveInitPath_CustomPath` — relative input resolved to absolute path

## Acceptance criteria

- [x] `soda init` writes a valid YAML config to the default path
- [x] `--output` flag allows writing to a custom location
- [x] `--force` flag allows overwriting existing config
- [x] Parent directories are created automatically
- [x] Error when config already exists without `--force`

Assisted-by: SODA

🤖 Generated with [Claude Code](https://claude.com/claude-code)