### PR TITLE
docs: document soda plugin install command (#219)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -460,6 +460,8 @@ If yes, include a "Docs to update" section in the issue body listing the files t
 | `soda history <ticket> --phase <name>` | Drill down into a specific phase |
 | `soda sessions` | List all previous pipeline runs with filtering and sorting |
 | `soda clean <ticket>` | Remove completed/failed pipeline state and worktrees |
+| `soda plugin install [--global] [--force]` | Install the SODA Claude Code plugin |
+| `soda plugin uninstall [--global]` | Remove the SODA Claude Code plugin |
 | `soda render-prompt <phase> <ticket>` | Render a phase prompt template for debugging |
 
 ## What NOT to do

--- a/README.md
+++ b/README.md
@@ -32,6 +32,39 @@ soda (Go TUI + Pipeline Engine)
 - `schemas/` — Structured output schemas per phase (Go structs → JSON Schema)
 - `config.example.yaml` — User configuration example
 
+## Claude Code Integration
+
+SODA ships an embedded Claude Code plugin that gives Claude knowledge of SODA
+pipelines and quick access to soda commands.
+
+### Install
+
+```bash
+soda plugin install              # project-local: .claude/plugins/soda/
+soda plugin install --global     # global: ~/.claude/plugins/soda/
+```
+
+### Uninstall
+
+```bash
+soda plugin uninstall            # remove project-local plugin
+soda plugin uninstall --global   # remove global plugin
+```
+
+### What the plugin provides
+
+| Component | Description |
+|-----------|-------------|
+| **Skill: `soda-pipeline`** | Teaches Claude about pipeline architecture, phase lifecycle, state management, and troubleshooting |
+| **`/soda:run <ticket>`** | Run the pipeline for a ticket |
+| **`/soda:status`** | Show current pipeline status |
+| **`/soda:sessions`** | List previous pipeline sessions |
+| **Agent: `pipeline-architect`** | Design-only agent that proposes a `phases.yaml` for the current project |
+
+The plugin is auto-discovered by Claude Code from `.claude/plugins/`. Plugin
+files are embedded in the soda binary and version-matched — updates come with
+`go install`.
+
 ## Key Design Decisions
 
 - **Go + bubbletea** for the CLI/TUI


### PR DESCRIPTION
## Summary

- Add a **Claude Code Integration** section to `README.md` documenting `soda plugin install` / `soda plugin uninstall`, the `--global` flag, and a table of installed plugin components (skill, slash commands, agent)
- Add `plugin install` and `plugin uninstall` rows to the CLI commands table in `AGENTS.md` with correct flags (`--global`, `--force`)

## Acceptance Criteria

- [x] README documents plugin install/uninstall usage
- [x] AGENTS.md CLI commands table updated with plugin subcommands
- [x] All documented flags match actual cobra definitions in `plugin.go`
- [x] Plugin component table matches embedded files

## Test Plan

- [x] `go build ./...` compiles cleanly
- [x] All 8 plugin tests pass (`go test ./cmd/soda/ -run TestPlugin`)
- [x] No regressions in other packages
- [x] Verified documented flags/paths against source code

🤖 Generated with [Claude Code](https://claude.com/claude-code)