### PR TITLE
docs: document soda init command (#212)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -452,6 +452,7 @@ If yes, include a "Docs to update" section in the issue body listing the files t
 
 | Command | Purpose |
 |---------|---------|
+| `soda init [-o path] [--force]` | Generate a starter config file (`~/.config/soda/config.yaml`) |
 | `soda run <ticket>` | Run the pipeline for a ticket |
 | `soda run <ticket> --from <phase>` | Resume from a specific phase |
 | `soda status` | Show active and recent pipelines (sorted by status group, then submission time) |

--- a/README.md
+++ b/README.md
@@ -14,6 +14,22 @@ OS-level isolation (Landlock, network namespaces, cgroups).
 
 Design phase. Not yet implemented.
 
+## Getting Started
+
+Generate a starter configuration file:
+
+```bash
+soda init                        # writes ~/.config/soda/config.yaml
+soda init -o ./soda.config.yaml  # write to a custom path
+soda init --force                # overwrite an existing config
+```
+
+The generated file contains sensible defaults (GitHub Issues source,
+`claude-sonnet-4-20250514` model, standard budget limits). Edit it to
+match your project before running the pipeline. See
+[config.example.yaml](config.example.yaml) for a fully annotated
+reference.
+
 ## Architecture
 
 ```

--- a/cmd/soda/init.go
+++ b/cmd/soda/init.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -45,6 +47,8 @@ func runInit(output string, force bool) error {
 	if !force {
 		if _, err := os.Stat(destPath); err == nil {
 			return fmt.Errorf("config file already exists: %s (use --force to overwrite)", destPath)
+		} else if !errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("init: stat %s: %w", destPath, err)
 		}
 	}
 

--- a/cmd/soda/init_test.go
+++ b/cmd/soda/init_test.go
@@ -99,6 +99,26 @@ func TestRunInit_ForceOverwrites(t *testing.T) {
 	}
 }
 
+func TestRunInit_StatErrorNotErrNotExist(t *testing.T) {
+	dir := t.TempDir()
+	// Create a parent dir with no read/execute permission so Stat fails
+	// with a permission error, not ErrNotExist.
+	noPerms := filepath.Join(dir, "noperm")
+	if err := os.Mkdir(noPerms, 0000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(noPerms, 0755) })
+
+	dest := filepath.Join(noPerms, "config.yaml")
+	err := runInit(dest, false)
+	if err == nil {
+		t.Fatal("expected error for inaccessible path, got nil")
+	}
+	if !strings.Contains(err.Error(), "stat") {
+		t.Errorf("error = %q, want stat context", err)
+	}
+}
+
 func TestResolveInitPath_DefaultPath(t *testing.T) {
 	p, err := resolveInitPath("")
 	if err != nil {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,4 +1,5 @@
 # ~/.config/soda/config.yaml
+# Auto-generate a starter version of this file with: soda init
 
 # Ticket source
 ticket_source: jira


### PR DESCRIPTION
## Summary

- Add a **Getting Started** section to README.md with `soda init` usage examples (default path, custom `-o` path, `--force` overwrite)
- Add `soda init [-o path] [--force]` to the CLI commands table in AGENTS.md
- Add cross-reference comment in config.example.yaml: `# Auto-generate a starter version of this file with: soda init`
- Fix: handle non-`ErrNotExist` stat errors (e.g. permission denied) in `soda init` with a corresponding test

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] New test `TestRunInit_StatErrorNotErrNotExist` covers the stat error edge case
- [x] `go vet ./...` clean
- [x] Build succeeds

## Acceptance criteria

- [x] README documents `soda init` with usage examples
- [x] config.example.yaml references auto-generation via `soda init`
- [x] AGENTS.md CLI commands table includes `soda init`

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)