### PR TITLE
feat(plugin): add /soda:resume slash command (#213)

### DIFF
--- a/cmd/soda/embeds/plugin/commands/resume.md
+++ b/cmd/soda/embeds/plugin/commands/resume.md
@@ -1,0 +1,13 @@
+---
+description: Resume a failed or interrupted SODA pipeline
+---
+
+Resume a SODA pipeline from the last failed or interrupted phase:
+
+```bash
+soda run $ARGUMENTS --from last
+```
+
+If a specific phase is provided in $ARGUMENTS, use it as the `--from` value instead of `last`.
+
+If no ticket key is provided, ask the user for one. You can check `soda status` or `soda sessions` to find recent tickets.

--- a/cmd/soda/plugin.go
+++ b/cmd/soda/plugin.go
@@ -143,7 +143,7 @@ func installPlugin(w io.Writer, destDir string, force bool) error {
 
 	fmt.Fprintf(w, "Installed soda plugin to %s/\n", destDir)
 	fmt.Fprintln(w, "  Skill:    soda-pipeline")
-	fmt.Fprintln(w, "  Commands: /soda:run, /soda:status, /soda:sessions")
+	fmt.Fprintln(w, "  Commands: /soda:run, /soda:resume, /soda:status, /soda:sessions")
 	fmt.Fprintln(w, "  Agent:    pipeline-architect")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Enable in Claude Code: the plugin is auto-discovered from .claude/plugins/")

--- a/cmd/soda/plugin_test.go
+++ b/cmd/soda/plugin_test.go
@@ -33,6 +33,7 @@ func TestInstallPlugin(t *testing.T) {
 		".claude-plugin/plugin.json",
 		"skills/soda-pipeline/SKILL.md",
 		"commands/run.md",
+		"commands/resume.md",
 		"commands/status.md",
 		"commands/sessions.md",
 		"agents/pipeline-architect.md",


### PR DESCRIPTION
## Summary
- Add new `/soda:resume` slash command that runs `soda run <ticket> --from last` to resume a failed or interrupted pipeline from its last running/failed phase
- Update plugin install output to list the new command alongside existing ones
- Add test coverage for the new command file in the plugin install test

## Test plan
- [x] `TestInstallPlugin` verifies `commands/resume.md` is included in installed files
- [x] `TestInstallPluginMatchesEmbedded` confirms installed file matches embedded version byte-for-byte
- [x] All existing tests continue to pass

## Acceptance criteria
- [x] `/soda:resume` slash command file exists with correct YAML frontmatter and body
- [x] Command delegates to `soda run $ARGUMENTS --from last`
- [x] Plugin install output lists `/soda:resume`
- [x] Tests cover the new file

🤖 Generated with [Claude Code](https://claude.com/claude-code)