### PR TITLE
feat(plugin): add /soda:clean slash command (#214)

### DIFF
--- a/cmd/soda/embeds/plugin/commands/clean.md
+++ b/cmd/soda/embeds/plugin/commands/clean.md
@@ -1,0 +1,13 @@
+---
+description: Clean completed/failed pipeline state and worktrees
+---
+
+Clean completed or failed SODA pipeline state and worktrees:
+
+```bash
+soda clean $ARGUMENTS
+```
+
+If no ticket key is provided, ask the user for one or suggest using `--all` to clean all terminal pipelines.
+
+This removes worktrees, branches, and state directories for pipelines that have completed or failed.

--- a/cmd/soda/plugin.go
+++ b/cmd/soda/plugin.go
@@ -143,7 +143,7 @@ func installPlugin(w io.Writer, destDir string, force bool) error {
 
 	fmt.Fprintf(w, "Installed soda plugin to %s/\n", destDir)
 	fmt.Fprintln(w, "  Skill:    soda-pipeline")
-	fmt.Fprintln(w, "  Commands: /soda:run, /soda:resume, /soda:status, /soda:sessions")
+	fmt.Fprintln(w, "  Commands: /soda:run, /soda:resume, /soda:status, /soda:sessions, /soda:clean")
 	fmt.Fprintln(w, "  Agent:    pipeline-architect")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Enable in Claude Code: the plugin is auto-discovered from .claude/plugins/")

--- a/cmd/soda/plugin_test.go
+++ b/cmd/soda/plugin_test.go
@@ -36,6 +36,7 @@ func TestInstallPlugin(t *testing.T) {
 		"commands/resume.md",
 		"commands/status.md",
 		"commands/sessions.md",
+		"commands/clean.md",
 		"agents/pipeline-architect.md",
 	}
 


### PR DESCRIPTION
## Summary

- Add `commands/clean.md` slash command definition following the same pattern as existing `run.md`, `status.md`, and `sessions.md` commands
- Update `plugin.go` install output to list `/soda:clean` alongside other available commands
- Add `commands/clean.md` to `expectedFiles` in `TestInstallPlugin` to verify correct embedding and installation

## Acceptance Criteria

- [x] New `commands/clean.md` file with YAML frontmatter and `soda clean $ARGUMENTS` bash block
- [x] `/soda:clean` listed in plugin install output
- [x] Test coverage updated to verify the new command file
- [x] All existing tests pass

## Test Plan

- Verified `go test ./cmd/soda/...` passes with new and existing tests
- `TestInstallPlugin` confirms `commands/clean.md` is written to disk
- `TestInstallPluginMatchesEmbedded` confirms the file is correctly embedded

Ticket: 214

🤖 Generated with [Claude Code](https://claude.com/claude-code)