### PR TITLE
feat(plugin): add /soda:history slash command (#215)

### DIFF
--- a/cmd/soda/embeds/plugin/commands/history.md
+++ b/cmd/soda/embeds/plugin/commands/history.md
@@ -1,0 +1,13 @@
+---
+description: Show phase details for a ticket
+---
+
+Show phase details for a SODA pipeline ticket:
+
+```bash
+soda history $ARGUMENTS
+```
+
+If no ticket key is provided, ask the user for one.
+
+This shows the phase-by-phase execution history including status, duration, cost, and any errors. Use `--detail` for full structured output or `--phase <name>` to drill into a specific phase.

--- a/cmd/soda/plugin.go
+++ b/cmd/soda/plugin.go
@@ -143,7 +143,7 @@ func installPlugin(w io.Writer, destDir string, force bool) error {
 
 	fmt.Fprintf(w, "Installed soda plugin to %s/\n", destDir)
 	fmt.Fprintln(w, "  Skill:    soda-pipeline")
-	fmt.Fprintln(w, "  Commands: /soda:run, /soda:resume, /soda:status, /soda:sessions, /soda:clean")
+	fmt.Fprintln(w, "  Commands: /soda:run, /soda:resume, /soda:status, /soda:sessions, /soda:clean, /soda:history")
 	fmt.Fprintln(w, "  Agent:    pipeline-architect")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Enable in Claude Code: the plugin is auto-discovered from .claude/plugins/")

--- a/cmd/soda/plugin_test.go
+++ b/cmd/soda/plugin_test.go
@@ -37,6 +37,7 @@ func TestInstallPlugin(t *testing.T) {
 		"commands/status.md",
 		"commands/sessions.md",
 		"commands/clean.md",
+		"commands/history.md",
 		"agents/pipeline-architect.md",
 	}
 


### PR DESCRIPTION
## Summary
- Add `commands/history.md` slash command definition to the embedded plugin, following the existing pattern for `run.md`, `status.md`, and `sessions.md`
- Update plugin install output to list `/soda:history` alongside existing commands
- Add test coverage verifying `history.md` is included in installed plugin files

## Acceptance Criteria
- [x] `/soda:history` slash command file exists at `cmd/soda/embeds/plugin/commands/history.md`
- [x] Command follows existing conventions (frontmatter, description, bash block with `$ARGUMENTS`)
- [x] Documented flags (`--detail`, `--phase`) match actual `soda history --help` output
- [x] Install output lists `/soda:history` alongside existing commands
- [x] `TestInstallPlugin` verifies `history.md` is embedded and copied

## Test Plan
- [x] All existing tests pass (`go test ./cmd/soda/...`)
- [x] `TestInstallPlugin` confirms `history.md` is included in installed files
- [x] No regressions in other plugin commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)