### PR TITLE
feat(plugin): add /soda:render slash command (#216)

### DIFF
--- a/cmd/soda/embeds/plugin/commands/render.md
+++ b/cmd/soda/embeds/plugin/commands/render.md
@@ -1,0 +1,13 @@
+---
+description: Render a phase prompt template for a ticket
+---
+
+Render a phase prompt template for a given ticket:
+
+```bash
+soda render-prompt $ARGUMENTS
+```
+
+If no ticket key or phase is provided, ask the user for them.
+
+Arguments are passed as `--ticket <key> --phase <phase>`.

--- a/cmd/soda/plugin.go
+++ b/cmd/soda/plugin.go
@@ -143,7 +143,7 @@ func installPlugin(w io.Writer, destDir string, force bool) error {
 
 	fmt.Fprintf(w, "Installed soda plugin to %s/\n", destDir)
 	fmt.Fprintln(w, "  Skill:    soda-pipeline")
-	fmt.Fprintln(w, "  Commands: /soda:run, /soda:resume, /soda:status, /soda:sessions, /soda:clean, /soda:history")
+	fmt.Fprintln(w, "  Commands: /soda:run, /soda:resume, /soda:status, /soda:sessions, /soda:clean, /soda:history, /soda:render")
 	fmt.Fprintln(w, "  Agent:    pipeline-architect")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Enable in Claude Code: the plugin is auto-discovered from .claude/plugins/")

--- a/cmd/soda/plugin_test.go
+++ b/cmd/soda/plugin_test.go
@@ -24,6 +24,9 @@ func TestInstallPlugin(t *testing.T) {
 	if !contains(output, "soda-pipeline") {
 		t.Errorf("expected output to mention soda-pipeline skill")
 	}
+	if !contains(output, "/soda:render") {
+		t.Errorf("expected output to mention /soda:render command")
+	}
 	if contains(output, "/soda:init") {
 		t.Errorf("output should not reference /soda:init (command does not exist)")
 	}
@@ -38,6 +41,7 @@ func TestInstallPlugin(t *testing.T) {
 		"commands/sessions.md",
 		"commands/clean.md",
 		"commands/history.md",
+		"commands/render.md",
 		"agents/pipeline-architect.md",
 	}
 


### PR DESCRIPTION
## Summary
- Add `render.md` slash command file mapping `/soda:render` to `soda render-prompt $ARGUMENTS` with `--ticket` and `--phase` flags
- Update `installPlugin()` output to list `/soda:render` alongside existing commands
- Add test assertions verifying `render.md` is embedded and `/soda:render` appears in install output

## Acceptance Criteria
- [x] `commands/render.md` created with correct YAML frontmatter and bash code block
- [x] Install output includes `/soda:render` in the commands list
- [x] Plugin tests updated and passing (6/6)

## Test plan
- All existing plugin tests continue to pass
- New assertion confirms `/soda:render` is printed during install
- `render.md` is included in the expected embedded files list

🤖 Generated with [Claude Code](https://claude.com/claude-code)