### PR TITLE
feat(cli): soda init command — config generation and file writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,16 +19,18 @@ Design phase. Not yet implemented.
 Generate a starter configuration file:
 
 ```bash
-soda init                        # writes ~/.config/soda/config.yaml
-soda init -o ./soda.config.yaml  # write to a custom path
-soda init --force                # overwrite an existing config
+soda init                        # auto-detect project stack, write soda.yaml
+soda init --dry-run              # preview generated config without writing
+soda init --phases               # also write phases.yaml alongside the config
+soda init --no-gitignore         # skip adding .soda/.worktrees to .gitignore
+soda init --force                # overwrite existing config
+soda init -o ./my-config.yaml    # write to a custom path
 ```
 
-The generated file contains sensible defaults (GitHub Issues source,
-`claude-sonnet-4-20250514` model, standard budget limits). Edit it to
-match your project before running the pipeline. See
-[config.example.yaml](config.example.yaml) for a fully annotated
-reference.
+The generated file auto-detects your project's language, forge, and
+tooling from the repository. Edit it to match your project before
+running the pipeline. See [config.example.yaml](config.example.yaml)
+for a fully annotated reference.
 
 ## Architecture
 

--- a/cmd/soda/init.go
+++ b/cmd/soda/init.go
@@ -26,34 +26,22 @@ refuses to overwrite an existing file unless --force is given.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			output, _ := cmd.Flags().GetString("output")
 			force, _ := cmd.Flags().GetBool("force")
-			return runInit(cmd.OutOrStdout(), output, force)
+			dryRun, _ := cmd.Flags().GetBool("dry-run")
+			return runInit(cmd.OutOrStdout(), output, force, dryRun)
 		},
 	}
 
 	cmd.Flags().StringP("output", "o", "", "output path (default: soda.yaml)")
 	cmd.Flags().Bool("force", false, "overwrite existing config file")
+	cmd.Flags().Bool("dry-run", false, "print generated config to stdout without writing")
 
 	return cmd
 }
 
 // runInit generates a config (optionally auto-detected) and writes it to disk.
+// When dryRun is true the generated YAML is printed to w without writing files.
 // Extracted for testability — accepts an io.Writer for output messages.
-func runInit(w io.Writer, output string, force bool) error {
-	// Resolve output path.
-	destPath, err := resolveInitPath(output)
-	if err != nil {
-		return err
-	}
-
-	// Check for existing file unless --force.
-	if !force {
-		if _, err := os.Stat(destPath); err == nil {
-			return fmt.Errorf("config file already exists: %s (use --force to overwrite)", destPath)
-		} else if !errors.Is(err, fs.ErrNotExist) {
-			return fmt.Errorf("init: stat %s: %w", destPath, err)
-		}
-	}
-
+func runInit(w io.Writer, output string, force bool, dryRun bool) error {
 	// Auto-detect project stack. Detection is best-effort: if it fails
 	// we fall back to DefaultConfig with placeholder values.
 	cfg := config.DefaultConfig()
@@ -68,6 +56,27 @@ func runInit(w io.Writer, output string, force bool) error {
 	data, err := config.Marshal(cfg)
 	if err != nil {
 		return fmt.Errorf("init: %w", err)
+	}
+
+	// Dry-run: print config to writer and return without writing files.
+	if dryRun {
+		_, writeErr := w.Write(data)
+		return writeErr
+	}
+
+	// Resolve output path.
+	destPath, err := resolveInitPath(output)
+	if err != nil {
+		return err
+	}
+
+	// Check for existing file unless --force.
+	if !force {
+		if _, err := os.Stat(destPath); err == nil {
+			return fmt.Errorf("config file already exists: %s (use --force to overwrite)", destPath)
+		} else if !errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("init: stat %s: %w", destPath, err)
+		}
 	}
 
 	// Ensure parent directory exists.

--- a/cmd/soda/init.go
+++ b/cmd/soda/init.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/decko/soda/internal/config"
 	"github.com/decko/soda/internal/detect"
+	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 )
 
@@ -31,7 +32,9 @@ refuses to overwrite an existing file unless --force is given.`,
 			dryRun, _ := cmd.Flags().GetBool("dry-run")
 			phases, _ := cmd.Flags().GetBool("phases")
 			noGitignore, _ := cmd.Flags().GetBool("no-gitignore")
-			return runInit(cmd.OutOrStdout(), output, force, dryRun, phases, noGitignore)
+			yes, _ := cmd.Flags().GetBool("yes")
+			isTTY := isatty.IsTerminal(os.Stdin.Fd()) || isatty.IsCygwinTerminal(os.Stdin.Fd())
+			return runInit(cmd.OutOrStdout(), cmd.InOrStdin(), isTTY, output, force, dryRun, phases, noGitignore, yes)
 		},
 	}
 
@@ -49,14 +52,16 @@ refuses to overwrite an existing file unless --force is given.`,
 // When dryRun is true the generated YAML is printed to w without writing files.
 // When phases is true the embedded phases.yaml is written alongside the config.
 // Unless noGitignore is true, .soda and .worktrees entries are added to .gitignore.
-// Extracted for testability — accepts an io.Writer for output messages.
-func runInit(w io.Writer, output string, force bool, dryRun bool, phases bool, noGitignore bool) error {
+// When isTTY is true and yes is false a confirmation prompt is shown before writing.
+// When isTTY is false (non-interactive) the file is written without prompting.
+// Extracted for testability — accepts an io.Writer for output and io.Reader for stdin.
+func runInit(w io.Writer, stdin io.Reader, isTTY bool, output string, force bool, dryRun bool, phases bool, noGitignore bool, yes bool) error {
 	// Auto-detect project stack. Detection is best-effort: if it fails
 	// we fall back to DefaultConfig with placeholder values.
 	cfg := config.DefaultConfig()
 	info, detectErr := detect.Detect(context.Background(), ".")
 	if detectErr != nil {
-		fmt.Fprintf(w, "Warning: project detection failed: %v\n", detectErr)
+		fmt.Fprintln(w, colorMsg("33", fmt.Sprintf("Warning: project detection failed: %v", detectErr)))
 	}
 	if info != nil {
 		cfg = configFromDetected(info)
@@ -88,6 +93,19 @@ func runInit(w io.Writer, output string, force bool, dryRun bool, phases bool, n
 		}
 	}
 
+	// Confirmation prompt: shown when running in a TTY and --yes was not given.
+	// In non-TTY environments (CI, pipes) the file is written automatically.
+	if isTTY && !yes {
+		confirmed, promptErr := confirmWrite(w, stdin, destPath)
+		if promptErr != nil {
+			return promptErr
+		}
+		if !confirmed {
+			fmt.Fprintln(w, "Aborted.")
+			return nil
+		}
+	}
+
 	// Ensure parent directory exists.
 	dir := filepath.Dir(destPath)
 	if err := os.MkdirAll(dir, 0755); err != nil {
@@ -99,7 +117,7 @@ func runInit(w io.Writer, output string, force bool, dryRun bool, phases bool, n
 		return fmt.Errorf("init: write config: %w", err)
 	}
 
-	fmt.Fprintf(w, "Config written to %s\n", destPath)
+	fmt.Fprintln(w, colorMsg("32", fmt.Sprintf("Config written to %s", destPath)))
 
 	// Write phases.yaml alongside the config when --phases is set.
 	if phases {
@@ -114,11 +132,34 @@ func runInit(w io.Writer, output string, force bool, dryRun bool, phases bool, n
 		gitignorePath := filepath.Join(filepath.Dir(destPath), ".gitignore")
 		if err := ensureGitignore(w, gitignorePath, cfg); err != nil {
 			// Gitignore is best-effort; warn but don't fail.
-			fmt.Fprintf(w, "Warning: could not update .gitignore: %v\n", err)
+			fmt.Fprintln(w, colorMsg("33", fmt.Sprintf("Warning: could not update .gitignore: %v", err)))
 		}
 	}
 
 	return nil
+}
+
+// confirmWrite prints a prompt to w and reads a line from stdin.
+// Returns true if the user accepts (empty input or "y"/"yes"), false otherwise.
+func confirmWrite(w io.Writer, stdin io.Reader, destPath string) (bool, error) {
+	fmt.Fprintf(w, "Write config to %s? [Y/n] ", destPath)
+	reader := bufio.NewReader(stdin)
+	line, err := reader.ReadString('\n')
+	if err != nil && err != io.EOF {
+		return false, fmt.Errorf("init: read confirmation: %w", err)
+	}
+	line = strings.TrimSpace(line)
+	return line == "" || strings.EqualFold(line, "y") || strings.EqualFold(line, "yes"), nil
+}
+
+// colorMsg wraps s in ANSI color escape codes using the given code (e.g. "32"
+// for green, "33" for yellow). When the NO_COLOR environment variable is set
+// (per https://no-color.org) the string is returned unchanged.
+func colorMsg(code, s string) string {
+	if os.Getenv("NO_COLOR") != "" {
+		return s
+	}
+	return "\033[" + code + "m" + s + "\033[0m"
 }
 
 // writePhases writes the embedded phases.yaml to phasesPath.
@@ -136,7 +177,7 @@ func writePhases(w io.Writer, phasesPath string, force bool) error {
 		return fmt.Errorf("init: write phases.yaml: %w", err)
 	}
 
-	fmt.Fprintf(w, "Phases written to %s\n", phasesPath)
+	fmt.Fprintln(w, colorMsg("32", fmt.Sprintf("Phases written to %s", phasesPath)))
 	return nil
 }
 
@@ -205,7 +246,7 @@ func ensureGitignore(w io.Writer, gitignorePath string, cfg *config.Config) erro
 		}
 	}
 
-	fmt.Fprintf(w, "Updated .gitignore with %s\n", strings.Join(toAdd, ", "))
+	fmt.Fprintln(w, colorMsg("32", fmt.Sprintf("Updated .gitignore with %s", strings.Join(toAdd, ", "))))
 	return nil
 }
 

--- a/cmd/soda/init.go
+++ b/cmd/soda/init.go
@@ -83,6 +83,9 @@ func runInit(w io.Writer, stdin io.Reader, isTTY bool, opts initOptions) error {
 	}
 	if info != nil {
 		cfg = configFromDetected(info)
+		if info.Forge == "gitlab" {
+			fmt.Fprintln(w, colorMsg("33", "Warning: GitLab detected but only GitHub ticket source is currently supported. Edit ticket_source in the generated config if needed."))
+		}
 	}
 
 	data, err := config.Marshal(cfg)
@@ -282,7 +285,9 @@ func configFromDetected(info *detect.ProjectInfo) *config.Config {
 		cfg.GitHub.Owner = info.Owner
 		cfg.GitHub.Repo = info.Repo
 	case "gitlab":
-		cfg.TicketSource = "github" // keep github as default; gitlab ticket source not yet supported
+		// GitLab ticket source is not yet supported; default to github as a
+		// placeholder. runInit emits a user-visible warning about this mismatch.
+		cfg.TicketSource = "github"
 		cfg.GitHub.Owner = info.Owner
 		cfg.GitHub.Repo = info.Repo
 	}

--- a/cmd/soda/init.go
+++ b/cmd/soda/init.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -8,6 +9,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/decko/soda/internal/config"
 	"github.com/decko/soda/internal/detect"
@@ -28,7 +30,8 @@ refuses to overwrite an existing file unless --force is given.`,
 			force, _ := cmd.Flags().GetBool("force")
 			dryRun, _ := cmd.Flags().GetBool("dry-run")
 			phases, _ := cmd.Flags().GetBool("phases")
-			return runInit(cmd.OutOrStdout(), output, force, dryRun, phases)
+			noGitignore, _ := cmd.Flags().GetBool("no-gitignore")
+			return runInit(cmd.OutOrStdout(), output, force, dryRun, phases, noGitignore)
 		},
 	}
 
@@ -36,6 +39,7 @@ refuses to overwrite an existing file unless --force is given.`,
 	cmd.Flags().Bool("force", false, "overwrite existing config file")
 	cmd.Flags().Bool("dry-run", false, "print generated config to stdout without writing")
 	cmd.Flags().Bool("phases", false, "also write phases.yaml alongside the config")
+	cmd.Flags().Bool("no-gitignore", false, "skip adding .soda and .worktrees to .gitignore")
 
 	return cmd
 }
@@ -43,8 +47,9 @@ refuses to overwrite an existing file unless --force is given.`,
 // runInit generates a config (optionally auto-detected) and writes it to disk.
 // When dryRun is true the generated YAML is printed to w without writing files.
 // When phases is true the embedded phases.yaml is written alongside the config.
+// Unless noGitignore is true, .soda and .worktrees entries are added to .gitignore.
 // Extracted for testability — accepts an io.Writer for output messages.
-func runInit(w io.Writer, output string, force bool, dryRun bool, phases bool) error {
+func runInit(w io.Writer, output string, force bool, dryRun bool, phases bool, noGitignore bool) error {
 	// Auto-detect project stack. Detection is best-effort: if it fails
 	// we fall back to DefaultConfig with placeholder values.
 	cfg := config.DefaultConfig()
@@ -103,6 +108,15 @@ func runInit(w io.Writer, output string, force bool, dryRun bool, phases bool) e
 		}
 	}
 
+	// Ensure .soda and .worktrees are in .gitignore unless --no-gitignore.
+	if !noGitignore {
+		gitignorePath := filepath.Join(filepath.Dir(destPath), ".gitignore")
+		if err := ensureGitignore(w, gitignorePath, cfg); err != nil {
+			// Gitignore is best-effort; warn but don't fail.
+			fmt.Fprintf(w, "Warning: could not update .gitignore: %v\n", err)
+		}
+	}
+
 	return nil
 }
 
@@ -122,6 +136,75 @@ func writePhases(w io.Writer, phasesPath string, force bool) error {
 	}
 
 	fmt.Fprintf(w, "Phases written to %s\n", phasesPath)
+	return nil
+}
+
+// ensureGitignore appends missing entries for the state and worktree directories
+// to the .gitignore at gitignorePath. It reads the existing file (if any) and
+// only appends entries that are not already present.
+func ensureGitignore(w io.Writer, gitignorePath string, cfg *config.Config) error {
+	stateDir := cfg.StateDir
+	if stateDir == "" {
+		stateDir = ".soda"
+	}
+	worktreeDir := cfg.WorktreeDir
+	if worktreeDir == "" {
+		worktreeDir = ".worktrees"
+	}
+
+	// Normalise to patterns with trailing slash (directory convention).
+	needed := []string{
+		stateDir + "/",
+		worktreeDir + "/",
+	}
+
+	// Read existing .gitignore lines.
+	existing := map[string]bool{}
+	data, err := os.ReadFile(gitignorePath)
+	if err == nil {
+		scanner := bufio.NewScanner(strings.NewReader(string(data)))
+		for scanner.Scan() {
+			line := strings.TrimSpace(scanner.Text())
+			existing[line] = true
+			// Also match without trailing slash since "foo" already covers "foo/".
+			existing[strings.TrimSuffix(line, "/")] = true
+		}
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("read .gitignore: %w", err)
+	}
+
+	var toAdd []string
+	for _, entry := range needed {
+		bare := strings.TrimSuffix(entry, "/")
+		if !existing[entry] && !existing[bare] {
+			toAdd = append(toAdd, entry)
+		}
+	}
+
+	if len(toAdd) == 0 {
+		return nil
+	}
+
+	file, err := os.OpenFile(gitignorePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("open .gitignore: %w", err)
+	}
+	defer file.Close()
+
+	// Ensure we start on a new line if the file doesn't end with one.
+	if len(data) > 0 && data[len(data)-1] != '\n' {
+		if _, err := file.WriteString("\n"); err != nil {
+			return fmt.Errorf("write newline to .gitignore: %w", err)
+		}
+	}
+
+	for _, entry := range toAdd {
+		if _, err := fmt.Fprintln(file, entry); err != nil {
+			return fmt.Errorf("write .gitignore entry: %w", err)
+		}
+	}
+
+	fmt.Fprintf(w, "Updated .gitignore with %s\n", strings.Join(toAdd, ", "))
 	return nil
 }
 

--- a/cmd/soda/init.go
+++ b/cmd/soda/init.go
@@ -265,6 +265,8 @@ func configFromDetected(info *detect.ProjectInfo) *config.Config {
 		cfg.GitHub.Repo = info.Repo
 	case "gitlab":
 		cfg.TicketSource = "github" // keep github as default; gitlab ticket source not yet supported
+		cfg.GitHub.Owner = info.Owner
+		cfg.GitHub.Repo = info.Repo
 	}
 
 	// Context files

--- a/cmd/soda/init.go
+++ b/cmd/soda/init.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -9,6 +10,7 @@ import (
 	"path/filepath"
 
 	"github.com/decko/soda/internal/config"
+	"github.com/decko/soda/internal/detect"
 	"github.com/spf13/cobra"
 )
 
@@ -34,7 +36,7 @@ refuses to overwrite an existing file unless --force is given.`,
 	return cmd
 }
 
-// runInit generates a default config and writes it to disk.
+// runInit generates a config (optionally auto-detected) and writes it to disk.
 // Extracted for testability — accepts an io.Writer for output messages.
 func runInit(w io.Writer, output string, force bool) error {
 	// Resolve output path.
@@ -52,8 +54,17 @@ func runInit(w io.Writer, output string, force bool) error {
 		}
 	}
 
-	// Generate default config.
+	// Auto-detect project stack. Detection is best-effort: if it fails
+	// we fall back to DefaultConfig with placeholder values.
 	cfg := config.DefaultConfig()
+	info, detectErr := detect.Detect(context.Background(), ".")
+	if detectErr != nil {
+		fmt.Fprintf(w, "Warning: project detection failed: %v\n", detectErr)
+	}
+	if info != nil {
+		cfg = configFromDetected(info)
+	}
+
 	data, err := config.Marshal(cfg)
 	if err != nil {
 		return fmt.Errorf("init: %w", err)
@@ -72,6 +83,59 @@ func runInit(w io.Writer, output string, force bool) error {
 
 	fmt.Fprintf(w, "Config written to %s\n", destPath)
 	return nil
+}
+
+// configFromDetected creates a Config populated with values from auto-detection.
+// Detected forge, owner, and repo are used to fill in ticket source and repo
+// config. When detection finds nothing useful, the result falls back to
+// DefaultConfig placeholder values for that field.
+func configFromDetected(info *detect.ProjectInfo) *config.Config {
+	cfg := config.DefaultConfig()
+
+	// Forge → ticket source
+	switch info.Forge {
+	case "github":
+		cfg.TicketSource = "github"
+		cfg.GitHub.Owner = info.Owner
+		cfg.GitHub.Repo = info.Repo
+	case "gitlab":
+		cfg.TicketSource = "github" // keep github as default; gitlab ticket source not yet supported
+	}
+
+	// Context files
+	if len(info.ContextFiles) > 0 {
+		cfg.Context = info.ContextFiles
+	}
+
+	// Repos
+	repoName := info.Repo
+	if repoName == "" {
+		repoName = "your-repo"
+	}
+	ownerRepo := info.Owner + "/" + info.Repo
+	if info.Owner == "" || info.Repo == "" {
+		ownerRepo = "your-user/your-repo"
+	}
+	targetRepo := ownerRepo
+	forge := info.Forge
+	if forge == "" {
+		forge = "github"
+	}
+
+	cfg.Repos = []config.RepoConfig{
+		{
+			Name:        repoName,
+			Forge:       forge,
+			PushTo:      ownerRepo,
+			Target:      targetRepo,
+			Description: "Main repository",
+			Formatter:   info.Formatter,
+			TestCommand: info.TestCommand,
+			Labels:      []string{"ai-assisted"},
+		},
+	}
+
+	return cfg
 }
 
 // resolveInitPath returns the destination path for the generated config.

--- a/cmd/soda/init.go
+++ b/cmd/soda/init.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/decko/soda/internal/config"
 	"github.com/decko/soda/internal/detect"
@@ -77,7 +78,9 @@ func runInit(w io.Writer, stdin io.Reader, isTTY bool, opts initOptions) error {
 	// Auto-detect project stack. Detection is best-effort: if it fails
 	// we fall back to DefaultConfig with placeholder values.
 	cfg := config.DefaultConfig()
-	info, detectErr := detect.Detect(context.Background(), ".")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	info, detectErr := detect.Detect(ctx, ".")
 	if detectErr != nil {
 		fmt.Fprintln(w, colorMsg("33", fmt.Sprintf("Warning: project detection failed: %v", detectErr)))
 	}

--- a/cmd/soda/init.go
+++ b/cmd/soda/init.go
@@ -17,6 +17,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// initOptions groups the flags for runInit so the function signature stays
+// readable and callers don't have to track positional booleans.
+type initOptions struct {
+	Output      string
+	Force       bool
+	DryRun      bool
+	Phases      bool
+	NoGitignore bool
+	Yes         bool
+}
+
 func newInitCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "init",
@@ -34,7 +45,14 @@ refuses to overwrite an existing file unless --force is given.`,
 			noGitignore, _ := cmd.Flags().GetBool("no-gitignore")
 			yes, _ := cmd.Flags().GetBool("yes")
 			isTTY := isatty.IsTerminal(os.Stdin.Fd()) || isatty.IsCygwinTerminal(os.Stdin.Fd())
-			return runInit(cmd.OutOrStdout(), cmd.InOrStdin(), isTTY, output, force, dryRun, phases, noGitignore, yes)
+			return runInit(cmd.OutOrStdout(), cmd.InOrStdin(), isTTY, initOptions{
+				Output:      output,
+				Force:       force,
+				DryRun:      dryRun,
+				Phases:      phases,
+				NoGitignore: noGitignore,
+				Yes:         yes,
+			})
 		},
 	}
 
@@ -49,13 +67,13 @@ refuses to overwrite an existing file unless --force is given.`,
 }
 
 // runInit generates a config (optionally auto-detected) and writes it to disk.
-// When dryRun is true the generated YAML is printed to w without writing files.
-// When phases is true the embedded phases.yaml is written alongside the config.
-// Unless noGitignore is true, .soda and .worktrees entries are added to .gitignore.
-// When isTTY is true and yes is false a confirmation prompt is shown before writing.
+// When opts.DryRun is true the generated YAML is printed to w without writing files.
+// When opts.Phases is true the embedded phases.yaml is written alongside the config.
+// Unless opts.NoGitignore is true, .soda and .worktrees entries are added to .gitignore.
+// When isTTY is true and opts.Yes is false a confirmation prompt is shown before writing.
 // When isTTY is false (non-interactive) the file is written without prompting.
 // Extracted for testability — accepts an io.Writer for output and io.Reader for stdin.
-func runInit(w io.Writer, stdin io.Reader, isTTY bool, output string, force bool, dryRun bool, phases bool, noGitignore bool, yes bool) error {
+func runInit(w io.Writer, stdin io.Reader, isTTY bool, opts initOptions) error {
 	// Auto-detect project stack. Detection is best-effort: if it fails
 	// we fall back to DefaultConfig with placeholder values.
 	cfg := config.DefaultConfig()
@@ -73,19 +91,19 @@ func runInit(w io.Writer, stdin io.Reader, isTTY bool, output string, force bool
 	}
 
 	// Dry-run: print config to writer and return without writing files.
-	if dryRun {
+	if opts.DryRun {
 		_, writeErr := w.Write(data)
 		return writeErr
 	}
 
 	// Resolve output path.
-	destPath, err := resolveInitPath(output)
+	destPath, err := resolveInitPath(opts.Output)
 	if err != nil {
 		return err
 	}
 
 	// Check for existing file unless --force.
-	if !force {
+	if !opts.Force {
 		if _, err := os.Stat(destPath); err == nil {
 			return fmt.Errorf("config file already exists: %s (use --force to overwrite)", destPath)
 		} else if !errors.Is(err, fs.ErrNotExist) {
@@ -95,7 +113,7 @@ func runInit(w io.Writer, stdin io.Reader, isTTY bool, output string, force bool
 
 	// Confirmation prompt: shown when running in a TTY and --yes was not given.
 	// In non-TTY environments (CI, pipes) the file is written automatically.
-	if isTTY && !yes {
+	if isTTY && !opts.Yes {
 		confirmed, promptErr := confirmWrite(w, stdin, destPath)
 		if promptErr != nil {
 			return promptErr
@@ -120,15 +138,15 @@ func runInit(w io.Writer, stdin io.Reader, isTTY bool, output string, force bool
 	fmt.Fprintln(w, colorMsg("32", fmt.Sprintf("Config written to %s", destPath)))
 
 	// Write phases.yaml alongside the config when --phases is set.
-	if phases {
+	if opts.Phases {
 		phasesPath := filepath.Join(filepath.Dir(destPath), "phases.yaml")
-		if err := writePhases(w, phasesPath, force); err != nil {
+		if err := writePhases(w, phasesPath, opts.Force); err != nil {
 			return err
 		}
 	}
 
 	// Ensure .soda and .worktrees are in .gitignore unless --no-gitignore.
-	if !noGitignore {
+	if !opts.NoGitignore {
 		gitignorePath := filepath.Join(filepath.Dir(destPath), ".gitignore")
 		if err := ensureGitignore(w, gitignorePath, cfg); err != nil {
 			// Gitignore is best-effort; warn but don't fail.

--- a/cmd/soda/init.go
+++ b/cmd/soda/init.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -14,29 +15,28 @@ import (
 func newInitCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "init",
-		Short: "Generate a starter config file",
-		Long: `Generate a starter soda config file with sensible defaults.
+		Short: "Auto-detect project stack and generate soda.yaml",
+		Long: `Auto-detect the project stack and generate a soda config file.
 
-By default the config is written to the standard location
-(~/.config/soda/config.yaml). Use --output to choose a
-different path. The command refuses to overwrite an existing
-file unless --force is given.`,
+By default the config is written to soda.yaml in the current
+directory. Use --output to choose a different path. The command
+refuses to overwrite an existing file unless --force is given.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			output, _ := cmd.Flags().GetString("output")
 			force, _ := cmd.Flags().GetBool("force")
-			return runInit(output, force)
+			return runInit(cmd.OutOrStdout(), output, force)
 		},
 	}
 
-	cmd.Flags().StringP("output", "o", "", "output path (default: ~/.config/soda/config.yaml)")
+	cmd.Flags().StringP("output", "o", "", "output path (default: soda.yaml)")
 	cmd.Flags().Bool("force", false, "overwrite existing config file")
 
 	return cmd
 }
 
 // runInit generates a default config and writes it to disk.
-// Extracted for testability.
-func runInit(output string, force bool) error {
+// Extracted for testability — accepts an io.Writer for output messages.
+func runInit(w io.Writer, output string, force bool) error {
 	// Resolve output path.
 	destPath, err := resolveInitPath(output)
 	if err != nil {
@@ -70,12 +70,12 @@ func runInit(output string, force bool) error {
 		return fmt.Errorf("init: write config: %w", err)
 	}
 
-	fmt.Printf("Config written to %s\n", destPath)
+	fmt.Fprintf(w, "Config written to %s\n", destPath)
 	return nil
 }
 
 // resolveInitPath returns the destination path for the generated config.
-// If output is empty, the default config path is used.
+// If output is empty, defaults to soda.yaml in the current directory.
 func resolveInitPath(output string) (string, error) {
 	if output != "" {
 		abs, err := filepath.Abs(output)
@@ -84,9 +84,9 @@ func resolveInitPath(output string) (string, error) {
 		}
 		return abs, nil
 	}
-	p, err := config.DefaultPath()
+	abs, err := filepath.Abs("soda.yaml")
 	if err != nil {
-		return "", fmt.Errorf("init: %w", err)
+		return "", fmt.Errorf("init: resolve path: %w", err)
 	}
-	return p, nil
+	return abs, nil
 }

--- a/cmd/soda/init.go
+++ b/cmd/soda/init.go
@@ -27,21 +27,24 @@ refuses to overwrite an existing file unless --force is given.`,
 			output, _ := cmd.Flags().GetString("output")
 			force, _ := cmd.Flags().GetBool("force")
 			dryRun, _ := cmd.Flags().GetBool("dry-run")
-			return runInit(cmd.OutOrStdout(), output, force, dryRun)
+			phases, _ := cmd.Flags().GetBool("phases")
+			return runInit(cmd.OutOrStdout(), output, force, dryRun, phases)
 		},
 	}
 
 	cmd.Flags().StringP("output", "o", "", "output path (default: soda.yaml)")
 	cmd.Flags().Bool("force", false, "overwrite existing config file")
 	cmd.Flags().Bool("dry-run", false, "print generated config to stdout without writing")
+	cmd.Flags().Bool("phases", false, "also write phases.yaml alongside the config")
 
 	return cmd
 }
 
 // runInit generates a config (optionally auto-detected) and writes it to disk.
 // When dryRun is true the generated YAML is printed to w without writing files.
+// When phases is true the embedded phases.yaml is written alongside the config.
 // Extracted for testability — accepts an io.Writer for output messages.
-func runInit(w io.Writer, output string, force bool, dryRun bool) error {
+func runInit(w io.Writer, output string, force bool, dryRun bool, phases bool) error {
 	// Auto-detect project stack. Detection is best-effort: if it fails
 	// we fall back to DefaultConfig with placeholder values.
 	cfg := config.DefaultConfig()
@@ -91,6 +94,34 @@ func runInit(w io.Writer, output string, force bool, dryRun bool) error {
 	}
 
 	fmt.Fprintf(w, "Config written to %s\n", destPath)
+
+	// Write phases.yaml alongside the config when --phases is set.
+	if phases {
+		phasesPath := filepath.Join(filepath.Dir(destPath), "phases.yaml")
+		if err := writePhases(w, phasesPath, force); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// writePhases writes the embedded phases.yaml to phasesPath.
+// It refuses to overwrite an existing file unless force is true.
+func writePhases(w io.Writer, phasesPath string, force bool) error {
+	if !force {
+		if _, err := os.Stat(phasesPath); err == nil {
+			return fmt.Errorf("phases file already exists: %s (use --force to overwrite)", phasesPath)
+		} else if !errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("init: stat %s: %w", phasesPath, err)
+		}
+	}
+
+	if err := os.WriteFile(phasesPath, embeddedPhases, 0644); err != nil {
+		return fmt.Errorf("init: write phases.yaml: %w", err)
+	}
+
+	fmt.Fprintf(w, "Phases written to %s\n", phasesPath)
 	return nil
 }
 

--- a/cmd/soda/init.go
+++ b/cmd/soda/init.go
@@ -82,12 +82,12 @@ func runInit(w io.Writer, stdin io.Reader, isTTY bool, opts initOptions) error {
 	defer cancel()
 	info, detectErr := detect.Detect(ctx, ".")
 	if detectErr != nil {
-		fmt.Fprintln(w, colorMsg("33", fmt.Sprintf("Warning: project detection failed: %v", detectErr)))
+		fmt.Fprintln(os.Stderr, colorMsg("33", fmt.Sprintf("Warning: project detection failed: %v", detectErr)))
 	}
 	if info != nil {
 		cfg = configFromDetected(info)
 		if info.Forge == "gitlab" {
-			fmt.Fprintln(w, colorMsg("33", "Warning: GitLab detected but only GitHub ticket source is currently supported. Edit ticket_source in the generated config if needed."))
+			fmt.Fprintln(os.Stderr, colorMsg("33", "Warning: GitLab detected but only GitHub ticket source is currently supported. Edit ticket_source in the generated config if needed."))
 		}
 	}
 

--- a/cmd/soda/init.go
+++ b/cmd/soda/init.go
@@ -40,6 +40,7 @@ refuses to overwrite an existing file unless --force is given.`,
 	cmd.Flags().Bool("dry-run", false, "print generated config to stdout without writing")
 	cmd.Flags().Bool("phases", false, "also write phases.yaml alongside the config")
 	cmd.Flags().Bool("no-gitignore", false, "skip adding .soda and .worktrees to .gitignore")
+	cmd.Flags().BoolP("yes", "y", false, "accept all defaults without prompting")
 
 	return cmd
 }

--- a/cmd/soda/init_test.go
+++ b/cmd/soda/init_test.go
@@ -368,6 +368,18 @@ func TestEnsureGitignore_ExistingEntriesWithoutSlash(t *testing.T) {
 	}
 }
 
+func TestNewInitCmd_YesFlagAccepted(t *testing.T) {
+	cmd := newInitCmd()
+	// Verify the --yes / -y flag is registered.
+	flag := cmd.Flags().Lookup("yes")
+	if flag == nil {
+		t.Fatal("--yes flag not registered")
+	}
+	if flag.Shorthand != "y" {
+		t.Errorf("--yes shorthand = %q, want %q", flag.Shorthand, "y")
+	}
+}
+
 func TestConfigFromDetected_GitHub(t *testing.T) {
 	info := &detect.ProjectInfo{
 		Language:     "go",

--- a/cmd/soda/init_test.go
+++ b/cmd/soda/init_test.go
@@ -17,7 +17,7 @@ func TestRunInit_WritesDefaultConfig(t *testing.T) {
 	dest := filepath.Join(dir, "soda.yaml")
 
 	var buf bytes.Buffer
-	if err := runInit(&buf, dest, false, false); err != nil {
+	if err := runInit(&buf, dest, false, false, false); err != nil {
 		t.Fatalf("runInit() error: %v", err)
 	}
 
@@ -52,7 +52,7 @@ func TestRunInit_CreatesParentDirs(t *testing.T) {
 	dir := t.TempDir()
 	dest := filepath.Join(dir, "deep", "nested", "soda.yaml")
 
-	if err := runInit(io.Discard, dest, false, false); err != nil {
+	if err := runInit(io.Discard, dest, false, false, false); err != nil {
 		t.Fatalf("runInit() error: %v", err)
 	}
 
@@ -70,7 +70,7 @@ func TestRunInit_RefusesOverwrite(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := runInit(io.Discard, dest, false, false)
+	err := runInit(io.Discard, dest, false, false, false)
 	if err == nil {
 		t.Fatal("expected error when file exists, got nil")
 	}
@@ -94,7 +94,7 @@ func TestRunInit_ForceOverwrites(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := runInit(io.Discard, dest, true, false); err != nil {
+	if err := runInit(io.Discard, dest, true, false, false); err != nil {
 		t.Fatalf("runInit(force=true) error: %v", err)
 	}
 
@@ -119,7 +119,7 @@ func TestRunInit_StatErrorNotErrNotExist(t *testing.T) {
 	t.Cleanup(func() { os.Chmod(noPerms, 0755) })
 
 	dest := filepath.Join(noPerms, "soda.yaml")
-	err := runInit(io.Discard, dest, false, false)
+	err := runInit(io.Discard, dest, false, false, false)
 	if err == nil {
 		t.Fatal("expected error for inaccessible path, got nil")
 	}
@@ -159,7 +159,7 @@ func TestRunInit_DryRun(t *testing.T) {
 	dest := filepath.Join(dir, "soda.yaml")
 
 	var buf bytes.Buffer
-	if err := runInit(&buf, dest, false, true); err != nil {
+	if err := runInit(&buf, dest, false, true, false); err != nil {
 		t.Fatalf("runInit(dryRun=true) error: %v", err)
 	}
 
@@ -175,6 +175,92 @@ func TestRunInit_DryRun(t *testing.T) {
 	}
 	if !strings.Contains(output, "mode:") {
 		t.Errorf("dry-run output missing mode field, got: %s", output)
+	}
+}
+
+func TestRunInit_PhasesWritten(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "soda.yaml")
+
+	var buf bytes.Buffer
+	if err := runInit(&buf, dest, false, false, true); err != nil {
+		t.Fatalf("runInit(phases=true) error: %v", err)
+	}
+
+	// Config must exist.
+	if _, err := os.Stat(dest); err != nil {
+		t.Fatalf("config not created: %v", err)
+	}
+
+	// phases.yaml must exist alongside the config.
+	phasesPath := filepath.Join(dir, "phases.yaml")
+	phasesData, err := os.ReadFile(phasesPath)
+	if err != nil {
+		t.Fatalf("phases.yaml not created: %v", err)
+	}
+	if len(phasesData) == 0 {
+		t.Fatal("phases.yaml is empty")
+	}
+
+	// Output must mention both files.
+	output := buf.String()
+	if !strings.Contains(output, "Config written") {
+		t.Errorf("output missing config confirmation: %s", output)
+	}
+	if !strings.Contains(output, "Phases written") {
+		t.Errorf("output missing phases confirmation: %s", output)
+	}
+}
+
+func TestRunInit_PhasesRefusesOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "soda.yaml")
+
+	// Pre-create phases.yaml.
+	phasesPath := filepath.Join(dir, "phases.yaml")
+	if err := os.WriteFile(phasesPath, []byte("existing"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runInit(io.Discard, dest, false, false, true)
+	if err == nil {
+		t.Fatal("expected error when phases.yaml exists, got nil")
+	}
+	if !strings.Contains(err.Error(), "phases file already exists") {
+		t.Errorf("error = %q, want phases file already exists", err.Error())
+	}
+
+	// Original phases content must be preserved.
+	data, _ := os.ReadFile(phasesPath)
+	if string(data) != "existing" {
+		t.Errorf("phases.yaml was modified: got %q", string(data))
+	}
+}
+
+func TestRunInit_PhasesForceOverwrites(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "soda.yaml")
+
+	// Pre-create phases.yaml with dummy content.
+	phasesPath := filepath.Join(dir, "phases.yaml")
+	if err := os.WriteFile(phasesPath, []byte("old-content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runInit(io.Discard, dest, true, false, true); err != nil {
+		t.Fatalf("runInit(force=true, phases=true) error: %v", err)
+	}
+
+	// phases.yaml must be overwritten with embedded content.
+	data, err := os.ReadFile(phasesPath)
+	if err != nil {
+		t.Fatalf("read phases.yaml: %v", err)
+	}
+	if string(data) == "old-content" {
+		t.Error("phases.yaml was not overwritten")
+	}
+	if len(data) == 0 {
+		t.Error("phases.yaml is empty after overwrite")
 	}
 }
 

--- a/cmd/soda/init_test.go
+++ b/cmd/soda/init_test.go
@@ -17,7 +17,7 @@ func TestRunInit_WritesDefaultConfig(t *testing.T) {
 	dest := filepath.Join(dir, "soda.yaml")
 
 	var buf bytes.Buffer
-	if err := runInit(&buf, strings.NewReader(""), false, dest, false, false, false, true, false); err != nil {
+	if err := runInit(&buf, strings.NewReader(""), false, initOptions{Output: dest, NoGitignore: true}); err != nil {
 		t.Fatalf("runInit() error: %v", err)
 	}
 
@@ -52,7 +52,7 @@ func TestRunInit_CreatesParentDirs(t *testing.T) {
 	dir := t.TempDir()
 	dest := filepath.Join(dir, "deep", "nested", "soda.yaml")
 
-	if err := runInit(io.Discard, strings.NewReader(""), false, dest, false, false, false, true, false); err != nil {
+	if err := runInit(io.Discard, strings.NewReader(""), false, initOptions{Output: dest, NoGitignore: true}); err != nil {
 		t.Fatalf("runInit() error: %v", err)
 	}
 
@@ -70,7 +70,7 @@ func TestRunInit_RefusesOverwrite(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := runInit(io.Discard, strings.NewReader(""), false, dest, false, false, false, true, false)
+	err := runInit(io.Discard, strings.NewReader(""), false, initOptions{Output: dest, NoGitignore: true})
 	if err == nil {
 		t.Fatal("expected error when file exists, got nil")
 	}
@@ -94,7 +94,7 @@ func TestRunInit_ForceOverwrites(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := runInit(io.Discard, strings.NewReader(""), false, dest, true, false, false, true, false); err != nil {
+	if err := runInit(io.Discard, strings.NewReader(""), false, initOptions{Output: dest, Force: true, NoGitignore: true}); err != nil {
 		t.Fatalf("runInit(force=true) error: %v", err)
 	}
 
@@ -119,7 +119,7 @@ func TestRunInit_StatErrorNotErrNotExist(t *testing.T) {
 	t.Cleanup(func() { os.Chmod(noPerms, 0755) })
 
 	dest := filepath.Join(noPerms, "soda.yaml")
-	err := runInit(io.Discard, strings.NewReader(""), false, dest, false, false, false, true, false)
+	err := runInit(io.Discard, strings.NewReader(""), false, initOptions{Output: dest, NoGitignore: true})
 	if err == nil {
 		t.Fatal("expected error for inaccessible path, got nil")
 	}
@@ -159,7 +159,7 @@ func TestRunInit_DryRun(t *testing.T) {
 	dest := filepath.Join(dir, "soda.yaml")
 
 	var buf bytes.Buffer
-	if err := runInit(&buf, strings.NewReader(""), false, dest, false, true, false, true, false); err != nil {
+	if err := runInit(&buf, strings.NewReader(""), false, initOptions{Output: dest, DryRun: true, NoGitignore: true}); err != nil {
 		t.Fatalf("runInit(dryRun=true) error: %v", err)
 	}
 
@@ -183,7 +183,7 @@ func TestRunInit_PhasesWritten(t *testing.T) {
 	dest := filepath.Join(dir, "soda.yaml")
 
 	var buf bytes.Buffer
-	if err := runInit(&buf, strings.NewReader(""), false, dest, false, false, true, true, false); err != nil {
+	if err := runInit(&buf, strings.NewReader(""), false, initOptions{Output: dest, Phases: true, NoGitignore: true}); err != nil {
 		t.Fatalf("runInit(phases=true) error: %v", err)
 	}
 
@@ -222,7 +222,7 @@ func TestRunInit_PhasesRefusesOverwrite(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := runInit(io.Discard, strings.NewReader(""), false, dest, false, false, true, true, false)
+	err := runInit(io.Discard, strings.NewReader(""), false, initOptions{Output: dest, Phases: true, NoGitignore: true})
 	if err == nil {
 		t.Fatal("expected error when phases.yaml exists, got nil")
 	}
@@ -247,7 +247,7 @@ func TestRunInit_PhasesForceOverwrites(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := runInit(io.Discard, strings.NewReader(""), false, dest, true, false, true, true, false); err != nil {
+	if err := runInit(io.Discard, strings.NewReader(""), false, initOptions{Output: dest, Force: true, Phases: true, NoGitignore: true}); err != nil {
 		t.Fatalf("runInit(force=true, phases=true) error: %v", err)
 	}
 
@@ -269,8 +269,8 @@ func TestRunInit_GitignoreCreated(t *testing.T) {
 	dest := filepath.Join(dir, "soda.yaml")
 
 	var buf bytes.Buffer
-	// noGitignore=false → should create/update .gitignore
-	if err := runInit(&buf, strings.NewReader(""), false, dest, false, false, false, false, false); err != nil {
+	// NoGitignore=false → should create/update .gitignore
+	if err := runInit(&buf, strings.NewReader(""), false, initOptions{Output: dest}); err != nil {
 		t.Fatalf("runInit() error: %v", err)
 	}
 
@@ -297,8 +297,8 @@ func TestRunInit_GitignoreSkippedWithFlag(t *testing.T) {
 	dir := t.TempDir()
 	dest := filepath.Join(dir, "soda.yaml")
 
-	// noGitignore=true → should NOT create .gitignore
-	if err := runInit(io.Discard, strings.NewReader(""), false, dest, false, false, false, true, false); err != nil {
+	// NoGitignore=true → should NOT create .gitignore
+	if err := runInit(io.Discard, strings.NewReader(""), false, initOptions{Output: dest, NoGitignore: true}); err != nil {
 		t.Fatalf("runInit() error: %v", err)
 	}
 
@@ -319,7 +319,7 @@ func TestRunInit_GitignoreAppendsWithoutDuplication(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	if err := runInit(&buf, strings.NewReader(""), false, dest, false, false, false, false, false); err != nil {
+	if err := runInit(&buf, strings.NewReader(""), false, initOptions{Output: dest}); err != nil {
 		t.Fatalf("runInit() error: %v", err)
 	}
 
@@ -467,7 +467,7 @@ func TestRunInit_ConfirmationPromptYes(t *testing.T) {
 	dest := filepath.Join(dir, "soda.yaml")
 
 	var buf bytes.Buffer
-	if err := runInit(&buf, strings.NewReader("y\n"), true, dest, false, false, false, true, false); err != nil {
+	if err := runInit(&buf, strings.NewReader("y\n"), true, initOptions{Output: dest, NoGitignore: true}); err != nil {
 		t.Fatalf("runInit() error: %v", err)
 	}
 
@@ -486,7 +486,7 @@ func TestRunInit_ConfirmationPromptNo(t *testing.T) {
 	dest := filepath.Join(dir, "soda.yaml")
 
 	var buf bytes.Buffer
-	if err := runInit(&buf, strings.NewReader("n\n"), true, dest, false, false, false, true, false); err != nil {
+	if err := runInit(&buf, strings.NewReader("n\n"), true, initOptions{Output: dest, NoGitignore: true}); err != nil {
 		t.Fatalf("runInit() error: %v", err)
 	}
 
@@ -505,7 +505,7 @@ func TestRunInit_YesSkipsPrompt(t *testing.T) {
 	dest := filepath.Join(dir, "soda.yaml")
 
 	var buf bytes.Buffer
-	if err := runInit(&buf, strings.NewReader(""), true, dest, false, false, false, true, true); err != nil {
+	if err := runInit(&buf, strings.NewReader(""), true, initOptions{Output: dest, NoGitignore: true, Yes: true}); err != nil {
 		t.Fatalf("runInit(yes=true) error: %v", err)
 	}
 
@@ -524,7 +524,7 @@ func TestRunInit_NonTTYAutoWrites(t *testing.T) {
 	dest := filepath.Join(dir, "soda.yaml")
 
 	var buf bytes.Buffer
-	if err := runInit(&buf, strings.NewReader(""), false, dest, false, false, false, true, false); err != nil {
+	if err := runInit(&buf, strings.NewReader(""), false, initOptions{Output: dest, NoGitignore: true}); err != nil {
 		t.Fatalf("runInit(isTTY=false) error: %v", err)
 	}
 
@@ -565,7 +565,7 @@ func TestRunInit_ColorOutput(t *testing.T) {
 	dest := filepath.Join(dir, "soda.yaml")
 
 	var buf bytes.Buffer
-	if err := runInit(&buf, strings.NewReader(""), false, dest, false, false, false, true, false); err != nil {
+	if err := runInit(&buf, strings.NewReader(""), false, initOptions{Output: dest, NoGitignore: true}); err != nil {
 		t.Fatalf("runInit() error: %v", err)
 	}
 
@@ -581,7 +581,7 @@ func TestRunInit_NoColorEnv(t *testing.T) {
 	dest := filepath.Join(dir, "soda.yaml")
 
 	var buf bytes.Buffer
-	if err := runInit(&buf, strings.NewReader(""), false, dest, false, false, false, true, false); err != nil {
+	if err := runInit(&buf, strings.NewReader(""), false, initOptions{Output: dest, NoGitignore: true}); err != nil {
 		t.Fatalf("runInit() error: %v", err)
 	}
 

--- a/cmd/soda/init_test.go
+++ b/cmd/soda/init_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/decko/soda/internal/config"
+	"github.com/decko/soda/internal/detect"
 )
 
 func TestRunInit_WritesDefaultConfig(t *testing.T) {
@@ -150,5 +151,109 @@ func TestResolveInitPath_CustomPath(t *testing.T) {
 	}
 	if filepath.Base(p) != "my-config.yaml" {
 		t.Errorf("base = %q, want my-config.yaml", filepath.Base(p))
+	}
+}
+
+func TestConfigFromDetected_GitHub(t *testing.T) {
+	info := &detect.ProjectInfo{
+		Language:     "go",
+		Forge:        "github",
+		Owner:        "acme",
+		Repo:         "myservice",
+		Formatter:    "gofmt -w .",
+		TestCommand:  "go test ./...",
+		ContextFiles: []string{"AGENTS.md", "CLAUDE.md"},
+	}
+
+	cfg := configFromDetected(info)
+
+	if cfg.TicketSource != "github" {
+		t.Errorf("TicketSource = %q, want %q", cfg.TicketSource, "github")
+	}
+	if cfg.GitHub.Owner != "acme" {
+		t.Errorf("GitHub.Owner = %q, want %q", cfg.GitHub.Owner, "acme")
+	}
+	if cfg.GitHub.Repo != "myservice" {
+		t.Errorf("GitHub.Repo = %q, want %q", cfg.GitHub.Repo, "myservice")
+	}
+	if len(cfg.Context) != 2 || cfg.Context[0] != "AGENTS.md" || cfg.Context[1] != "CLAUDE.md" {
+		t.Errorf("Context = %v, want [AGENTS.md CLAUDE.md]", cfg.Context)
+	}
+	if len(cfg.Repos) != 1 {
+		t.Fatalf("len(Repos) = %d, want 1", len(cfg.Repos))
+	}
+	repo := cfg.Repos[0]
+	if repo.Name != "myservice" {
+		t.Errorf("Repos[0].Name = %q, want %q", repo.Name, "myservice")
+	}
+	if repo.Forge != "github" {
+		t.Errorf("Repos[0].Forge = %q, want %q", repo.Forge, "github")
+	}
+	if repo.PushTo != "acme/myservice" {
+		t.Errorf("Repos[0].PushTo = %q, want %q", repo.PushTo, "acme/myservice")
+	}
+	if repo.Formatter != "gofmt -w ." {
+		t.Errorf("Repos[0].Formatter = %q, want %q", repo.Formatter, "gofmt -w .")
+	}
+	if repo.TestCommand != "go test ./..." {
+		t.Errorf("Repos[0].TestCommand = %q, want %q", repo.TestCommand, "go test ./...")
+	}
+}
+
+func TestConfigFromDetected_NoForge(t *testing.T) {
+	info := &detect.ProjectInfo{
+		Language:    "python",
+		Forge:       "",
+		Owner:       "",
+		Repo:        "",
+		Formatter:   "black .",
+		TestCommand: "pytest",
+	}
+
+	cfg := configFromDetected(info)
+
+	// Should fall back to github ticket source with placeholders.
+	if cfg.TicketSource != "github" {
+		t.Errorf("TicketSource = %q, want %q", cfg.TicketSource, "github")
+	}
+	if len(cfg.Repos) != 1 {
+		t.Fatalf("len(Repos) = %d, want 1", len(cfg.Repos))
+	}
+	repo := cfg.Repos[0]
+	if repo.Name != "your-repo" {
+		t.Errorf("Repos[0].Name = %q, want %q", repo.Name, "your-repo")
+	}
+	if repo.PushTo != "your-user/your-repo" {
+		t.Errorf("Repos[0].PushTo = %q, want %q", repo.PushTo, "your-user/your-repo")
+	}
+	if repo.Formatter != "black ." {
+		t.Errorf("Repos[0].Formatter = %q, want %q", repo.Formatter, "black .")
+	}
+	if repo.TestCommand != "pytest" {
+		t.Errorf("Repos[0].TestCommand = %q, want %q", repo.TestCommand, "pytest")
+	}
+}
+
+func TestConfigFromDetected_GitLab(t *testing.T) {
+	info := &detect.ProjectInfo{
+		Language:    "rust",
+		Forge:       "gitlab",
+		Owner:       "team",
+		Repo:        "backend",
+		Formatter:   "cargo fmt",
+		TestCommand: "cargo test",
+	}
+
+	cfg := configFromDetected(info)
+
+	// GitLab forge should still use github ticket source (gitlab not yet supported).
+	if cfg.TicketSource != "github" {
+		t.Errorf("TicketSource = %q, want %q", cfg.TicketSource, "github")
+	}
+	if len(cfg.Repos) != 1 {
+		t.Fatalf("len(Repos) = %d, want 1", len(cfg.Repos))
+	}
+	if cfg.Repos[0].Forge != "gitlab" {
+		t.Errorf("Repos[0].Forge = %q, want %q", cfg.Repos[0].Forge, "gitlab")
 	}
 }

--- a/cmd/soda/init_test.go
+++ b/cmd/soda/init_test.go
@@ -606,10 +606,24 @@ func TestConfigFromDetected_GitLab(t *testing.T) {
 	if cfg.TicketSource != "github" {
 		t.Errorf("TicketSource = %q, want %q", cfg.TicketSource, "github")
 	}
+
+	// GitHub ticket config should be populated with detected owner/repo so
+	// that the config is internally consistent (ticket source points at the
+	// same repo as cfg.Repos[0]).
+	if cfg.GitHub.Owner != "team" {
+		t.Errorf("GitHub.Owner = %q, want %q", cfg.GitHub.Owner, "team")
+	}
+	if cfg.GitHub.Repo != "backend" {
+		t.Errorf("GitHub.Repo = %q, want %q", cfg.GitHub.Repo, "backend")
+	}
+
 	if len(cfg.Repos) != 1 {
 		t.Fatalf("len(Repos) = %d, want 1", len(cfg.Repos))
 	}
 	if cfg.Repos[0].Forge != "gitlab" {
 		t.Errorf("Repos[0].Forge = %q, want %q", cfg.Repos[0].Forge, "gitlab")
+	}
+	if cfg.Repos[0].PushTo != "team/backend" {
+		t.Errorf("Repos[0].PushTo = %q, want %q", cfg.Repos[0].PushTo, "team/backend")
 	}
 }

--- a/cmd/soda/init_test.go
+++ b/cmd/soda/init_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,9 +13,10 @@ import (
 
 func TestRunInit_WritesDefaultConfig(t *testing.T) {
 	dir := t.TempDir()
-	dest := filepath.Join(dir, "config.yaml")
+	dest := filepath.Join(dir, "soda.yaml")
 
-	if err := runInit(dest, false); err != nil {
+	var buf bytes.Buffer
+	if err := runInit(&buf, dest, false); err != nil {
 		t.Fatalf("runInit() error: %v", err)
 	}
 
@@ -37,13 +40,18 @@ func TestRunInit_WritesDefaultConfig(t *testing.T) {
 	if cfg.Mode == "" {
 		t.Error("loaded config has empty Mode")
 	}
+
+	// Output message must mention the path.
+	if !strings.Contains(buf.String(), dest) {
+		t.Errorf("output = %q, want to mention %q", buf.String(), dest)
+	}
 }
 
 func TestRunInit_CreatesParentDirs(t *testing.T) {
 	dir := t.TempDir()
-	dest := filepath.Join(dir, "deep", "nested", "config.yaml")
+	dest := filepath.Join(dir, "deep", "nested", "soda.yaml")
 
-	if err := runInit(dest, false); err != nil {
+	if err := runInit(io.Discard, dest, false); err != nil {
 		t.Fatalf("runInit() error: %v", err)
 	}
 
@@ -54,14 +62,14 @@ func TestRunInit_CreatesParentDirs(t *testing.T) {
 
 func TestRunInit_RefusesOverwrite(t *testing.T) {
 	dir := t.TempDir()
-	dest := filepath.Join(dir, "config.yaml")
+	dest := filepath.Join(dir, "soda.yaml")
 
 	// Write a dummy file.
 	if err := os.WriteFile(dest, []byte("existing"), 0644); err != nil {
 		t.Fatal(err)
 	}
 
-	err := runInit(dest, false)
+	err := runInit(io.Discard, dest, false)
 	if err == nil {
 		t.Fatal("expected error when file exists, got nil")
 	}
@@ -78,14 +86,14 @@ func TestRunInit_RefusesOverwrite(t *testing.T) {
 
 func TestRunInit_ForceOverwrites(t *testing.T) {
 	dir := t.TempDir()
-	dest := filepath.Join(dir, "config.yaml")
+	dest := filepath.Join(dir, "soda.yaml")
 
 	// Write a dummy file.
 	if err := os.WriteFile(dest, []byte("old"), 0644); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := runInit(dest, true); err != nil {
+	if err := runInit(io.Discard, dest, true); err != nil {
 		t.Fatalf("runInit(force=true) error: %v", err)
 	}
 
@@ -109,8 +117,8 @@ func TestRunInit_StatErrorNotErrNotExist(t *testing.T) {
 	}
 	t.Cleanup(func() { os.Chmod(noPerms, 0755) })
 
-	dest := filepath.Join(noPerms, "config.yaml")
-	err := runInit(dest, false)
+	dest := filepath.Join(noPerms, "soda.yaml")
+	err := runInit(io.Discard, dest, false)
 	if err == nil {
 		t.Fatal("expected error for inaccessible path, got nil")
 	}
@@ -127,8 +135,8 @@ func TestResolveInitPath_DefaultPath(t *testing.T) {
 	if !filepath.IsAbs(p) {
 		t.Errorf("path %q is not absolute", p)
 	}
-	if filepath.Base(p) != "config.yaml" {
-		t.Errorf("base = %q, want config.yaml", filepath.Base(p))
+	if filepath.Base(p) != "soda.yaml" {
+		t.Errorf("base = %q, want soda.yaml", filepath.Base(p))
 	}
 }
 

--- a/cmd/soda/init_test.go
+++ b/cmd/soda/init_test.go
@@ -17,7 +17,7 @@ func TestRunInit_WritesDefaultConfig(t *testing.T) {
 	dest := filepath.Join(dir, "soda.yaml")
 
 	var buf bytes.Buffer
-	if err := runInit(&buf, dest, false, false, false, true); err != nil {
+	if err := runInit(&buf, strings.NewReader(""), false, dest, false, false, false, true, false); err != nil {
 		t.Fatalf("runInit() error: %v", err)
 	}
 
@@ -52,7 +52,7 @@ func TestRunInit_CreatesParentDirs(t *testing.T) {
 	dir := t.TempDir()
 	dest := filepath.Join(dir, "deep", "nested", "soda.yaml")
 
-	if err := runInit(io.Discard, dest, false, false, false, true); err != nil {
+	if err := runInit(io.Discard, strings.NewReader(""), false, dest, false, false, false, true, false); err != nil {
 		t.Fatalf("runInit() error: %v", err)
 	}
 
@@ -70,7 +70,7 @@ func TestRunInit_RefusesOverwrite(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := runInit(io.Discard, dest, false, false, false, true)
+	err := runInit(io.Discard, strings.NewReader(""), false, dest, false, false, false, true, false)
 	if err == nil {
 		t.Fatal("expected error when file exists, got nil")
 	}
@@ -94,7 +94,7 @@ func TestRunInit_ForceOverwrites(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := runInit(io.Discard, dest, true, false, false, true); err != nil {
+	if err := runInit(io.Discard, strings.NewReader(""), false, dest, true, false, false, true, false); err != nil {
 		t.Fatalf("runInit(force=true) error: %v", err)
 	}
 
@@ -119,7 +119,7 @@ func TestRunInit_StatErrorNotErrNotExist(t *testing.T) {
 	t.Cleanup(func() { os.Chmod(noPerms, 0755) })
 
 	dest := filepath.Join(noPerms, "soda.yaml")
-	err := runInit(io.Discard, dest, false, false, false, true)
+	err := runInit(io.Discard, strings.NewReader(""), false, dest, false, false, false, true, false)
 	if err == nil {
 		t.Fatal("expected error for inaccessible path, got nil")
 	}
@@ -159,7 +159,7 @@ func TestRunInit_DryRun(t *testing.T) {
 	dest := filepath.Join(dir, "soda.yaml")
 
 	var buf bytes.Buffer
-	if err := runInit(&buf, dest, false, true, false, true); err != nil {
+	if err := runInit(&buf, strings.NewReader(""), false, dest, false, true, false, true, false); err != nil {
 		t.Fatalf("runInit(dryRun=true) error: %v", err)
 	}
 
@@ -183,7 +183,7 @@ func TestRunInit_PhasesWritten(t *testing.T) {
 	dest := filepath.Join(dir, "soda.yaml")
 
 	var buf bytes.Buffer
-	if err := runInit(&buf, dest, false, false, true, true); err != nil {
+	if err := runInit(&buf, strings.NewReader(""), false, dest, false, false, true, true, false); err != nil {
 		t.Fatalf("runInit(phases=true) error: %v", err)
 	}
 
@@ -222,7 +222,7 @@ func TestRunInit_PhasesRefusesOverwrite(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := runInit(io.Discard, dest, false, false, true, true)
+	err := runInit(io.Discard, strings.NewReader(""), false, dest, false, false, true, true, false)
 	if err == nil {
 		t.Fatal("expected error when phases.yaml exists, got nil")
 	}
@@ -247,7 +247,7 @@ func TestRunInit_PhasesForceOverwrites(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := runInit(io.Discard, dest, true, false, true, true); err != nil {
+	if err := runInit(io.Discard, strings.NewReader(""), false, dest, true, false, true, true, false); err != nil {
 		t.Fatalf("runInit(force=true, phases=true) error: %v", err)
 	}
 
@@ -270,7 +270,7 @@ func TestRunInit_GitignoreCreated(t *testing.T) {
 
 	var buf bytes.Buffer
 	// noGitignore=false → should create/update .gitignore
-	if err := runInit(&buf, dest, false, false, false, false); err != nil {
+	if err := runInit(&buf, strings.NewReader(""), false, dest, false, false, false, false, false); err != nil {
 		t.Fatalf("runInit() error: %v", err)
 	}
 
@@ -298,7 +298,7 @@ func TestRunInit_GitignoreSkippedWithFlag(t *testing.T) {
 	dest := filepath.Join(dir, "soda.yaml")
 
 	// noGitignore=true → should NOT create .gitignore
-	if err := runInit(io.Discard, dest, false, false, false, true); err != nil {
+	if err := runInit(io.Discard, strings.NewReader(""), false, dest, false, false, false, true, false); err != nil {
 		t.Fatalf("runInit() error: %v", err)
 	}
 
@@ -319,7 +319,7 @@ func TestRunInit_GitignoreAppendsWithoutDuplication(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	if err := runInit(&buf, dest, false, false, false, false); err != nil {
+	if err := runInit(&buf, strings.NewReader(""), false, dest, false, false, false, false, false); err != nil {
 		t.Fatalf("runInit() error: %v", err)
 	}
 
@@ -457,6 +457,136 @@ func TestConfigFromDetected_NoForge(t *testing.T) {
 	}
 	if repo.TestCommand != "pytest" {
 		t.Errorf("Repos[0].TestCommand = %q, want %q", repo.TestCommand, "pytest")
+	}
+}
+
+// TestRunInit_ConfirmationPromptYes verifies that when isTTY=true and the user
+// types "y", the file is written and the prompt is shown.
+func TestRunInit_ConfirmationPromptYes(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "soda.yaml")
+
+	var buf bytes.Buffer
+	if err := runInit(&buf, strings.NewReader("y\n"), true, dest, false, false, false, true, false); err != nil {
+		t.Fatalf("runInit() error: %v", err)
+	}
+
+	if _, err := os.Stat(dest); err != nil {
+		t.Fatalf("file should be written after 'y' response: %v", err)
+	}
+	if !strings.Contains(buf.String(), "Write config to") {
+		t.Errorf("output should show prompt, got: %s", buf.String())
+	}
+}
+
+// TestRunInit_ConfirmationPromptNo verifies that when isTTY=true and the user
+// types "n", the file is NOT written and "Aborted" is reported.
+func TestRunInit_ConfirmationPromptNo(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "soda.yaml")
+
+	var buf bytes.Buffer
+	if err := runInit(&buf, strings.NewReader("n\n"), true, dest, false, false, false, true, false); err != nil {
+		t.Fatalf("runInit() error: %v", err)
+	}
+
+	if _, err := os.Stat(dest); err == nil {
+		t.Fatal("file should not be written after 'n' response")
+	}
+	if !strings.Contains(buf.String(), "Aborted") {
+		t.Errorf("output should mention abort, got: %s", buf.String())
+	}
+}
+
+// TestRunInit_YesSkipsPrompt verifies that --yes skips the confirmation prompt
+// even when isTTY=true.
+func TestRunInit_YesSkipsPrompt(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "soda.yaml")
+
+	var buf bytes.Buffer
+	if err := runInit(&buf, strings.NewReader(""), true, dest, false, false, false, true, true); err != nil {
+		t.Fatalf("runInit(yes=true) error: %v", err)
+	}
+
+	if _, err := os.Stat(dest); err != nil {
+		t.Fatalf("file should be written with --yes: %v", err)
+	}
+	if strings.Contains(buf.String(), "Write config to") {
+		t.Errorf("--yes should skip prompt, got: %s", buf.String())
+	}
+}
+
+// TestRunInit_NonTTYAutoWrites verifies that in a non-TTY environment the file
+// is written automatically without showing a confirmation prompt.
+func TestRunInit_NonTTYAutoWrites(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "soda.yaml")
+
+	var buf bytes.Buffer
+	if err := runInit(&buf, strings.NewReader(""), false, dest, false, false, false, true, false); err != nil {
+		t.Fatalf("runInit(isTTY=false) error: %v", err)
+	}
+
+	if _, err := os.Stat(dest); err != nil {
+		t.Fatalf("non-TTY should auto-write without prompt: %v", err)
+	}
+	if strings.Contains(buf.String(), "Write config to") {
+		t.Errorf("non-TTY should not show prompt, got: %s", buf.String())
+	}
+}
+
+// TestColorMsg_WithColor verifies that color codes are emitted when NO_COLOR is unset.
+func TestColorMsg_WithColor(t *testing.T) {
+	t.Setenv("NO_COLOR", "")
+	result := colorMsg("32", "hello")
+	if !strings.Contains(result, "\033[32m") {
+		t.Errorf("colorMsg should contain ANSI code, got: %q", result)
+	}
+	if !strings.Contains(result, "hello") {
+		t.Errorf("colorMsg should contain message, got: %q", result)
+	}
+}
+
+// TestColorMsg_NoColor verifies that ANSI codes are suppressed when NO_COLOR is set.
+func TestColorMsg_NoColor(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	result := colorMsg("32", "hello")
+	if result != "hello" {
+		t.Errorf("colorMsg with NO_COLOR should return plain text, got: %q", result)
+	}
+}
+
+// TestRunInit_ColorOutput verifies that success messages include ANSI color codes
+// when NO_COLOR is not set.
+func TestRunInit_ColorOutput(t *testing.T) {
+	t.Setenv("NO_COLOR", "")
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "soda.yaml")
+
+	var buf bytes.Buffer
+	if err := runInit(&buf, strings.NewReader(""), false, dest, false, false, false, true, false); err != nil {
+		t.Fatalf("runInit() error: %v", err)
+	}
+
+	if !strings.Contains(buf.String(), "\033[") {
+		t.Errorf("output should contain ANSI color codes, got: %q", buf.String())
+	}
+}
+
+// TestRunInit_NoColorEnv verifies that ANSI codes are absent when NO_COLOR is set.
+func TestRunInit_NoColorEnv(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "soda.yaml")
+
+	var buf bytes.Buffer
+	if err := runInit(&buf, strings.NewReader(""), false, dest, false, false, false, true, false); err != nil {
+		t.Fatalf("runInit() error: %v", err)
+	}
+
+	if strings.Contains(buf.String(), "\033[") {
+		t.Errorf("NO_COLOR should suppress ANSI codes, got: %q", buf.String())
 	}
 }
 

--- a/cmd/soda/init_test.go
+++ b/cmd/soda/init_test.go
@@ -17,7 +17,7 @@ func TestRunInit_WritesDefaultConfig(t *testing.T) {
 	dest := filepath.Join(dir, "soda.yaml")
 
 	var buf bytes.Buffer
-	if err := runInit(&buf, dest, false); err != nil {
+	if err := runInit(&buf, dest, false, false); err != nil {
 		t.Fatalf("runInit() error: %v", err)
 	}
 
@@ -52,7 +52,7 @@ func TestRunInit_CreatesParentDirs(t *testing.T) {
 	dir := t.TempDir()
 	dest := filepath.Join(dir, "deep", "nested", "soda.yaml")
 
-	if err := runInit(io.Discard, dest, false); err != nil {
+	if err := runInit(io.Discard, dest, false, false); err != nil {
 		t.Fatalf("runInit() error: %v", err)
 	}
 
@@ -70,7 +70,7 @@ func TestRunInit_RefusesOverwrite(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := runInit(io.Discard, dest, false)
+	err := runInit(io.Discard, dest, false, false)
 	if err == nil {
 		t.Fatal("expected error when file exists, got nil")
 	}
@@ -94,7 +94,7 @@ func TestRunInit_ForceOverwrites(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := runInit(io.Discard, dest, true); err != nil {
+	if err := runInit(io.Discard, dest, true, false); err != nil {
 		t.Fatalf("runInit(force=true) error: %v", err)
 	}
 
@@ -119,7 +119,7 @@ func TestRunInit_StatErrorNotErrNotExist(t *testing.T) {
 	t.Cleanup(func() { os.Chmod(noPerms, 0755) })
 
 	dest := filepath.Join(noPerms, "soda.yaml")
-	err := runInit(io.Discard, dest, false)
+	err := runInit(io.Discard, dest, false, false)
 	if err == nil {
 		t.Fatal("expected error for inaccessible path, got nil")
 	}
@@ -151,6 +151,30 @@ func TestResolveInitPath_CustomPath(t *testing.T) {
 	}
 	if filepath.Base(p) != "my-config.yaml" {
 		t.Errorf("base = %q, want my-config.yaml", filepath.Base(p))
+	}
+}
+
+func TestRunInit_DryRun(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "soda.yaml")
+
+	var buf bytes.Buffer
+	if err := runInit(&buf, dest, false, true); err != nil {
+		t.Fatalf("runInit(dryRun=true) error: %v", err)
+	}
+
+	// File must NOT be written.
+	if _, err := os.Stat(dest); err == nil {
+		t.Fatal("dry-run should not write a file")
+	}
+
+	// Output must contain valid YAML config.
+	output := buf.String()
+	if !strings.Contains(output, "ticket_source") {
+		t.Errorf("dry-run output missing ticket_source, got: %s", output)
+	}
+	if !strings.Contains(output, "mode:") {
+		t.Errorf("dry-run output missing mode field, got: %s", output)
 	}
 }
 

--- a/cmd/soda/init_test.go
+++ b/cmd/soda/init_test.go
@@ -17,7 +17,7 @@ func TestRunInit_WritesDefaultConfig(t *testing.T) {
 	dest := filepath.Join(dir, "soda.yaml")
 
 	var buf bytes.Buffer
-	if err := runInit(&buf, dest, false, false, false); err != nil {
+	if err := runInit(&buf, dest, false, false, false, true); err != nil {
 		t.Fatalf("runInit() error: %v", err)
 	}
 
@@ -52,7 +52,7 @@ func TestRunInit_CreatesParentDirs(t *testing.T) {
 	dir := t.TempDir()
 	dest := filepath.Join(dir, "deep", "nested", "soda.yaml")
 
-	if err := runInit(io.Discard, dest, false, false, false); err != nil {
+	if err := runInit(io.Discard, dest, false, false, false, true); err != nil {
 		t.Fatalf("runInit() error: %v", err)
 	}
 
@@ -70,7 +70,7 @@ func TestRunInit_RefusesOverwrite(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := runInit(io.Discard, dest, false, false, false)
+	err := runInit(io.Discard, dest, false, false, false, true)
 	if err == nil {
 		t.Fatal("expected error when file exists, got nil")
 	}
@@ -94,7 +94,7 @@ func TestRunInit_ForceOverwrites(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := runInit(io.Discard, dest, true, false, false); err != nil {
+	if err := runInit(io.Discard, dest, true, false, false, true); err != nil {
 		t.Fatalf("runInit(force=true) error: %v", err)
 	}
 
@@ -119,7 +119,7 @@ func TestRunInit_StatErrorNotErrNotExist(t *testing.T) {
 	t.Cleanup(func() { os.Chmod(noPerms, 0755) })
 
 	dest := filepath.Join(noPerms, "soda.yaml")
-	err := runInit(io.Discard, dest, false, false, false)
+	err := runInit(io.Discard, dest, false, false, false, true)
 	if err == nil {
 		t.Fatal("expected error for inaccessible path, got nil")
 	}
@@ -159,7 +159,7 @@ func TestRunInit_DryRun(t *testing.T) {
 	dest := filepath.Join(dir, "soda.yaml")
 
 	var buf bytes.Buffer
-	if err := runInit(&buf, dest, false, true, false); err != nil {
+	if err := runInit(&buf, dest, false, true, false, true); err != nil {
 		t.Fatalf("runInit(dryRun=true) error: %v", err)
 	}
 
@@ -183,7 +183,7 @@ func TestRunInit_PhasesWritten(t *testing.T) {
 	dest := filepath.Join(dir, "soda.yaml")
 
 	var buf bytes.Buffer
-	if err := runInit(&buf, dest, false, false, true); err != nil {
+	if err := runInit(&buf, dest, false, false, true, true); err != nil {
 		t.Fatalf("runInit(phases=true) error: %v", err)
 	}
 
@@ -222,7 +222,7 @@ func TestRunInit_PhasesRefusesOverwrite(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := runInit(io.Discard, dest, false, false, true)
+	err := runInit(io.Discard, dest, false, false, true, true)
 	if err == nil {
 		t.Fatal("expected error when phases.yaml exists, got nil")
 	}
@@ -247,7 +247,7 @@ func TestRunInit_PhasesForceOverwrites(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := runInit(io.Discard, dest, true, false, true); err != nil {
+	if err := runInit(io.Discard, dest, true, false, true, true); err != nil {
 		t.Fatalf("runInit(force=true, phases=true) error: %v", err)
 	}
 
@@ -261,6 +261,110 @@ func TestRunInit_PhasesForceOverwrites(t *testing.T) {
 	}
 	if len(data) == 0 {
 		t.Error("phases.yaml is empty after overwrite")
+	}
+}
+
+func TestRunInit_GitignoreCreated(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "soda.yaml")
+
+	var buf bytes.Buffer
+	// noGitignore=false → should create/update .gitignore
+	if err := runInit(&buf, dest, false, false, false, false); err != nil {
+		t.Fatalf("runInit() error: %v", err)
+	}
+
+	gitignorePath := filepath.Join(dir, ".gitignore")
+	data, err := os.ReadFile(gitignorePath)
+	if err != nil {
+		t.Fatalf("read .gitignore: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, ".soda/") {
+		t.Errorf(".gitignore missing .soda/ entry: %s", content)
+	}
+	if !strings.Contains(content, ".worktrees/") {
+		t.Errorf(".gitignore missing .worktrees/ entry: %s", content)
+	}
+
+	// Output must mention the update.
+	if !strings.Contains(buf.String(), "Updated .gitignore") {
+		t.Errorf("output missing gitignore update message: %s", buf.String())
+	}
+}
+
+func TestRunInit_GitignoreSkippedWithFlag(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "soda.yaml")
+
+	// noGitignore=true → should NOT create .gitignore
+	if err := runInit(io.Discard, dest, false, false, false, true); err != nil {
+		t.Fatalf("runInit() error: %v", err)
+	}
+
+	gitignorePath := filepath.Join(dir, ".gitignore")
+	if _, err := os.Stat(gitignorePath); err == nil {
+		t.Error("--no-gitignore should prevent .gitignore creation")
+	}
+}
+
+func TestRunInit_GitignoreAppendsWithoutDuplication(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "soda.yaml")
+
+	// Pre-create .gitignore with .soda/ already present.
+	gitignorePath := filepath.Join(dir, ".gitignore")
+	if err := os.WriteFile(gitignorePath, []byte("# existing\n.soda/\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if err := runInit(&buf, dest, false, false, false, false); err != nil {
+		t.Fatalf("runInit() error: %v", err)
+	}
+
+	data, err := os.ReadFile(gitignorePath)
+	if err != nil {
+		t.Fatalf("read .gitignore: %v", err)
+	}
+	content := string(data)
+
+	// .soda/ should appear exactly once (not duplicated).
+	count := strings.Count(content, ".soda/")
+	if count != 1 {
+		t.Errorf(".soda/ appears %d times, want 1: %s", count, content)
+	}
+
+	// .worktrees/ should be appended.
+	if !strings.Contains(content, ".worktrees/") {
+		t.Errorf(".gitignore missing .worktrees/ entry: %s", content)
+	}
+}
+
+func TestEnsureGitignore_ExistingEntriesWithoutSlash(t *testing.T) {
+	dir := t.TempDir()
+	gitignorePath := filepath.Join(dir, ".gitignore")
+
+	// Entries without trailing slash should still prevent duplication.
+	if err := os.WriteFile(gitignorePath, []byte(".soda\n.worktrees\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{StateDir: ".soda", WorktreeDir: ".worktrees"}
+
+	var buf bytes.Buffer
+	if err := ensureGitignore(&buf, gitignorePath, cfg); err != nil {
+		t.Fatalf("ensureGitignore() error: %v", err)
+	}
+
+	// Should not add anything since both entries already exist (without slash).
+	if buf.Len() > 0 {
+		t.Errorf("expected no output (nothing to add), got: %s", buf.String())
+	}
+
+	data, _ := os.ReadFile(gitignorePath)
+	if strings.Contains(string(data), ".soda/") {
+		t.Error("should not duplicate entries that exist without trailing slash")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `soda init` command that auto-detects project stack via `detect.Detect()` and generates `soda.yaml`
- Supports `--yes`, `--force`, `--dry-run`, `--phases`, `--no-gitignore`, `--output` flags
- Appends `.soda/` and `.worktrees/` to `.gitignore` (dedup-aware)
- TTY confirmation prompt, auto-write in non-TTY
- Colored output respecting `NO_COLOR`
- Detection warnings written to stderr to avoid contaminating `--dry-run` pipe output

Closes #211

Assisted-by: Claude Opus 4.6