### PR TITLE
fix(pipeline): rework feedback loses context from prior cycles (#241)

### DIFF
--- a/cmd/soda/embeds/prompts/implement.md
+++ b/cmd/soda/embeds/prompts/implement.md
@@ -21,6 +21,17 @@ Summary: {{.Ticket.Summary}}
 {{- end}}
 
 {{- if .ReworkFeedback}}
+{{- if .ReworkFeedback.PriorCycles}}
+
+## Context: Prior Review Cycles
+
+The following issues were reported in earlier rework cycles. Some may have been fixed already.
+Use this context to avoid re-introducing previously-fixed issues or repeating the same mistakes.
+
+{{- range .ReworkFeedback.PriorCycles}}
+- **Cycle {{.Cycle}}** ({{.Source}}, verdict: {{.Verdict}}): {{.Summary}}
+{{- end}}
+{{- end}}
 {{- if eq .ReworkFeedback.Source "review"}}
 
 ## MANDATORY: Specialist Review Findings (MUST address)

--- a/cmd/soda/embeds/prompts/patch.md
+++ b/cmd/soda/embeds/prompts/patch.md
@@ -24,6 +24,17 @@ The following diff shows what was implemented (base...HEAD):
 {{- end}}
 
 {{- if .ReworkFeedback}}
+{{- if .ReworkFeedback.PriorCycles}}
+
+## Context: Prior Verification Cycles
+
+The following issues were reported in earlier patch cycles. Some may have been fixed already.
+Use this context to avoid re-introducing previously-fixed issues or repeating the same mistakes.
+
+{{- range .ReworkFeedback.PriorCycles}}
+- **Cycle {{.Cycle}}** ({{.Source}}, verdict: {{.Verdict}}): {{.Summary}}
+{{- end}}
+{{- end}}
 
 ## FIXES REQUIRED
 

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -1028,12 +1028,11 @@ func (e *Engine) extractFeedbackFrom(source string) *ReworkFeedback {
 // exists, the verdict is not FAIL, or the plan has changed since verify
 // ran (staleness guard).
 //
-// This function always reads the current verify.json, not archived
-// generations. On each rework cycle (patch retry), verify re-runs after
-// implement (because verify depends on implement), overwriting
-// verify.json with the latest results. The next call to
-// extractVerifyFeedback therefore returns only the most recent
-// failures — previous failures that were fixed are no longer present.
+// The top-level fields (Verdict, FixesRequired, etc.) always reflect
+// only the most recent verify.json. PriorCycles is populated from
+// archived results (verify.json.1, verify.json.2, ...) so the LLM
+// has context about what was previously reported.
+//
 // Only critical/major code issues and failed criteria/commands are
 // included to keep prompt context focused.
 func (e *Engine) extractVerifyFeedback() *ReworkFeedback {
@@ -1128,6 +1127,9 @@ func (e *Engine) extractVerifyFeedback() *ReworkFeedback {
 		}
 	}
 
+	// Collect prior cycle context from archived verify results.
+	fb.PriorCycles = e.collectPriorVerifyCycles()
+
 	return fb
 }
 
@@ -1135,11 +1137,10 @@ func (e *Engine) extractVerifyFeedback() *ReworkFeedback {
 // feedback when the verdict is "rework". Returns nil if no review result
 // exists or the verdict is not "rework".
 //
-// Like extractVerifyFeedback, this reads the current review.json which
-// is overwritten each time the review phase re-runs. On a patch retry
-// (rework cycle), review re-runs after implement, so the next
-// extraction sees only the latest findings — previously reported issues
-// that were fixed will not appear. Only critical/major findings are
+// The top-level fields (Verdict, ReviewFindings) reflect the most recent
+// review.json. PriorCycles is populated from archived results
+// (review.json.1, review.json.2, ...) so the LLM has context about
+// what was previously reported. Only critical/major findings are
 // included to keep prompt context focused.
 func (e *Engine) extractReviewFeedback() *ReworkFeedback {
 	raw, err := e.state.ReadResult("review")
@@ -1168,7 +1169,129 @@ func (e *Engine) extractReviewFeedback() *ReworkFeedback {
 		}
 	}
 
+	// Collect prior cycle context from archived review results.
+	fb.PriorCycles = e.collectPriorReviewCycles()
+
 	return fb
+}
+
+// collectPriorReviewCycles reads archived review results (review.json.1,
+// review.json.2, ...) and builds PriorCycle summaries. Only cycles with
+// a "rework" verdict are included (pass cycles don't carry useful context
+// for rework). Returns nil if no prior cycles exist.
+func (e *Engine) collectPriorReviewCycles() []PriorCycle {
+	reviewPS := e.state.Meta().Phases["review"]
+	if reviewPS == nil || reviewPS.Generation <= 1 {
+		return nil
+	}
+
+	var priors []PriorCycle
+	for gen := 1; gen < reviewPS.Generation; gen++ {
+		raw, err := e.state.ReadArchivedResult("review", gen)
+		if err != nil {
+			continue
+		}
+
+		var result schemas.ReviewOutput
+		if err := json.Unmarshal(raw, &result); err != nil {
+			continue
+		}
+
+		// Only include rework cycles — pass cycles don't carry useful context.
+		if !strings.EqualFold(result.Verdict, "rework") {
+			continue
+		}
+
+		summary := summarizeReviewFindings(result.Findings)
+		if summary == "" {
+			continue
+		}
+
+		priors = append(priors, PriorCycle{
+			Cycle:   gen,
+			Source:  "review",
+			Verdict: result.Verdict,
+			Summary: summary,
+		})
+	}
+	return priors
+}
+
+// collectPriorVerifyCycles reads archived verify results (verify.json.1,
+// verify.json.2, ...) and builds PriorCycle summaries. Only cycles with
+// a FAIL verdict are included. Returns nil if no prior cycles exist.
+func (e *Engine) collectPriorVerifyCycles() []PriorCycle {
+	verifyPS := e.state.Meta().Phases["verify"]
+	if verifyPS == nil || verifyPS.Generation <= 1 {
+		return nil
+	}
+
+	var priors []PriorCycle
+	for gen := 1; gen < verifyPS.Generation; gen++ {
+		raw, err := e.state.ReadArchivedResult("verify", gen)
+		if err != nil {
+			continue
+		}
+
+		var result struct {
+			Verdict       string   `json:"verdict"`
+			FixesRequired []string `json:"fixes_required"`
+		}
+		if err := json.Unmarshal(raw, &result); err != nil {
+			continue
+		}
+
+		// Only include FAIL cycles.
+		if !strings.EqualFold(result.Verdict, "FAIL") {
+			continue
+		}
+
+		summary := summarizeVerifyFailures(result.FixesRequired)
+		if summary == "" {
+			continue
+		}
+
+		priors = append(priors, PriorCycle{
+			Cycle:   gen,
+			Source:  "verify",
+			Verdict: result.Verdict,
+			Summary: summary,
+		})
+	}
+	return priors
+}
+
+// summarizeReviewFindings produces a concise summary of review findings
+// for prior cycle context. Includes only critical/major findings.
+func summarizeReviewFindings(findings []schemas.ReviewFinding) string {
+	var parts []string
+	for _, f := range findings {
+		sev := strings.ToLower(f.Severity)
+		if sev == "critical" || sev == "major" {
+			loc := f.File
+			if f.Line > 0 {
+				loc = fmt.Sprintf("%s:%d", f.File, f.Line)
+			}
+			if loc != "" {
+				parts = append(parts, fmt.Sprintf("[%s] %s — %s", f.Severity, loc, f.Issue))
+			} else {
+				parts = append(parts, fmt.Sprintf("[%s] %s", f.Severity, f.Issue))
+			}
+		}
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.Join(parts, "; ")
+}
+
+// summarizeVerifyFailures produces a concise summary of verify failures
+// for prior cycle context.
+func summarizeVerifyFailures(fixesRequired []string) string {
+	if len(fixesRequired) == 0 {
+		return ""
+	}
+	return strings.Join(fixesRequired, "; ")
 }
 
 // computeDiffContext returns the git diff of the current branch against the

--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -8906,6 +8906,417 @@ func TestEngine_PhaseBudgetCumulativePreRunCheck(t *testing.T) {
 	}
 }
 
+func TestEngine_ReworkFeedbackIncludesPriorReviewCycles(t *testing.T) {
+	// When review produces "rework" and routes back to implement, the
+	// implement prompt should include prior cycle context from archived
+	// review results. This test simulates two review cycles: the first
+	// produces a rework, and the second (after re-implement) also produces
+	// a rework. The second implement should see prior cycle context from
+	// the first review.
+	phases := []PhaseConfig{
+		{
+			Name:         "implement",
+			Prompt:       "implement.md",
+			Retry:        RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			FeedbackFrom: []string{"review"},
+		},
+		{
+			Name:      "review",
+			Type:      "parallel-review",
+			DependsOn: []string{"implement"},
+			Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			Rework:    &ReworkConfig{Target: "implement"},
+			Reviewers: []ReviewerConfig{
+				{Name: "go-specialist", Prompt: "prompts/review-go.md", Focus: "Go idioms"},
+			},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"implement": {
+				// First implement.
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(`{"tests_passed":true}`),
+					RawText: "impl1",
+					CostUSD: 0.10,
+				}},
+				// Second implement (after first rework).
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(`{"tests_passed":true}`),
+					RawText: "impl2",
+					CostUSD: 0.10,
+				}},
+				// Third implement (after second rework).
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(`{"tests_passed":true}`),
+					RawText: "impl3",
+					CostUSD: 0.10,
+				}},
+			},
+			"review/go-specialist": {
+				// First review: rework with critical finding.
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(`{"findings":[{"severity":"critical","file":"handler.go","line":42,"issue":"nil deref","suggestion":"add nil check"}]}`),
+					RawText: "critical issue",
+					CostUSD: 0.15,
+				}},
+				// Second review: rework with different finding.
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(`{"findings":[{"severity":"major","file":"util.go","line":10,"issue":"unchecked error","suggestion":"check return value"}]}`),
+					RawText: "major issue",
+					CostUSD: 0.15,
+				}},
+				// Third review: pass.
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(`{"findings":[]}`),
+					RawText: "no issues",
+					CostUSD: 0.15,
+				}},
+			},
+		},
+	}
+
+	stateDir := t.TempDir()
+	promptDir := t.TempDir()
+	workDir := t.TempDir()
+
+	// Template that renders PriorCycles.
+	implTmpl := `Phase: implement
+Ticket: {{.Ticket.Key}}
+{{- if .ReworkFeedback}}
+REWORK:
+Source: {{.ReworkFeedback.Source}}
+Verdict: {{.ReworkFeedback.Verdict}}
+{{- range .ReworkFeedback.ReviewFindings}}
+Finding: [{{.Severity}}] {{.File}}:{{.Line}} — {{.Issue}}
+{{- end}}
+{{- if .ReworkFeedback.PriorCycles}}
+PRIOR_CYCLES:
+{{- range .ReworkFeedback.PriorCycles}}
+Cycle{{.Cycle}}: [{{.Source}}] {{.Verdict}} — {{.Summary}}
+{{- end}}
+{{- end}}
+{{- end}}
+`
+	if err := os.WriteFile(filepath.Join(promptDir, "implement.md"), []byte(implTmpl), 0644); err != nil {
+		t.Fatal(err)
+	}
+	reviewPromptDir := filepath.Join(promptDir, "prompts")
+	if err := os.MkdirAll(reviewPromptDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(reviewPromptDir, "review-go.md"), []byte("Reviewer: go-specialist\nTicket: {{.Ticket.Key}}\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := LoadOrCreate(stateDir, "PRIOR-1")
+	if err != nil {
+		t.Fatalf("LoadOrCreate: %v", err)
+	}
+
+	var events []Event
+	cfg := EngineConfig{
+		Pipeline:        &PhasePipeline{Phases: phases},
+		Loader:          NewPromptLoader(promptDir),
+		Ticket:          TicketData{Key: "PRIOR-1", Summary: "Prior cycles test"},
+		Model:           "test-model",
+		WorkDir:         workDir,
+		MaxCostUSD:      0,
+		MaxReworkCycles: 3,
+		Mode:            Autonomous,
+		SleepFunc:       func(time.Duration) {},
+		JitterFunc:      func(time.Duration) time.Duration { return 0 },
+		OnEvent: func(e Event) {
+			events = append(events, e)
+		},
+	}
+
+	engine := NewEngine(mock, state, cfg)
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// Find the implement runner calls.
+	var implPrompts []string
+	for _, call := range mock.calls {
+		if call.Phase == "implement" {
+			implPrompts = append(implPrompts, call.SystemPrompt)
+		}
+	}
+
+	if len(implPrompts) < 3 {
+		t.Fatalf("expected 3 implement calls, got %d", len(implPrompts))
+	}
+
+	// First implement: no rework feedback.
+	if strings.Contains(implPrompts[0], "REWORK:") {
+		t.Error("first implement should not have rework feedback")
+	}
+
+	// Second implement: rework feedback from first review, no prior cycles.
+	if !strings.Contains(implPrompts[1], "REWORK:") {
+		t.Error("second implement should have rework feedback")
+	}
+	if !strings.Contains(implPrompts[1], "nil deref") {
+		t.Error("second implement should reference nil deref finding")
+	}
+	if strings.Contains(implPrompts[1], "PRIOR_CYCLES:") {
+		t.Error("second implement should NOT have prior cycles (first rework)")
+	}
+
+	// Third implement: rework feedback from second review, WITH prior cycle context.
+	if !strings.Contains(implPrompts[2], "REWORK:") {
+		t.Error("third implement should have rework feedback")
+	}
+	if !strings.Contains(implPrompts[2], "unchecked error") {
+		t.Error("third implement should reference unchecked error finding")
+	}
+	if !strings.Contains(implPrompts[2], "PRIOR_CYCLES:") {
+		t.Error("third implement should have prior cycles")
+	}
+	if !strings.Contains(implPrompts[2], "nil deref") {
+		t.Error("third implement prior cycles should reference nil deref from cycle 1")
+	}
+}
+
+func TestEngine_ReworkFeedbackIncludesPriorVerifyCycles(t *testing.T) {
+	// When verify produces "FAIL" and routes to patch (corrective),
+	// the patch prompt should include prior cycle context from archived
+	// verify results.
+	phases := []PhaseConfig{
+		{
+			Name:   "implement",
+			Prompt: "implement.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+		{
+			Name:         "patch",
+			Type:         "corrective",
+			Prompt:       "patch.md",
+			DependsOn:    []string{"implement"},
+			FeedbackFrom: []string{"verify"},
+			Retry:        RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+		{
+			Name:      "verify",
+			Prompt:    "verify.md",
+			DependsOn: []string{"implement"},
+			Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			Corrective: &CorrectiveConfig{
+				Phase:       "patch",
+				MaxAttempts: 3,
+				OnExhausted: "stop",
+			},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"implement": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"tests_passed":true}`),
+					RawText: "impl",
+					CostUSD: 0.10,
+				},
+			}},
+			"patch": {
+				// First patch.
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(`{"ticket_key":"TEST-1","fix_results":[],"files_changed":[],"tests_passed":true,"too_complex":false}`),
+					RawText: "patched1",
+					CostUSD: 0.10,
+				}},
+				// Second patch.
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(`{"ticket_key":"TEST-1","fix_results":[],"files_changed":[],"tests_passed":true,"too_complex":false}`),
+					RawText: "patched2",
+					CostUSD: 0.10,
+				}},
+			},
+			"verify": {
+				// First verify: FAIL with test A.
+				{result: &runner.RunResult{
+					Output: json.RawMessage(`{
+						"verdict":"FAIL",
+						"fixes_required":["fix test A"],
+						"criteria_results":[{"criterion":"tests pass","passed":false,"evidence":"exit code 1"}],
+						"command_results":[]
+					}`),
+					RawText: "fail",
+					CostUSD: 0.05,
+				}},
+				// Second verify (after first patch): FAIL with same criterion but new fix.
+				{result: &runner.RunResult{
+					Output: json.RawMessage(`{
+						"verdict":"FAIL",
+						"fixes_required":["fix test B"],
+						"criteria_results":[{"criterion":"tests pass","passed":false,"evidence":"assertion error"}],
+						"command_results":[]
+					}`),
+					RawText: "fail2",
+					CostUSD: 0.05,
+				}},
+				// Third verify (after second patch): PASS.
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(`{"verdict":"PASS","criteria_results":[],"command_results":[]}`),
+					RawText: "pass",
+					CostUSD: 0.05,
+				}},
+			},
+		},
+	}
+
+	stateDir := t.TempDir()
+	promptDir := t.TempDir()
+	workDir := t.TempDir()
+
+	implTmpl := "Phase: implement\nTicket: {{.Ticket.Key}}\n"
+	verifyTmpl := "Phase: verify\nTicket: {{.Ticket.Key}}\n"
+	patchTmpl := `Phase: patch
+Ticket: {{.Ticket.Key}}
+{{- if .ReworkFeedback}}
+REWORK:
+Source: {{.ReworkFeedback.Source}}
+Verdict: {{.ReworkFeedback.Verdict}}
+{{- range .ReworkFeedback.FixesRequired}}
+Fix: {{.}}
+{{- end}}
+{{- if .ReworkFeedback.PriorCycles}}
+PRIOR_CYCLES:
+{{- range .ReworkFeedback.PriorCycles}}
+Cycle{{.Cycle}}: [{{.Source}}] {{.Verdict}} — {{.Summary}}
+{{- end}}
+{{- end}}
+{{- end}}
+`
+	if err := os.WriteFile(filepath.Join(promptDir, "implement.md"), []byte(implTmpl), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(promptDir, "verify.md"), []byte(verifyTmpl), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(promptDir, "patch.md"), []byte(patchTmpl), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := LoadOrCreate(stateDir, "VPRIOR-1")
+	if err != nil {
+		t.Fatalf("LoadOrCreate: %v", err)
+	}
+
+	cfg := EngineConfig{
+		Pipeline:   &PhasePipeline{Phases: phases},
+		Loader:     NewPromptLoader(promptDir),
+		Ticket:     TicketData{Key: "VPRIOR-1", Summary: "Verify prior cycles test"},
+		Model:      "test-model",
+		WorkDir:    workDir,
+		MaxCostUSD: 0,
+		Mode:       Autonomous,
+		SleepFunc:  func(time.Duration) {},
+		JitterFunc: func(time.Duration) time.Duration { return 0 },
+	}
+
+	engine := NewEngine(mock, state, cfg)
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// Find the patch runner calls.
+	var patchPrompts []string
+	for _, call := range mock.calls {
+		if call.Phase == "patch" {
+			patchPrompts = append(patchPrompts, call.SystemPrompt)
+		}
+	}
+
+	if len(patchPrompts) < 2 {
+		t.Fatalf("expected 2 patch calls, got %d", len(patchPrompts))
+	}
+
+	// First patch: rework feedback from first verify, no prior cycles.
+	if !strings.Contains(patchPrompts[0], "fix test A") {
+		t.Error("first patch should reference 'fix test A'")
+	}
+	if strings.Contains(patchPrompts[0], "PRIOR_CYCLES:") {
+		t.Error("first patch should NOT have prior cycles")
+	}
+
+	// Second patch: rework feedback from second verify, WITH prior cycle context.
+	if !strings.Contains(patchPrompts[1], "fix test B") {
+		t.Error("second patch should reference 'fix test B'")
+	}
+	if !strings.Contains(patchPrompts[1], "PRIOR_CYCLES:") {
+		t.Error("second patch should have prior cycles")
+	}
+	if !strings.Contains(patchPrompts[1], "fix test A") {
+		t.Error("second patch prior cycles should reference 'fix test A' from cycle 1")
+	}
+}
+
+func TestSummarizeReviewFindings(t *testing.T) {
+	t.Run("includes_critical_and_major", func(t *testing.T) {
+		findings := []schemas.ReviewFinding{
+			{Severity: "critical", File: "handler.go", Line: 42, Issue: "nil deref"},
+			{Severity: "major", File: "util.go", Issue: "unchecked error"},
+			{Severity: "minor", File: "style.go", Issue: "unused import"},
+		}
+		summary := summarizeReviewFindings(findings)
+		if !strings.Contains(summary, "nil deref") {
+			t.Errorf("summary should contain critical finding, got: %s", summary)
+		}
+		if !strings.Contains(summary, "unchecked error") {
+			t.Errorf("summary should contain major finding, got: %s", summary)
+		}
+		if strings.Contains(summary, "unused import") {
+			t.Errorf("summary should NOT contain minor finding, got: %s", summary)
+		}
+	})
+
+	t.Run("empty_when_no_critical_or_major", func(t *testing.T) {
+		findings := []schemas.ReviewFinding{
+			{Severity: "minor", File: "style.go", Issue: "unused import"},
+		}
+		if summary := summarizeReviewFindings(findings); summary != "" {
+			t.Errorf("summary should be empty for minor-only findings, got: %s", summary)
+		}
+	})
+
+	t.Run("empty_when_no_findings", func(t *testing.T) {
+		if summary := summarizeReviewFindings(nil); summary != "" {
+			t.Errorf("summary should be empty for nil findings, got: %s", summary)
+		}
+	})
+
+	t.Run("includes_line_numbers", func(t *testing.T) {
+		findings := []schemas.ReviewFinding{
+			{Severity: "critical", File: "x.go", Line: 10, Issue: "bad"},
+		}
+		summary := summarizeReviewFindings(findings)
+		if !strings.Contains(summary, "x.go:10") {
+			t.Errorf("summary should contain line number, got: %s", summary)
+		}
+	})
+}
+
+func TestSummarizeVerifyFailures(t *testing.T) {
+	t.Run("joins_fixes", func(t *testing.T) {
+		fixes := []string{"fix A", "fix B"}
+		summary := summarizeVerifyFailures(fixes)
+		if summary != "fix A; fix B" {
+			t.Errorf("summary = %q, want %q", summary, "fix A; fix B")
+		}
+	})
+
+	t.Run("empty_when_no_fixes", func(t *testing.T) {
+		if summary := summarizeVerifyFailures(nil); summary != "" {
+			t.Errorf("summary should be empty for nil fixes, got: %s", summary)
+		}
+	})
+}
+
 func TestEngine_PhaseBudgetRunnerCapSubtractsCumulativeCost(t *testing.T) {
 	// When a phase re-runs via rework, the runner's MaxBudgetUSD should
 	// reflect the remaining per-phase budget (MaxCostPerPhase - CumulativeCost),

--- a/internal/pipeline/prompt.go
+++ b/internal/pipeline/prompt.go
@@ -44,16 +44,16 @@ type DetectedStackData struct {
 // ReworkFeedback holds selective feedback from a failed verify phase
 // or a review-rework verdict, injected into implement's prompt on resume.
 //
-// Reset behavior on patch retry: ReworkFeedback is rebuilt from scratch
-// on every rework cycle — it is never accumulated across cycles. When
-// the engine routes back to implement (patch retry), buildPromptData
-// calls extractVerifyFeedback / extractReviewFeedback which read the
-// CURRENT verify.json or review.json result on disk. After implement
-// re-runs, verify and review re-run too (they depend on implement),
-// overwriting the previous result files. So on the next rework cycle,
-// implement sees only the latest failures, not a union of all prior
-// failures. This ensures the LLM focuses on remaining issues rather
-// than re-fixing already-resolved ones.
+// Current-cycle feedback is rebuilt from the latest verify.json or
+// review.json on each rework cycle. After implement re-runs, verify
+// and review re-run too (they depend on implement), overwriting the
+// previous result files. So the top-level fields (Verdict, FixesRequired,
+// etc.) always reflect only the most recent failures.
+//
+// PriorCycles preserves summarized context from earlier rework cycles
+// (read from archived results like review.json.1, verify.json.2, etc.)
+// so the LLM can see what was previously flagged and avoid repeating
+// mistakes or regressing on issues that were already fixed.
 type ReworkFeedback struct {
 	Verdict        string
 	Source         string // "verify" or "review"
@@ -62,6 +62,17 @@ type ReworkFeedback struct {
 	CodeIssues     []ReworkCodeIssue
 	FailedCommands []FailedCommand
 	ReviewFindings []schemas.ReviewFinding
+	PriorCycles    []PriorCycle
+}
+
+// PriorCycle holds a summarized snapshot of feedback from a previous
+// rework cycle. Populated from archived result files (e.g., review.json.1)
+// so the LLM has context about what was previously reported.
+type PriorCycle struct {
+	Cycle   int    // 1-based cycle number
+	Source  string // "verify" or "review"
+	Verdict string
+	Summary string // human-readable summary of findings from that cycle
 }
 
 // FailedCriterion is a single acceptance criterion that failed verification.

--- a/internal/pipeline/prompt_test.go
+++ b/internal/pipeline/prompt_test.go
@@ -311,6 +311,13 @@ func TestValidateTemplate(t *testing.T) {
 		}
 	})
 
+	t.Run("valid_template_with_prior_cycles", func(t *testing.T) {
+		tmpl := `{{- if .ReworkFeedback}}{{- if .ReworkFeedback.PriorCycles}}{{range .ReworkFeedback.PriorCycles}}Cycle {{.Cycle}}: {{.Summary}}{{end}}{{- end}}{{- end}}`
+		if err := ValidateTemplate(tmpl); err != nil {
+			t.Fatalf("ValidateTemplate: %v", err)
+		}
+	})
+
 	t.Run("valid_template_with_existing_spec_and_plan", func(t *testing.T) {
 		tmpl := `{{- if .Ticket.ExistingSpec}}Spec: {{.Ticket.ExistingSpec}}{{- end}}
 {{- if .Ticket.ExistingPlan}}Plan: {{.Ticket.ExistingPlan}}{{- end}}`
@@ -866,6 +873,132 @@ Context: {{.}}
 		// Without feedback, should not have FIXES REQUIRED section.
 		if strings.Contains(result, "FIXES REQUIRED") {
 			t.Error("patch prompt should NOT contain FIXES REQUIRED when no feedback")
+		}
+	})
+
+	t.Run("renders_implement_prompt_with_prior_review_cycles", func(t *testing.T) {
+		tmplBytes, err := os.ReadFile(filepath.Join("..", "..", "cmd", "soda", "embeds", "prompts", "implement.md"))
+		if err != nil {
+			t.Skipf("skipping: cannot read embedded implement.md: %v", err)
+		}
+		tmpl := string(tmplBytes)
+
+		data := PromptData{
+			Ticket:       TicketData{Key: "TEST-241", Summary: "prior cycles test"},
+			WorktreePath: "/tmp/wt",
+			Branch:       "soda/TEST-241",
+			BaseBranch:   "main",
+			Config:       PromptConfigData{Formatter: "gofmt -w .", TestCommand: "go test ./..."},
+			ReworkFeedback: &ReworkFeedback{
+				Source:  "review",
+				Verdict: "rework",
+				ReviewFindings: []schemas.ReviewFinding{
+					{Severity: "major", File: "handler.go", Line: 20, Issue: "missing error check", Suggestion: "add error handling", Source: "go-specialist"},
+				},
+				PriorCycles: []PriorCycle{
+					{Cycle: 1, Source: "review", Verdict: "rework", Summary: "[critical] handler.go:42 — nil deref"},
+				},
+			},
+		}
+
+		result, err := RenderPrompt(tmpl, data)
+		if err != nil {
+			t.Fatalf("RenderPrompt: %v", err)
+		}
+
+		// Should contain prior cycles section.
+		if !strings.Contains(result, "Prior Review Cycles") {
+			t.Errorf("implement prompt should contain 'Prior Review Cycles' header;\ngot: %s", result)
+		}
+		if !strings.Contains(result, "Cycle 1") {
+			t.Errorf("implement prompt should contain 'Cycle 1';\ngot: %s", result)
+		}
+		if !strings.Contains(result, "nil deref") {
+			t.Errorf("implement prompt should contain prior cycle summary;\ngot: %s", result)
+		}
+		// Should also contain current findings.
+		if !strings.Contains(result, "missing error check") {
+			t.Errorf("implement prompt should contain current finding;\ngot: %s", result)
+		}
+	})
+
+	t.Run("renders_implement_prompt_without_prior_cycles_on_first_rework", func(t *testing.T) {
+		tmplBytes, err := os.ReadFile(filepath.Join("..", "..", "cmd", "soda", "embeds", "prompts", "implement.md"))
+		if err != nil {
+			t.Skipf("skipping: cannot read embedded implement.md: %v", err)
+		}
+		tmpl := string(tmplBytes)
+
+		data := PromptData{
+			Ticket:       TicketData{Key: "TEST-241", Summary: "no prior cycles"},
+			WorktreePath: "/tmp/wt",
+			Branch:       "soda/TEST-241",
+			BaseBranch:   "main",
+			Config:       PromptConfigData{Formatter: "gofmt -w .", TestCommand: "go test ./..."},
+			ReworkFeedback: &ReworkFeedback{
+				Source:  "review",
+				Verdict: "rework",
+				ReviewFindings: []schemas.ReviewFinding{
+					{Severity: "critical", File: "x.go", Line: 1, Issue: "bad", Suggestion: "fix", Source: "go-specialist"},
+				},
+				// No PriorCycles on first rework.
+			},
+		}
+
+		result, err := RenderPrompt(tmpl, data)
+		if err != nil {
+			t.Fatalf("RenderPrompt: %v", err)
+		}
+
+		// Should NOT contain prior cycles section.
+		if strings.Contains(result, "Prior Review Cycles") {
+			t.Errorf("implement prompt should NOT contain 'Prior Review Cycles' on first rework;\ngot: %s", result)
+		}
+		// Should contain current findings.
+		if !strings.Contains(result, "bad") {
+			t.Errorf("implement prompt should contain current finding;\ngot: %s", result)
+		}
+	})
+
+	t.Run("renders_patch_prompt_with_prior_verify_cycles", func(t *testing.T) {
+		tmplBytes, err := os.ReadFile(filepath.Join("..", "..", "cmd", "soda", "embeds", "prompts", "patch.md"))
+		if err != nil {
+			t.Skipf("skipping: cannot read embedded patch.md: %v", err)
+		}
+		tmpl := string(tmplBytes)
+
+		data := PromptData{
+			Ticket:       TicketData{Key: "TEST-241", Summary: "patch prior cycles"},
+			WorktreePath: "/tmp/wt",
+			Branch:       "soda/TEST-241",
+			BaseBranch:   "main",
+			Config:       PromptConfigData{Formatter: "gofmt -w .", TestCommand: "go test ./..."},
+			DiffContext:  "--- a/file.go\n+++ b/file.go\n@@ -1 +1 @@\n-old\n+new",
+			ReworkFeedback: &ReworkFeedback{
+				Source:        "verify",
+				Verdict:       "FAIL",
+				FixesRequired: []string{"fix the remaining test"},
+				PriorCycles: []PriorCycle{
+					{Cycle: 1, Source: "verify", Verdict: "FAIL", Summary: "fix the original test"},
+				},
+			},
+		}
+
+		result, err := RenderPrompt(tmpl, data)
+		if err != nil {
+			t.Fatalf("RenderPrompt: %v", err)
+		}
+
+		// Should contain prior cycles section.
+		if !strings.Contains(result, "Prior Verification Cycles") {
+			t.Errorf("patch prompt should contain 'Prior Verification Cycles' header;\ngot: %s", result)
+		}
+		if !strings.Contains(result, "fix the original test") {
+			t.Errorf("patch prompt should contain prior cycle summary;\ngot: %s", result)
+		}
+		// Should also contain current fix.
+		if !strings.Contains(result, "fix the remaining test") {
+			t.Errorf("patch prompt should contain current fix;\ngot: %s", result)
 		}
 	})
 }

--- a/internal/pipeline/state.go
+++ b/internal/pipeline/state.go
@@ -211,6 +211,18 @@ func (s *State) ReadResult(phase string) (json.RawMessage, error) {
 	return json.RawMessage(data), nil
 }
 
+// ReadArchivedResult reads an archived result file (<phase>.json.<generation>).
+// Archived results are created by MarkRunning when a phase is re-run,
+// preserving the previous generation's output for history and context.
+func (s *State) ReadArchivedResult(phase string, generation int) (json.RawMessage, error) {
+	path := fmt.Sprintf("%s.%d", filepath.Join(s.dir, phase+".json"), generation)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return json.RawMessage(data), nil
+}
+
 // WriteLog writes a debug log file (logs/<phase>_<suffix>.md).
 func (s *State) WriteLog(phase, suffix string, content []byte) error {
 	logsDir := filepath.Join(s.dir, "logs")

--- a/internal/pipeline/state_test.go
+++ b/internal/pipeline/state_test.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -415,6 +416,88 @@ func TestReadResult_NotExist(t *testing.T) {
 	if !errors.Is(err, os.ErrNotExist) {
 		t.Errorf("expected os.ErrNotExist, got %v", err)
 	}
+}
+
+func TestReadArchivedResult(t *testing.T) {
+	t.Run("reads_archived_generation", func(t *testing.T) {
+		dir := t.TempDir()
+		state, _ := LoadOrCreate(dir, "T-ARC")
+
+		// First generation
+		state.MarkRunning("review")
+		state.WriteResult("review", json.RawMessage(`{"verdict":"rework","findings":[{"severity":"major","issue":"bad pattern"}]}`))
+		state.MarkCompleted("review")
+
+		// Re-run archives generation 1
+		state.MarkRunning("review")
+		state.WriteResult("review", json.RawMessage(`{"verdict":"pass","findings":[]}`))
+		state.MarkCompleted("review")
+
+		// Read archived generation 1
+		archived, err := state.ReadArchivedResult("review", 1)
+		if err != nil {
+			t.Fatalf("ReadArchivedResult: %v", err)
+		}
+		if !strings.Contains(string(archived), "bad pattern") {
+			t.Errorf("archived result should contain first-gen findings, got: %s", archived)
+		}
+
+		// Current result should be the pass
+		current, err := state.ReadResult("review")
+		if err != nil {
+			t.Fatalf("ReadResult: %v", err)
+		}
+		if !strings.Contains(string(current), `"pass"`) {
+			t.Errorf("current result should contain pass verdict, got: %s", current)
+		}
+	})
+
+	t.Run("returns_error_for_missing_generation", func(t *testing.T) {
+		dir := t.TempDir()
+		state, _ := LoadOrCreate(dir, "T-ARC2")
+
+		_, err := state.ReadArchivedResult("review", 99)
+		if !errors.Is(err, os.ErrNotExist) {
+			t.Errorf("expected os.ErrNotExist, got %v", err)
+		}
+	})
+
+	t.Run("reads_multiple_archived_generations", func(t *testing.T) {
+		dir := t.TempDir()
+		state, _ := LoadOrCreate(dir, "T-ARC3")
+
+		// Generation 1
+		state.MarkRunning("verify")
+		state.WriteResult("verify", json.RawMessage(`{"verdict":"FAIL","fixes_required":["fix A"]}`))
+		state.MarkCompleted("verify")
+
+		// Generation 2 (archives gen 1)
+		state.MarkRunning("verify")
+		state.WriteResult("verify", json.RawMessage(`{"verdict":"FAIL","fixes_required":["fix B"]}`))
+		state.MarkCompleted("verify")
+
+		// Generation 3 (archives gen 2)
+		state.MarkRunning("verify")
+		state.WriteResult("verify", json.RawMessage(`{"verdict":"PASS"}`))
+		state.MarkCompleted("verify")
+
+		// Read archived generations
+		gen1, err := state.ReadArchivedResult("verify", 1)
+		if err != nil {
+			t.Fatalf("ReadArchivedResult gen 1: %v", err)
+		}
+		if !strings.Contains(string(gen1), "fix A") {
+			t.Errorf("gen 1 should contain 'fix A', got: %s", gen1)
+		}
+
+		gen2, err := state.ReadArchivedResult("verify", 2)
+		if err != nil {
+			t.Fatalf("ReadArchivedResult gen 2: %v", err)
+		}
+		if !strings.Contains(string(gen2), "fix B") {
+			t.Errorf("gen 2 should contain 'fix B', got: %s", gen2)
+		}
+	})
 }
 
 func TestWriteLog(t *testing.T) {


### PR DESCRIPTION
## Summary

Rework cycles (implement → review → rework → implement) were losing context from prior review/verify cycles because archived result files were never read back. The LLM would re-introduce issues that were already flagged or repeat the same mistakes.

This PR fixes the problem by:

- **Adding `PriorCycle` type and `PriorCycles` field** on `ReworkFeedback` to carry summarized context from earlier cycles
- **Adding `ReadArchivedResult`** to `State` for reading archived result files (`<phase>.json.<gen>`)
- **Collecting prior cycle context** via `collectPriorReviewCycles` / `collectPriorVerifyCycles` helpers that read archived results and extract critical/major findings
- **Rendering prior cycles** in `implement.md` and `patch.md` prompt templates so the LLM sees what was previously flagged before the current mandatory findings

## Test plan

- [x] Unit tests for `PriorCycle` summarizer functions
- [x] Unit tests for `ReadArchivedResult` (state layer)
- [x] Template rendering tests for prior cycles in implement and patch prompts
- [x] Integration tests simulating multi-cycle rework scenarios with prior cycle context injection
- [x] All existing tests pass (`go test ./...`)
- [x] `go vet ./...` clean

## Acceptance criteria

- [x] Prior review/verify cycle summaries are injected into rework prompts
- [x] Only rework/FAIL verdicts with critical/major findings are included
- [x] Context accumulates across multiple rework cycles
- [x] No regressions in existing pipeline behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)