### PR TITLE
fix(pipeline): wire up max_cost_per_phase enforcement (#164)

### DIFF
--- a/cmd/soda/run_test.go
+++ b/cmd/soda/run_test.go
@@ -644,6 +644,39 @@ func TestPrintSummaryBudgetExceeded(t *testing.T) {
 	}
 }
 
+func TestPrintSummaryPhaseBudgetExceeded(t *testing.T) {
+	dir := t.TempDir()
+	state, _ := pipeline.LoadOrCreate(dir, "PROJ-25")
+	meta := state.Meta()
+	meta.Branch = "soda/PROJ-25"
+	meta.TotalCost = 9.00
+
+	meta.Phases["triage"] = &pipeline.PhaseState{Status: pipeline.PhaseCompleted, DurationMs: 10000, Cost: 0.50}
+	meta.Phases["plan"] = &pipeline.PhaseState{Status: pipeline.PhaseCompleted, DurationMs: 20000, Cost: 0.50}
+	meta.Phases["implement"] = &pipeline.PhaseState{Status: pipeline.PhaseFailed, DurationMs: 60000, Cost: 8.00, Error: "phase budget exceeded"}
+
+	phaseBudgetErr := &pipeline.PhaseBudgetExceededError{Limit: 8.00, Actual: 8.00, Phase: "implement"}
+	var buf bytes.Buffer
+	fprintSummary(&buf, state, testPhases(), "Phase budget test", 4*time.Minute, phaseBudgetErr, nil)
+	output := buf.String()
+
+	if !strings.Contains(output, "Next steps") {
+		t.Error("expected next steps section")
+	}
+	if !strings.Contains(output, "Per-phase budget limit ($8.00)") {
+		t.Error("expected per-phase budget limit in output")
+	}
+	if !strings.Contains(output, "limits.max_cost_per_phase") {
+		t.Error("expected config key suggestion")
+	}
+	if !strings.Contains(output, "--from implement") {
+		t.Error("expected --from implement suggestion")
+	}
+	if !strings.Contains(output, "resume with higher per-phase budget") {
+		t.Error("expected parenthetical explaining --from suggestion")
+	}
+}
+
 func TestPrintSummaryTransientError(t *testing.T) {
 	dir := t.TempDir()
 	state, _ := pipeline.LoadOrCreate(dir, "PROJ-30")

--- a/internal/pipeline/monitor_poll.go
+++ b/internal/pipeline/monitor_poll.go
@@ -232,6 +232,17 @@ func (e *Engine) runMonitor(ctx context.Context, phase PhaseConfig) error {
 						"skipping":   "monitor_response",
 					},
 				})
+			} else if e.config.MaxCostPerPhase > 0 && e.state.Meta().Phases[phase.Name] != nil && e.state.Meta().Phases[phase.Name].CumulativeCost >= e.config.MaxCostPerPhase {
+				// Per-phase budget exceeded — skip response, same as global budget.
+				e.emit(Event{
+					Phase: phase.Name,
+					Kind:  EventPhaseBudgetExceeded,
+					Data: map[string]any{
+						"phase_cost": e.state.Meta().Phases[phase.Name].CumulativeCost,
+						"limit":      e.config.MaxCostPerPhase,
+						"skipping":   "monitor_response",
+					},
+				})
 			} else {
 				output, err := e.respondToComments(ctx, phase, classified, monState)
 				if err != nil {
@@ -659,6 +670,14 @@ func (e *Engine) respondToComments(ctx context.Context, phase PhaseConfig, class
 	remaining := 0.0
 	if e.config.MaxCostUSD > 0 {
 		remaining = e.config.MaxCostUSD - e.state.Meta().TotalCost
+	}
+	// Cap with per-phase limit: use the remaining per-phase budget
+	// (MaxCostPerPhase minus cumulative cost already spent) as the tighter bound.
+	if e.config.MaxCostPerPhase > 0 {
+		perPhaseRemaining := e.config.MaxCostPerPhase - e.state.Meta().Phases[phase.Name].CumulativeCost
+		if remaining <= 0 || perPhaseRemaining < remaining {
+			remaining = perPhaseRemaining
+		}
 	}
 
 	// Restrict tools for reply-only sessions (questions only — no code changes).

--- a/internal/pipeline/monitor_poll_test.go
+++ b/internal/pipeline/monitor_poll_test.go
@@ -2160,6 +2160,192 @@ func TestMonitor_CorruptStateReturnsError(t *testing.T) {
 	}
 }
 
+func TestMonitor_PhaseBudgetExceededSkipsResponse(t *testing.T) {
+	// When per-phase budget is already exceeded, the monitor should skip
+	// response execution (like it does for global budget), without consuming
+	// a response round.
+	poller := &mockPRPoller{
+		statusResponses: []mockPRStatusResponse{
+			{status: &PRStatus{State: "open", Approved: false}},
+			{status: &PRStatus{State: "open", Approved: true}},
+		},
+		commentResponses: []mockCommentResponse{
+			{comments: []PRComment{
+				{ID: "IC_1", Author: "reviewer", Body: "Fix this."},
+			}},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{},
+	}
+
+	engine, state, events := setupMonitorEngineWithRunner(t, mock, poller, nil, func(cfg *EngineConfig) {
+		cfg.MaxCostPerPhase = 1.0
+	})
+
+	// Pre-set the monitor phase's cumulative cost to exceed the per-phase limit.
+	state.Meta().Phases["monitor"] = &PhaseState{
+		Status:         PhaseRunning,
+		Generation:     1,
+		CumulativeCost: 1.5, // exceeds $1.0 per-phase limit
+	}
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// Should have phase_budget_exceeded event with skipping=monitor_response.
+	hasPhaseBudgetExceeded := false
+	for _, evt := range *events {
+		if evt.Kind == EventPhaseBudgetExceeded {
+			if skipping, _ := evt.Data["skipping"].(string); skipping == "monitor_response" {
+				hasPhaseBudgetExceeded = true
+			}
+		}
+	}
+	if !hasPhaseBudgetExceeded {
+		t.Error("phase_budget_exceeded event with skipping=monitor_response not emitted")
+	}
+
+	// Runner should NOT have been called.
+	mock.mu.Lock()
+	callCount := len(mock.calls)
+	mock.mu.Unlock()
+	if callCount != 0 {
+		t.Errorf("runner call count = %d, want 0 (per-phase budget exceeded)", callCount)
+	}
+
+	// Response rounds should NOT be incremented.
+	monState, err := state.ReadMonitorState()
+	if err != nil {
+		t.Fatalf("ReadMonitorState: %v", err)
+	}
+	if monState.ResponseRounds != 0 {
+		t.Errorf("ResponseRounds = %d, want 0 (per-phase budget-skipped rounds should not consume budget)", monState.ResponseRounds)
+	}
+}
+
+func TestMonitor_PhaseBudgetCapsRunnerOpts(t *testing.T) {
+	// When MaxCostPerPhase is set, the runner's MaxBudgetUSD should be
+	// capped to the remaining per-phase budget, not just the global remaining.
+	poller := &mockPRPoller{
+		statusResponses: []mockPRStatusResponse{
+			{status: &PRStatus{State: "open", Approved: false}},
+			{status: &PRStatus{State: "open", Approved: true}},
+		},
+		commentResponses: []mockCommentResponse{
+			{comments: []PRComment{
+				{ID: "IC_1", Author: "reviewer", Body: "Fix this bug.", Path: "main.go"},
+			}},
+		},
+	}
+
+	monitorOutput := json.RawMessage(`{
+		"ticket_key":"TEST-MON",
+		"pr_url":"https://github.com/decko/soda/pull/49",
+		"comments_handled":[{"comment_id":"IC_1","author":"reviewer","content":"Fix this bug.","action":"fixed","response":"Fixed.","classification":"code_change","authoritative":true}],
+		"tests_passed":true
+	}`)
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"monitor/response_0": {{
+				result: &runner.RunResult{Output: monitorOutput, CostUSD: 0.10},
+			}},
+		},
+	}
+
+	engine, state, _ := setupMonitorEngineWithRunner(t, mock, poller, nil, func(cfg *EngineConfig) {
+		cfg.MaxCostUSD = 100.0    // plenty of global budget
+		cfg.MaxCostPerPhase = 5.0 // per-phase limit is tighter
+	})
+
+	// Pre-set cumulative cost to $2 so remaining per-phase budget is $3.
+	state.Meta().Phases["monitor"] = &PhaseState{
+		Status:         PhaseRunning,
+		Generation:     1,
+		CumulativeCost: 2.0,
+	}
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// Verify runner was called with the tighter per-phase cap.
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	if len(mock.calls) != 1 {
+		t.Fatalf("runner call count = %d, want 1", len(mock.calls))
+	}
+	// Remaining per-phase = 5.0 - 2.0 = 3.0, which is tighter than global remaining (100.0).
+	if mock.calls[0].MaxBudgetUSD != 3.0 {
+		t.Errorf("MaxBudgetUSD = %f, want 3.0 (per-phase remaining)", mock.calls[0].MaxBudgetUSD)
+	}
+}
+
+func TestMonitor_PhaseBudgetDoesNotBlockWhenDisabled(t *testing.T) {
+	// When MaxCostPerPhase is 0 (disabled), monitor responses should not
+	// be affected by per-phase budget checks.
+	poller := &mockPRPoller{
+		statusResponses: []mockPRStatusResponse{
+			{status: &PRStatus{State: "open", Approved: false}},
+			{status: &PRStatus{State: "open", Approved: true}},
+		},
+		commentResponses: []mockCommentResponse{
+			{comments: []PRComment{
+				{ID: "IC_1", Author: "reviewer", Body: "Fix this."},
+			}},
+		},
+	}
+
+	monitorOutput := json.RawMessage(`{
+		"ticket_key":"TEST-MON",
+		"pr_url":"https://github.com/decko/soda/pull/49",
+		"comments_handled":[{"comment_id":"IC_1","author":"reviewer","content":"Fix this.","action":"fixed","response":"Done.","classification":"code_change","authoritative":true}],
+		"tests_passed":true
+	}`)
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"monitor/response_0": {{
+				result: &runner.RunResult{Output: monitorOutput, CostUSD: 50.0},
+			}},
+		},
+	}
+
+	engine, state, events := setupMonitorEngineWithRunner(t, mock, poller, nil, func(cfg *EngineConfig) {
+		cfg.MaxCostPerPhase = 0 // disabled
+	})
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// Runner should have been called normally.
+	mock.mu.Lock()
+	callCount := len(mock.calls)
+	mock.mu.Unlock()
+	if callCount != 1 {
+		t.Errorf("runner call count = %d, want 1", callCount)
+	}
+
+	// Should NOT have phase_budget_exceeded event.
+	for _, evt := range *events {
+		if evt.Kind == EventPhaseBudgetExceeded {
+			t.Error("phase_budget_exceeded should not be emitted when MaxCostPerPhase is 0")
+		}
+	}
+
+	monState, err := state.ReadMonitorState()
+	if err != nil {
+		t.Fatalf("ReadMonitorState: %v", err)
+	}
+	if monState.ResponseRounds != 1 {
+		t.Errorf("ResponseRounds = %d, want 1", monState.ResponseRounds)
+	}
+}
+
 func TestCheckNewComments_ClassifierFailureDoesNotAdvanceLastCommentID(t *testing.T) {
 	// When the classifier fails to construct (e.g., invalid selfUser),
 	// LastCommentID must NOT be advanced. Otherwise, comments are


### PR DESCRIPTION
## Summary

- **Wire up per-phase budget enforcement in monitor responses**: The monitor polling loop's `respondToComments` path was missing `max_cost_per_phase` enforcement that `runPhase` and `runParallelReview` already had. Now caps the runner's `MaxBudgetUSD` to the remaining per-phase budget and skips execution when budget is already exceeded.
- **Add CLI summary test for PhaseBudgetExceededError**: Verifies the `formatNextSteps` handler correctly renders the per-phase budget limit, config key hint, and resume suggestion in failure output.

## Test plan

- [x] Three new monitor-level tests: skip on exceeded budget, runner budget cap, disabled (zero) no-op
- [x] CLI summary test for `PhaseBudgetExceededError` output formatting
- [x] All existing tests pass with no regressions

## Acceptance criteria

- [x] `respondToComments` skips execution when per-phase cumulative cost ≥ `max_cost_per_phase`
- [x] `respondToComments` caps runner `MaxBudgetUSD` to remaining per-phase budget
- [x] Enforcement is disabled when `max_cost_per_phase` is 0 (unconfigured)
- [x] `PhaseBudgetExceededError` renders correctly in CLI summary output

🤖 Generated with [Claude Code](https://claude.com/claude-code)