### PR TITLE
fix(monitor): require self_user config for comment classification (#177)

### DIFF
--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -525,6 +525,11 @@ func handleEvent(ctx context.Context, cancel context.CancelFunc, engine *pipelin
 		}
 		prog.Message(fmt.Sprintf("Created worktree: %s (%s)", wt, branch))
 
+	case pipeline.EventMonitorWarning:
+		if w, ok := event.Data["warning"].(string); ok {
+			prog.Message(fmt.Sprintf("  ⚠️  %s", w))
+		}
+
 	case pipeline.EventMonitorSkipped:
 		prog.PhaseSkipped("monitor")
 

--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -214,6 +214,34 @@ func runPipeline(cmd *cobra.Command, cfg *config.Config, ticketKey string) error
 	// Set up PR poller for monitor phase.
 	prPoller := pipeline.NewGitHubPRPoller("")
 
+	// Wire monitor config: self_user, bot_users, profile, CODEOWNERS.
+	selfUser := cfg.Monitor.SelfUser
+	botUsers := cfg.Monitor.BotUsers
+
+	var monitorProfile *pipeline.MonitorProfile
+	if cfg.Monitor.Profile != "" {
+		profile, profileErr := pipeline.GetMonitorProfile(pipeline.MonitorProfileName(cfg.Monitor.Profile))
+		if profileErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: invalid monitor profile %q: %v\n", cfg.Monitor.Profile, profileErr)
+		} else {
+			monitorProfile = profile
+		}
+	}
+
+	var authorityResolver pipeline.AuthorityResolver
+	if cfg.Monitor.CODEOWNERS != "" {
+		coPath := cfg.Monitor.CODEOWNERS
+		if !filepath.IsAbs(coPath) {
+			coPath = filepath.Join(workDir, coPath)
+		}
+		rules, coErr := pipeline.ParseCODEOWNERS(coPath)
+		if coErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: could not load CODEOWNERS %q: %v\n", cfg.Monitor.CODEOWNERS, coErr)
+		} else {
+			authorityResolver = pipeline.NewCODEOWNERSAuthority(rules)
+		}
+	}
+
 	// When TUI mode is active, create a bidirectional pause channel and an
 	// event channel. The send end of the pause channel goes to the TUI, the
 	// receive end to the engine. The event channel bridges engine events to
@@ -226,20 +254,24 @@ func runPipeline(cmd *cobra.Command, cfg *config.Config, ticketKey string) error
 	}
 
 	engineCfg := pipeline.EngineConfig{
-		Pipeline:        pl,
-		Loader:          loader,
-		Ticket:          ticketData,
-		PromptConfig:    promptConfig,
-		PromptContext:   promptContext,
-		DetectedStack:   detectedStack,
-		Model:           cfg.Model,
-		WorkDir:         workDir,
-		WorktreeBase:    filepath.Join(workDir, cfg.WorktreeDir),
-		BaseBranch:      "main",
-		MaxCostUSD:      cfg.Limits.MaxCostPerTicket,
-		MaxCostPerPhase: cfg.Limits.MaxCostPerPhase,
-		Mode:            mode,
-		PRPoller:        prPoller,
+		Pipeline:          pl,
+		Loader:            loader,
+		Ticket:            ticketData,
+		PromptConfig:      promptConfig,
+		PromptContext:     promptContext,
+		DetectedStack:     detectedStack,
+		Model:             cfg.Model,
+		WorkDir:           workDir,
+		WorktreeBase:      filepath.Join(workDir, cfg.WorktreeDir),
+		BaseBranch:        "main",
+		MaxCostUSD:        cfg.Limits.MaxCostPerTicket,
+		MaxCostPerPhase:   cfg.Limits.MaxCostPerPhase,
+		Mode:              mode,
+		PRPoller:          prPoller,
+		SelfUser:          selfUser,
+		BotUsers:          botUsers,
+		MonitorProfile:    monitorProfile,
+		AuthorityResolver: authorityResolver,
 		OnEvent: func(event pipeline.Event) {
 			if event.Kind == pipeline.EventPhaseSkipped || event.Kind == pipeline.EventMonitorSkipped {
 				skippedPhases[event.Phase] = true

--- a/cmd/soda/run_test.go
+++ b/cmd/soda/run_test.go
@@ -857,6 +857,50 @@ func TestBuildPromptConfigDetectDefaults(t *testing.T) {
 	})
 }
 
+func TestHandleEventMonitorWarning(t *testing.T) {
+	dir := t.TempDir()
+	state, _ := pipeline.LoadOrCreate(dir, "T-1")
+
+	var buf bytes.Buffer
+	prog := progress.New(&buf, false)
+
+	event := pipeline.Event{
+		Kind: pipeline.EventMonitorWarning,
+		Data: map[string]any{
+			"warning": "self_user not configured; falling back to stub (required for comment classification)",
+		},
+	}
+	handleEvent(context.Background(), nil, nil, state, prog, event)
+
+	output := buf.String()
+	if !strings.Contains(output, "self_user not configured") {
+		t.Errorf("expected warning message in output, got %q", output)
+	}
+	if !strings.Contains(output, "⚠️") {
+		t.Errorf("expected ⚠️ emoji in output, got %q", output)
+	}
+}
+
+func TestHandleEventMonitorWarningMissingData(t *testing.T) {
+	dir := t.TempDir()
+	state, _ := pipeline.LoadOrCreate(dir, "T-1")
+
+	var buf bytes.Buffer
+	prog := progress.New(&buf, false)
+
+	// Event with no "warning" key should not panic or output anything.
+	event := pipeline.Event{
+		Kind: pipeline.EventMonitorWarning,
+		Data: map[string]any{},
+	}
+	handleEvent(context.Background(), nil, nil, state, prog, event)
+
+	output := buf.String()
+	if strings.Contains(output, "⚠️") {
+		t.Errorf("expected no output for missing warning data, got %q", output)
+	}
+}
+
 func TestHandleEventPatchExhaustedCycles(t *testing.T) {
 	// Verify that handleEvent correctly extracts patch_cycles as int
 	// (native Go type from the engine) and falls back to float64 (JSON).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -144,18 +145,33 @@ func DefaultConfig() *Config {
 				Labels:      []string{"ai-assisted"},
 			},
 		},
-		Monitor: MonitorConfig{
-			SelfUser: "your-bot-username",
-		},
+		// Monitor.SelfUser left empty so that the empty-string guard in
+		// runMonitor triggers a warning and stub fallback. Users must set
+		// self_user explicitly in their config for comment classification.
+		Monitor: MonitorConfig{},
 	}
 }
 
 // Marshal serialises a Config to YAML bytes.
+// When SelfUser is empty the serialised output includes an inline comment
+// reminding users that the field is required for comment classification.
 func Marshal(cfg *Config) ([]byte, error) {
 	data, err := yaml.Marshal(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("config: marshal: %w", err)
 	}
+
+	// When self_user is empty, replace the bare `self_user: ""` line with
+	// a commented-out example so the requirement is obvious in the generated file.
+	if cfg.Monitor.SelfUser == "" {
+		data = bytes.Replace(
+			data,
+			[]byte("  self_user: \"\""),
+			[]byte("  self_user: \"\" # REQUIRED — set to your bot's GitHub username for comment classification"),
+			1,
+		)
+	}
+
 	return data, nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -144,6 +144,9 @@ func DefaultConfig() *Config {
 				Labels:      []string{"ai-assisted"},
 			},
 		},
+		Monitor: MonitorConfig{
+			SelfUser: "your-bot-username",
+		},
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,16 @@ type Config struct {
 	Context      []string            `yaml:"context"`
 	PhaseContext map[string][]string `yaml:"phase_context"`
 	Repos        []RepoConfig        `yaml:"repos"`
+	Monitor      MonitorConfig       `yaml:"monitor"`
+}
+
+// MonitorConfig holds monitor phase settings loaded from the config file.
+// These values are wired into EngineConfig at startup.
+type MonitorConfig struct {
+	Profile    string   `yaml:"profile"`    // monitor profile preset: conservative, smart, aggressive
+	SelfUser   string   `yaml:"self_user"`  // PR author username for self-comment filtering
+	BotUsers   []string `yaml:"bot_users"`  // known bot usernames to filter out
+	CODEOWNERS string   `yaml:"codeowners"` // path to CODEOWNERS file for authority resolution
 }
 
 // JiraConfig holds Jira ticket source settings.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/decko/soda/internal/pipeline"
@@ -226,8 +227,8 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.GitHub.Owner != "your-org" {
 		t.Errorf("GitHub.Owner = %q, want %q", cfg.GitHub.Owner, "your-org")
 	}
-	if cfg.Monitor.SelfUser != "your-bot-username" {
-		t.Errorf("Monitor.SelfUser = %q, want %q", cfg.Monitor.SelfUser, "your-bot-username")
+	if cfg.Monitor.SelfUser != "" {
+		t.Errorf("Monitor.SelfUser = %q, want empty (so runMonitor falls back to stub)", cfg.Monitor.SelfUser)
 	}
 }
 
@@ -264,6 +265,38 @@ func TestMarshalRoundTrip(t *testing.T) {
 	}
 	if roundTripped.Repos[0].Name != original.Repos[0].Name {
 		t.Errorf("Repos[0].Name = %q, want %q", roundTripped.Repos[0].Name, original.Repos[0].Name)
+	}
+}
+
+func TestMarshal_EmptySelfUserComment(t *testing.T) {
+	cfg := DefaultConfig()
+	// SelfUser should be empty by default.
+	if cfg.Monitor.SelfUser != "" {
+		t.Fatalf("DefaultConfig().Monitor.SelfUser = %q, want empty", cfg.Monitor.SelfUser)
+	}
+
+	data, err := Marshal(cfg)
+	if err != nil {
+		t.Fatalf("Marshal() error: %v", err)
+	}
+
+	yaml := string(data)
+	if !strings.Contains(yaml, "REQUIRED") {
+		t.Errorf("expected REQUIRED comment in marshalled output when SelfUser is empty, got:\n%s", yaml)
+	}
+	if !strings.Contains(yaml, "self_user") {
+		t.Errorf("expected self_user field in marshalled output, got:\n%s", yaml)
+	}
+
+	// When SelfUser is set, the comment should NOT appear.
+	cfg.Monitor.SelfUser = "my-bot"
+	data, err = Marshal(cfg)
+	if err != nil {
+		t.Fatalf("Marshal() error: %v", err)
+	}
+	yamlSet := string(data)
+	if strings.Contains(yamlSet, "REQUIRED") {
+		t.Errorf("REQUIRED comment should not appear when SelfUser is set, got:\n%s", yamlSet)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -131,6 +131,16 @@ func TestLoad(t *testing.T) {
 				if len(cfg.Repos) != 0 {
 					t.Errorf("len(Repos) = %d, want 0", len(cfg.Repos))
 				}
+				// Monitor config should be zero-valued when not in file.
+				if cfg.Monitor.SelfUser != "" {
+					t.Errorf("Monitor.SelfUser = %q, want empty", cfg.Monitor.SelfUser)
+				}
+				if cfg.Monitor.Profile != "" {
+					t.Errorf("Monitor.Profile = %q, want empty", cfg.Monitor.Profile)
+				}
+				if len(cfg.Monitor.BotUsers) != 0 {
+					t.Errorf("len(Monitor.BotUsers) = %d, want 0", len(cfg.Monitor.BotUsers))
+				}
 			},
 		},
 		{
@@ -251,6 +261,42 @@ func TestMarshalRoundTrip(t *testing.T) {
 	}
 	if roundTripped.Repos[0].Name != original.Repos[0].Name {
 		t.Errorf("Repos[0].Name = %q, want %q", roundTripped.Repos[0].Name, original.Repos[0].Name)
+	}
+}
+
+func TestMarshalRoundTrip_MonitorConfig(t *testing.T) {
+	original := DefaultConfig()
+	original.Monitor = MonitorConfig{
+		Profile:    "smart",
+		SelfUser:   "soda-bot",
+		BotUsers:   []string{"dependabot", "renovate"},
+		CODEOWNERS: ".github/CODEOWNERS",
+	}
+
+	data, err := Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal() error: %v", err)
+	}
+
+	var roundTripped Config
+	if err := yaml.Unmarshal(data, &roundTripped); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if roundTripped.Monitor.Profile != "smart" {
+		t.Errorf("Monitor.Profile = %q, want %q", roundTripped.Monitor.Profile, "smart")
+	}
+	if roundTripped.Monitor.SelfUser != "soda-bot" {
+		t.Errorf("Monitor.SelfUser = %q, want %q", roundTripped.Monitor.SelfUser, "soda-bot")
+	}
+	if len(roundTripped.Monitor.BotUsers) != 2 {
+		t.Fatalf("len(Monitor.BotUsers) = %d, want 2", len(roundTripped.Monitor.BotUsers))
+	}
+	if roundTripped.Monitor.BotUsers[0] != "dependabot" {
+		t.Errorf("Monitor.BotUsers[0] = %q, want %q", roundTripped.Monitor.BotUsers[0], "dependabot")
+	}
+	if roundTripped.Monitor.CODEOWNERS != ".github/CODEOWNERS" {
+		t.Errorf("Monitor.CODEOWNERS = %q, want %q", roundTripped.Monitor.CODEOWNERS, ".github/CODEOWNERS")
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -100,6 +100,25 @@ func TestLoad(t *testing.T) {
 				if cfg.GitHub.Plan.EndMarker != "<!-- plan:end -->" {
 					t.Errorf("GitHub.Plan.EndMarker = %q, want %q", cfg.GitHub.Plan.EndMarker, "<!-- plan:end -->")
 				}
+				// Monitor config
+				if cfg.Monitor.Profile != "smart" {
+					t.Errorf("Monitor.Profile = %q, want %q", cfg.Monitor.Profile, "smart")
+				}
+				if cfg.Monitor.SelfUser != "soda-bot" {
+					t.Errorf("Monitor.SelfUser = %q, want %q", cfg.Monitor.SelfUser, "soda-bot")
+				}
+				if len(cfg.Monitor.BotUsers) != 2 {
+					t.Fatalf("len(Monitor.BotUsers) = %d, want 2", len(cfg.Monitor.BotUsers))
+				}
+				if cfg.Monitor.BotUsers[0] != "dependabot" {
+					t.Errorf("Monitor.BotUsers[0] = %q, want %q", cfg.Monitor.BotUsers[0], "dependabot")
+				}
+				if cfg.Monitor.BotUsers[1] != "renovate" {
+					t.Errorf("Monitor.BotUsers[1] = %q, want %q", cfg.Monitor.BotUsers[1], "renovate")
+				}
+				if cfg.Monitor.CODEOWNERS != ".github/CODEOWNERS" {
+					t.Errorf("Monitor.CODEOWNERS = %q, want %q", cfg.Monitor.CODEOWNERS, ".github/CODEOWNERS")
+				}
 			},
 		},
 		{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -226,6 +226,9 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.GitHub.Owner != "your-org" {
 		t.Errorf("GitHub.Owner = %q, want %q", cfg.GitHub.Owner, "your-org")
 	}
+	if cfg.Monitor.SelfUser != "your-bot-username" {
+		t.Errorf("Monitor.SelfUser = %q, want %q", cfg.Monitor.SelfUser, "your-bot-username")
+	}
 }
 
 func TestMarshalRoundTrip(t *testing.T) {

--- a/internal/config/testdata/valid.yaml
+++ b/internal/config/testdata/valid.yaml
@@ -56,3 +56,10 @@ repos:
       - ai-assisted
     trailers:
       - "Assisted-by: SODA <noreply@soda.dev>"
+monitor:
+  profile: smart
+  self_user: soda-bot
+  bot_users:
+    - dependabot
+    - renovate
+  codeowners: .github/CODEOWNERS

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -161,6 +161,11 @@ func (m *Model) handleEvent(ev pipeline.Event) {
 			m.stats.warning = msg
 		}
 
+	case pipeline.EventMonitorWarning:
+		if w, ok := ev.Data["warning"].(string); ok {
+			m.output.appendLine("⚠️  " + w)
+		}
+
 	case pipeline.EventCheckpointPause:
 		m.paused = true
 		m.keys.paused = true

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -424,6 +424,36 @@ func TestPauseBuffersEvents(t *testing.T) {
 	}
 }
 
+func TestMonitorWarningAppendsOutput(t *testing.T) {
+	m := testModel()
+	m.handleEvent(pipeline.Event{
+		Kind: pipeline.EventMonitorWarning,
+		Data: map[string]any{
+			"warning": "self_user not configured; falling back to stub (required for comment classification)",
+		},
+	})
+	if len(m.output.lines) != 1 {
+		t.Fatalf("expected 1 output line, got %d", len(m.output.lines))
+	}
+	if !strings.Contains(m.output.lines[0], "self_user not configured") {
+		t.Errorf("expected warning text in output, got %q", m.output.lines[0])
+	}
+	if !strings.Contains(m.output.lines[0], "⚠️") {
+		t.Errorf("expected ⚠️ prefix in output, got %q", m.output.lines[0])
+	}
+}
+
+func TestMonitorWarningMissingData(t *testing.T) {
+	m := testModel()
+	m.handleEvent(pipeline.Event{
+		Kind: pipeline.EventMonitorWarning,
+		Data: map[string]any{},
+	})
+	if len(m.output.lines) != 0 {
+		t.Errorf("expected no output for missing warning data, got %d lines", len(m.output.lines))
+	}
+}
+
 func TestCheckpointPause(t *testing.T) {
 	m := testModel()
 	m.handleEvent(pipeline.Event{Kind: pipeline.EventCheckpointPause})


### PR DESCRIPTION
## Summary

- Changed `DefaultConfig()` to use an empty `Monitor.SelfUser` instead of `"your-bot-username"`, which silently passed the non-empty check in `runMonitor()` and would never match the real bot's username — causing self-authored comments to not be filtered
- Updated `Marshal()` to emit an inline `# REQUIRED` YAML comment when `SelfUser` is empty, making the configuration requirement visible in generated config files (e.g. `soda init`)
- Added tests for the new default value and the marshal annotation behavior

## Test plan

- [x] `TestDefaultConfig` asserts `SelfUser` is empty
- [x] `TestMarshal_EmptySelfUserComment` verifies `# REQUIRED` comment present when empty, absent when set
- [x] All existing tests pass across `cmd/soda`, `internal/config`, `internal/tui`, `internal/pipeline`
- [x] `soda init --dry-run` shows `self_user: "" # REQUIRED — ...` in output

## Acceptance criteria

- [x] Monitor correctly classifies external comments as actionable
- [x] Self-authored comments are not re-processed
- [x] Clear error message if `self_user` cannot be determined

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)