### PR TITLE
feat(pipeline): add max_pipeline_duration timeout

### DIFF
--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -253,25 +253,36 @@ func runPipeline(cmd *cobra.Command, cfg *config.Config, ticketKey string) error
 		tuiEventCh = make(chan pipeline.Event, 64)
 	}
 
+	// Parse max_pipeline_duration from config. Zero/empty means no limit.
+	var maxPipelineDuration time.Duration
+	if cfg.Limits.MaxPipelineDuration != "" {
+		parsed, parseErr := time.ParseDuration(cfg.Limits.MaxPipelineDuration)
+		if parseErr != nil {
+			return fmt.Errorf("run: invalid max_pipeline_duration %q: %w", cfg.Limits.MaxPipelineDuration, parseErr)
+		}
+		maxPipelineDuration = parsed
+	}
+
 	engineCfg := pipeline.EngineConfig{
-		Pipeline:          pl,
-		Loader:            loader,
-		Ticket:            ticketData,
-		PromptConfig:      promptConfig,
-		PromptContext:     promptContext,
-		DetectedStack:     detectedStack,
-		Model:             cfg.Model,
-		WorkDir:           workDir,
-		WorktreeBase:      filepath.Join(workDir, cfg.WorktreeDir),
-		BaseBranch:        "main",
-		MaxCostUSD:        cfg.Limits.MaxCostPerTicket,
-		MaxCostPerPhase:   cfg.Limits.MaxCostPerPhase,
-		Mode:              mode,
-		PRPoller:          prPoller,
-		SelfUser:          selfUser,
-		BotUsers:          botUsers,
-		MonitorProfile:    monitorProfile,
-		AuthorityResolver: authorityResolver,
+		Pipeline:            pl,
+		Loader:              loader,
+		Ticket:              ticketData,
+		PromptConfig:        promptConfig,
+		PromptContext:       promptContext,
+		DetectedStack:       detectedStack,
+		Model:               cfg.Model,
+		WorkDir:             workDir,
+		WorktreeBase:        filepath.Join(workDir, cfg.WorktreeDir),
+		BaseBranch:          "main",
+		MaxCostUSD:          cfg.Limits.MaxCostPerTicket,
+		MaxCostPerPhase:     cfg.Limits.MaxCostPerPhase,
+		MaxPipelineDuration: maxPipelineDuration,
+		Mode:                mode,
+		PRPoller:            prPoller,
+		SelfUser:            selfUser,
+		BotUsers:            botUsers,
+		MonitorProfile:      monitorProfile,
+		AuthorityResolver:   authorityResolver,
 		OnEvent: func(event pipeline.Event) {
 			if event.Kind == pipeline.EventPhaseSkipped || event.Kind == pipeline.EventMonitorSkipped {
 				skippedPhases[event.Phase] = true
@@ -667,6 +678,17 @@ func handleEvent(ctx context.Context, cancel context.CancelFunc, engine *pipelin
 			limit = l
 		}
 		prog.Message(fmt.Sprintf("  ❌ Phase budget exceeded: $%.2f / $%.2f", phaseCost, limit))
+
+	case pipeline.EventPipelineTimeout:
+		var limit string
+		if l, ok := event.Data["limit"].(string); ok {
+			limit = l
+		}
+		var phase string
+		if p, ok := event.Data["phase"].(string); ok {
+			phase = p
+		}
+		prog.Message(fmt.Sprintf("  ⏹  Pipeline timeout after %s (during %s)", limit, phase))
 	}
 }
 
@@ -978,6 +1000,14 @@ func formatNextSteps(w io.Writer, meta *pipeline.PipelineMeta, phases []pipeline
 	worktree := meta.Worktree
 
 	switch {
+	case isPipelineTimeoutError(runErr):
+		var pte *pipeline.PipelineTimeoutError
+		errors.As(runErr, &pte)
+		fmt.Fprintf(w, "  Pipeline timed out after %s (limit: %s) during phase %q.\n",
+			pte.Elapsed.Truncate(time.Second), pte.Limit.Truncate(time.Second), pte.Phase)
+		fmt.Fprintf(w, "  • Increase the limit in soda.yaml (limits.max_pipeline_duration) and resume:\n")
+		fmt.Fprintf(w, "    soda run %s --from %s  (resume with higher time limit)\n", ticket, pte.Phase)
+
 	case isVerifyGateError(runErr):
 		// Verify gate: the implementation didn't pass verification.
 		fmt.Fprintf(w, "  1. Review the verify output above for failing criteria\n")
@@ -1077,6 +1107,11 @@ func isTransientError(err error) bool {
 func isParseError(err error) bool {
 	var pe *claude.ParseError
 	return errors.As(err, &pe)
+}
+
+func isPipelineTimeoutError(err error) bool {
+	var pte *pipeline.PipelineTimeoutError
+	return errors.As(err, &pte)
 }
 
 func buildPromptConfig(cfg *config.Config) pipeline.PromptConfigData {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -38,10 +38,11 @@ sandbox:
     cpu_percent: 200
     max_pids: 256
 
-# Budget
+# Budget and duration limits
 limits:
   max_cost_per_ticket: 30.00
   max_cost_per_phase: 15.00
+  max_pipeline_duration: "2h"  # max wall-clock time for the entire pipeline; empty or "0" means no limit
 
 # Worktrees
 worktree_dir: .worktrees

--- a/internal/claude/runner.go
+++ b/internal/claude/runner.go
@@ -158,9 +158,12 @@ func (r *Runner) Stream(ctx context.Context, opts RunOpts, onChunk func(string))
 
 	args := BuildArgs(opts, r.model)
 
-	// Apply fallback timeout if caller's context has no deadline
+	// Apply per-phase timeout. When the context already has a deadline
+	// (e.g., from a pipeline-level timeout), use the earlier of the two
+	// deadlines so that per-phase timeouts are not silently disabled.
 	if opts.Timeout > 0 {
-		if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		phaseDeadline := time.Now().Add(opts.Timeout)
+		if existingDeadline, hasDeadline := ctx.Deadline(); !hasDeadline || phaseDeadline.Before(existingDeadline) {
 			var cancel context.CancelFunc
 			ctx, cancel = context.WithTimeout(ctx, opts.Timeout)
 			defer cancel()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -86,10 +86,11 @@ type SandboxLimits struct {
 	MaxPIDs    int `yaml:"max_pids"`
 }
 
-// LimitsConfig holds budget limits.
+// LimitsConfig holds budget and duration limits.
 type LimitsConfig struct {
-	MaxCostPerTicket float64 `yaml:"max_cost_per_ticket"`
-	MaxCostPerPhase  float64 `yaml:"max_cost_per_phase"`
+	MaxCostPerTicket    float64 `yaml:"max_cost_per_ticket"`
+	MaxCostPerPhase     float64 `yaml:"max_cost_per_phase"`
+	MaxPipelineDuration string  `yaml:"max_pipeline_duration,omitempty"` // Go duration string (e.g., "2h", "90m"); 0 or empty means no limit
 }
 
 // RepoConfig holds per-repo configuration.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -41,6 +41,9 @@ func TestLoad(t *testing.T) {
 				if cfg.Limits.MaxCostPerPhase != 8.0 {
 					t.Errorf("MaxCostPerPhase = %f, want 8.0", cfg.Limits.MaxCostPerPhase)
 				}
+				if cfg.Limits.MaxPipelineDuration != "2h" {
+					t.Errorf("MaxPipelineDuration = %q, want %q", cfg.Limits.MaxPipelineDuration, "2h")
+				}
 				if cfg.StateDir != ".soda" {
 					t.Errorf("StateDir = %q, want %q", cfg.StateDir, ".soda")
 				}

--- a/internal/config/testdata/valid.yaml
+++ b/internal/config/testdata/valid.yaml
@@ -35,6 +35,7 @@ sandbox:
 limits:
   max_cost_per_ticket: 15.00
   max_cost_per_phase: 8.00
+  max_pipeline_duration: "2h"
 worktree_dir: .worktrees
 state_dir: .soda
 context:

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -2407,8 +2407,13 @@ func (e *Engine) lastRunningPhase() string {
 		}
 	}
 	// Fall back to PhaseFailed — the timed-out phase was marked failed
-	// before the error propagated here.
-	for _, phase := range e.config.Pipeline.Phases {
+	// before the error propagated here. Iterate in reverse because phases
+	// execute sequentially and stop on first error, so the LAST failed
+	// phase in pipeline order is the one that just failed. Earlier phases
+	// may retain stale PhaseFailed status from a prior run (e.g., when
+	// Resume is called from a later phase).
+	for i := len(e.config.Pipeline.Phases) - 1; i >= 0; i-- {
+		phase := e.config.Pipeline.Phases[i]
 		if ps := e.state.Meta().Phases[phase.Name]; ps != nil && ps.Status == PhaseFailed {
 			return phase.Name
 		}

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -79,15 +79,17 @@ func (e *Engine) remoteName() string {
 // Engine orchestrates a pipeline run, tying together the runner,
 // state management, prompt rendering, and retry logic.
 type Engine struct {
-	runner       runner.Runner
-	config       EngineConfig
-	state        *State
-	confirmCh    chan struct{}
-	reranPhases  map[string]bool // phases that ran (not skipped) in this execution
-	pauseMu      sync.Mutex
-	paused       bool
-	pauseCond    *sync.Cond
-	inCheckpoint bool // true while blocked on <-confirmCh; guarded by pauseMu
+	runner           runner.Runner
+	config           EngineConfig
+	state            *State
+	confirmCh        chan struct{}
+	reranPhases      map[string]bool // phases that ran (not skipped) in this execution
+	pauseMu          sync.Mutex
+	paused           bool
+	pauseCond        *sync.Cond
+	inCheckpoint     bool      // true while blocked on <-confirmCh; guarded by pauseMu
+	pipelineStart    time.Time // wall-clock time when applyPipelineTimeout was called
+	pipelineDeadline time.Time // deadline set by applyPipelineTimeout; zero if no timeout
 }
 
 // NewEngine creates an Engine with sensible defaults for sleep and jitter.
@@ -2320,18 +2322,30 @@ func (e *Engine) emitChunk(event Event) {
 }
 
 // applyPipelineTimeout wraps ctx with a deadline when MaxPipelineDuration is
-// configured. Returns the (possibly wrapped) context and a cancel function
-// that must always be deferred.
+// configured. It stores pipelineStart and pipelineDeadline so wrapTimeoutError
+// can compute actual elapsed time and distinguish the pipeline's own deadline
+// from an external parent context deadline. Returns the (possibly wrapped)
+// context and a cancel function that must always be deferred.
 func (e *Engine) applyPipelineTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
 	if e.config.MaxPipelineDuration <= 0 {
 		return ctx, func() {}
 	}
-	return context.WithTimeout(ctx, e.config.MaxPipelineDuration)
+	now := e.now()
+	e.pipelineStart = now
+	e.pipelineDeadline = now.Add(e.config.MaxPipelineDuration)
+	return context.WithDeadline(ctx, e.pipelineDeadline)
 }
 
 // wrapTimeoutError checks whether err is a context deadline exceeded caused
-// by the pipeline-level timeout. If so, it emits an EventPipelineTimeout
-// event and returns a PipelineTimeoutError. Otherwise it returns err unchanged.
+// by the pipeline's own timeout (not an external parent context deadline).
+// If so, it emits an EventPipelineTimeout event and returns a
+// PipelineTimeoutError with actual elapsed time. Otherwise it returns err
+// unchanged.
+//
+// To distinguish the pipeline's deadline from an external caller's deadline,
+// the method compares ctx.Deadline() against e.pipelineDeadline. If they
+// don't match (within a small tolerance), the deadline came from an external
+// source (e.g., HTTP handler, CI timeout) and the error is returned as-is.
 func (e *Engine) wrapTimeoutError(ctx context.Context, err error) error {
 	if e.config.MaxPipelineDuration <= 0 {
 		return err
@@ -2340,12 +2354,24 @@ func (e *Engine) wrapTimeoutError(ctx context.Context, err error) error {
 		return err
 	}
 
-	// Determine elapsed time.
-	elapsed := e.config.MaxPipelineDuration // best approximation when timeout fires
-	if deadline, ok := ctx.Deadline(); ok {
-		// The deadline already passed, so elapsed ≈ timeout duration.
-		_ = deadline // silence unused
+	// Guard: only wrap if the deadline that fired is the pipeline's own.
+	// An external parent context with a shorter deadline would produce a
+	// different deadline value, and wrapping that as PipelineTimeoutError
+	// would produce misleading diagnostics.
+	if e.pipelineDeadline.IsZero() {
+		return err
 	}
+	if ctxDeadline, ok := ctx.Deadline(); ok {
+		// Allow 1s tolerance for clock jitter between WithDeadline creation
+		// and this check.
+		diff := ctxDeadline.Sub(e.pipelineDeadline)
+		if diff < -time.Second || diff > time.Second {
+			return err
+		}
+	}
+
+	// Compute actual elapsed time from the stored start time.
+	elapsed := e.now().Sub(e.pipelineStart)
 
 	// Find the phase that was running when the timeout fired.
 	phase := e.lastRunningPhase()
@@ -2366,11 +2392,24 @@ func (e *Engine) wrapTimeoutError(ctx context.Context, err error) error {
 	}
 }
 
-// lastRunningPhase returns the name of the phase that has status "running"
-// in the pipeline meta, or "unknown" if none is found.
+// lastRunningPhase returns the name of the phase that was active when the
+// pipeline stopped. It checks for PhaseRunning first (preferred), then falls
+// back to PhaseFailed — because runPhase calls MarkFailed before the error
+// propagates to wrapTimeoutError, a timed-out phase will have PhaseFailed
+// status by the time this method runs. Since phases execute sequentially and
+// stop on first error, there will be at most one failed phase.
+// Returns "unknown" if no running or failed phase is found.
 func (e *Engine) lastRunningPhase() string {
+	// Prefer PhaseRunning (e.g., parallel-review goroutines).
 	for _, phase := range e.config.Pipeline.Phases {
 		if ps := e.state.Meta().Phases[phase.Name]; ps != nil && ps.Status == PhaseRunning {
+			return phase.Name
+		}
+	}
+	// Fall back to PhaseFailed — the timed-out phase was marked failed
+	// before the error propagated here.
+	for _, phase := range e.config.Pipeline.Phases {
+		if ps := e.state.Meta().Phases[phase.Name]; ps != nil && ps.Status == PhaseFailed {
 			return phase.Name
 		}
 	}

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -32,30 +32,31 @@ const DefaultMaxReworkCycles = 2
 
 // EngineConfig holds everything needed to construct an Engine.
 type EngineConfig struct {
-	Pipeline          *PhasePipeline
-	Loader            *PromptLoader
-	Ticket            TicketData
-	PromptConfig      PromptConfigData
-	PromptContext     ContextData
-	DetectedStack     DetectedStackData // auto-detected project stack info; zero value if detection was skipped
-	Model             string
-	WorkDir           string
-	WorktreeBase      string
-	BaseBranch        string
-	MaxCostUSD        float64
-	MaxCostPerPhase   float64 // per-phase cost cap; 0 means no per-phase limit
-	MaxReworkCycles   int     // max review→implement rework loops; 0 means use default (2)
-	Mode              Mode
-	OnEvent           func(Event)
-	PauseSignal       <-chan bool // receives true=pause, false=resume from TUI; nil disables
-	SleepFunc         func(time.Duration)
-	JitterFunc        func(max time.Duration) time.Duration
-	PRPoller          PRPoller          // for monitor phase polling; nil disables monitor
-	NowFunc           func() time.Time  // for testability; defaults to time.Now
-	AuthorityResolver AuthorityResolver // for comment authority checks; nil → all authoritative
-	MonitorProfile    *MonitorProfile   // behavioral profile; nil → use polling config as-is
-	SelfUser          string            // PR author username for self-comment filtering
-	BotUsers          []string          // known bot usernames to filter
+	Pipeline            *PhasePipeline
+	Loader              *PromptLoader
+	Ticket              TicketData
+	PromptConfig        PromptConfigData
+	PromptContext       ContextData
+	DetectedStack       DetectedStackData // auto-detected project stack info; zero value if detection was skipped
+	Model               string
+	WorkDir             string
+	WorktreeBase        string
+	BaseBranch          string
+	MaxCostUSD          float64
+	MaxCostPerPhase     float64       // per-phase cost cap; 0 means no per-phase limit
+	MaxPipelineDuration time.Duration // max wall-clock time for the entire pipeline; 0 means no limit
+	MaxReworkCycles     int           // max review→implement rework loops; 0 means use default (2)
+	Mode                Mode
+	OnEvent             func(Event)
+	PauseSignal         <-chan bool // receives true=pause, false=resume from TUI; nil disables
+	SleepFunc           func(time.Duration)
+	JitterFunc          func(max time.Duration) time.Duration
+	PRPoller            PRPoller          // for monitor phase polling; nil disables monitor
+	NowFunc             func() time.Time  // for testability; defaults to time.Now
+	AuthorityResolver   AuthorityResolver // for comment authority checks; nil → all authoritative
+	MonitorProfile      *MonitorProfile   // behavioral profile; nil → use polling config as-is
+	SelfUser            string            // PR author username for self-comment filtering
+	BotUsers            []string          // known bot usernames to filter
 }
 
 // maxReworkCycles returns the configured max rework cycles, defaulting to DefaultMaxReworkCycles.
@@ -304,6 +305,10 @@ func (e *Engine) Run(ctx context.Context) error {
 	}
 	defer e.state.ReleaseLock()
 
+	// Apply pipeline-level timeout if configured.
+	ctx, cancel := e.applyPipelineTimeout(ctx)
+	defer cancel()
+
 	// Cache ticket summary in meta for soda sessions/history display.
 	if e.state.Meta().Summary == "" && e.config.Ticket.Summary != "" {
 		e.state.Meta().Summary = e.config.Ticket.Summary
@@ -317,7 +322,7 @@ func (e *Engine) Run(ctx context.Context) error {
 	e.emit(Event{Kind: EventEngineStarted})
 
 	if err := e.executePhases(ctx, e.config.Pipeline.Phases, false); err != nil {
-		return err
+		return e.wrapTimeoutError(ctx, err)
 	}
 
 	e.emit(Event{Kind: EventEngineCompleted})
@@ -342,6 +347,10 @@ func (e *Engine) Resume(ctx context.Context, fromPhase string) error {
 	}
 	defer e.state.ReleaseLock()
 
+	// Apply pipeline-level timeout if configured.
+	ctx, cancel := e.applyPipelineTimeout(ctx)
+	defer cancel()
+
 	// Cache ticket summary in meta for soda sessions/history display.
 	if e.state.Meta().Summary == "" && e.config.Ticket.Summary != "" {
 		e.state.Meta().Summary = e.config.Ticket.Summary
@@ -357,7 +366,7 @@ func (e *Engine) Resume(ctx context.Context, fromPhase string) error {
 	// The fromPhase (first in slice) is always re-run, even if completed.
 	// Mark it with forceFirst=true so executePhases skips the shouldSkip check.
 	if err := e.executePhases(ctx, e.config.Pipeline.Phases[startIdx:], true); err != nil {
-		return err
+		return e.wrapTimeoutError(ctx, err)
 	}
 
 	e.emit(Event{Kind: EventEngineCompleted})
@@ -2308,6 +2317,64 @@ func (e *Engine) emitChunk(event Event) {
 	if e.config.OnEvent != nil {
 		e.config.OnEvent(event)
 	}
+}
+
+// applyPipelineTimeout wraps ctx with a deadline when MaxPipelineDuration is
+// configured. Returns the (possibly wrapped) context and a cancel function
+// that must always be deferred.
+func (e *Engine) applyPipelineTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	if e.config.MaxPipelineDuration <= 0 {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, e.config.MaxPipelineDuration)
+}
+
+// wrapTimeoutError checks whether err is a context deadline exceeded caused
+// by the pipeline-level timeout. If so, it emits an EventPipelineTimeout
+// event and returns a PipelineTimeoutError. Otherwise it returns err unchanged.
+func (e *Engine) wrapTimeoutError(ctx context.Context, err error) error {
+	if e.config.MaxPipelineDuration <= 0 {
+		return err
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+
+	// Determine elapsed time.
+	elapsed := e.config.MaxPipelineDuration // best approximation when timeout fires
+	if deadline, ok := ctx.Deadline(); ok {
+		// The deadline already passed, so elapsed ≈ timeout duration.
+		_ = deadline // silence unused
+	}
+
+	// Find the phase that was running when the timeout fired.
+	phase := e.lastRunningPhase()
+
+	e.emit(Event{
+		Kind: EventPipelineTimeout,
+		Data: map[string]any{
+			"limit":   e.config.MaxPipelineDuration.String(),
+			"elapsed": elapsed.String(),
+			"phase":   phase,
+		},
+	})
+
+	return &PipelineTimeoutError{
+		Limit:   e.config.MaxPipelineDuration,
+		Elapsed: elapsed,
+		Phase:   phase,
+	}
+}
+
+// lastRunningPhase returns the name of the phase that has status "running"
+// in the pipeline meta, or "unknown" if none is found.
+func (e *Engine) lastRunningPhase() string {
+	for _, phase := range e.config.Pipeline.Phases {
+		if ps := e.state.Meta().Phases[phase.Name]; ps != nil && ps.Status == PhaseRunning {
+			return phase.Name
+		}
+	}
+	return "unknown"
 }
 
 // emitPhaseFailed emits a phase_failed event with error, duration, and cost

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -2357,6 +2357,10 @@ func (e *Engine) wrapTimeoutError(ctx context.Context, err error) error {
 	// Guard: only wrap if the deadline that fired is the pipeline's own.
 	// An external parent context with a shorter deadline would produce a
 	// different deadline value, and wrapping that as PipelineTimeoutError
+	// would produce misleading diagnostics. Per-phase timeouts create a
+	// child context with an earlier deadline, so they also won't match.
+	// An external parent context with a shorter deadline would produce a
+	// different deadline value, and wrapping that as PipelineTimeoutError
 	// would produce misleading diagnostics.
 	if e.pipelineDeadline.IsZero() {
 		return err

--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -9554,6 +9554,86 @@ func TestEngine_PipelineTimeout_Resume(t *testing.T) {
 	}
 }
 
+func TestEngine_PipelineTimeout_ResumeWithStaleFailed(t *testing.T) {
+	// Regression test: when resuming from a later phase, earlier phases may
+	// retain stale PhaseFailed status from a prior run. lastRunningPhase must
+	// return the LAST failed phase (the one that just timed out), not the
+	// first failed phase (which is stale).
+	//
+	// Scenario: 3-phase pipeline [triage → implement → review].
+	// Prior run: triage succeeded, implement failed. Now we resume from
+	// implement, which succeeds, but review times out. The stale PhaseFailed
+	// status on implement from the prior run should NOT be returned — review
+	// (the last failed phase) should be returned.
+	phases := []PhaseConfig{
+		{
+			Name:   "triage",
+			Prompt: "triage.md",
+			Retry:  RetryConfig{Transient: 0, Parse: 0, Semantic: 0},
+		},
+		{
+			Name:      "implement",
+			Prompt:    "implement.md",
+			DependsOn: []string{"triage"},
+			Retry:     RetryConfig{Transient: 0, Parse: 0, Semantic: 0},
+		},
+		{
+			Name:      "review",
+			Prompt:    "review.md",
+			DependsOn: []string{"implement"},
+			Retry:     RetryConfig{Transient: 0, Parse: 0, Semantic: 0},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"implement": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"ok":true}`),
+					RawText: "implement ok",
+					CostUSD: 0.01,
+				},
+			}},
+			"review": {{
+				result: nil,
+				err:    context.DeadlineExceeded,
+			}},
+		},
+	}
+
+	engine, state := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.MaxPipelineDuration = 200 * time.Millisecond
+	})
+
+	// Pre-complete triage from a prior run.
+	_ = state.MarkRunning("triage")
+	_ = state.WriteResult("triage", json.RawMessage(`{"automatable":true}`))
+	_ = state.WriteArtifact("triage", []byte("done"))
+	_ = state.MarkCompleted("triage")
+
+	// Simulate implement having failed in a prior run (stale PhaseFailed).
+	// MarkRunning creates the phase entry, then MarkFailed sets status=failed.
+	_ = state.MarkRunning("implement")
+	_ = state.MarkFailed("implement", fmt.Errorf("prior run failure"))
+
+	// Resume from implement: implement will succeed (re-run), then review
+	// will return DeadlineExceeded, triggering the pipeline timeout.
+	err := engine.Resume(context.Background(), "implement")
+	if err == nil {
+		t.Fatal("expected error from pipeline timeout")
+	}
+
+	var timeoutErr *PipelineTimeoutError
+	if !errors.As(err, &timeoutErr) {
+		t.Fatalf("expected PipelineTimeoutError, got: %T: %v", err, err)
+	}
+	// Phase should be "review" — the phase that actually timed out — not
+	// "implement" which had stale PhaseFailed status from the prior run.
+	if timeoutErr.Phase != "review" {
+		t.Errorf("Phase = %q, want %q (lastRunningPhase returned stale failed phase)", timeoutErr.Phase, "review")
+	}
+}
+
 func TestEngine_PipelineTimeout_ZeroMeansNoLimit(t *testing.T) {
 	phases := []PhaseConfig{
 		{

--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -9476,6 +9476,14 @@ func TestEngine_PipelineTimeout_Run(t *testing.T) {
 	if timeoutErr.Limit != 50*time.Millisecond {
 		t.Errorf("Limit = %v, want 50ms", timeoutErr.Limit)
 	}
+	// Phase should be "plan" — that's the phase that was running when the timeout fired.
+	if timeoutErr.Phase != "plan" {
+		t.Errorf("Phase = %q, want %q", timeoutErr.Phase, "plan")
+	}
+	// Elapsed should be > 0 (actual wall-clock time).
+	if timeoutErr.Elapsed <= 0 {
+		t.Errorf("Elapsed = %v, want > 0", timeoutErr.Elapsed)
+	}
 
 	// Verify pipeline_timeout event was emitted.
 	hasTimeoutEvent := false
@@ -9535,6 +9543,14 @@ func TestEngine_PipelineTimeout_Resume(t *testing.T) {
 	var timeoutErr *PipelineTimeoutError
 	if !errors.As(err, &timeoutErr) {
 		t.Fatalf("expected PipelineTimeoutError, got: %T: %v", err, err)
+	}
+	// Phase should be "plan" — that's the phase that was running when the timeout fired.
+	if timeoutErr.Phase != "plan" {
+		t.Errorf("Phase = %q, want %q", timeoutErr.Phase, "plan")
+	}
+	// Elapsed should be > 0 (actual wall-clock time).
+	if timeoutErr.Elapsed <= 0 {
+		t.Errorf("Elapsed = %v, want > 0", timeoutErr.Elapsed)
 	}
 }
 
@@ -9606,5 +9622,45 @@ func TestEngine_PipelineTimeout_NonDeadlineErrorNotWrapped(t *testing.T) {
 	var timeoutErr *PipelineTimeoutError
 	if errors.As(err, &timeoutErr) {
 		t.Error("non-deadline error should not be wrapped as PipelineTimeoutError")
+	}
+}
+
+func TestEngine_PipelineTimeout_ExternalDeadlineNotWrapped(t *testing.T) {
+	phases := []PhaseConfig{
+		{
+			Name:   "triage",
+			Prompt: "triage.md",
+			Retry:  RetryConfig{Transient: 0, Parse: 0, Semantic: 0},
+		},
+	}
+
+	// The phase returns DeadlineExceeded, simulating an external context timeout.
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"triage": {{
+				result: nil,
+				err:    context.DeadlineExceeded,
+			}},
+		},
+	}
+
+	engine, _ := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.MaxPipelineDuration = 10 * time.Minute // large pipeline timeout
+	})
+
+	// Use an external context with a very short deadline (shorter than the pipeline's).
+	externalCtx, externalCancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer externalCancel()
+
+	err := engine.Run(externalCtx)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	// Should NOT be wrapped as PipelineTimeoutError because the deadline
+	// that fired belongs to the external parent context, not the pipeline.
+	var timeoutErr *PipelineTimeoutError
+	if errors.As(err, &timeoutErr) {
+		t.Error("external context deadline should not be wrapped as PipelineTimeoutError")
 	}
 }

--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -9422,3 +9422,189 @@ func TestEngine_PhaseBudgetRunnerCapSubtractsCumulativeCost(t *testing.T) {
 		t.Errorf("implement called %d times, want 2", implCalls)
 	}
 }
+
+func TestEngine_PipelineTimeout_Run(t *testing.T) {
+	phases := []PhaseConfig{
+		{
+			Name:   "triage",
+			Prompt: "triage.md",
+			Retry:  RetryConfig{Transient: 0, Parse: 0, Semantic: 0},
+		},
+		{
+			Name:      "plan",
+			Prompt:    "plan.md",
+			DependsOn: []string{"triage"},
+			Retry:     RetryConfig{Transient: 0, Parse: 0, Semantic: 0},
+		},
+	}
+
+	// The plan phase blocks until context is cancelled, simulating a slow phase
+	// that exceeds the pipeline timeout.
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"triage": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"automatable":true}`),
+					RawText: "triage ok",
+					CostUSD: 0.01,
+				},
+			}},
+			"plan": {{
+				result: nil,
+				err:    context.DeadlineExceeded,
+			}},
+		},
+	}
+
+	var events []Event
+	engine, _ := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.MaxPipelineDuration = 50 * time.Millisecond
+		cfg.OnEvent = func(ev Event) {
+			events = append(events, ev)
+		}
+	})
+
+	err := engine.Run(context.Background())
+	if err == nil {
+		t.Fatal("expected error from pipeline timeout")
+	}
+
+	var timeoutErr *PipelineTimeoutError
+	if !errors.As(err, &timeoutErr) {
+		t.Fatalf("expected PipelineTimeoutError, got: %T: %v", err, err)
+	}
+	if timeoutErr.Limit != 50*time.Millisecond {
+		t.Errorf("Limit = %v, want 50ms", timeoutErr.Limit)
+	}
+
+	// Verify pipeline_timeout event was emitted.
+	hasTimeoutEvent := false
+	for _, ev := range events {
+		if ev.Kind == EventPipelineTimeout {
+			hasTimeoutEvent = true
+		}
+	}
+	if !hasTimeoutEvent {
+		t.Error("pipeline_timeout event not emitted")
+	}
+}
+
+func TestEngine_PipelineTimeout_Resume(t *testing.T) {
+	phases := []PhaseConfig{
+		{
+			Name:   "triage",
+			Prompt: "triage.md",
+			Retry:  RetryConfig{Transient: 0, Parse: 0, Semantic: 0},
+		},
+		{
+			Name:      "plan",
+			Prompt:    "plan.md",
+			DependsOn: []string{"triage"},
+			Retry:     RetryConfig{Transient: 0, Parse: 0, Semantic: 0},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"plan": {{
+				result: nil,
+				err:    context.DeadlineExceeded,
+			}},
+		},
+	}
+
+	var events []Event
+	engine, state := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.MaxPipelineDuration = 50 * time.Millisecond
+		cfg.OnEvent = func(ev Event) {
+			events = append(events, ev)
+		}
+	})
+
+	// Pre-complete triage so Resume from plan works.
+	_ = state.MarkRunning("triage")
+	_ = state.WriteResult("triage", json.RawMessage(`{"automatable":true}`))
+	_ = state.WriteArtifact("triage", []byte("done"))
+	_ = state.MarkCompleted("triage")
+
+	err := engine.Resume(context.Background(), "plan")
+	if err == nil {
+		t.Fatal("expected error from pipeline timeout")
+	}
+
+	var timeoutErr *PipelineTimeoutError
+	if !errors.As(err, &timeoutErr) {
+		t.Fatalf("expected PipelineTimeoutError, got: %T: %v", err, err)
+	}
+}
+
+func TestEngine_PipelineTimeout_ZeroMeansNoLimit(t *testing.T) {
+	phases := []PhaseConfig{
+		{
+			Name:   "triage",
+			Prompt: "triage.md",
+			Retry:  RetryConfig{Transient: 0, Parse: 0, Semantic: 0},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"triage": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"automatable":true}`),
+					RawText: "ok",
+					CostUSD: 0.01,
+				},
+			}},
+		},
+	}
+
+	engine, state := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.MaxPipelineDuration = 0 // no limit
+	})
+
+	err := engine.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if !state.IsCompleted("triage") {
+		t.Error("triage should be completed")
+	}
+}
+
+func TestEngine_PipelineTimeout_NonDeadlineErrorNotWrapped(t *testing.T) {
+	phases := []PhaseConfig{
+		{
+			Name:   "triage",
+			Prompt: "triage.md",
+			Retry:  RetryConfig{Transient: 0, Parse: 0, Semantic: 0},
+		},
+	}
+
+	// Return a non-timeout error.
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"triage": {{
+				result: nil,
+				err:    fmt.Errorf("some other error"),
+			}},
+		},
+	}
+
+	engine, _ := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.MaxPipelineDuration = 5 * time.Minute
+	})
+
+	err := engine.Run(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	// Should NOT be wrapped as PipelineTimeoutError since the context
+	// deadline was not exceeded.
+	var timeoutErr *PipelineTimeoutError
+	if errors.As(err, &timeoutErr) {
+		t.Error("non-deadline error should not be wrapped as PipelineTimeoutError")
+	}
+}

--- a/internal/pipeline/errors.go
+++ b/internal/pipeline/errors.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"fmt"
 	"strings"
+	"time"
 )
 
 // BudgetExceededError is returned when accumulated cost exceeds the configured limit.
@@ -39,6 +40,19 @@ type DependencyNotMetError struct {
 func (e *DependencyNotMetError) Error() string {
 	return fmt.Sprintf("pipeline: phase %s requires %s to be completed",
 		e.Phase, e.Dependency)
+}
+
+// PipelineTimeoutError is returned when the total pipeline duration exceeds
+// the configured max_pipeline_duration limit.
+type PipelineTimeoutError struct {
+	Limit   time.Duration
+	Elapsed time.Duration
+	Phase   string // phase that was running (or about to start) when timeout fired
+}
+
+func (e *PipelineTimeoutError) Error() string {
+	return fmt.Sprintf("pipeline: timeout after %s (limit %s) during phase %s",
+		e.Elapsed.Truncate(time.Second), e.Limit.Truncate(time.Second), e.Phase)
 }
 
 // PhaseGateError is returned when domain gating fails after a phase succeeds.

--- a/internal/pipeline/errors_test.go
+++ b/internal/pipeline/errors_test.go
@@ -4,7 +4,37 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 )
+
+func TestPipelineTimeoutError(t *testing.T) {
+	err := &PipelineTimeoutError{
+		Limit:   2 * time.Hour,
+		Elapsed: 2*time.Hour + 5*time.Minute,
+		Phase:   "implement",
+	}
+	msg := err.Error()
+	if msg == "" {
+		t.Fatal("Error() should return non-empty string")
+	}
+	if !strings.Contains(msg, "implement") {
+		t.Errorf("Error() should contain phase name, got: %s", msg)
+	}
+	if !strings.Contains(msg, "2h0m0s") {
+		t.Errorf("Error() should contain limit, got: %s", msg)
+	}
+	if !strings.Contains(msg, "2h5m0s") {
+		t.Errorf("Error() should contain elapsed, got: %s", msg)
+	}
+
+	var target *PipelineTimeoutError
+	if !errors.As(err, &target) {
+		t.Error("errors.As should match PipelineTimeoutError")
+	}
+	if target.Phase != "implement" {
+		t.Errorf("Phase = %q, want %q", target.Phase, "implement")
+	}
+}
 
 func TestBudgetExceededError(t *testing.T) {
 	err := &BudgetExceededError{Limit: 15.00, Actual: 15.50, Phase: "verify"}

--- a/internal/pipeline/events.go
+++ b/internal/pipeline/events.go
@@ -78,6 +78,7 @@ const (
 	EventPatchEscalationSkipped   = "patch_escalation_skipped"
 	EventPatchRegression          = "patch_regression"
 	EventReworkMinorsDowngraded   = "rework_minors_downgraded"
+	EventPipelineTimeout          = "pipeline_timeout"
 )
 
 // ReadEvents reads and parses all events from the events.jsonl file in dir.


### PR DESCRIPTION
## Summary

- Add `MaxPipelineDuration` config field and `PipelineTimeoutError` type
- `applyPipelineTimeout()` wraps the engine context with a deadline
- `wrapTimeoutError()` distinguishes pipeline timeout from per-phase/external timeouts via deadline comparison
- Fix: per-phase timeouts now use `min(phase_deadline, pipeline_deadline)` instead of being silently disabled when a pipeline deadline exists
- `EventPipelineTimeout` emitted with limit, elapsed, and phase info
- `lastRunningPhase()` correctly identifies the timed-out phase (handles stale PhaseFailed from prior runs)

Closes #165

Assisted-by: Claude Opus 4.6