### PR TITLE
chore: bump default budgets and review timeout

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -40,8 +40,8 @@ sandbox:
 
 # Budget
 limits:
-  max_cost_per_ticket: 15.00
-  max_cost_per_phase: 8.00
+  max_cost_per_ticket: 30.00
+  max_cost_per_phase: 15.00
 
 # Worktrees
 worktree_dir: .worktrees

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -118,8 +118,8 @@ func DefaultConfig() *Config {
 		WorktreeDir: ".worktrees",
 		StateDir:    ".soda",
 		Limits: LimitsConfig{
-			MaxCostPerTicket: 15.00,
-			MaxCostPerPhase:  8.00,
+			MaxCostPerTicket: 30.00,
+			MaxCostPerPhase:  15.00,
 		},
 		Context: []string{"AGENTS.md"},
 		Repos: []RepoConfig{

--- a/phases.yaml
+++ b/phases.yaml
@@ -110,7 +110,7 @@ phases:
       - Glob
       - Grep
       - Bash
-    timeout: 5m
+    timeout: 12m
     retry:
       transient: 2
       parse: 1


### PR DESCRIPTION
## Summary

- `max_cost_per_ticket`: $15 → $30
- `max_cost_per_phase`: $8 → $15
- Review phase timeout: 5m → 12m (aligns with AGENTS.md)

## Why

The $8 per-phase limit caused budget exhaustion on any medium-complexity issue with rework cycles (#165, #177, #226 all hit this). The 5m review timeout was too tight for parallel-review — with 2 reviewers on 400+ line changesets, one reviewer regularly exceeded 5 minutes, causing the entire phase to fail. This was observed across 10+ review attempts today.

Assisted-by: Claude Opus 4.6