### PR TITLE
chore: add reviewer stagger and raki manifest

### DIFF
--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -1918,6 +1918,9 @@ func (e *Engine) runParallelReview(ctx context.Context, phase PhaseConfig) error
 	results := make([]reviewerResult, len(phase.Reviewers))
 
 	for idx, reviewer := range phase.Reviewers {
+		if idx > 0 && phase.ReviewerStagger.Duration > 0 {
+			e.config.SleepFunc(phase.ReviewerStagger.Duration)
+		}
 		wg.Add(1)
 		go func(idx int, reviewer ReviewerConfig) {
 			defer wg.Done()

--- a/internal/pipeline/phase.go
+++ b/internal/pipeline/phase.go
@@ -17,20 +17,21 @@ type PhasePipeline struct {
 
 // PhaseConfig holds the configuration for a single phase.
 type PhaseConfig struct {
-	Name         string            `yaml:"name"`
-	Prompt       string            `yaml:"prompt"`
-	Schema       string            `yaml:"schema"`
-	Model        string            `yaml:"model,omitempty"` // per-phase model override; empty uses global EngineConfig.Model
-	Tools        []string          `yaml:"tools"`
-	Timeout      Duration          `yaml:"timeout"`
-	Type         string            `yaml:"type"`
-	Retry        RetryConfig       `yaml:"retry"`
-	DependsOn    []string          `yaml:"depends_on"`
-	Polling      *PollingConfig    `yaml:"polling,omitempty"`
-	Reviewers    []ReviewerConfig  `yaml:"reviewers,omitempty"`
-	Rework       *ReworkConfig     `yaml:"rework,omitempty"`
-	Corrective   *CorrectiveConfig `yaml:"corrective,omitempty"`
-	FeedbackFrom []string          `yaml:"feedback_from,omitempty"` // ordered feedback sources injected into prompt
+	Name            string            `yaml:"name"`
+	Prompt          string            `yaml:"prompt"`
+	Schema          string            `yaml:"schema"`
+	Model           string            `yaml:"model,omitempty"` // per-phase model override; empty uses global EngineConfig.Model
+	Tools           []string          `yaml:"tools"`
+	Timeout         Duration          `yaml:"timeout"`
+	Type            string            `yaml:"type"`
+	Retry           RetryConfig       `yaml:"retry"`
+	DependsOn       []string          `yaml:"depends_on"`
+	Polling         *PollingConfig    `yaml:"polling,omitempty"`
+	Reviewers       []ReviewerConfig  `yaml:"reviewers,omitempty"`
+	ReviewerStagger Duration          `yaml:"reviewer_stagger,omitempty"`
+	Rework          *ReworkConfig     `yaml:"rework,omitempty"`
+	Corrective      *CorrectiveConfig `yaml:"corrective,omitempty"`
+	FeedbackFrom    []string          `yaml:"feedback_from,omitempty"` // ordered feedback sources injected into prompt
 }
 
 // ReworkConfig configures rework routing for a phase. When a phase with

--- a/phases.yaml
+++ b/phases.yaml
@@ -126,6 +126,7 @@ phases:
       - name: ai-harness
         prompt: prompts/review-harness.md
         focus: "prompt engineering, context budget, Claude CLI integration, sandbox, structured output"
+    reviewer_stagger: 5s
     rework:
       target: implement
     # Routing: critical/major → rework (route back to target),

--- a/raki.yaml
+++ b/raki.yaml
@@ -1,0 +1,2 @@
+sessions:
+  path: .soda


### PR DESCRIPTION
Add configurable `reviewer_stagger` delay between reviewer launches in parallel-review to reduce API contention. Default 5s in phases.yaml.

Also add `raki.yaml` manifest for pipeline quality evaluation via [raki](https://github.com/decko/raki).

Assisted-by: Claude Opus 4.6