### PR TITLE
fix(cli): soda clean --force and remote branch deletion

### DIFF
--- a/cmd/soda/clean.go
+++ b/cmd/soda/clean.go
@@ -87,9 +87,10 @@ func cleanTicket(stateDir, ticketKey string, dryRun, force bool) error {
 		return fmt.Errorf("read meta: %w", err)
 	}
 
-	// Try to acquire flock to ensure pipeline is not running
+	// Try to acquire flock to ensure pipeline is not running.
+	// Always checked, even with --force, to prevent cleaning running pipelines.
 	lockPath := filepath.Join(ticketDir, "lock")
-	if !force && !tryLock(lockPath) {
+	if !tryLock(lockPath) {
 		fmt.Fprintf(os.Stderr, "Skipping %s: pipeline is running\n", ticketKey)
 		return errSkipped
 	}

--- a/cmd/soda/clean.go
+++ b/cmd/soda/clean.go
@@ -41,7 +41,7 @@ func newCleanCmd() *cobra.Command {
 
 	cmd.Flags().Bool("all", false, "clean all tickets in terminal state")
 	cmd.Flags().Bool("dry-run", false, "show what would be cleaned without doing it")
-	cmd.Flags().Bool("force", false, "clean even if pipeline is running or not in terminal state")
+	cmd.Flags().Bool("force", false, "clean even if not in terminal state (does not override running pipeline lock)")
 
 	return cmd
 }

--- a/cmd/soda/clean.go
+++ b/cmd/soda/clean.go
@@ -27,12 +27,13 @@ func newCleanCmd() *cobra.Command {
 			}
 			all, _ := cmd.Flags().GetBool("all")
 			dryRun, _ := cmd.Flags().GetBool("dry-run")
+			force, _ := cmd.Flags().GetBool("force")
 
 			if len(args) == 1 {
-				return cleanTicket(cfg.StateDir, args[0], dryRun)
+				return cleanTicket(cfg.StateDir, args[0], dryRun, force)
 			}
 			if all {
-				return cleanAll(cfg.StateDir, dryRun)
+				return cleanAll(cfg.StateDir, dryRun, force)
 			}
 			return fmt.Errorf("specify a ticket key or use --all")
 		},
@@ -40,11 +41,12 @@ func newCleanCmd() *cobra.Command {
 
 	cmd.Flags().Bool("all", false, "clean all tickets in terminal state")
 	cmd.Flags().Bool("dry-run", false, "show what would be cleaned without doing it")
+	cmd.Flags().Bool("force", false, "clean even if pipeline is running or not in terminal state")
 
 	return cmd
 }
 
-func cleanAll(stateDir string, dryRun bool) error {
+func cleanAll(stateDir string, dryRun, force bool) error {
 	entries, err := os.ReadDir(stateDir)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -61,7 +63,7 @@ func cleanAll(stateDir string, dryRun bool) error {
 		if !entry.IsDir() {
 			continue
 		}
-		if err := cleanTicket(stateDir, entry.Name(), dryRun); err != nil {
+		if err := cleanTicket(stateDir, entry.Name(), dryRun, force); err != nil {
 			if !errors.Is(err, errSkipped) {
 				fmt.Fprintf(os.Stderr, "Warning: %s: %v\n", entry.Name(), err)
 			}
@@ -76,7 +78,7 @@ func cleanAll(stateDir string, dryRun bool) error {
 	return nil
 }
 
-func cleanTicket(stateDir, ticketKey string, dryRun bool) error {
+func cleanTicket(stateDir, ticketKey string, dryRun, force bool) error {
 	ticketDir := filepath.Join(stateDir, ticketKey)
 	metaPath := filepath.Join(ticketDir, "meta.json")
 
@@ -87,14 +89,14 @@ func cleanTicket(stateDir, ticketKey string, dryRun bool) error {
 
 	// Try to acquire flock to ensure pipeline is not running
 	lockPath := filepath.Join(ticketDir, "lock")
-	if !tryLock(lockPath) {
+	if !force && !tryLock(lockPath) {
 		fmt.Fprintf(os.Stderr, "Skipping %s: pipeline is running\n", ticketKey)
 		return errSkipped
 	}
 
 	// Check terminal state
-	if !isTerminal(meta) {
-		fmt.Fprintf(os.Stderr, "Skipping %s: not in terminal state\n", ticketKey)
+	if !force && !isTerminal(meta) {
+		fmt.Fprintf(os.Stderr, "Skipping %s: not in terminal state (use --force to override)\n", ticketKey)
 		return errSkipped
 	}
 
@@ -103,7 +105,12 @@ func cleanTicket(stateDir, ticketKey string, dryRun bool) error {
 		if dryRun {
 			fmt.Printf("Would remove worktree: %s\n", meta.Worktree)
 		} else {
-			out, wtErr := exec.Command("git", "worktree", "remove", meta.Worktree).CombinedOutput()
+			wtArgs := []string{"worktree", "remove"}
+			if force {
+				wtArgs = append(wtArgs, "--force")
+			}
+			wtArgs = append(wtArgs, meta.Worktree)
+			out, wtErr := exec.Command("git", wtArgs...).CombinedOutput()
 			if wtErr != nil {
 				fmt.Fprintf(os.Stderr, "Warning: git worktree remove %s: %s\n", meta.Worktree, string(out))
 			} else {
@@ -112,18 +119,26 @@ func cleanTicket(stateDir, ticketKey string, dryRun bool) error {
 		}
 	}
 
-	// Delete branch
+	// Delete branch (local + remote)
 	if meta.Branch != "" {
 		if dryRun {
 			fmt.Printf("Would delete branch: %s\n", meta.Branch)
+			fmt.Printf("Would delete remote branch: origin/%s\n", meta.Branch)
 		} else {
 			repoDir, err := resolveRepoDir()
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Warning: cannot resolve repo dir to delete branch %s: %v\n", meta.Branch, err)
-			} else if brErr := sodagit.DeleteBranch(repoDir, meta.Branch); brErr != nil {
-				fmt.Fprintf(os.Stderr, "Warning: git branch delete %s: %v\n", meta.Branch, brErr)
 			} else {
-				fmt.Printf("Deleted branch: %s\n", meta.Branch)
+				if brErr := sodagit.DeleteBranch(repoDir, meta.Branch); brErr != nil {
+					fmt.Fprintf(os.Stderr, "Warning: git branch delete %s: %v\n", meta.Branch, brErr)
+				} else {
+					fmt.Printf("Deleted branch: %s\n", meta.Branch)
+				}
+				if rmErr := sodagit.DeleteRemoteBranch(repoDir, "origin", meta.Branch); rmErr != nil {
+					fmt.Fprintf(os.Stderr, "Warning: git remote branch delete origin/%s: %v\n", meta.Branch, rmErr)
+				} else {
+					fmt.Printf("Deleted remote branch: origin/%s\n", meta.Branch)
+				}
 			}
 		}
 	}

--- a/cmd/soda/clean.go
+++ b/cmd/soda/clean.go
@@ -113,7 +113,7 @@ func cleanTicket(ctx context.Context, stateDir, ticketKey string, dryRun, force 
 				wtArgs = append(wtArgs, "--force")
 			}
 			wtArgs = append(wtArgs, meta.Worktree)
-			out, wtErr := exec.Command("git", wtArgs...).CombinedOutput()
+			out, wtErr := exec.CommandContext(ctx, "git", wtArgs...).CombinedOutput()
 			if wtErr != nil {
 				fmt.Fprintf(os.Stderr, "Warning: git worktree remove %s: %s\n", meta.Worktree, string(out))
 			} else {

--- a/cmd/soda/clean.go
+++ b/cmd/soda/clean.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -29,11 +30,12 @@ func newCleanCmd() *cobra.Command {
 			dryRun, _ := cmd.Flags().GetBool("dry-run")
 			force, _ := cmd.Flags().GetBool("force")
 
+			ctx := cmd.Context()
 			if len(args) == 1 {
-				return cleanTicket(cfg.StateDir, args[0], dryRun, force)
+				return cleanTicket(ctx, cfg.StateDir, args[0], dryRun, force)
 			}
 			if all {
-				return cleanAll(cfg.StateDir, dryRun, force)
+				return cleanAll(ctx, cfg.StateDir, dryRun, force)
 			}
 			return fmt.Errorf("specify a ticket key or use --all")
 		},
@@ -46,7 +48,7 @@ func newCleanCmd() *cobra.Command {
 	return cmd
 }
 
-func cleanAll(stateDir string, dryRun, force bool) error {
+func cleanAll(ctx context.Context, stateDir string, dryRun, force bool) error {
 	entries, err := os.ReadDir(stateDir)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -63,7 +65,7 @@ func cleanAll(stateDir string, dryRun, force bool) error {
 		if !entry.IsDir() {
 			continue
 		}
-		if err := cleanTicket(stateDir, entry.Name(), dryRun, force); err != nil {
+		if err := cleanTicket(ctx, stateDir, entry.Name(), dryRun, force); err != nil {
 			if !errors.Is(err, errSkipped) {
 				fmt.Fprintf(os.Stderr, "Warning: %s: %v\n", entry.Name(), err)
 			}
@@ -78,7 +80,7 @@ func cleanAll(stateDir string, dryRun, force bool) error {
 	return nil
 }
 
-func cleanTicket(stateDir, ticketKey string, dryRun, force bool) error {
+func cleanTicket(ctx context.Context, stateDir, ticketKey string, dryRun, force bool) error {
 	ticketDir := filepath.Join(stateDir, ticketKey)
 	metaPath := filepath.Join(ticketDir, "meta.json")
 
@@ -135,7 +137,7 @@ func cleanTicket(stateDir, ticketKey string, dryRun, force bool) error {
 				} else {
 					fmt.Printf("Deleted branch: %s\n", meta.Branch)
 				}
-				if rmErr := sodagit.DeleteRemoteBranch(repoDir, "origin", meta.Branch); rmErr != nil {
+				if rmErr := sodagit.DeleteRemoteBranch(ctx, repoDir, "origin", meta.Branch); rmErr != nil {
 					fmt.Fprintf(os.Stderr, "Warning: git remote branch delete origin/%s: %v\n", meta.Branch, rmErr)
 				} else {
 					fmt.Printf("Deleted remote branch: origin/%s\n", meta.Branch)

--- a/cmd/soda/clean_test.go
+++ b/cmd/soda/clean_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"os"
@@ -96,7 +97,7 @@ func TestCleanTicket_TerminalState(t *testing.T) {
 		},
 	})
 
-	err := cleanTicket(stateDir, "TICKET-1", false, false)
+	err := cleanTicket(context.Background(), stateDir, "TICKET-1", false, false)
 	if err != nil {
 		t.Fatalf("cleanTicket: %v", err)
 	}
@@ -117,7 +118,7 @@ func TestCleanTicket_SkipsNonTerminal(t *testing.T) {
 		},
 	})
 
-	err := cleanTicket(stateDir, "TICKET-1", false, false)
+	err := cleanTicket(context.Background(), stateDir, "TICKET-1", false, false)
 	if err != errSkipped {
 		t.Fatalf("expected errSkipped, got %v", err)
 	}
@@ -138,7 +139,7 @@ func TestCleanTicket_ForceBypassesTerminalCheck(t *testing.T) {
 		},
 	})
 
-	err := cleanTicket(stateDir, "TICKET-1", false, true)
+	err := cleanTicket(context.Background(), stateDir, "TICKET-1", false, true)
 	if err != nil {
 		t.Fatalf("cleanTicket with force: %v", err)
 	}
@@ -159,7 +160,7 @@ func TestCleanTicket_DryRun(t *testing.T) {
 		},
 	})
 
-	err := cleanTicket(stateDir, "TICKET-1", true, false)
+	err := cleanTicket(context.Background(), stateDir, "TICKET-1", true, false)
 	if err != nil {
 		t.Fatalf("cleanTicket dry-run: %v", err)
 	}
@@ -186,7 +187,7 @@ func TestCleanAll_CleansTerminal(t *testing.T) {
 		},
 	})
 
-	err := cleanAll(stateDir, false, false)
+	err := cleanAll(context.Background(), stateDir, false, false)
 	if err != nil {
 		t.Fatalf("cleanAll: %v", err)
 	}
@@ -217,7 +218,7 @@ func TestCleanAll_ForceRemovesAll(t *testing.T) {
 		},
 	})
 
-	err := cleanAll(stateDir, false, true)
+	err := cleanAll(context.Background(), stateDir, false, true)
 	if err != nil {
 		t.Fatalf("cleanAll with force: %v", err)
 	}
@@ -232,7 +233,7 @@ func TestCleanAll_ForceRemovesAll(t *testing.T) {
 }
 
 func TestCleanAll_NonexistentDir(t *testing.T) {
-	err := cleanAll("/tmp/nonexistent-soda-clean-test", false, false)
+	err := cleanAll(context.Background(), "/tmp/nonexistent-soda-clean-test", false, false)
 	if err != nil {
 		t.Fatalf("cleanAll should not error for nonexistent dir: %v", err)
 	}
@@ -287,7 +288,7 @@ func TestCleanTicket_ForceStillChecksFlockWhenLockHeld(t *testing.T) {
 	defer syscall.Flock(int(fd.Fd()), syscall.LOCK_UN) //nolint:errcheck
 
 	// Even with force=true, cleanTicket must refuse because the lock is held.
-	err = cleanTicket(stateDir, "TICKET-1", false, true)
+	err = cleanTicket(context.Background(), stateDir, "TICKET-1", false, true)
 	if !errors.Is(err, errSkipped) {
 		t.Fatalf("expected errSkipped when lock is held with force=true, got %v", err)
 	}
@@ -311,7 +312,7 @@ func TestCleanTicket_DryRunWithBranchShowsRemote(t *testing.T) {
 
 	// Dry-run should not error even without a git repo context —
 	// it only prints what it would do.
-	err := cleanTicket(stateDir, "TICKET-1", true, false)
+	err := cleanTicket(context.Background(), stateDir, "TICKET-1", true, false)
 	if err != nil {
 		t.Fatalf("cleanTicket dry-run with branch: %v", err)
 	}

--- a/cmd/soda/clean_test.go
+++ b/cmd/soda/clean_test.go
@@ -1,0 +1,283 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/decko/soda/internal/pipeline"
+)
+
+func writeCleanMeta(t *testing.T, dir string, meta *pipeline.PipelineMeta) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	data, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		t.Fatalf("MarshalIndent: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "meta.json"), data, 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}
+
+func TestIsTerminal(t *testing.T) {
+	tests := []struct {
+		name string
+		meta *pipeline.PipelineMeta
+		want bool
+	}{
+		{
+			name: "no phases → terminal",
+			meta: &pipeline.PipelineMeta{Phases: map[string]*pipeline.PhaseState{}},
+			want: true,
+		},
+		{
+			name: "all completed → terminal",
+			meta: &pipeline.PipelineMeta{Phases: map[string]*pipeline.PhaseState{
+				"triage":    {Status: pipeline.PhaseCompleted},
+				"implement": {Status: pipeline.PhaseCompleted},
+			}},
+			want: true,
+		},
+		{
+			name: "has failed → terminal",
+			meta: &pipeline.PipelineMeta{Phases: map[string]*pipeline.PhaseState{
+				"triage":    {Status: pipeline.PhaseCompleted},
+				"implement": {Status: pipeline.PhaseFailed},
+			}},
+			want: true,
+		},
+		{
+			name: "has running → not terminal",
+			meta: &pipeline.PipelineMeta{Phases: map[string]*pipeline.PhaseState{
+				"triage":    {Status: pipeline.PhaseCompleted},
+				"implement": {Status: pipeline.PhaseRunning},
+			}},
+			want: false,
+		},
+		{
+			name: "has retrying → not terminal",
+			meta: &pipeline.PipelineMeta{Phases: map[string]*pipeline.PhaseState{
+				"triage":    {Status: pipeline.PhaseCompleted},
+				"implement": {Status: pipeline.PhaseRetrying},
+			}},
+			want: false,
+		},
+		{
+			name: "only pending → not terminal",
+			meta: &pipeline.PipelineMeta{Phases: map[string]*pipeline.PhaseState{
+				"triage": {Status: pipeline.PhasePending},
+			}},
+			want: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isTerminal(tc.meta)
+			if got != tc.want {
+				t.Errorf("isTerminal() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCleanTicket_TerminalState(t *testing.T) {
+	stateDir := t.TempDir()
+
+	writeCleanMeta(t, filepath.Join(stateDir, "TICKET-1"), &pipeline.PipelineMeta{
+		Ticket: "TICKET-1",
+		Phases: map[string]*pipeline.PhaseState{
+			"triage": {Status: pipeline.PhaseCompleted},
+		},
+	})
+
+	err := cleanTicket(stateDir, "TICKET-1", false, false)
+	if err != nil {
+		t.Fatalf("cleanTicket: %v", err)
+	}
+
+	// Verify state directory was removed.
+	if _, statErr := os.Stat(filepath.Join(stateDir, "TICKET-1")); !os.IsNotExist(statErr) {
+		t.Error("expected state dir to be removed")
+	}
+}
+
+func TestCleanTicket_SkipsNonTerminal(t *testing.T) {
+	stateDir := t.TempDir()
+
+	writeCleanMeta(t, filepath.Join(stateDir, "TICKET-1"), &pipeline.PipelineMeta{
+		Ticket: "TICKET-1",
+		Phases: map[string]*pipeline.PhaseState{
+			"triage": {Status: pipeline.PhasePending},
+		},
+	})
+
+	err := cleanTicket(stateDir, "TICKET-1", false, false)
+	if err != errSkipped {
+		t.Fatalf("expected errSkipped, got %v", err)
+	}
+
+	// Verify state directory still exists.
+	if _, statErr := os.Stat(filepath.Join(stateDir, "TICKET-1")); statErr != nil {
+		t.Errorf("expected state dir to still exist: %v", statErr)
+	}
+}
+
+func TestCleanTicket_ForceBypassesTerminalCheck(t *testing.T) {
+	stateDir := t.TempDir()
+
+	writeCleanMeta(t, filepath.Join(stateDir, "TICKET-1"), &pipeline.PipelineMeta{
+		Ticket: "TICKET-1",
+		Phases: map[string]*pipeline.PhaseState{
+			"triage": {Status: pipeline.PhasePending},
+		},
+	})
+
+	err := cleanTicket(stateDir, "TICKET-1", false, true)
+	if err != nil {
+		t.Fatalf("cleanTicket with force: %v", err)
+	}
+
+	// Verify state directory was removed despite non-terminal state.
+	if _, statErr := os.Stat(filepath.Join(stateDir, "TICKET-1")); !os.IsNotExist(statErr) {
+		t.Error("expected state dir to be removed with --force")
+	}
+}
+
+func TestCleanTicket_DryRun(t *testing.T) {
+	stateDir := t.TempDir()
+
+	writeCleanMeta(t, filepath.Join(stateDir, "TICKET-1"), &pipeline.PipelineMeta{
+		Ticket: "TICKET-1",
+		Phases: map[string]*pipeline.PhaseState{
+			"triage": {Status: pipeline.PhaseCompleted},
+		},
+	})
+
+	err := cleanTicket(stateDir, "TICKET-1", true, false)
+	if err != nil {
+		t.Fatalf("cleanTicket dry-run: %v", err)
+	}
+
+	// Verify state directory still exists after dry-run.
+	if _, statErr := os.Stat(filepath.Join(stateDir, "TICKET-1")); statErr != nil {
+		t.Errorf("expected state dir to still exist after dry-run: %v", statErr)
+	}
+}
+
+func TestCleanAll_CleansTerminal(t *testing.T) {
+	stateDir := t.TempDir()
+
+	writeCleanMeta(t, filepath.Join(stateDir, "TICKET-1"), &pipeline.PipelineMeta{
+		Ticket: "TICKET-1",
+		Phases: map[string]*pipeline.PhaseState{
+			"triage": {Status: pipeline.PhaseCompleted},
+		},
+	})
+	writeCleanMeta(t, filepath.Join(stateDir, "TICKET-2"), &pipeline.PipelineMeta{
+		Ticket: "TICKET-2",
+		Phases: map[string]*pipeline.PhaseState{
+			"triage": {Status: pipeline.PhasePending},
+		},
+	})
+
+	err := cleanAll(stateDir, false, false)
+	if err != nil {
+		t.Fatalf("cleanAll: %v", err)
+	}
+
+	// TICKET-1 (terminal) should be removed.
+	if _, statErr := os.Stat(filepath.Join(stateDir, "TICKET-1")); !os.IsNotExist(statErr) {
+		t.Error("expected TICKET-1 to be removed")
+	}
+	// TICKET-2 (non-terminal) should still exist.
+	if _, statErr := os.Stat(filepath.Join(stateDir, "TICKET-2")); statErr != nil {
+		t.Errorf("expected TICKET-2 to still exist: %v", statErr)
+	}
+}
+
+func TestCleanAll_ForceRemovesAll(t *testing.T) {
+	stateDir := t.TempDir()
+
+	writeCleanMeta(t, filepath.Join(stateDir, "TICKET-1"), &pipeline.PipelineMeta{
+		Ticket: "TICKET-1",
+		Phases: map[string]*pipeline.PhaseState{
+			"triage": {Status: pipeline.PhaseCompleted},
+		},
+	})
+	writeCleanMeta(t, filepath.Join(stateDir, "TICKET-2"), &pipeline.PipelineMeta{
+		Ticket: "TICKET-2",
+		Phases: map[string]*pipeline.PhaseState{
+			"triage": {Status: pipeline.PhasePending},
+		},
+	})
+
+	err := cleanAll(stateDir, false, true)
+	if err != nil {
+		t.Fatalf("cleanAll with force: %v", err)
+	}
+
+	// Both should be removed when force is true.
+	if _, statErr := os.Stat(filepath.Join(stateDir, "TICKET-1")); !os.IsNotExist(statErr) {
+		t.Error("expected TICKET-1 to be removed")
+	}
+	if _, statErr := os.Stat(filepath.Join(stateDir, "TICKET-2")); !os.IsNotExist(statErr) {
+		t.Error("expected TICKET-2 to be removed with --force")
+	}
+}
+
+func TestCleanAll_NonexistentDir(t *testing.T) {
+	err := cleanAll("/tmp/nonexistent-soda-clean-test", false, false)
+	if err != nil {
+		t.Fatalf("cleanAll should not error for nonexistent dir: %v", err)
+	}
+}
+
+func TestNewCleanCmd_Flags(t *testing.T) {
+	cmd := newCleanCmd()
+
+	allFlag := cmd.Flags().Lookup("all")
+	if allFlag == nil {
+		t.Fatal("--all flag not found")
+	}
+
+	dryRunFlag := cmd.Flags().Lookup("dry-run")
+	if dryRunFlag == nil {
+		t.Fatal("--dry-run flag not found")
+	}
+
+	forceFlag := cmd.Flags().Lookup("force")
+	if forceFlag == nil {
+		t.Fatal("--force flag not found")
+	}
+	if forceFlag.DefValue != "false" {
+		t.Errorf("--force default = %q, want %q", forceFlag.DefValue, "false")
+	}
+}
+
+func TestCleanTicket_DryRunWithBranchShowsRemote(t *testing.T) {
+	stateDir := t.TempDir()
+
+	writeCleanMeta(t, filepath.Join(stateDir, "TICKET-1"), &pipeline.PipelineMeta{
+		Ticket: "TICKET-1",
+		Branch: "soda/TICKET-1",
+		Phases: map[string]*pipeline.PhaseState{
+			"triage": {Status: pipeline.PhaseCompleted},
+		},
+	})
+
+	// Dry-run should not error even without a git repo context —
+	// it only prints what it would do.
+	err := cleanTicket(stateDir, "TICKET-1", true, false)
+	if err != nil {
+		t.Fatalf("cleanTicket dry-run with branch: %v", err)
+	}
+
+	// Verify state directory still exists after dry-run.
+	if _, statErr := os.Stat(filepath.Join(stateDir, "TICKET-1")); statErr != nil {
+		t.Errorf("expected state dir to still exist after dry-run: %v", statErr)
+	}
+}

--- a/cmd/soda/clean_test.go
+++ b/cmd/soda/clean_test.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 
 	"github.com/decko/soda/internal/pipeline"
@@ -255,6 +257,44 @@ func TestNewCleanCmd_Flags(t *testing.T) {
 	}
 	if forceFlag.DefValue != "false" {
 		t.Errorf("--force default = %q, want %q", forceFlag.DefValue, "false")
+	}
+}
+
+// TestCleanTicket_ForceStillChecksFlockWhenLockHeld verifies that --force does
+// NOT bypass the flock safety check. If a pipeline is actively running (lock
+// held), cleanTicket must return errSkipped even when force=true.
+func TestCleanTicket_ForceStillChecksFlockWhenLockHeld(t *testing.T) {
+	stateDir := t.TempDir()
+	ticketDir := filepath.Join(stateDir, "TICKET-1")
+
+	writeCleanMeta(t, ticketDir, &pipeline.PipelineMeta{
+		Ticket: "TICKET-1",
+		Phases: map[string]*pipeline.PhaseState{
+			"triage": {Status: pipeline.PhaseRunning},
+		},
+	})
+
+	// Acquire an exclusive flock on the lock file to simulate a running pipeline.
+	lockPath := filepath.Join(ticketDir, "lock")
+	fd, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		t.Fatalf("open lock file: %v", err)
+	}
+	defer fd.Close()
+	if err := syscall.Flock(int(fd.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		t.Fatalf("flock: %v", err)
+	}
+	defer syscall.Flock(int(fd.Fd()), syscall.LOCK_UN) //nolint:errcheck
+
+	// Even with force=true, cleanTicket must refuse because the lock is held.
+	err = cleanTicket(stateDir, "TICKET-1", false, true)
+	if !errors.Is(err, errSkipped) {
+		t.Fatalf("expected errSkipped when lock is held with force=true, got %v", err)
+	}
+
+	// State directory must still exist — nothing was cleaned.
+	if _, statErr := os.Stat(ticketDir); statErr != nil {
+		t.Errorf("expected state dir to still exist: %v", statErr)
 	}
 }
 

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -182,8 +182,8 @@ func DeleteBranch(repoDir, branch string) error {
 // DeleteRemoteBranch deletes a branch on the specified remote by running
 // "git push <remote> --delete <branch>". Returns nil if the branch was
 // deleted or did not exist on the remote.
-func DeleteRemoteBranch(repoDir, remote, branch string) error {
-	cmd := exec.Command("git", "push", remote, "--delete", branch)
+func DeleteRemoteBranch(ctx context.Context, repoDir, remote, branch string) error {
+	cmd := exec.CommandContext(ctx, "git", "push", remote, "--delete", branch)
 	cmd.Dir = repoDir
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -179,6 +179,24 @@ func DeleteBranch(repoDir, branch string) error {
 	return nil
 }
 
+// DeleteRemoteBranch deletes a branch on the specified remote by running
+// "git push <remote> --delete <branch>". Returns nil if the branch was
+// deleted or did not exist on the remote.
+func DeleteRemoteBranch(repoDir, remote, branch string) error {
+	cmd := exec.Command("git", "push", remote, "--delete", branch)
+	cmd.Dir = repoDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		outStr := string(output)
+		// Treat as success when the remote branch doesn't exist.
+		if strings.Contains(outStr, "remote ref does not exist") {
+			return nil
+		}
+		return fmt.Errorf("git: delete remote branch %s/%s: %s: %w", remote, branch, strings.TrimSpace(outStr), err)
+	}
+	return nil
+}
+
 // Diff returns the output of "git diff <base>...HEAD" for the given
 // repoDir. The three-dot syntax shows changes introduced on the current
 // branch since it diverged from base. Returns an empty string and nil

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -232,6 +232,71 @@ func TestDeleteBranch(t *testing.T) {
 	})
 }
 
+func TestDeleteRemoteBranch(t *testing.T) {
+	t.Run("deletes_existing_remote_branch", func(t *testing.T) {
+		// Create a "remote" bare repo and a local clone that pushes a branch.
+		bareDir := t.TempDir()
+		run(t, bareDir, "git", "init", "--bare", "-b", "main")
+
+		localDir := t.TempDir()
+		run(t, localDir, "git", "clone", bareDir, ".")
+		run(t, localDir, "git", "config", "user.email", "test@test.com")
+		run(t, localDir, "git", "config", "user.name", "Test")
+		run(t, localDir, "git", "commit", "--allow-empty", "-m", "init")
+		run(t, localDir, "git", "push", "origin", "main")
+
+		// Create and push a feature branch.
+		run(t, localDir, "git", "checkout", "-b", "feat/remote-delete")
+		run(t, localDir, "git", "commit", "--allow-empty", "-m", "feature commit")
+		run(t, localDir, "git", "push", "origin", "feat/remote-delete")
+
+		// Verify remote branch exists.
+		cmd := exec.Command("git", "ls-remote", "--heads", "origin", "feat/remote-delete")
+		cmd.Dir = localDir
+		out, err := cmd.Output()
+		if err != nil {
+			t.Fatalf("git ls-remote: %v", err)
+		}
+		if len(out) == 0 {
+			t.Fatal("remote branch feat/remote-delete should exist before deletion")
+		}
+
+		// Delete the remote branch.
+		if err := DeleteRemoteBranch(localDir, "origin", "feat/remote-delete"); err != nil {
+			t.Fatalf("DeleteRemoteBranch: %v", err)
+		}
+
+		// Verify it no longer exists.
+		cmd = exec.Command("git", "ls-remote", "--heads", "origin", "feat/remote-delete")
+		cmd.Dir = localDir
+		out, err = cmd.Output()
+		if err != nil {
+			t.Fatalf("git ls-remote after delete: %v", err)
+		}
+		if len(out) != 0 {
+			t.Error("remote branch feat/remote-delete should not exist after deletion")
+		}
+	})
+
+	t.Run("no_error_for_nonexistent_remote_branch", func(t *testing.T) {
+		// Create a "remote" bare repo and a local clone.
+		bareDir := t.TempDir()
+		run(t, bareDir, "git", "init", "--bare", "-b", "main")
+
+		localDir := t.TempDir()
+		run(t, localDir, "git", "clone", bareDir, ".")
+		run(t, localDir, "git", "config", "user.email", "test@test.com")
+		run(t, localDir, "git", "config", "user.name", "Test")
+		run(t, localDir, "git", "commit", "--allow-empty", "-m", "init")
+		run(t, localDir, "git", "push", "origin", "main")
+
+		err := DeleteRemoteBranch(localDir, "origin", "feat/does-not-exist")
+		if err != nil {
+			t.Fatalf("DeleteRemoteBranch should not error for nonexistent branch: %v", err)
+		}
+	})
+}
+
 func TestNeedsMergeWithBase(t *testing.T) {
 	t.Run("no_conflicts_when_base_unchanged", func(t *testing.T) {
 		repoDir := initGitRepo(t)

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -262,7 +262,7 @@ func TestDeleteRemoteBranch(t *testing.T) {
 		}
 
 		// Delete the remote branch.
-		if err := DeleteRemoteBranch(localDir, "origin", "feat/remote-delete"); err != nil {
+		if err := DeleteRemoteBranch(context.Background(), localDir, "origin", "feat/remote-delete"); err != nil {
 			t.Fatalf("DeleteRemoteBranch: %v", err)
 		}
 
@@ -278,6 +278,27 @@ func TestDeleteRemoteBranch(t *testing.T) {
 		}
 	})
 
+	t.Run("respects_context_cancellation", func(t *testing.T) {
+		// Create a "remote" bare repo and a local clone.
+		bareDir := t.TempDir()
+		run(t, bareDir, "git", "init", "--bare", "-b", "main")
+
+		localDir := t.TempDir()
+		run(t, localDir, "git", "clone", bareDir, ".")
+		run(t, localDir, "git", "config", "user.email", "test@test.com")
+		run(t, localDir, "git", "config", "user.name", "Test")
+		run(t, localDir, "git", "commit", "--allow-empty", "-m", "init")
+		run(t, localDir, "git", "push", "origin", "main")
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		err := DeleteRemoteBranch(ctx, localDir, "origin", "feat/cancel-test")
+		if err == nil {
+			t.Fatal("expected error from cancelled context")
+		}
+	})
+
 	t.Run("no_error_for_nonexistent_remote_branch", func(t *testing.T) {
 		// Create a "remote" bare repo and a local clone.
 		bareDir := t.TempDir()
@@ -290,7 +311,7 @@ func TestDeleteRemoteBranch(t *testing.T) {
 		run(t, localDir, "git", "commit", "--allow-empty", "-m", "init")
 		run(t, localDir, "git", "push", "origin", "main")
 
-		err := DeleteRemoteBranch(localDir, "origin", "feat/does-not-exist")
+		err := DeleteRemoteBranch(context.Background(), localDir, "origin", "feat/does-not-exist")
 		if err != nil {
 			t.Fatalf("DeleteRemoteBranch should not error for nonexistent branch: %v", err)
 		}


### PR DESCRIPTION
## Summary

- Add `--force` flag to `soda clean` for dirty worktree removal
- Add remote branch deletion via `git push origin --delete` (best-effort)
- Thread `context.Context` through clean commands for cancellation
- Flock always checked even with `--force` (cannot clean running pipelines)
- 9 clean tests + 3 remote branch tests

Closes #253

Assisted-by: Claude Opus 4.6