### PR TITLE
fix(pipeline): auto-reset stale phase costs on fresh run [#256]

### DIFF
--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -327,6 +327,7 @@ func (e *Engine) Run(ctx context.Context) error {
 	if err := e.state.ResetPhaseCosts(); err != nil {
 		return fmt.Errorf("engine: reset phase costs: %w", err)
 	}
+	e.emit(Event{Kind: EventPhaseCostsReset})
 
 	e.reranPhases = make(map[string]bool)
 	e.emit(Event{Kind: EventEngineStarted})

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -320,6 +320,14 @@ func (e *Engine) Run(ctx context.Context) error {
 		return err
 	}
 
+	// Reset per-phase CumulativeCost so that stale costs from a prior
+	// pipeline execution do not block per-phase budget enforcement.
+	// Within this execution, CumulativeCost accumulates correctly
+	// across rework generations via MarkRunning / AccumulateCost.
+	if err := e.state.ResetPhaseCosts(); err != nil {
+		return fmt.Errorf("engine: reset phase costs: %w", err)
+	}
+
 	e.reranPhases = make(map[string]bool)
 	e.emit(Event{Kind: EventEngineStarted})
 

--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -9834,6 +9834,52 @@ func TestEngine_FreshRunResetsStalePhaseCosts(t *testing.T) {
 	}
 }
 
+func TestEngine_RunEmitsPhaseCostsResetEvent(t *testing.T) {
+	// Run() must emit EventPhaseCostsReset after successfully resetting
+	// per-phase cumulative costs.
+	phases := []PhaseConfig{
+		{
+			Name:   "triage",
+			Prompt: "triage.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"triage": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"automatable":true}`),
+					RawText: "triage ok",
+					CostUSD: 0.10,
+				},
+			}},
+		},
+	}
+
+	var events []Event
+	engine, _ := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.OnEvent = func(e Event) {
+			events = append(events, e)
+		}
+	})
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	var found bool
+	for _, ev := range events {
+		if ev.Kind == EventPhaseCostsReset {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("phase_costs_reset event not emitted by Run()")
+	}
+}
+
 func TestEngine_ResumeDoesNotResetPhaseCosts(t *testing.T) {
 	// Resume() must NOT reset CumulativeCost — it continues an existing
 	// execution where rework-cycle tracking relies on accumulated costs.

--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -9744,3 +9744,151 @@ func TestEngine_PipelineTimeout_ExternalDeadlineNotWrapped(t *testing.T) {
 		t.Error("external context deadline should not be wrapped as PipelineTimeoutError")
 	}
 }
+
+func TestEngine_FreshRunResetsStalePhaseCosts(t *testing.T) {
+	// A fresh Run() must reset CumulativeCost for all phases so that
+	// stale costs from a prior execution do not trigger per-phase budget
+	// enforcement. This test simulates:
+	//   Run 1: implement accumulates CumulativeCost = $4.00, then fails
+	//   Run 2 (fresh): implement re-runs with fresh CumulativeCost = $0
+	// Without the reset, Run 2 would start with CumulativeCost = $4.00
+	// and exceed the $5 limit after just $1 of new spend.
+	phases := []PhaseConfig{
+		{
+			Name:   "implement",
+			Prompt: "implement.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+	}
+
+	// Run 1: implement costs $4.00 but fails (simulating a crash).
+	mock1 := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"implement": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"tests_passed":true}`),
+					RawText: "impl v1",
+					CostUSD: 4.0,
+				},
+			}},
+		},
+	}
+
+	engine1, state := setupEngine(t, phases, mock1, func(cfg *EngineConfig) {
+		cfg.MaxCostPerPhase = 5.0
+	})
+
+	if err := engine1.Run(context.Background()); err != nil {
+		t.Fatalf("Run 1: %v", err)
+	}
+
+	// Simulate: implement completed in Run 1 but pipeline as a whole
+	// failed later. Mark implement as failed so Run 2 will re-run it.
+	state.Meta().Phases["implement"].Status = PhaseFailed
+	_ = state.flushMeta()
+
+	// After Run 1, CumulativeCost should be $4.00.
+	implPS := state.Meta().Phases["implement"]
+	if implPS == nil {
+		t.Fatal("implement phase state is nil after Run 1")
+	}
+	if !approxEqual(implPS.CumulativeCost, 4.0) {
+		t.Fatalf("CumulativeCost after Run 1 = %f, want 4.0", implPS.CumulativeCost)
+	}
+
+	// Run 2 (fresh): implement costs $3.00. Without the reset, cumulative
+	// would be $7.00 and exceed the $5 limit.
+	mock2 := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"implement": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"tests_passed":true}`),
+					RawText: "impl v2",
+					CostUSD: 3.0,
+				},
+			}},
+		},
+	}
+
+	engine2 := NewEngine(mock2, state, EngineConfig{
+		Pipeline:        &PhasePipeline{Phases: phases},
+		Loader:          engine1.config.Loader,
+		Ticket:          TicketData{Key: "TEST-1", Summary: "Test ticket"},
+		Model:           "test-model",
+		WorkDir:         engine1.config.WorkDir,
+		MaxCostPerPhase: 5.0,
+		Mode:            Autonomous,
+		SleepFunc:       func(time.Duration) {},
+		JitterFunc:      func(time.Duration) time.Duration { return 0 },
+	})
+
+	// This must succeed — the reset clears stale CumulativeCost.
+	if err := engine2.Run(context.Background()); err != nil {
+		t.Fatalf("Run 2 should succeed after cost reset, got: %v", err)
+	}
+
+	// CumulativeCost should reflect only Run 2's spend.
+	implPS = state.Meta().Phases["implement"]
+	if !approxEqual(implPS.CumulativeCost, 3.0) {
+		t.Errorf("CumulativeCost after Run 2 = %f, want 3.0 (Run 2 spend only)", implPS.CumulativeCost)
+	}
+}
+
+func TestEngine_ResumeDoesNotResetPhaseCosts(t *testing.T) {
+	// Resume() must NOT reset CumulativeCost — it continues an existing
+	// execution where rework-cycle tracking relies on accumulated costs.
+	phases := []PhaseConfig{
+		{
+			Name:   "triage",
+			Prompt: "triage.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+		{
+			Name:      "implement",
+			Prompt:    "implement.md",
+			DependsOn: []string{"triage"},
+			Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"implement": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"tests_passed":true}`),
+					RawText: "impl",
+					CostUSD: 2.0,
+				},
+			}},
+		},
+	}
+
+	engine, state := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.MaxCostPerPhase = 10.0
+	})
+
+	// Pre-seed triage as completed so Resume("implement") finds its dep met.
+	state.MarkRunning("triage")
+	state.AccumulateCost("triage", 0.10)
+	state.MarkCompleted("triage")
+
+	// Pre-seed implement with CumulativeCost from a prior rework cycle.
+	state.MarkRunning("implement")
+	state.AccumulateCost("implement", 3.0)
+	state.MarkCompleted("implement")
+
+	priorCumulative := state.Meta().Phases["implement"].CumulativeCost
+
+	// Resume from implement — CumulativeCost should be preserved.
+	if err := engine.Resume(context.Background(), "implement"); err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+
+	implPS := state.Meta().Phases["implement"]
+	// CumulativeCost should include BOTH the prior $3.00 and the new $2.00.
+	expectedCumulative := priorCumulative + 2.0
+	if !approxEqual(implPS.CumulativeCost, expectedCumulative) {
+		t.Errorf("CumulativeCost after Resume = %f, want %f (prior + new)",
+			implPS.CumulativeCost, expectedCumulative)
+	}
+}

--- a/internal/pipeline/events.go
+++ b/internal/pipeline/events.go
@@ -79,6 +79,7 @@ const (
 	EventPatchRegression          = "patch_regression"
 	EventReworkMinorsDowngraded   = "rework_minors_downgraded"
 	EventPipelineTimeout          = "pipeline_timeout"
+	EventPhaseCostsReset          = "phase_costs_reset"
 )
 
 // ReadEvents reads and parses all events from the events.jsonl file in dir.

--- a/internal/pipeline/monitor_poll_test.go
+++ b/internal/pipeline/monitor_poll_test.go
@@ -2185,14 +2185,16 @@ func TestMonitor_PhaseBudgetExceededSkipsResponse(t *testing.T) {
 	})
 
 	// Pre-set the monitor phase's cumulative cost to exceed the per-phase limit.
+	// Use Resume (not Run) so that ResetPhaseCosts does not clear the pre-seeded value —
+	// this test simulates a mid-execution scenario where cost has already accumulated.
 	state.Meta().Phases["monitor"] = &PhaseState{
 		Status:         PhaseRunning,
 		Generation:     1,
 		CumulativeCost: 1.5, // exceeds $1.0 per-phase limit
 	}
 
-	if err := engine.Run(context.Background()); err != nil {
-		t.Fatalf("Run: %v", err)
+	if err := engine.Resume(context.Background(), "monitor"); err != nil {
+		t.Fatalf("Resume: %v", err)
 	}
 
 	// Should have phase_budget_exceeded event with skipping=monitor_response.
@@ -2262,14 +2264,16 @@ func TestMonitor_PhaseBudgetCapsRunnerOpts(t *testing.T) {
 	})
 
 	// Pre-set cumulative cost to $2 so remaining per-phase budget is $3.
+	// Use Resume (not Run) so that ResetPhaseCosts does not clear the pre-seeded value —
+	// this test simulates a mid-execution scenario where cost has already accumulated.
 	state.Meta().Phases["monitor"] = &PhaseState{
 		Status:         PhaseRunning,
 		Generation:     1,
 		CumulativeCost: 2.0,
 	}
 
-	if err := engine.Run(context.Background()); err != nil {
-		t.Fatalf("Run: %v", err)
+	if err := engine.Resume(context.Background(), "monitor"); err != nil {
+		t.Fatalf("Resume: %v", err)
 	}
 
 	// Verify runner was called with the tighter per-phase cap.

--- a/internal/pipeline/state.go
+++ b/internal/pipeline/state.go
@@ -166,6 +166,18 @@ func (s *State) MarkFailed(phase string, phaseErr error) error {
 	return s.flushMeta()
 }
 
+// ResetPhaseCosts zeroes the CumulativeCost for every phase in the pipeline
+// metadata. This is called at the start of a fresh Run() so that per-phase
+// budget enforcement (checkPhaseBudget) is not blocked by stale costs
+// accumulated during a prior pipeline execution. Within a single execution,
+// CumulativeCost is preserved across rework generations by MarkRunning/AccumulateCost.
+func (s *State) ResetPhaseCosts() error {
+	for _, ps := range s.meta.Phases {
+		ps.CumulativeCost = 0
+	}
+	return s.flushMeta()
+}
+
 // AccumulateCost adds cost to the phase and total. Phase must exist (via MarkRunning).
 // Both the per-generation Cost and the cross-generation CumulativeCost are updated.
 func (s *State) AccumulateCost(phase string, cost float64) error {

--- a/internal/pipeline/state_test.go
+++ b/internal/pipeline/state_test.go
@@ -720,3 +720,117 @@ func TestCrashSafety_OrphanedTmp(t *testing.T) {
 		t.Error("triage should still be completed after crash resume")
 	}
 }
+
+func TestResetPhaseCosts(t *testing.T) {
+	t.Run("zeroes_cumulative_cost_for_all_phases", func(t *testing.T) {
+		dir := t.TempDir()
+		state, _ := LoadOrCreate(dir, "T-RST")
+
+		// Simulate a prior run that accumulated costs.
+		state.MarkRunning("triage")
+		state.AccumulateCost("triage", 0.10)
+		state.MarkCompleted("triage")
+
+		state.MarkRunning("implement")
+		state.AccumulateCost("implement", 2.00)
+		state.MarkCompleted("implement")
+
+		// Verify costs exist before reset.
+		if !approxEqual(state.Meta().Phases["triage"].CumulativeCost, 0.10) {
+			t.Errorf("triage CumulativeCost before reset = %v, want 0.10",
+				state.Meta().Phases["triage"].CumulativeCost)
+		}
+		if !approxEqual(state.Meta().Phases["implement"].CumulativeCost, 2.00) {
+			t.Errorf("implement CumulativeCost before reset = %v, want 2.00",
+				state.Meta().Phases["implement"].CumulativeCost)
+		}
+
+		// Reset.
+		if err := state.ResetPhaseCosts(); err != nil {
+			t.Fatalf("ResetPhaseCosts: %v", err)
+		}
+
+		// CumulativeCost should be zero for all phases.
+		for name, ps := range state.Meta().Phases {
+			if ps.CumulativeCost != 0 {
+				t.Errorf("phase %q CumulativeCost after reset = %v, want 0", name, ps.CumulativeCost)
+			}
+		}
+	})
+
+	t.Run("preserves_total_cost", func(t *testing.T) {
+		dir := t.TempDir()
+		state, _ := LoadOrCreate(dir, "T-RST2")
+
+		state.MarkRunning("plan")
+		state.AccumulateCost("plan", 1.50)
+		state.MarkCompleted("plan")
+
+		totalBefore := state.Meta().TotalCost
+		if err := state.ResetPhaseCosts(); err != nil {
+			t.Fatalf("ResetPhaseCosts: %v", err)
+		}
+
+		// TotalCost must NOT be reset — it tracks overall ticket spend.
+		if !approxEqual(state.Meta().TotalCost, totalBefore) {
+			t.Errorf("TotalCost after reset = %v, want %v (should be preserved)",
+				state.Meta().TotalCost, totalBefore)
+		}
+	})
+
+	t.Run("preserves_phase_status_and_generation", func(t *testing.T) {
+		dir := t.TempDir()
+		state, _ := LoadOrCreate(dir, "T-RST3")
+
+		state.MarkRunning("verify")
+		state.AccumulateCost("verify", 0.30)
+		state.MarkCompleted("verify")
+
+		if err := state.ResetPhaseCosts(); err != nil {
+			t.Fatalf("ResetPhaseCosts: %v", err)
+		}
+
+		ps := state.Meta().Phases["verify"]
+		if ps.Status != PhaseCompleted {
+			t.Errorf("status after reset = %q, want %q", ps.Status, PhaseCompleted)
+		}
+		if ps.Generation != 1 {
+			t.Errorf("generation after reset = %d, want 1", ps.Generation)
+		}
+	})
+
+	t.Run("no_phases_is_noop", func(t *testing.T) {
+		dir := t.TempDir()
+		state, _ := LoadOrCreate(dir, "T-RST4")
+
+		if err := state.ResetPhaseCosts(); err != nil {
+			t.Fatalf("ResetPhaseCosts on empty phases: %v", err)
+		}
+	})
+
+	t.Run("persists_to_disk", func(t *testing.T) {
+		dir := t.TempDir()
+		state, _ := LoadOrCreate(dir, "T-RST5")
+
+		state.MarkRunning("triage")
+		state.AccumulateCost("triage", 0.50)
+		state.MarkCompleted("triage")
+
+		if err := state.ResetPhaseCosts(); err != nil {
+			t.Fatalf("ResetPhaseCosts: %v", err)
+		}
+
+		// Reload from disk and verify CumulativeCost was persisted as 0.
+		state2, err := LoadOrCreate(dir, "T-RST5")
+		if err != nil {
+			t.Fatalf("reload: %v", err)
+		}
+		ps := state2.Meta().Phases["triage"]
+		if ps == nil {
+			t.Fatal("triage phase not found after reload")
+		}
+		if ps.CumulativeCost != 0 {
+			t.Errorf("CumulativeCost after reload = %v, want 0", ps.CumulativeCost)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Add `State.ResetPhaseCosts()` to zero `CumulativeCost` for all phases at the start of `Engine.Run()`, preventing stale costs from a prior pipeline execution from blocking per-phase budget enforcement on a fresh run.
- Emit `EventPhaseCostsReset` after a successful reset so consumers can observe the cost clearing.
- Existing tests updated to use `Resume()` instead of `Run()` where pre-seeded cumulative costs must survive (mid-execution scenarios).

## Test plan

- [x] `TestResetPhaseCosts` — unit tests for `State.ResetPhaseCosts()`: zeroes all phases, preserves `TotalCost`, preserves status/generation, no-op on empty phases, persists to disk
- [x] `TestEngine_FreshRunResetsStalePhaseCosts` — end-to-end: Run 1 accumulates $4, Run 2 spends $3 under a $5 limit — succeeds only because costs were reset
- [x] `TestEngine_RunEmitsPhaseCostsResetEvent` — verifies `EventPhaseCostsReset` is emitted during `Run()`
- [x] `TestEngine_ResumeDoesNotResetPhaseCosts` — verifies `Resume()` preserves accumulated costs across rework cycles
- [x] Existing `TestMonitor_PhaseBudgetExceededSkipsResponse` and `TestMonitor_PhaseBudgetCapsRunnerOpts` updated to use `Resume()` to avoid reset clearing pre-seeded values

## Acceptance criteria

- [x] Fresh `Run()` zeroes `CumulativeCost` for all phases before execution begins
- [x] `Resume()` does NOT reset `CumulativeCost` (rework tracking preserved)
- [x] `TotalCost` is unaffected by the reset
- [x] Phase status and generation are unaffected by the reset
- [x] `EventPhaseCostsReset` event is emitted after reset
- [x] Reset is persisted to disk

🤖 Generated with [Claude Code](https://claude.com/claude-code)