### PR TITLE
feat(pipeline): focused rework prompt with sequential finding fixing (#265)

### DIFF
--- a/cmd/soda/embeds/prompts/implement.md
+++ b/cmd/soda/embeds/prompts/implement.md
@@ -37,61 +37,72 @@ Use this context to avoid re-introducing previously-fixed issues or repeating th
 ## MANDATORY: Specialist Review Findings (MUST address)
 
 The following issues were identified by specialist reviewers.
-You MUST address every critical and major finding below. Do not repeat the same mistakes.
+You MUST address every finding below **one at a time, in order**. Do not repeat the same mistakes.
 
-{{- range .ReworkFeedback.ReviewFindings}}
+Do NOT address multiple findings in a single edit. Fix one, verify it, then move to the next.
 
-### {{.Source}}
-- [{{.Severity}}] {{.File}}{{if .Line}}:{{.Line}}{{end}} — {{.Issue}}
-  Suggestion: {{.Suggestion}}
+{{- range $idx, $finding := .ReworkFeedback.ReviewFindings}}
+
+### Finding {{add $idx 1}} of {{len $.ReworkFeedback.ReviewFindings}}: {{$finding.Source}}
+- [{{$finding.Severity}}] {{$finding.File}}{{if $finding.Line}}:{{$finding.Line}}{{end}} — {{$finding.Issue}}
+  Suggestion: {{$finding.Suggestion}}
+→ Fix this finding, then verify before proceeding.
 {{- end}}
 
-After implementing, verify that each finding above is addressed before reporting completion.
 If any feedback above contradicts the Implementation Plan, the feedback takes precedence — it reflects issues found in the actual implementation.
 {{- else}}
 
 ## MANDATORY: Previous Verification Failures
 
 The following issues were identified in the previous implementation attempt.
-You MUST address every item below. Do not repeat the same mistakes.
+You MUST address every item below **one at a time, in order**. Do not repeat the same mistakes.
+
+Do NOT address multiple findings in a single edit. Fix one, verify it, then move to the next.
 
 ### Verdict: {{.ReworkFeedback.Verdict}}
 
 {{- if .ReworkFeedback.FixesRequired}}
 ### Fixes Required
-{{range .ReworkFeedback.FixesRequired}}- **{{.}}**
+{{range $idx, $fix := .ReworkFeedback.FixesRequired}}#### Finding {{add $idx 1}} of {{len $.ReworkFeedback.FixesRequired}}
+- **{{$fix}}**
+→ Fix this finding, then verify before proceeding.
 {{end}}
 {{- end}}
 
 {{- if .ReworkFeedback.FailedCriteria}}
 ### Failed Acceptance Criteria
-{{range .ReworkFeedback.FailedCriteria}}- **FAIL**: {{.Criterion}}
-  Evidence: {{.Evidence}}
+{{range $idx, $fc := .ReworkFeedback.FailedCriteria}}#### Finding {{add $idx 1}} of {{len $.ReworkFeedback.FailedCriteria}}
+- **FAIL**: {{$fc.Criterion}}
+  Evidence: {{$fc.Evidence}}
+→ Fix this finding, then verify before proceeding.
 {{end}}
 {{- end}}
 
 {{- if .ReworkFeedback.CodeIssues}}
 ### Code Issues
-{{range .ReworkFeedback.CodeIssues}}- **{{.Severity}}** {{.File}}{{if .Line}}:{{.Line}}{{end}}: {{.Issue}}
-{{- if .SuggestedFix}}
-  Suggested fix: {{.SuggestedFix}}
+{{range $idx, $ci := .ReworkFeedback.CodeIssues}}#### Finding {{add $idx 1}} of {{len $.ReworkFeedback.CodeIssues}}
+- **{{$ci.Severity}}** {{$ci.File}}{{if $ci.Line}}:{{$ci.Line}}{{end}}: {{$ci.Issue}}
+{{- if $ci.SuggestedFix}}
+  Suggested fix: {{$ci.SuggestedFix}}
 {{- end}}
+→ Fix this finding, then verify before proceeding.
 {{end}}
 {{- end}}
 
 {{- if .ReworkFeedback.FailedCommands}}
 ### Failed Commands
-{{range .ReworkFeedback.FailedCommands}}- `{{.Command}}` (exit {{.ExitCode}})
-{{- if .Output}}
+{{range $idx, $cmd := .ReworkFeedback.FailedCommands}}#### Finding {{add $idx 1}} of {{len $.ReworkFeedback.FailedCommands}}
+- `{{$cmd.Command}}` (exit {{$cmd.ExitCode}})
+{{- if $cmd.Output}}
 ```
-{{.Output}}
+{{$cmd.Output}}
 ```
 {{- end}}
+→ Fix this finding, then verify before proceeding.
 {{end}}
 {{- end}}
 
 If any feedback above contradicts the Implementation Plan, the feedback takes precedence — it reflects issues found in the actual implementation.
-After implementing, verify that each fix above is addressed before reporting completion.
 {{- end}}
 {{- end}}
 

--- a/cmd/soda/embeds/prompts/patch.md
+++ b/cmd/soda/embeds/prompts/patch.md
@@ -38,40 +38,50 @@ Use this context to avoid re-introducing previously-fixed issues or repeating th
 
 ## FIXES REQUIRED
 
-You will address the issues listed below. Report one fix_result per item in the Fixes section (use fix_index matching the number shown).
+You will address the issues listed below **one at a time, in order**. Report one fix_result per item in the Fixes section (use fix_index matching the 0-based index).
+
+Do NOT address multiple findings in a single edit. Fix one, verify it, then move to the next.
 
 ### Verdict: {{.ReworkFeedback.Verdict}}
 
 {{- if .ReworkFeedback.FixesRequired}}
 ### Fixes
-{{range $idx, $fix := .ReworkFeedback.FixesRequired}}{{$idx}}. **{{$fix}}**
+{{range $idx, $fix := .ReworkFeedback.FixesRequired}}#### Finding {{add $idx 1}} of {{len $.ReworkFeedback.FixesRequired}}
+{{$idx}}. **{{$fix}}**
+→ Fix this finding, then verify before proceeding.
 {{end}}
 {{- end}}
 
 {{- if .ReworkFeedback.FailedCriteria}}
 ### Failed Acceptance Criteria
-{{range $idx, $fc := .ReworkFeedback.FailedCriteria}}{{$idx}}. **FAIL**: {{$fc.Criterion}}
+{{range $idx, $fc := .ReworkFeedback.FailedCriteria}}#### Finding {{add $idx 1}} of {{len $.ReworkFeedback.FailedCriteria}}
+{{$idx}}. **FAIL**: {{$fc.Criterion}}
    Evidence: {{$fc.Evidence}}
+→ Fix this finding, then verify before proceeding.
 {{end}}
 {{- end}}
 
 {{- if .ReworkFeedback.CodeIssues}}
 ### Code Issues
-{{range $idx, $ci := .ReworkFeedback.CodeIssues}}{{$idx}}. **{{$ci.Severity}}** {{$ci.File}}{{if $ci.Line}}:{{$ci.Line}}{{end}}: {{$ci.Issue}}
+{{range $idx, $ci := .ReworkFeedback.CodeIssues}}#### Finding {{add $idx 1}} of {{len $.ReworkFeedback.CodeIssues}}
+{{$idx}}. **{{$ci.Severity}}** {{$ci.File}}{{if $ci.Line}}:{{$ci.Line}}{{end}}: {{$ci.Issue}}
 {{- if $ci.SuggestedFix}}
    Suggested fix: {{$ci.SuggestedFix}}
 {{- end}}
+→ Fix this finding, then verify before proceeding.
 {{end}}
 {{- end}}
 
 {{- if .ReworkFeedback.FailedCommands}}
 ### Failed Commands
-{{range $idx, $cmd := .ReworkFeedback.FailedCommands}}{{$idx}}. `{{$cmd.Command}}` (exit {{$cmd.ExitCode}})
+{{range $idx, $cmd := .ReworkFeedback.FailedCommands}}#### Finding {{add $idx 1}} of {{len $.ReworkFeedback.FailedCommands}}
+{{$idx}}. `{{$cmd.Command}}` (exit {{$cmd.ExitCode}})
 {{- if $cmd.Output}}
 ```
 {{$cmd.Output}}
 ```
 {{- end}}
+→ Fix this finding, then verify before proceeding.
 {{end}}
 {{- end}}
 {{- end}}
@@ -108,5 +118,5 @@ Base: {{.BaseBranch}}
 {{- if .Config.TestCommand}}
 6. **Run the tests** after changes: `{{.Config.TestCommand}}`
 {{- end}}
-7. **Each fix_result must map 1:1** to the numbered items in the **Fixes** section only. Use the same 0-based index. Code Issues provide additional context but do not need separate fix_results.
+7. **Each fix_result must map 1:1** to the numbered items in the **Fixes** section only. Use the same 0-based index (the number before each fix). Display headers show 1-based "Finding X of N" but fix_index uses the 0-based number. Code Issues provide additional context but do not need separate fix_results.
 8. **Commit** the fix with a message referencing the ticket key and fix number.

--- a/internal/pipeline/prompt.go
+++ b/internal/pipeline/prompt.go
@@ -266,13 +266,20 @@ func (loader *PromptLoader) LoadWithSource(name string) (*LoadResult, error) {
 	return nil, fmt.Errorf("prompt: %s not found in %v", name, loader.dirs)
 }
 
+// promptFuncs is a shared FuncMap registered on every prompt template.
+// Go templates have no built-in arithmetic; the add function enables
+// 1-based display indexing via {{add $idx 1}}.
+var promptFuncs = template.FuncMap{
+	"add": func(a, b int) int { return a + b },
+}
+
 // ValidateTemplate parses a Go text/template and executes it against a
 // zero-value PromptData. This catches syntax errors and references to
 // fields that don't exist on PromptData. Templates that only fail at
 // render time due to missing runtime data (e.g. nil pointer deref on
 // optional sections) are not caught here — they require RenderPrompt.
 func ValidateTemplate(tmpl string) error {
-	parsed, err := template.New("prompt").Option("missingkey=error").Parse(tmpl)
+	parsed, err := template.New("prompt").Funcs(promptFuncs).Option("missingkey=error").Parse(tmpl)
 	if err != nil {
 		return fmt.Errorf("prompt: parse template: %w", err)
 	}
@@ -287,7 +294,7 @@ func ValidateTemplate(tmpl string) error {
 
 // RenderPrompt executes a Go text/template against the given data.
 func RenderPrompt(tmpl string, data PromptData) (string, error) {
-	parsed, err := template.New("prompt").Option("missingkey=error").Parse(tmpl)
+	parsed, err := template.New("prompt").Funcs(promptFuncs).Option("missingkey=error").Parse(tmpl)
 	if err != nil {
 		return "", fmt.Errorf("prompt: parse template: %w", err)
 	}

--- a/internal/pipeline/prompt_test.go
+++ b/internal/pipeline/prompt_test.go
@@ -365,6 +365,13 @@ func TestValidateTemplate(t *testing.T) {
 			t.Fatalf("ValidateTemplate: %v", err)
 		}
 	})
+
+	t.Run("valid_template_with_add_funcmap", func(t *testing.T) {
+		tmpl := `{{- if .ReworkFeedback}}{{range $idx, $fix := .ReworkFeedback.FixesRequired}}Finding {{add $idx 1}} of {{len $.ReworkFeedback.FixesRequired}}{{end}}{{- end}}`
+		if err := ValidateTemplate(tmpl); err != nil {
+			t.Fatalf("ValidateTemplate should accept add FuncMap: %v", err)
+		}
+	})
 }
 
 func TestRenderPrompt(t *testing.T) {
@@ -543,6 +550,16 @@ Verdict: {{.ReworkFeedback.Verdict}}
 		if !strings.Contains(result, "the feedback takes precedence") {
 			t.Error("implement prompt should say 'the feedback takes precedence' for review rework feedback")
 		}
+		// Sequential finding format.
+		if !strings.Contains(result, "Finding 1 of 1") {
+			t.Error("implement prompt should contain sequential 'Finding 1 of 1' header for single review finding")
+		}
+		if !strings.Contains(result, "Fix this finding, then verify before proceeding") {
+			t.Error("implement prompt should contain verify instruction for review finding")
+		}
+		if !strings.Contains(result, "Do NOT address multiple findings in a single edit") {
+			t.Error("implement prompt should contain sequential fix instruction for review source")
+		}
 	})
 
 	t.Run("rework_feedback_takes_precedence_over_plan_verify_source", func(t *testing.T) {
@@ -575,6 +592,16 @@ Verdict: {{.ReworkFeedback.Verdict}}
 		}
 		if !strings.Contains(result, "the feedback takes precedence") {
 			t.Error("implement prompt should say 'the feedback takes precedence' for verify rework feedback")
+		}
+		// Sequential finding format.
+		if !strings.Contains(result, "Finding 1 of 1") {
+			t.Error("implement prompt should contain sequential 'Finding 1 of 1' header for single verify fix")
+		}
+		if !strings.Contains(result, "Fix this finding, then verify before proceeding") {
+			t.Error("implement prompt should contain verify instruction for verify finding")
+		}
+		if !strings.Contains(result, "Do NOT address multiple findings in a single edit") {
+			t.Error("implement prompt should contain sequential fix instruction for verify source")
 		}
 	})
 
@@ -848,6 +875,16 @@ Context: {{.}}
 		if strings.Contains(result, "Implementation Plan") {
 			t.Error("patch prompt should NOT contain Implementation Plan section")
 		}
+		// Sequential finding format.
+		if !strings.Contains(result, "Finding 1 of 1") {
+			t.Error("patch prompt should contain sequential 'Finding 1 of 1' header")
+		}
+		if !strings.Contains(result, "Fix this finding, then verify before proceeding") {
+			t.Error("patch prompt should contain verify instruction")
+		}
+		if !strings.Contains(result, "Do NOT address multiple findings in a single edit") {
+			t.Error("patch prompt should contain sequential fix instruction")
+		}
 	})
 
 	t.Run("renders_patch_prompt_without_feedback", func(t *testing.T) {
@@ -919,6 +956,13 @@ Context: {{.}}
 		// Should also contain current findings.
 		if !strings.Contains(result, "missing error check") {
 			t.Errorf("implement prompt should contain current finding;\ngot: %s", result)
+		}
+		// Sequential finding format.
+		if !strings.Contains(result, "Finding 1 of 1") {
+			t.Error("implement prompt should contain sequential 'Finding 1 of 1' header for single review finding with prior cycles")
+		}
+		if !strings.Contains(result, "Fix this finding, then verify before proceeding") {
+			t.Error("implement prompt should contain verify instruction with prior cycles")
 		}
 	})
 
@@ -999,6 +1043,48 @@ Context: {{.}}
 		// Should also contain current fix.
 		if !strings.Contains(result, "fix the remaining test") {
 			t.Errorf("patch prompt should contain current fix;\ngot: %s", result)
+		}
+	})
+
+	t.Run("renders_multi_finding_sequential_indexing", func(t *testing.T) {
+		tmplBytes, err := os.ReadFile(filepath.Join("..", "..", "cmd", "soda", "embeds", "prompts", "implement.md"))
+		if err != nil {
+			t.Skipf("skipping: cannot read embedded implement.md: %v", err)
+		}
+		tmpl := string(tmplBytes)
+
+		data := PromptData{
+			Ticket:       TicketData{Key: "TEST-265", Summary: "multi-finding test"},
+			WorktreePath: "/tmp/wt",
+			Branch:       "soda/TEST-265",
+			BaseBranch:   "main",
+			Config:       PromptConfigData{Formatter: "gofmt -w .", TestCommand: "go test ./..."},
+			ReworkFeedback: &ReworkFeedback{
+				Source:  "review",
+				Verdict: "rework",
+				ReviewFindings: []schemas.ReviewFinding{
+					{Severity: "critical", File: "a.go", Line: 1, Issue: "issue-a", Suggestion: "fix-a", Source: "go-specialist"},
+					{Severity: "major", File: "b.go", Line: 2, Issue: "issue-b", Suggestion: "fix-b", Source: "go-specialist"},
+					{Severity: "minor", File: "c.go", Line: 3, Issue: "issue-c", Suggestion: "fix-c", Source: "go-specialist"},
+				},
+			},
+		}
+
+		result, err := RenderPrompt(tmpl, data)
+		if err != nil {
+			t.Fatalf("RenderPrompt: %v", err)
+		}
+
+		// All three sequential headers must be present.
+		for _, want := range []string{"Finding 1 of 3", "Finding 2 of 3", "Finding 3 of 3"} {
+			if !strings.Contains(result, want) {
+				t.Errorf("implement prompt should contain %q;\ngot: %s", want, result)
+			}
+		}
+		// Each finding should have the verify instruction.
+		count := strings.Count(result, "Fix this finding, then verify before proceeding")
+		if count != 3 {
+			t.Errorf("expected 3 verify instructions, got %d;\nresult: %s", count, result)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- **Add `add` FuncMap helper** to `prompt.go` for 1-based indexing in Go templates (`{{add $idx 1}}`)
- **Rework `implement.md`** to render findings sequentially with "Finding X of N" headers, each followed by "→ Fix this finding, then verify before proceeding" and a "Do NOT address multiple findings in a single edit" directive
- **Rework `patch.md`** with the same sequential pattern across all finding categories (Fixes, FailedCriteria, CodeIssues, FailedCommands), clarifying 0-based `fix_index` vs 1-based display
- **Add comprehensive tests** verifying sequential format rendering, `add` FuncMap registration, and multi-finding indexing correctness

## Acceptance Criteria

- [x] Findings rendered sequentially with index (`Finding X of N`)
- [x] "Fix, then verify before proceeding" on each finding
- [x] "Do NOT address multiple findings in a single edit" directive present
- [x] Templates compile and render correctly (all 26 `TestRenderPrompt` subtests pass)
- [x] `add` FuncMap registered in both `ValidateTemplate` and `RenderPrompt`
- [x] No regressions — all pipeline, cmd/soda, and schemas tests pass
- [x] `go vet` clean

## Test Plan

- [x] Run `go test ./internal/pipeline/... -run TestRenderPrompt` — all 26 subtests pass
- [x] Verify multi-finding test: 3 findings → "Finding 1 of 3", "Finding 2 of 3", "Finding 3 of 3" with exactly 3 verify instructions
- [x] Run `go vet ./...` — clean
- [x] Run full test suite — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)