### PR TITLE
feat(cli): soda log command — tail pipeline events

### DIFF
--- a/cmd/soda/log.go
+++ b/cmd/soda/log.go
@@ -102,6 +102,10 @@ func followEvents(w io.Writer, path string, sinceTime time.Time, phase string) e
 
 	for _, ev := range filterEvents(events, sinceTime, phase) {
 		fmt.Fprintln(w, pipeline.FormatEvent(ev))
+	}
+	// Check terminal events on the unfiltered list so that --phase filters
+	// cannot mask engine_completed / engine_failed (which have Phase="").
+	for _, ev := range events {
 		if isTerminalEvent(ev) {
 			return nil
 		}
@@ -127,6 +131,9 @@ func followEvents(w io.Writer, path string, sinceTime time.Time, phase string) e
 
 			for _, ev := range filterEvents(newEvents, sinceTime, phase) {
 				fmt.Fprintln(w, pipeline.FormatEvent(ev))
+			}
+			// Check terminal events on the unfiltered list.
+			for _, ev := range newEvents {
 				if isTerminalEvent(ev) {
 					return nil
 				}
@@ -140,7 +147,7 @@ func readEventsFromPath(path string) ([]pipeline.Event, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, fmt.Errorf("log: no events file found at %s\nRun 'soda run <ticket>' to start a pipeline first.", path)
+			return nil, fmt.Errorf("log: no events file found at %s (run 'soda run <ticket>' first)", path)
 		}
 		return nil, fmt.Errorf("log: read events: %w", err)
 	}
@@ -227,5 +234,9 @@ func filterEvents(events []pipeline.Event, sinceTime time.Time, phase string) []
 // isTerminalEvent returns true for events that indicate the pipeline
 // has reached a terminal state.
 func isTerminalEvent(ev pipeline.Event) bool {
-	return ev.Kind == pipeline.EventEngineCompleted || ev.Kind == pipeline.EventEngineFailed
+	switch ev.Kind {
+	case pipeline.EventEngineCompleted, pipeline.EventEngineFailed, pipeline.EventPipelineTimeout:
+		return true
+	}
+	return false
 }

--- a/cmd/soda/log.go
+++ b/cmd/soda/log.go
@@ -1,0 +1,231 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/decko/soda/internal/pipeline"
+	"github.com/spf13/cobra"
+)
+
+func newLogCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "log <ticket>",
+		Short: "Tail pipeline events for a ticket",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := loadConfig(cmd)
+			if err != nil {
+				return err
+			}
+			follow, _ := cmd.Flags().GetBool("follow")
+			since, _ := cmd.Flags().GetString("since")
+			phase, _ := cmd.Flags().GetString("phase")
+			n, _ := cmd.Flags().GetInt("n")
+			return runLog(cmd.OutOrStdout(), cfg.StateDir, args[0], follow, since, phase, n)
+		},
+	}
+
+	cmd.Flags().BoolP("follow", "f", false, "follow new events (tail -f style)")
+	cmd.Flags().String("since", "", "show events since duration (e.g. 5m, 1h)")
+	cmd.Flags().String("phase", "", "filter events to a specific phase")
+	cmd.Flags().IntP("n", "n", 0, "show only the last N events")
+
+	return cmd
+}
+
+func runLog(w io.Writer, stateDir, ticketKey string, follow bool, since, phase string, lastN int) error {
+	ticketDir := filepath.Join(stateDir, ticketKey)
+	eventsPath := filepath.Join(ticketDir, "events.jsonl")
+
+	// Parse --since if provided.
+	var sinceTime time.Time
+	if since != "" {
+		dur, err := time.ParseDuration(since)
+		if err != nil {
+			return fmt.Errorf("log: invalid --since duration %q: %w", since, err)
+		}
+		sinceTime = time.Now().Add(-dur)
+	}
+
+	if !follow {
+		return printEvents(w, eventsPath, sinceTime, phase, lastN)
+	}
+
+	return followEvents(w, eventsPath, sinceTime, phase)
+}
+
+// printEvents reads and prints all matching events from the file.
+func printEvents(w io.Writer, path string, sinceTime time.Time, phase string, lastN int) error {
+	events, err := readEventsFromPath(path)
+	if err != nil {
+		return err
+	}
+
+	filtered := filterEvents(events, sinceTime, phase)
+
+	// Apply --n: show only the last N events.
+	if lastN > 0 && len(filtered) > lastN {
+		filtered = filtered[len(filtered)-lastN:]
+	}
+
+	for _, ev := range filtered {
+		fmt.Fprintln(w, pipeline.FormatEvent(ev))
+	}
+	return nil
+}
+
+// followEvents prints existing events then polls for new ones until a
+// terminal event is seen or the process receives SIGINT/SIGTERM.
+func followEvents(w io.Writer, path string, sinceTime time.Time, phase string) error {
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	// Print existing events first.
+	var offset int64
+	events, newOffset, err := readEventsFromOffset(path, 0)
+	if err != nil {
+		// If the file doesn't exist yet in follow mode, start from scratch.
+		if !os.IsNotExist(err) {
+			return err
+		}
+	}
+	offset = newOffset
+
+	for _, ev := range filterEvents(events, sinceTime, phase) {
+		fmt.Fprintln(w, pipeline.FormatEvent(ev))
+		if isTerminalEvent(ev) {
+			return nil
+		}
+	}
+
+	// Poll loop.
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			newEvents, newOff, readErr := readEventsFromOffset(path, offset)
+			if readErr != nil {
+				if os.IsNotExist(readErr) {
+					continue
+				}
+				return readErr
+			}
+			offset = newOff
+
+			for _, ev := range filterEvents(newEvents, sinceTime, phase) {
+				fmt.Fprintln(w, pipeline.FormatEvent(ev))
+				if isTerminalEvent(ev) {
+					return nil
+				}
+			}
+		}
+	}
+}
+
+// readEventsFromPath reads all events from the file at path.
+func readEventsFromPath(path string) ([]pipeline.Event, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("log: no events file found at %s\nRun 'soda run <ticket>' to start a pipeline first.", path)
+		}
+		return nil, fmt.Errorf("log: read events: %w", err)
+	}
+	return parseEventsData(data), nil
+}
+
+// readEventsFromOffset reads events from path starting at byte offset.
+// Returns the parsed events and the new offset. If the file does not exist,
+// returns os.ErrNotExist so the caller can decide how to handle it.
+func readEventsFromOffset(path string, offset int64) ([]pipeline.Event, int64, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, offset, err
+	}
+	defer f.Close()
+
+	if _, err := f.Seek(offset, io.SeekStart); err != nil {
+		return nil, offset, fmt.Errorf("log: seek: %w", err)
+	}
+
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return nil, offset, fmt.Errorf("log: read: %w", err)
+	}
+
+	if len(data) == 0 {
+		return nil, offset, nil
+	}
+
+	// Only process complete lines; buffer partial lines for next read.
+	lastNewline := -1
+	for i := len(data) - 1; i >= 0; i-- {
+		if data[i] == '\n' {
+			lastNewline = i
+			break
+		}
+	}
+	if lastNewline < 0 {
+		// No complete line yet.
+		return nil, offset, nil
+	}
+
+	completeData := data[:lastNewline+1]
+	newOffset := offset + int64(len(completeData))
+	return parseEventsData(completeData), newOffset, nil
+}
+
+// parseEventsData parses JSONL data into events, skipping malformed lines.
+func parseEventsData(data []byte) []pipeline.Event {
+	var events []pipeline.Event
+	for _, line := range strings.Split(strings.TrimRight(string(data), "\n"), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var ev pipeline.Event
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			continue
+		}
+		events = append(events, ev)
+	}
+	return events
+}
+
+// filterEvents applies phase and since-time filters.
+func filterEvents(events []pipeline.Event, sinceTime time.Time, phase string) []pipeline.Event {
+	if sinceTime.IsZero() && phase == "" {
+		return events
+	}
+
+	var filtered []pipeline.Event
+	for _, ev := range events {
+		if !sinceTime.IsZero() && ev.Timestamp.Before(sinceTime) {
+			continue
+		}
+		if phase != "" && ev.Phase != phase {
+			continue
+		}
+		filtered = append(filtered, ev)
+	}
+	return filtered
+}
+
+// isTerminalEvent returns true for events that indicate the pipeline
+// has reached a terminal state.
+func isTerminalEvent(ev pipeline.Event) bool {
+	return ev.Kind == pipeline.EventEngineCompleted || ev.Kind == pipeline.EventEngineFailed
+}

--- a/cmd/soda/log.go
+++ b/cmd/soda/log.go
@@ -29,15 +29,15 @@ func newLogCmd() *cobra.Command {
 			follow, _ := cmd.Flags().GetBool("follow")
 			since, _ := cmd.Flags().GetString("since")
 			phase, _ := cmd.Flags().GetString("phase")
-			n, _ := cmd.Flags().GetInt("n")
-			return runLog(cmd.OutOrStdout(), cfg.StateDir, args[0], follow, since, phase, n)
+			lastN, _ := cmd.Flags().GetInt("last")
+			return runLog(cmd.OutOrStdout(), cfg.StateDir, args[0], follow, since, phase, lastN)
 		},
 	}
 
 	cmd.Flags().BoolP("follow", "f", false, "follow new events (tail -f style)")
 	cmd.Flags().String("since", "", "show events since duration (e.g. 5m, 1h)")
 	cmd.Flags().String("phase", "", "filter events to a specific phase")
-	cmd.Flags().IntP("n", "n", 0, "show only the last N events")
+	cmd.Flags().IntP("last", "n", 0, "show only the last N events")
 
 	return cmd
 }
@@ -60,7 +60,7 @@ func runLog(w io.Writer, stateDir, ticketKey string, follow bool, since, phase s
 		return printEvents(w, eventsPath, sinceTime, phase, lastN)
 	}
 
-	return followEvents(w, eventsPath, sinceTime, phase)
+	return followEvents(w, eventsPath, sinceTime, phase, lastN)
 }
 
 // printEvents reads and prints all matching events from the file.
@@ -72,7 +72,7 @@ func printEvents(w io.Writer, path string, sinceTime time.Time, phase string, la
 
 	filtered := filterEvents(events, sinceTime, phase)
 
-	// Apply --n: show only the last N events.
+	// Apply --last: show only the last N events.
 	if lastN > 0 && len(filtered) > lastN {
 		filtered = filtered[len(filtered)-lastN:]
 	}
@@ -85,7 +85,7 @@ func printEvents(w io.Writer, path string, sinceTime time.Time, phase string, la
 
 // followEvents prints existing events then polls for new ones until a
 // terminal event is seen or the process receives SIGINT/SIGTERM.
-func followEvents(w io.Writer, path string, sinceTime time.Time, phase string) error {
+func followEvents(w io.Writer, path string, sinceTime time.Time, phase string, lastN int) error {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 
@@ -100,7 +100,12 @@ func followEvents(w io.Writer, path string, sinceTime time.Time, phase string) e
 	}
 	offset = newOffset
 
-	for _, ev := range filterEvents(events, sinceTime, phase) {
+	filtered := filterEvents(events, sinceTime, phase)
+	// Apply --last: show only the last N historical events (tail -f -n semantics).
+	if lastN > 0 && len(filtered) > lastN {
+		filtered = filtered[len(filtered)-lastN:]
+	}
+	for _, ev := range filtered {
 		fmt.Fprintln(w, pipeline.FormatEvent(ev))
 	}
 	// Check terminal events on the unfiltered list so that --phase filters

--- a/cmd/soda/log.go
+++ b/cmd/soda/log.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -94,7 +95,7 @@ func followEvents(w io.Writer, path string, sinceTime time.Time, phase string, l
 	events, newOffset, err := readEventsFromOffset(path, 0)
 	if err != nil {
 		// If the file doesn't exist yet in follow mode, start from scratch.
-		if !os.IsNotExist(err) {
+		if !errors.Is(err, os.ErrNotExist) {
 			return err
 		}
 	}
@@ -127,7 +128,7 @@ func followEvents(w io.Writer, path string, sinceTime time.Time, phase string, l
 		case <-ticker.C:
 			newEvents, newOff, readErr := readEventsFromOffset(path, offset)
 			if readErr != nil {
-				if os.IsNotExist(readErr) {
+				if errors.Is(readErr, os.ErrNotExist) {
 					continue
 				}
 				return readErr
@@ -151,7 +152,7 @@ func followEvents(w io.Writer, path string, sinceTime time.Time, phase string, l
 func readEventsFromPath(path string) ([]pipeline.Event, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return nil, fmt.Errorf("log: no events file found at %s (run 'soda run <ticket>' first)", path)
 		}
 		return nil, fmt.Errorf("log: read events: %w", err)

--- a/cmd/soda/log_test.go
+++ b/cmd/soda/log_test.go
@@ -134,6 +134,10 @@ func TestRunLog_MissingFile(t *testing.T) {
 	if !strings.Contains(errMsg, "events.jsonl") {
 		t.Errorf("error should mention events.jsonl path, got: %s", errMsg)
 	}
+	// Error should be single-line (no embedded newlines).
+	if strings.Contains(errMsg, "\n") {
+		t.Errorf("error message should be single-line, got: %s", errMsg)
+	}
 }
 
 func TestRunLog_PhaseFilter(t *testing.T) {
@@ -300,6 +304,75 @@ func TestFollowEvents_TerminalFailed(t *testing.T) {
 	}
 }
 
+func TestFollowEvents_PhaseFilterWithTerminalEvent(t *testing.T) {
+	// Regression test: --phase filter must not prevent follow mode from
+	// detecting terminal events (engine_completed has Phase="").
+	stateDir := t.TempDir()
+	ticketDir := filepath.Join(stateDir, "TEST-7")
+	if err := os.MkdirAll(ticketDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	ts := time.Date(2026, 4, 11, 10, 0, 0, 0, time.UTC)
+	events := []pipeline.Event{
+		{Timestamp: ts, Kind: pipeline.EventEngineStarted},
+		{Timestamp: ts.Add(time.Second), Phase: "triage", Kind: pipeline.EventPhaseStarted},
+		{Timestamp: ts.Add(2 * time.Second), Phase: "triage", Kind: pipeline.EventPhaseCompleted},
+		{Timestamp: ts.Add(3 * time.Second), Kind: pipeline.EventEngineCompleted},
+	}
+	writeTestEvents(t, ticketDir, events)
+
+	var buf bytes.Buffer
+	eventsPath := filepath.Join(ticketDir, "events.jsonl")
+
+	// With --phase triage, engine_completed (Phase="") is filtered from
+	// output but must still cause follow mode to exit.
+	err := followEvents(&buf, eventsPath, time.Time{}, "triage")
+	if err != nil {
+		t.Fatalf("followEvents: %v", err)
+	}
+
+	output := buf.String()
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	// Only triage events should be printed (engine_completed is filtered).
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 triage lines, got %d:\n%s", len(lines), output)
+	}
+	for _, line := range lines {
+		if !strings.Contains(line, "[triage]") {
+			t.Errorf("expected [triage] in every line, got: %s", line)
+		}
+	}
+}
+
+func TestFollowEvents_PipelineTimeoutTerminal(t *testing.T) {
+	stateDir := t.TempDir()
+	ticketDir := filepath.Join(stateDir, "TEST-8")
+	if err := os.MkdirAll(ticketDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	ts := time.Date(2026, 4, 11, 10, 0, 0, 0, time.UTC)
+	events := []pipeline.Event{
+		{Timestamp: ts, Kind: pipeline.EventEngineStarted},
+		{Timestamp: ts.Add(time.Second), Kind: pipeline.EventPipelineTimeout, Data: map[string]any{"limit": "30m"}},
+	}
+	writeTestEvents(t, ticketDir, events)
+
+	var buf bytes.Buffer
+	eventsPath := filepath.Join(ticketDir, "events.jsonl")
+
+	err := followEvents(&buf, eventsPath, time.Time{}, "")
+	if err != nil {
+		t.Fatalf("followEvents: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "pipeline_timeout") {
+		t.Errorf("output should contain pipeline_timeout, got: %s", output)
+	}
+}
+
 func TestIsTerminalEvent(t *testing.T) {
 	tests := []struct {
 		kind string
@@ -307,6 +380,7 @@ func TestIsTerminalEvent(t *testing.T) {
 	}{
 		{pipeline.EventEngineCompleted, true},
 		{pipeline.EventEngineFailed, true},
+		{pipeline.EventPipelineTimeout, true},
 		{pipeline.EventEngineStarted, false},
 		{pipeline.EventPhaseStarted, false},
 		{pipeline.EventPhaseCompleted, false},

--- a/cmd/soda/log_test.go
+++ b/cmd/soda/log_test.go
@@ -62,16 +62,16 @@ func TestNewLogCmd_Flags(t *testing.T) {
 		t.Errorf("--phase default = %q, want empty", phaseFlag.DefValue)
 	}
 
-	// Verify --n/-n flag exists and defaults to 0.
-	nFlag := cmd.Flags().Lookup("n")
-	if nFlag == nil {
-		t.Fatal("--n flag not found")
+	// Verify --last/-n flag exists and defaults to 0.
+	lastFlag := cmd.Flags().Lookup("last")
+	if lastFlag == nil {
+		t.Fatal("--last flag not found")
 	}
-	if nFlag.DefValue != "0" {
-		t.Errorf("--n default = %q, want %q", nFlag.DefValue, "0")
+	if lastFlag.DefValue != "0" {
+		t.Errorf("--last default = %q, want %q", lastFlag.DefValue, "0")
 	}
-	if nFlag.Shorthand != "n" {
-		t.Errorf("--n shorthand = %q, want %q", nFlag.Shorthand, "n")
+	if lastFlag.Shorthand != "n" {
+		t.Errorf("--last shorthand = %q, want %q", lastFlag.Shorthand, "n")
 	}
 }
 
@@ -261,7 +261,7 @@ func TestFollowEvents_TerminalEvent(t *testing.T) {
 
 	// followEvents should return immediately because events already contain
 	// a terminal event (engine_completed).
-	err := followEvents(&buf, eventsPath, time.Time{}, "")
+	err := followEvents(&buf, eventsPath, time.Time{}, "", 0)
 	if err != nil {
 		t.Fatalf("followEvents: %v", err)
 	}
@@ -293,7 +293,7 @@ func TestFollowEvents_TerminalFailed(t *testing.T) {
 	var buf bytes.Buffer
 	eventsPath := filepath.Join(ticketDir, "events.jsonl")
 
-	err := followEvents(&buf, eventsPath, time.Time{}, "")
+	err := followEvents(&buf, eventsPath, time.Time{}, "", 0)
 	if err != nil {
 		t.Fatalf("followEvents: %v", err)
 	}
@@ -327,7 +327,7 @@ func TestFollowEvents_PhaseFilterWithTerminalEvent(t *testing.T) {
 
 	// With --phase triage, engine_completed (Phase="") is filtered from
 	// output but must still cause follow mode to exit.
-	err := followEvents(&buf, eventsPath, time.Time{}, "triage")
+	err := followEvents(&buf, eventsPath, time.Time{}, "triage", 0)
 	if err != nil {
 		t.Fatalf("followEvents: %v", err)
 	}
@@ -342,6 +342,49 @@ func TestFollowEvents_PhaseFilterWithTerminalEvent(t *testing.T) {
 		if !strings.Contains(line, "[triage]") {
 			t.Errorf("expected [triage] in every line, got: %s", line)
 		}
+	}
+}
+
+func TestFollowEvents_LastN(t *testing.T) {
+	// Verify that --last limits the initial batch of events in follow mode
+	// (tail -f -n semantics).
+	stateDir := t.TempDir()
+	ticketDir := filepath.Join(stateDir, "TEST-LASTN")
+	if err := os.MkdirAll(ticketDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	ts := time.Date(2026, 4, 11, 10, 0, 0, 0, time.UTC)
+	events := []pipeline.Event{
+		{Timestamp: ts, Kind: pipeline.EventEngineStarted},
+		{Timestamp: ts.Add(time.Second), Phase: "triage", Kind: pipeline.EventPhaseStarted},
+		{Timestamp: ts.Add(2 * time.Second), Phase: "triage", Kind: pipeline.EventPhaseCompleted},
+		{Timestamp: ts.Add(3 * time.Second), Phase: "plan", Kind: pipeline.EventPhaseStarted},
+		{Timestamp: ts.Add(4 * time.Second), Kind: pipeline.EventEngineCompleted},
+	}
+	writeTestEvents(t, ticketDir, events)
+
+	var buf bytes.Buffer
+	eventsPath := filepath.Join(ticketDir, "events.jsonl")
+
+	// With lastN=2, only the last 2 filtered events should be printed before
+	// follow mode detects the terminal event and exits.
+	err := followEvents(&buf, eventsPath, time.Time{}, "", 2)
+	if err != nil {
+		t.Fatalf("followEvents: %v", err)
+	}
+
+	output := buf.String()
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	// Last 2 of all 5 events: plan phase_started and engine_completed.
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines with lastN=2, got %d:\n%s", len(lines), output)
+	}
+	if !strings.Contains(lines[0], "[plan] phase_started") {
+		t.Errorf("line 0 should be plan phase_started, got: %s", lines[0])
+	}
+	if !strings.Contains(lines[1], "engine_completed") {
+		t.Errorf("line 1 should be engine_completed, got: %s", lines[1])
 	}
 }
 
@@ -362,7 +405,7 @@ func TestFollowEvents_PipelineTimeoutTerminal(t *testing.T) {
 	var buf bytes.Buffer
 	eventsPath := filepath.Join(ticketDir, "events.jsonl")
 
-	err := followEvents(&buf, eventsPath, time.Time{}, "")
+	err := followEvents(&buf, eventsPath, time.Time{}, "", 0)
 	if err != nil {
 		t.Fatalf("followEvents: %v", err)
 	}

--- a/cmd/soda/log_test.go
+++ b/cmd/soda/log_test.go
@@ -1,0 +1,359 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/decko/soda/internal/pipeline"
+)
+
+// writeTestEvents writes events to events.jsonl in the given ticket directory.
+func writeTestEvents(t *testing.T, ticketDir string, events []pipeline.Event) {
+	t.Helper()
+	var buf bytes.Buffer
+	for _, ev := range events {
+		data, err := json.Marshal(ev)
+		if err != nil {
+			t.Fatalf("marshal event: %v", err)
+		}
+		buf.Write(data)
+		buf.WriteByte('\n')
+	}
+	if err := os.WriteFile(filepath.Join(ticketDir, "events.jsonl"), buf.Bytes(), 0644); err != nil {
+		t.Fatalf("write events.jsonl: %v", err)
+	}
+}
+
+func TestNewLogCmd_Flags(t *testing.T) {
+	cmd := newLogCmd()
+
+	// Verify --follow/-f flag exists and defaults to false.
+	followFlag := cmd.Flags().Lookup("follow")
+	if followFlag == nil {
+		t.Fatal("--follow flag not found")
+	}
+	if followFlag.DefValue != "false" {
+		t.Errorf("--follow default = %q, want %q", followFlag.DefValue, "false")
+	}
+	if followFlag.Shorthand != "f" {
+		t.Errorf("--follow shorthand = %q, want %q", followFlag.Shorthand, "f")
+	}
+
+	// Verify --since flag exists and defaults to empty.
+	sinceFlag := cmd.Flags().Lookup("since")
+	if sinceFlag == nil {
+		t.Fatal("--since flag not found")
+	}
+	if sinceFlag.DefValue != "" {
+		t.Errorf("--since default = %q, want empty", sinceFlag.DefValue)
+	}
+
+	// Verify --phase flag exists and defaults to empty.
+	phaseFlag := cmd.Flags().Lookup("phase")
+	if phaseFlag == nil {
+		t.Fatal("--phase flag not found")
+	}
+	if phaseFlag.DefValue != "" {
+		t.Errorf("--phase default = %q, want empty", phaseFlag.DefValue)
+	}
+
+	// Verify --n/-n flag exists and defaults to 0.
+	nFlag := cmd.Flags().Lookup("n")
+	if nFlag == nil {
+		t.Fatal("--n flag not found")
+	}
+	if nFlag.DefValue != "0" {
+		t.Errorf("--n default = %q, want %q", nFlag.DefValue, "0")
+	}
+	if nFlag.Shorthand != "n" {
+		t.Errorf("--n shorthand = %q, want %q", nFlag.Shorthand, "n")
+	}
+}
+
+func TestRunLog_PrintEvents(t *testing.T) {
+	stateDir := t.TempDir()
+	ticketDir := filepath.Join(stateDir, "TEST-1")
+	if err := os.MkdirAll(ticketDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	ts := time.Date(2026, 4, 11, 10, 0, 0, 0, time.UTC)
+	events := []pipeline.Event{
+		{Timestamp: ts, Kind: pipeline.EventEngineStarted},
+		{Timestamp: ts.Add(time.Second), Phase: "triage", Kind: pipeline.EventPhaseStarted, Data: map[string]any{"generation": float64(1)}},
+		{Timestamp: ts.Add(2 * time.Second), Phase: "triage", Kind: pipeline.EventPhaseCompleted, Data: map[string]any{"cost": 0.12}},
+	}
+	writeTestEvents(t, ticketDir, events)
+
+	var buf bytes.Buffer
+	err := runLog(&buf, stateDir, "TEST-1", false, "", "", 0)
+	if err != nil {
+		t.Fatalf("runLog: %v", err)
+	}
+
+	output := buf.String()
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines, got %d:\n%s", len(lines), output)
+	}
+
+	// Verify format: HH:MM:SS [phase] kind key=val
+	if !strings.Contains(lines[0], "10:00:00 engine_started") {
+		t.Errorf("line 0: unexpected format: %s", lines[0])
+	}
+	if !strings.Contains(lines[1], "[triage] phase_started") {
+		t.Errorf("line 1: unexpected format: %s", lines[1])
+	}
+	if !strings.Contains(lines[2], "[triage] phase_completed") {
+		t.Errorf("line 2: unexpected format: %s", lines[2])
+	}
+}
+
+func TestRunLog_MissingFile(t *testing.T) {
+	stateDir := t.TempDir()
+	ticketDir := filepath.Join(stateDir, "MISSING-1")
+	if err := os.MkdirAll(ticketDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	var buf bytes.Buffer
+	err := runLog(&buf, stateDir, "MISSING-1", false, "", "", 0)
+	if err == nil {
+		t.Fatal("expected error for missing events file")
+	}
+
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, "no events file found") {
+		t.Errorf("error should mention 'no events file found', got: %s", errMsg)
+	}
+	if !strings.Contains(errMsg, "events.jsonl") {
+		t.Errorf("error should mention events.jsonl path, got: %s", errMsg)
+	}
+}
+
+func TestRunLog_PhaseFilter(t *testing.T) {
+	stateDir := t.TempDir()
+	ticketDir := filepath.Join(stateDir, "TEST-2")
+	if err := os.MkdirAll(ticketDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	ts := time.Date(2026, 4, 11, 10, 0, 0, 0, time.UTC)
+	events := []pipeline.Event{
+		{Timestamp: ts, Kind: pipeline.EventEngineStarted},
+		{Timestamp: ts.Add(time.Second), Phase: "triage", Kind: pipeline.EventPhaseStarted},
+		{Timestamp: ts.Add(2 * time.Second), Phase: "triage", Kind: pipeline.EventPhaseCompleted},
+		{Timestamp: ts.Add(3 * time.Second), Phase: "plan", Kind: pipeline.EventPhaseStarted},
+		{Timestamp: ts.Add(4 * time.Second), Phase: "plan", Kind: pipeline.EventPhaseCompleted},
+	}
+	writeTestEvents(t, ticketDir, events)
+
+	var buf bytes.Buffer
+	err := runLog(&buf, stateDir, "TEST-2", false, "", "triage", 0)
+	if err != nil {
+		t.Fatalf("runLog: %v", err)
+	}
+
+	output := buf.String()
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 triage lines, got %d:\n%s", len(lines), output)
+	}
+	for _, line := range lines {
+		if !strings.Contains(line, "[triage]") {
+			t.Errorf("expected [triage] in every line, got: %s", line)
+		}
+	}
+}
+
+func TestRunLog_SinceFilter(t *testing.T) {
+	stateDir := t.TempDir()
+	ticketDir := filepath.Join(stateDir, "TEST-3")
+	if err := os.MkdirAll(ticketDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	now := time.Now()
+	events := []pipeline.Event{
+		{Timestamp: now.Add(-2 * time.Hour), Kind: pipeline.EventEngineStarted},
+		{Timestamp: now.Add(-30 * time.Minute), Phase: "triage", Kind: pipeline.EventPhaseStarted},
+		{Timestamp: now.Add(-5 * time.Minute), Phase: "triage", Kind: pipeline.EventPhaseCompleted},
+		{Timestamp: now.Add(-1 * time.Minute), Phase: "plan", Kind: pipeline.EventPhaseStarted},
+	}
+	writeTestEvents(t, ticketDir, events)
+
+	var buf bytes.Buffer
+	err := runLog(&buf, stateDir, "TEST-3", false, "10m", "", 0)
+	if err != nil {
+		t.Fatalf("runLog: %v", err)
+	}
+
+	output := buf.String()
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 events within last 10m, got %d:\n%s", len(lines), output)
+	}
+}
+
+func TestRunLog_LastN(t *testing.T) {
+	stateDir := t.TempDir()
+	ticketDir := filepath.Join(stateDir, "TEST-4")
+	if err := os.MkdirAll(ticketDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	ts := time.Date(2026, 4, 11, 10, 0, 0, 0, time.UTC)
+	events := []pipeline.Event{
+		{Timestamp: ts, Kind: pipeline.EventEngineStarted},
+		{Timestamp: ts.Add(time.Second), Phase: "triage", Kind: pipeline.EventPhaseStarted},
+		{Timestamp: ts.Add(2 * time.Second), Phase: "triage", Kind: pipeline.EventPhaseCompleted},
+		{Timestamp: ts.Add(3 * time.Second), Phase: "plan", Kind: pipeline.EventPhaseStarted},
+		{Timestamp: ts.Add(4 * time.Second), Phase: "plan", Kind: pipeline.EventPhaseCompleted},
+	}
+	writeTestEvents(t, ticketDir, events)
+
+	var buf bytes.Buffer
+	err := runLog(&buf, stateDir, "TEST-4", false, "", "", 2)
+	if err != nil {
+		t.Fatalf("runLog: %v", err)
+	}
+
+	output := buf.String()
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines with --n 2, got %d:\n%s", len(lines), output)
+	}
+	// Should be the last 2 events.
+	if !strings.Contains(lines[0], "[plan] phase_started") {
+		t.Errorf("line 0 should be plan phase_started, got: %s", lines[0])
+	}
+	if !strings.Contains(lines[1], "[plan] phase_completed") {
+		t.Errorf("line 1 should be plan phase_completed, got: %s", lines[1])
+	}
+}
+
+func TestFollowEvents_TerminalEvent(t *testing.T) {
+	stateDir := t.TempDir()
+	ticketDir := filepath.Join(stateDir, "TEST-5")
+	if err := os.MkdirAll(ticketDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	ts := time.Date(2026, 4, 11, 10, 0, 0, 0, time.UTC)
+	events := []pipeline.Event{
+		{Timestamp: ts, Kind: pipeline.EventEngineStarted},
+		{Timestamp: ts.Add(time.Second), Phase: "triage", Kind: pipeline.EventPhaseStarted},
+		{Timestamp: ts.Add(2 * time.Second), Kind: pipeline.EventEngineCompleted},
+	}
+	writeTestEvents(t, ticketDir, events)
+
+	var buf bytes.Buffer
+	eventsPath := filepath.Join(ticketDir, "events.jsonl")
+
+	// followEvents should return immediately because events already contain
+	// a terminal event (engine_completed).
+	err := followEvents(&buf, eventsPath, time.Time{}, "")
+	if err != nil {
+		t.Fatalf("followEvents: %v", err)
+	}
+
+	output := buf.String()
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines, got %d:\n%s", len(lines), output)
+	}
+	if !strings.Contains(lines[2], "engine_completed") {
+		t.Errorf("last line should contain engine_completed, got: %s", lines[2])
+	}
+}
+
+func TestFollowEvents_TerminalFailed(t *testing.T) {
+	stateDir := t.TempDir()
+	ticketDir := filepath.Join(stateDir, "TEST-6")
+	if err := os.MkdirAll(ticketDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	ts := time.Date(2026, 4, 11, 10, 0, 0, 0, time.UTC)
+	events := []pipeline.Event{
+		{Timestamp: ts, Kind: pipeline.EventEngineStarted},
+		{Timestamp: ts.Add(time.Second), Kind: pipeline.EventEngineFailed, Data: map[string]any{"error": "budget exceeded"}},
+	}
+	writeTestEvents(t, ticketDir, events)
+
+	var buf bytes.Buffer
+	eventsPath := filepath.Join(ticketDir, "events.jsonl")
+
+	err := followEvents(&buf, eventsPath, time.Time{}, "")
+	if err != nil {
+		t.Fatalf("followEvents: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "engine_failed") {
+		t.Errorf("output should contain engine_failed, got: %s", output)
+	}
+}
+
+func TestIsTerminalEvent(t *testing.T) {
+	tests := []struct {
+		kind string
+		want bool
+	}{
+		{pipeline.EventEngineCompleted, true},
+		{pipeline.EventEngineFailed, true},
+		{pipeline.EventEngineStarted, false},
+		{pipeline.EventPhaseStarted, false},
+		{pipeline.EventPhaseCompleted, false},
+		{pipeline.EventPhaseFailed, false},
+	}
+	for _, tc := range tests {
+		ev := pipeline.Event{Kind: tc.kind}
+		got := isTerminalEvent(ev)
+		if got != tc.want {
+			t.Errorf("isTerminalEvent(%q) = %v, want %v", tc.kind, got, tc.want)
+		}
+	}
+}
+
+func TestFilterEvents(t *testing.T) {
+	ts := time.Date(2026, 4, 11, 10, 0, 0, 0, time.UTC)
+	events := []pipeline.Event{
+		{Timestamp: ts, Kind: pipeline.EventEngineStarted},
+		{Timestamp: ts.Add(time.Second), Phase: "triage", Kind: pipeline.EventPhaseStarted},
+		{Timestamp: ts.Add(2 * time.Second), Phase: "plan", Kind: pipeline.EventPhaseStarted},
+	}
+
+	t.Run("no filters", func(t *testing.T) {
+		got := filterEvents(events, time.Time{}, "")
+		if len(got) != 3 {
+			t.Errorf("expected 3 events, got %d", len(got))
+		}
+	})
+
+	t.Run("phase filter", func(t *testing.T) {
+		got := filterEvents(events, time.Time{}, "triage")
+		if len(got) != 1 {
+			t.Errorf("expected 1 event, got %d", len(got))
+		}
+	})
+
+	t.Run("since filter", func(t *testing.T) {
+		got := filterEvents(events, ts.Add(500*time.Millisecond), "")
+		if len(got) != 2 {
+			t.Errorf("expected 2 events after cutoff, got %d", len(got))
+		}
+	})
+
+	t.Run("phase and since combined", func(t *testing.T) {
+		got := filterEvents(events, ts.Add(500*time.Millisecond), "plan")
+		if len(got) != 1 {
+			t.Errorf("expected 1 event, got %d", len(got))
+		}
+	})
+}

--- a/cmd/soda/main.go
+++ b/cmd/soda/main.go
@@ -45,6 +45,7 @@ func newRootCmd() *cobra.Command {
 		newStatusCmd(),
 		newSessionsCmd(),
 		newHistoryCmd(),
+		newLogCmd(),
 		newCleanCmd(),
 		newCostCmd(),
 		newRenderCmd(),

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -367,7 +367,9 @@ func (e *Engine) Run(ctx context.Context) error {
 	e.emit(Event{Kind: EventEngineStarted})
 
 	if err := e.executePhases(ctx, e.config.Pipeline.Phases, false); err != nil {
-		return e.wrapTimeoutError(ctx, err)
+		wrapped := e.wrapTimeoutError(ctx, err)
+		e.emit(Event{Kind: EventEngineFailed, Data: map[string]any{"error": wrapped.Error()}})
+		return wrapped
 	}
 
 	e.emit(Event{Kind: EventEngineCompleted})
@@ -414,7 +416,9 @@ func (e *Engine) Resume(ctx context.Context, fromPhase string) error {
 	// The fromPhase (first in slice) is always re-run, even if completed.
 	// Mark it with forceFirst=true so executePhases skips the shouldSkip check.
 	if err := e.executePhases(ctx, e.config.Pipeline.Phases[startIdx:], true); err != nil {
-		return e.wrapTimeoutError(ctx, err)
+		wrapped := e.wrapTimeoutError(ctx, err)
+		e.emit(Event{Kind: EventEngineFailed, Data: map[string]any{"error": wrapped.Error()}})
+		return wrapped
 	}
 
 	e.emit(Event{Kind: EventEngineCompleted})

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -368,7 +368,10 @@ func (e *Engine) Run(ctx context.Context) error {
 
 	if err := e.executePhases(ctx, e.config.Pipeline.Phases, false); err != nil {
 		wrapped := e.wrapTimeoutError(ctx, err)
-		e.emit(Event{Kind: EventEngineFailed, Data: map[string]any{"error": wrapped.Error()}})
+		var pte *PipelineTimeoutError
+		if !errors.As(wrapped, &pte) {
+			e.emit(Event{Kind: EventEngineFailed, Data: map[string]any{"error": wrapped.Error()}})
+		}
 		return wrapped
 	}
 
@@ -417,7 +420,10 @@ func (e *Engine) Resume(ctx context.Context, fromPhase string) error {
 	// Mark it with forceFirst=true so executePhases skips the shouldSkip check.
 	if err := e.executePhases(ctx, e.config.Pipeline.Phases[startIdx:], true); err != nil {
 		wrapped := e.wrapTimeoutError(ctx, err)
-		e.emit(Event{Kind: EventEngineFailed, Data: map[string]any{"error": wrapped.Error()}})
+		var pte *PipelineTimeoutError
+		if !errors.As(wrapped, &pte) {
+			e.emit(Event{Kind: EventEngineFailed, Data: map[string]any{"error": wrapped.Error()}})
+		}
 		return wrapped
 	}
 

--- a/internal/pipeline/events.go
+++ b/internal/pipeline/events.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 )
@@ -85,6 +86,39 @@ const (
 	EventPhaseCostsReset          = "phase_costs_reset"
 	EventBinaryVersionMismatch    = "binary_version_mismatch"
 )
+
+// FormatEvent formats an event as a compact, human-readable line:
+//
+//	HH:MM:SS [phase] kind key=val key=val
+//
+// Data keys are sorted for stable output.
+func FormatEvent(e Event) string {
+	ts := e.Timestamp.Format("15:04:05")
+	var b strings.Builder
+	b.WriteString(ts)
+	if e.Phase != "" {
+		b.WriteString(" [")
+		b.WriteString(e.Phase)
+		b.WriteByte(']')
+	}
+	b.WriteByte(' ')
+	b.WriteString(e.Kind)
+
+	if len(e.Data) > 0 {
+		keys := make([]string, 0, len(e.Data))
+		for k := range e.Data {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			b.WriteByte(' ')
+			b.WriteString(k)
+			b.WriteByte('=')
+			b.WriteString(fmt.Sprintf("%v", e.Data[k]))
+		}
+	}
+	return b.String()
+}
 
 // ReadEvents reads and parses all events from the events.jsonl file in dir.
 // Returns an empty slice if the file does not exist.

--- a/internal/pipeline/events.go
+++ b/internal/pipeline/events.go
@@ -114,7 +114,12 @@ func FormatEvent(e Event) string {
 			b.WriteByte(' ')
 			b.WriteString(k)
 			b.WriteByte('=')
-			b.WriteString(fmt.Sprintf("%v", e.Data[k]))
+			v := fmt.Sprintf("%v", e.Data[k])
+			if strings.ContainsAny(v, " \t\n") {
+				b.WriteString(fmt.Sprintf("%q", v))
+			} else {
+				b.WriteString(v)
+			}
 		}
 	}
 	return b.String()

--- a/internal/pipeline/events_test.go
+++ b/internal/pipeline/events_test.go
@@ -103,6 +103,73 @@ not valid json
 	})
 }
 
+func TestFormatEvent(t *testing.T) {
+	ts := time.Date(2026, 4, 11, 10, 5, 30, 0, time.UTC)
+
+	tests := []struct {
+		name  string
+		event Event
+		want  string
+	}{
+		{
+			name: "phase_started with data",
+			event: Event{
+				Timestamp: ts,
+				Phase:     "triage",
+				Kind:      EventPhaseStarted,
+				Data:      map[string]any{"generation": float64(1)},
+			},
+			want: "10:05:30 [triage] phase_started generation=1",
+		},
+		{
+			name: "engine_started no phase",
+			event: Event{
+				Timestamp: ts,
+				Kind:      EventEngineStarted,
+			},
+			want: "10:05:30 engine_started",
+		},
+		{
+			name: "no data",
+			event: Event{
+				Timestamp: ts,
+				Phase:     "plan",
+				Kind:      EventPhaseCompleted,
+			},
+			want: "10:05:30 [plan] phase_completed",
+		},
+		{
+			name: "multiple data keys sorted",
+			event: Event{
+				Timestamp: ts,
+				Phase:     "implement",
+				Kind:      EventPhaseCompleted,
+				Data:      map[string]any{"cost": 0.42, "duration_ms": float64(3000)},
+			},
+			want: "10:05:30 [implement] phase_completed cost=0.42 duration_ms=3000",
+		},
+		{
+			name: "string data value",
+			event: Event{
+				Timestamp: ts,
+				Phase:     "verify",
+				Kind:      EventPhaseFailed,
+				Data:      map[string]any{"error": "tests failed"},
+			},
+			want: "10:05:30 [verify] phase_failed error=tests failed",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := FormatEvent(tc.event)
+			if got != tc.want {
+				t.Errorf("FormatEvent() =\n  %q\nwant:\n  %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestLogEvent(t *testing.T) {
 	t.Run("appends_event_to_jsonl", func(t *testing.T) {
 		dir := t.TempDir()

--- a/internal/pipeline/events_test.go
+++ b/internal/pipeline/events_test.go
@@ -156,7 +156,7 @@ func TestFormatEvent(t *testing.T) {
 				Kind:      EventPhaseFailed,
 				Data:      map[string]any{"error": "tests failed"},
 			},
-			want: "10:05:30 [verify] phase_failed error=tests failed",
+			want: `10:05:30 [verify] phase_failed error="tests failed"`,
 		},
 	}
 


### PR DESCRIPTION
## Summary

- Add `soda log <ticket>` command to tail `.soda/<ticket>/events.jsonl`
- `--follow` / `-f` for live tailing with poll-based follow
- `--since`, `--phase`, `--last` filters
- `FormatEvent()` for human-readable event formatting (quotes values with spaces)
- `EventEngineFailed` emitted on non-timeout failures (no duplicate with `EventPipelineTimeout`)

Closes #267

Assisted-by: Claude Opus 4.6