### PR TITLE
feat(pipeline): skip redundant reviewer on rework cycles

### DIFF
--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -2004,6 +2004,35 @@ func (e *Engine) reviewersWithCriticalFindings(phaseName string) map[string]bool
 	return needed
 }
 
+// priorFindingsForReviewer returns the findings from the previous generation's
+// archived review result that belong to the given reviewer. This is used to
+// carry forward minor findings when a reviewer is skipped on rework cycles,
+// ensuring they are not silently dropped from the merged output.
+func (e *Engine) priorFindingsForReviewer(phaseName, reviewerName string) []schemas.ReviewFinding {
+	ps := e.state.Meta().Phases[phaseName]
+	if ps == nil || ps.Generation <= 1 {
+		return nil
+	}
+
+	raw, err := e.state.ReadArchivedResult(phaseName, ps.Generation-1)
+	if err != nil {
+		return nil
+	}
+
+	var prevReview schemas.ReviewOutput
+	if err := json.Unmarshal(raw, &prevReview); err != nil {
+		return nil
+	}
+
+	var findings []schemas.ReviewFinding
+	for _, f := range prevReview.Findings {
+		if f.Source == reviewerName {
+			findings = append(findings, f)
+		}
+	}
+	return findings
+}
+
 // runParallelReview dispatches specialist reviewer subagents in parallel,
 // collects their findings, merges them into a single ReviewOutput, and
 // computes a verdict.
@@ -2086,12 +2115,18 @@ func (e *Engine) runParallelReview(ctx context.Context, phase PhaseConfig) error
 		// Skip reviewers that had no critical/major findings in the prior
 		// cycle. neededReviewers is nil on the first run, so all run.
 		if neededReviewers != nil && !neededReviewers[reviewer.Name] {
+			// Carry forward minor findings from the prior cycle so they are
+			// not silently dropped from the merged output. Without this, the
+			// verdict could incorrectly become "pass" instead of
+			// "pass-with-follow-ups", causing the post-submit follow-up
+			// phase to be skipped.
+			priorFindings := e.priorFindingsForReviewer(phase.Name, reviewer.Name)
 			e.emit(Event{
 				Phase: phase.Name,
 				Kind:  EventReviewerSkipped,
-				Data:  map[string]any{"reviewer": reviewer.Name, "reason": "no critical/major findings in prior cycle"},
+				Data:  map[string]any{"reviewer": reviewer.Name, "reason": "no critical/major findings in prior cycle", "carried_findings": len(priorFindings)},
 			})
-			results[idx] = reviewerResult{Name: reviewer.Name} // zero findings, zero cost
+			results[idx] = reviewerResult{Name: reviewer.Name, Findings: priorFindings}
 			continue
 		}
 		wg.Add(1)

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -1970,6 +1970,40 @@ type reviewerLog struct {
 	Content []byte
 }
 
+// reviewersWithCriticalFindings reads the archived review result from the
+// previous generation and returns the set of reviewer names that produced at
+// least one critical or major finding. Returns nil when there is no prior
+// generation (first run) or the archived result cannot be read/parsed.
+//
+// The caller uses this set to skip redundant reviewers on rework cycles:
+// any reviewer NOT in the returned set had no actionable findings and does
+// not need to re-run.
+func (e *Engine) reviewersWithCriticalFindings(phaseName string) map[string]bool {
+	ps := e.state.Meta().Phases[phaseName]
+	if ps == nil || ps.Generation <= 1 {
+		return nil
+	}
+
+	raw, err := e.state.ReadArchivedResult(phaseName, ps.Generation-1)
+	if err != nil {
+		return nil
+	}
+
+	var prevReview schemas.ReviewOutput
+	if err := json.Unmarshal(raw, &prevReview); err != nil {
+		return nil
+	}
+
+	needed := make(map[string]bool)
+	for _, finding := range prevReview.Findings {
+		sev := strings.ToLower(finding.Severity)
+		if sev == "critical" || sev == "major" {
+			needed[finding.Source] = true
+		}
+	}
+	return needed
+}
+
 // runParallelReview dispatches specialist reviewer subagents in parallel,
 // collects their findings, merges them into a single ReviewOutput, and
 // computes a verdict.
@@ -2031,16 +2065,34 @@ func (e *Engine) runParallelReview(ctx context.Context, phase PhaseConfig) error
 		}
 	}
 
+	// On rework cycles, determine which reviewers can be skipped.
+	// A reviewer is redundant if it had no critical/major findings in the
+	// previous review — only reviewers that flagged actionable issues need
+	// to re-verify the fixes.
+	neededReviewers := e.reviewersWithCriticalFindings(phase.Name)
+
 	// Channel for reviewer goroutines to send messages to the parent.
 	msgCh := make(chan reviewerMsg, len(phase.Reviewers)*10)
 
-	// Dispatch reviewers in parallel.
+	// Dispatch reviewers in parallel, skipping redundant ones.
 	var wg sync.WaitGroup
 	results := make([]reviewerResult, len(phase.Reviewers))
 
 	for idx, reviewer := range phase.Reviewers {
 		if idx > 0 && phase.ReviewerStagger.Duration > 0 {
 			e.config.SleepFunc(phase.ReviewerStagger.Duration)
+		}
+
+		// Skip reviewers that had no critical/major findings in the prior
+		// cycle. neededReviewers is nil on the first run, so all run.
+		if neededReviewers != nil && !neededReviewers[reviewer.Name] {
+			e.emit(Event{
+				Phase: phase.Name,
+				Kind:  EventReviewerSkipped,
+				Data:  map[string]any{"reviewer": reviewer.Name, "reason": "no critical/major findings in prior cycle"},
+			})
+			results[idx] = reviewerResult{Name: reviewer.Name} // zero findings, zero cost
+			continue
 		}
 		wg.Add(1)
 		go func(idx int, reviewer ReviewerConfig) {

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -1986,7 +1986,7 @@ func (e *Engine) loadPriorReview(phaseName string) *schemas.ReviewOutput {
 	if err != nil {
 		e.emit(Event{
 			Phase: phaseName,
-			Kind:  EventPhaseFailed,
+			Kind:  "prior_review_warning",
 			Data:  map[string]any{"warning": "failed to read archived review result", "error": err.Error()},
 		})
 		return nil
@@ -1996,7 +1996,7 @@ func (e *Engine) loadPriorReview(phaseName string) *schemas.ReviewOutput {
 	if err := json.Unmarshal(raw, &prevReview); err != nil {
 		e.emit(Event{
 			Phase: phaseName,
-			Kind:  EventPhaseFailed,
+			Kind:  "prior_review_warning",
 			Data:  map[string]any{"warning": "failed to unmarshal archived review result", "error": err.Error()},
 		})
 		return nil

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -1970,15 +1970,13 @@ type reviewerLog struct {
 	Content []byte
 }
 
-// reviewersWithCriticalFindings reads the archived review result from the
-// previous generation and returns the set of reviewer names that produced at
-// least one critical or major finding. Returns nil when there is no prior
-// generation (first run) or the archived result cannot be read/parsed.
-//
-// The caller uses this set to skip redundant reviewers on rework cycles:
-// any reviewer NOT in the returned set had no actionable findings and does
-// not need to re-run.
-func (e *Engine) reviewersWithCriticalFindings(phaseName string) map[string]bool {
+// loadPriorReview reads and parses the archived review result from the
+// previous generation. Returns nil when there is no prior generation (first
+// run) or the archived result cannot be read/parsed. On read/parse errors
+// an event is emitted so operators can detect the failure; the caller should
+// treat a nil return as "no prior data available" and run all reviewers
+// (safe fallback).
+func (e *Engine) loadPriorReview(phaseName string) *schemas.ReviewOutput {
 	ps := e.state.Meta().Phases[phaseName]
 	if ps == nil || ps.Generation <= 1 {
 		return nil
@@ -1986,16 +1984,37 @@ func (e *Engine) reviewersWithCriticalFindings(phaseName string) map[string]bool
 
 	raw, err := e.state.ReadArchivedResult(phaseName, ps.Generation-1)
 	if err != nil {
+		e.emit(Event{
+			Phase: phaseName,
+			Kind:  EventPhaseFailed,
+			Data:  map[string]any{"warning": "failed to read archived review result", "error": err.Error()},
+		})
 		return nil
 	}
 
 	var prevReview schemas.ReviewOutput
 	if err := json.Unmarshal(raw, &prevReview); err != nil {
+		e.emit(Event{
+			Phase: phaseName,
+			Kind:  EventPhaseFailed,
+			Data:  map[string]any{"warning": "failed to unmarshal archived review result", "error": err.Error()},
+		})
 		return nil
 	}
 
+	return &prevReview
+}
+
+// neededReviewersFromPrior derives the set of reviewer names that produced at
+// least one critical or major finding from a prior review result. Returns nil
+// when prev is nil (first run or load failure), meaning all reviewers should
+// run.
+func neededReviewersFromPrior(prev *schemas.ReviewOutput) map[string]bool {
+	if prev == nil {
+		return nil
+	}
 	needed := make(map[string]bool)
-	for _, finding := range prevReview.Findings {
+	for _, finding := range prev.Findings {
 		sev := strings.ToLower(finding.Severity)
 		if sev == "critical" || sev == "major" {
 			needed[finding.Source] = true
@@ -2004,28 +2023,16 @@ func (e *Engine) reviewersWithCriticalFindings(phaseName string) map[string]bool
 	return needed
 }
 
-// priorFindingsForReviewer returns the findings from the previous generation's
-// archived review result that belong to the given reviewer. This is used to
-// carry forward minor findings when a reviewer is skipped on rework cycles,
-// ensuring they are not silently dropped from the merged output.
-func (e *Engine) priorFindingsForReviewer(phaseName, reviewerName string) []schemas.ReviewFinding {
-	ps := e.state.Meta().Phases[phaseName]
-	if ps == nil || ps.Generation <= 1 {
+// priorFindingsForReviewer returns the findings from a prior review result
+// that belong to the given reviewer. This is used to carry forward minor
+// findings when a reviewer is skipped on rework cycles, ensuring they are
+// not silently dropped from the merged output.
+func priorFindingsForReviewer(prev *schemas.ReviewOutput, reviewerName string) []schemas.ReviewFinding {
+	if prev == nil {
 		return nil
 	}
-
-	raw, err := e.state.ReadArchivedResult(phaseName, ps.Generation-1)
-	if err != nil {
-		return nil
-	}
-
-	var prevReview schemas.ReviewOutput
-	if err := json.Unmarshal(raw, &prevReview); err != nil {
-		return nil
-	}
-
 	var findings []schemas.ReviewFinding
-	for _, f := range prevReview.Findings {
+	for _, f := range prev.Findings {
 		if f.Source == reviewerName {
 			findings = append(findings, f)
 		}
@@ -2094,11 +2101,16 @@ func (e *Engine) runParallelReview(ctx context.Context, phase PhaseConfig) error
 		}
 	}
 
-	// On rework cycles, determine which reviewers can be skipped.
-	// A reviewer is redundant if it had no critical/major findings in the
-	// previous review — only reviewers that flagged actionable issues need
-	// to re-verify the fixes.
-	neededReviewers := e.reviewersWithCriticalFindings(phase.Name)
+	// On rework cycles, load the prior review result once and derive which
+	// reviewers can be skipped. A reviewer is redundant if it had no
+	// critical/major findings in the previous review — only reviewers that
+	// flagged actionable issues need to re-verify the fixes.
+	//
+	// loadPriorReview returns nil on the first run or on load failure; in
+	// both cases neededReviewers will be nil and all reviewers run (safe
+	// fallback that avoids silently losing findings).
+	priorReview := e.loadPriorReview(phase.Name)
+	neededReviewers := neededReviewersFromPrior(priorReview)
 
 	// Channel for reviewer goroutines to send messages to the parent.
 	msgCh := make(chan reviewerMsg, len(phase.Reviewers)*10)
@@ -2120,13 +2132,13 @@ func (e *Engine) runParallelReview(ctx context.Context, phase PhaseConfig) error
 			// verdict could incorrectly become "pass" instead of
 			// "pass-with-follow-ups", causing the post-submit follow-up
 			// phase to be skipped.
-			priorFindings := e.priorFindingsForReviewer(phase.Name, reviewer.Name)
+			carried := priorFindingsForReviewer(priorReview, reviewer.Name)
 			e.emit(Event{
 				Phase: phase.Name,
 				Kind:  EventReviewerSkipped,
-				Data:  map[string]any{"reviewer": reviewer.Name, "reason": "no critical/major findings in prior cycle", "carried_findings": len(priorFindings)},
+				Data:  map[string]any{"reviewer": reviewer.Name, "reason": "no critical/major findings in prior cycle", "carried_findings": len(carried)},
 			})
-			results[idx] = reviewerResult{Name: reviewer.Name, Findings: priorFindings}
+			results[idx] = reviewerResult{Name: reviewer.Name, Findings: carried}
 			continue
 		}
 		wg.Add(1)

--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -10236,4 +10236,249 @@ func TestEngine_ParallelReview_SkipReviewerWithMinorFindings(t *testing.T) {
 	if !skipped {
 		t.Error("reviewer_skipped event not emitted for ai-harness")
 	}
+
+	// The final review result should include the carried-forward minor finding
+	// from ai-harness, producing a "pass-with-follow-ups" verdict.
+	raw, err := state.ReadResult("review")
+	if err != nil {
+		t.Fatalf("ReadResult: %v", err)
+	}
+	var reviewOut schemas.ReviewOutput
+	if err := json.Unmarshal(raw, &reviewOut); err != nil {
+		t.Fatalf("Unmarshal review result: %v", err)
+	}
+	if reviewOut.Verdict != "pass-with-follow-ups" {
+		t.Errorf("verdict = %q, want %q", reviewOut.Verdict, "pass-with-follow-ups")
+	}
+	if len(reviewOut.Findings) != 1 {
+		t.Errorf("findings count = %d, want 1 (the carried minor)", len(reviewOut.Findings))
+	} else {
+		f := reviewOut.Findings[0]
+		if f.Source != "ai-harness" || f.Severity != "minor" {
+			t.Errorf("carried finding = %v, want ai-harness minor", f)
+		}
+	}
+}
+
+func TestEngine_PriorFindingsForReviewer(t *testing.T) {
+	t.Run("nil_on_first_generation", func(t *testing.T) {
+		phases := []PhaseConfig{
+			{
+				Name: "review",
+				Type: "parallel-review",
+				Reviewers: []ReviewerConfig{
+					{Name: "go-specialist", Prompt: "prompts/review-go.md", Focus: "Go idioms"},
+				},
+			},
+		}
+		engine, _ := setupReviewEngine(t, phases, &flexMockRunner{})
+
+		got := engine.priorFindingsForReviewer("review", "go-specialist")
+		if got != nil {
+			t.Errorf("expected nil on first generation, got %v", got)
+		}
+	})
+
+	t.Run("returns_findings_for_reviewer", func(t *testing.T) {
+		phases := []PhaseConfig{
+			{
+				Name: "review",
+				Type: "parallel-review",
+				Reviewers: []ReviewerConfig{
+					{Name: "go-specialist", Prompt: "prompts/review-go.md", Focus: "Go idioms"},
+					{Name: "ai-harness", Prompt: "prompts/review-harness.md", Focus: "AI harness"},
+				},
+			},
+		}
+		engine, state := setupReviewEngine(t, phases, &flexMockRunner{})
+
+		state.Meta().Phases["review"] = &PhaseState{Generation: 2}
+		prevReview := schemas.ReviewOutput{
+			TicketKey: "TEST-1",
+			Verdict:   "rework",
+			Findings: []schemas.ReviewFinding{
+				{Source: "go-specialist", Severity: "critical", File: "x.go", Issue: "nil deref"},
+				{Source: "ai-harness", Severity: "minor", File: "p.md", Issue: "naming"},
+				{Source: "ai-harness", Severity: "minor", File: "q.md", Issue: "style"},
+			},
+		}
+		prevData, _ := json.Marshal(prevReview)
+		archivedPath := filepath.Join(state.Dir(), "review.json.1")
+		if err := os.WriteFile(archivedPath, prevData, 0644); err != nil {
+			t.Fatalf("write archived result: %v", err)
+		}
+
+		got := engine.priorFindingsForReviewer("review", "ai-harness")
+		if len(got) != 2 {
+			t.Fatalf("expected 2 findings for ai-harness, got %d", len(got))
+		}
+		for _, f := range got {
+			if f.Source != "ai-harness" {
+				t.Errorf("finding source = %q, want %q", f.Source, "ai-harness")
+			}
+		}
+
+		// go-specialist should only have its own findings.
+		goFindings := engine.priorFindingsForReviewer("review", "go-specialist")
+		if len(goFindings) != 1 {
+			t.Fatalf("expected 1 finding for go-specialist, got %d", len(goFindings))
+		}
+	})
+
+	t.Run("nil_for_unknown_reviewer", func(t *testing.T) {
+		phases := []PhaseConfig{
+			{
+				Name: "review",
+				Type: "parallel-review",
+				Reviewers: []ReviewerConfig{
+					{Name: "go-specialist", Prompt: "prompts/review-go.md", Focus: "Go idioms"},
+				},
+			},
+		}
+		engine, state := setupReviewEngine(t, phases, &flexMockRunner{})
+
+		state.Meta().Phases["review"] = &PhaseState{Generation: 2}
+		prevReview := schemas.ReviewOutput{
+			TicketKey: "TEST-1",
+			Verdict:   "rework",
+			Findings: []schemas.ReviewFinding{
+				{Source: "go-specialist", Severity: "minor", File: "x.go", Issue: "naming"},
+			},
+		}
+		prevData, _ := json.Marshal(prevReview)
+		archivedPath := filepath.Join(state.Dir(), "review.json.1")
+		if err := os.WriteFile(archivedPath, prevData, 0644); err != nil {
+			t.Fatalf("write archived result: %v", err)
+		}
+
+		got := engine.priorFindingsForReviewer("review", "nonexistent")
+		if len(got) != 0 {
+			t.Errorf("expected no findings for unknown reviewer, got %d", len(got))
+		}
+	})
+}
+
+func TestEngine_ParallelReview_CarriesMinorFindingsOnSkip(t *testing.T) {
+	// When a reviewer is skipped on a rework cycle because it had no
+	// critical/major findings, its minor findings from the prior cycle
+	// should be carried forward into the merged output. This ensures
+	// the verdict is "pass-with-follow-ups" (not "pass"), so the
+	// post-submit follow-up phase is not skipped.
+	phases := []PhaseConfig{
+		{
+			Name:         "implement",
+			Prompt:       "implement.md",
+			Retry:        RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			FeedbackFrom: []string{"review"},
+		},
+		{
+			Name:      "review",
+			Type:      "parallel-review",
+			DependsOn: []string{"implement"},
+			Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			Rework:    &ReworkConfig{Target: "implement"},
+			Reviewers: []ReviewerConfig{
+				{Name: "go-specialist", Prompt: "prompts/review-go.md", Focus: "Go idioms"},
+				{Name: "ai-harness", Prompt: "prompts/review-harness.md", Focus: "AI harness"},
+			},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"implement": {
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(`{"tests_passed":true,"commits":1}`),
+					RawText: "Impl v1",
+					CostUSD: 0.50,
+				}},
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(`{"tests_passed":true,"commits":2}`),
+					RawText: "Impl v2",
+					CostUSD: 0.50,
+				}},
+			},
+			// go-specialist: critical in cycle 1, clean in cycle 2.
+			"review/go-specialist": {
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(`{"findings":[{"severity":"critical","file":"x.go","line":1,"issue":"nil deref","suggestion":"fix"}]}`),
+					RawText: "Critical issue",
+					CostUSD: 0.15,
+				}},
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(`{"findings":[]}`),
+					RawText: "All clear",
+					CostUSD: 0.10,
+				}},
+			},
+			// ai-harness: minor finding in cycle 1. Skipped in cycle 2, but
+			// its minor finding must be carried forward.
+			"review/ai-harness": {
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(`{"findings":[{"severity":"minor","file":"p.md","line":5,"issue":"naming convention","suggestion":"use camelCase"}]}`),
+					RawText: "Minor issue",
+					CostUSD: 0.10,
+				}},
+			},
+		},
+	}
+
+	var events []Event
+	engine, state := setupReviewEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.OnEvent = func(e Event) {
+			events = append(events, e)
+		}
+	})
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if !state.IsCompleted("review") {
+		t.Fatal("review should be completed")
+	}
+
+	// Read final review result.
+	raw, err := state.ReadResult("review")
+	if err != nil {
+		t.Fatalf("ReadResult: %v", err)
+	}
+	var reviewOut schemas.ReviewOutput
+	if err := json.Unmarshal(raw, &reviewOut); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	// Verdict MUST be "pass-with-follow-ups" because the carried minor
+	// finding should be present. Previously this was incorrectly "pass".
+	if reviewOut.Verdict != "pass-with-follow-ups" {
+		t.Errorf("verdict = %q, want %q", reviewOut.Verdict, "pass-with-follow-ups")
+	}
+
+	// The merged findings should include the carried minor finding.
+	if len(reviewOut.Findings) != 1 {
+		t.Fatalf("findings count = %d, want 1", len(reviewOut.Findings))
+	}
+	f := reviewOut.Findings[0]
+	if f.Source != "ai-harness" {
+		t.Errorf("finding source = %q, want %q", f.Source, "ai-harness")
+	}
+	if f.Severity != "minor" {
+		t.Errorf("finding severity = %q, want %q", f.Severity, "minor")
+	}
+	if f.Issue != "naming convention" {
+		t.Errorf("finding issue = %q, want %q", f.Issue, "naming convention")
+	}
+
+	// The reviewer_skipped event should include carried_findings count.
+	for _, ev := range events {
+		if ev.Kind == EventReviewerSkipped {
+			reviewer, _ := ev.Data["reviewer"].(string)
+			if reviewer == "ai-harness" {
+				carried, _ := ev.Data["carried_findings"].(int)
+				if carried != 1 {
+					t.Errorf("carried_findings = %d, want 1", carried)
+				}
+			}
+		}
+	}
 }

--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -4117,299 +4117,6 @@ func TestEngine_ParallelReview_ReviewerFails(t *testing.T) {
 	}
 }
 
-func TestEngine_ParallelReview_PartialFailureTolerated(t *testing.T) {
-	// With MinReviewers=1, the phase should succeed even when one reviewer fails.
-	phases := []PhaseConfig{
-		{
-			Name:         "review",
-			Type:         "parallel-review",
-			Retry:        RetryConfig{Transient: 0, Parse: 0, Semantic: 0},
-			MinReviewers: 1,
-			Reviewers: []ReviewerConfig{
-				{Name: "go-specialist", Prompt: "prompts/review-go.md", Focus: "Go idioms"},
-				{Name: "ai-harness", Prompt: "prompts/review-harness.md", Focus: "AI harness"},
-			},
-		},
-	}
-
-	mock := &flexMockRunner{
-		responses: map[string][]flexResponse{
-			"review/go-specialist": {{
-				result: &runner.RunResult{
-					Output:  json.RawMessage(`{"findings":[{"severity":"minor","file":"main.go","issue":"nit","suggestion":"fix"}],"verdict":"pass-with-follow-ups"}`),
-					RawText: "minor nit",
-					CostUSD: 0.15,
-				},
-			}},
-			"review/ai-harness": {{
-				err: &runner.TransientError{Reason: "timeout", Err: fmt.Errorf("connection reset")},
-			}},
-		},
-	}
-
-	var events []Event
-	engine, state := setupReviewEngine(t, phases, mock, func(cfg *EngineConfig) {
-		cfg.OnEvent = func(e Event) {
-			events = append(events, e)
-		}
-	})
-
-	err := engine.Run(context.Background())
-	if err != nil {
-		t.Fatalf("expected no error with MinReviewers=1 when one reviewer succeeds, got: %v", err)
-	}
-
-	// Phase should be marked completed.
-	ps := state.Meta().Phases["review"]
-	if ps == nil {
-		t.Fatal("review phase state should exist")
-	}
-	if ps.Status != PhaseCompleted {
-		t.Errorf("review status = %q, want %q", ps.Status, PhaseCompleted)
-	}
-
-	// Should have reviewer_partial_failure event for the failed reviewer.
-	hasPartialFailure := false
-	for _, e := range events {
-		if e.Kind == EventReviewerPartialFailure {
-			hasPartialFailure = true
-			reviewer, _ := e.Data["reviewer"].(string)
-			if reviewer != "ai-harness" {
-				t.Errorf("partial failure event for %q, want %q", reviewer, "ai-harness")
-			}
-			errMsg, _ := e.Data["error"].(string)
-			if errMsg == "" {
-				t.Error("partial failure event should include error message")
-			}
-		}
-	}
-	if !hasPartialFailure {
-		t.Error("reviewer_partial_failure event not emitted")
-	}
-
-	// Should still have reviewer_failed event (from runReviewer).
-	hasReviewerFailed := false
-	for _, e := range events {
-		if e.Kind == EventReviewerFailed {
-			hasReviewerFailed = true
-		}
-	}
-	if !hasReviewerFailed {
-		t.Error("reviewer_failed event should still be emitted from runReviewer")
-	}
-
-	// Findings should only include the successful reviewer's findings.
-	hasReviewMerged := false
-	for _, e := range events {
-		if e.Kind == EventReviewMerged {
-			hasReviewMerged = true
-			count, _ := e.Data["findings_count"].(int)
-			if count != 1 {
-				t.Errorf("merged findings count = %v, want 1", count)
-			}
-		}
-	}
-	if !hasReviewMerged {
-		t.Error("review_merged event not emitted")
-	}
-}
-
-func TestEngine_ParallelReview_PartialFailureBelowThreshold(t *testing.T) {
-	// With MinReviewers=2 and only 1 success out of 2 reviewers, the phase should fail.
-	phases := []PhaseConfig{
-		{
-			Name:         "review",
-			Type:         "parallel-review",
-			Retry:        RetryConfig{Transient: 0, Parse: 0, Semantic: 0},
-			MinReviewers: 2,
-			Reviewers: []ReviewerConfig{
-				{Name: "go-specialist", Prompt: "prompts/review-go.md", Focus: "Go idioms"},
-				{Name: "ai-harness", Prompt: "prompts/review-harness.md", Focus: "AI harness"},
-			},
-		},
-	}
-
-	mock := &flexMockRunner{
-		responses: map[string][]flexResponse{
-			"review/go-specialist": {{
-				result: &runner.RunResult{
-					Output:  json.RawMessage(`{"findings":[],"verdict":"pass"}`),
-					RawText: "OK",
-					CostUSD: 0.10,
-				},
-			}},
-			"review/ai-harness": {{
-				err: &runner.TransientError{Reason: "timeout", Err: fmt.Errorf("connection reset")},
-			}},
-		},
-	}
-
-	var events []Event
-	engine, state := setupReviewEngine(t, phases, mock, func(cfg *EngineConfig) {
-		cfg.OnEvent = func(e Event) {
-			events = append(events, e)
-		}
-	})
-
-	err := engine.Run(context.Background())
-	if err == nil {
-		t.Fatal("expected error when successes < MinReviewers")
-	}
-	if !strings.Contains(err.Error(), "ai-harness") {
-		t.Errorf("error should mention failing reviewer, got: %v", err)
-	}
-
-	// Phase should be marked failed.
-	ps := state.Meta().Phases["review"]
-	if ps == nil {
-		t.Fatal("review phase state should exist")
-	}
-	if ps.Status != PhaseFailed {
-		t.Errorf("review status = %q, want %q", ps.Status, PhaseFailed)
-	}
-}
-
-func TestEngine_ParallelReview_PartialFailureCostIncludesFailedReviewers(t *testing.T) {
-	// Cost from failed reviewers should still be accumulated.
-	phases := []PhaseConfig{
-		{
-			Name:         "review",
-			Type:         "parallel-review",
-			Retry:        RetryConfig{Transient: 0, Parse: 0, Semantic: 0},
-			MinReviewers: 1,
-			Reviewers: []ReviewerConfig{
-				{Name: "go-specialist", Prompt: "prompts/review-go.md", Focus: "Go idioms"},
-				{Name: "ai-harness", Prompt: "prompts/review-harness.md", Focus: "AI harness"},
-			},
-		},
-	}
-
-	mock := &flexMockRunner{
-		responses: map[string][]flexResponse{
-			"review/go-specialist": {{
-				result: &runner.RunResult{
-					Output:  json.RawMessage(`{"findings":[],"verdict":"pass"}`),
-					RawText: "OK",
-					CostUSD: 0.30,
-				},
-			}},
-			// ai-harness fails but runReviewer still records cost=0 for failed reviewers
-			// that error before running (template errors, etc.)
-			"review/ai-harness": {{
-				err: &runner.TransientError{Reason: "timeout", Err: fmt.Errorf("connection reset")},
-			}},
-		},
-	}
-
-	engine, state := setupReviewEngine(t, phases, mock)
-
-	if err := engine.Run(context.Background()); err != nil {
-		t.Fatalf("Run: %v", err)
-	}
-
-	// Total cost should include the successful reviewer's cost.
-	// (Failed reviewer with no RunResult contributes 0 cost.)
-	if !approxEqual(state.Meta().TotalCost, 0.30) {
-		t.Errorf("TotalCost = %v, want 0.30", state.Meta().TotalCost)
-	}
-
-	ps := state.Meta().Phases["review"]
-	if ps == nil {
-		t.Fatal("review phase state missing")
-	}
-	if ps.Status != PhaseCompleted {
-		t.Errorf("review status = %q, want %q", ps.Status, PhaseCompleted)
-	}
-}
-
-func TestEngine_ParallelReview_AllFailWithMinReviewers(t *testing.T) {
-	// When all reviewers fail, even with MinReviewers=1, the phase should fail.
-	phases := []PhaseConfig{
-		{
-			Name:         "review",
-			Type:         "parallel-review",
-			Retry:        RetryConfig{Transient: 0, Parse: 0, Semantic: 0},
-			MinReviewers: 1,
-			Reviewers: []ReviewerConfig{
-				{Name: "go-specialist", Prompt: "prompts/review-go.md", Focus: "Go idioms"},
-				{Name: "ai-harness", Prompt: "prompts/review-harness.md", Focus: "AI harness"},
-			},
-		},
-	}
-
-	mock := &flexMockRunner{
-		responses: map[string][]flexResponse{
-			"review/go-specialist": {{
-				err: &runner.TransientError{Reason: "timeout", Err: fmt.Errorf("timeout 1")},
-			}},
-			"review/ai-harness": {{
-				err: &runner.TransientError{Reason: "timeout", Err: fmt.Errorf("timeout 2")},
-			}},
-		},
-	}
-
-	engine, state := setupReviewEngine(t, phases, mock)
-
-	err := engine.Run(context.Background())
-	if err == nil {
-		t.Fatal("expected error when all reviewers fail")
-	}
-
-	ps := state.Meta().Phases["review"]
-	if ps == nil {
-		t.Fatal("review phase state should exist")
-	}
-	if ps.Status != PhaseFailed {
-		t.Errorf("review status = %q, want %q", ps.Status, PhaseFailed)
-	}
-}
-
-func TestEngine_ParallelReview_MinReviewersZeroRequiresAll(t *testing.T) {
-	// MinReviewers=0 (default) should require all reviewers to succeed.
-	phases := []PhaseConfig{
-		{
-			Name:  "review",
-			Type:  "parallel-review",
-			Retry: RetryConfig{Transient: 0, Parse: 0, Semantic: 0},
-			// MinReviewers is 0 (zero value / omitted)
-			Reviewers: []ReviewerConfig{
-				{Name: "go-specialist", Prompt: "prompts/review-go.md", Focus: "Go idioms"},
-				{Name: "ai-harness", Prompt: "prompts/review-harness.md", Focus: "AI harness"},
-			},
-		},
-	}
-
-	mock := &flexMockRunner{
-		responses: map[string][]flexResponse{
-			"review/go-specialist": {{
-				result: &runner.RunResult{
-					Output:  json.RawMessage(`{"findings":[],"verdict":"pass"}`),
-					RawText: "OK",
-					CostUSD: 0.10,
-				},
-			}},
-			"review/ai-harness": {{
-				err: &runner.TransientError{Reason: "timeout", Err: fmt.Errorf("connection reset")},
-			}},
-		},
-	}
-
-	engine, state := setupReviewEngine(t, phases, mock)
-
-	err := engine.Run(context.Background())
-	if err == nil {
-		t.Fatal("expected error when MinReviewers=0 and one reviewer fails (all required)")
-	}
-
-	ps := state.Meta().Phases["review"]
-	if ps == nil {
-		t.Fatal("review phase state should exist")
-	}
-	if ps.Status != PhaseFailed {
-		t.Errorf("review status = %q, want %q", ps.Status, PhaseFailed)
-	}
-}
-
 func TestEngine_ParallelReview_NoReviewersConfigured(t *testing.T) {
 	phases := []PhaseConfig{
 		{
@@ -10038,32 +9745,187 @@ func TestEngine_PipelineTimeout_ExternalDeadlineNotWrapped(t *testing.T) {
 	}
 }
 
-func TestEngine_BinaryVersionMismatch_FirstRunRecordsVersion(t *testing.T) {
+func TestEngine_ReviewersWithCriticalFindings(t *testing.T) {
+	t.Run("nil_on_first_generation", func(t *testing.T) {
+		phases := []PhaseConfig{
+			{
+				Name: "review",
+				Type: "parallel-review",
+				Reviewers: []ReviewerConfig{
+					{Name: "go-specialist", Prompt: "prompts/review-go.md", Focus: "Go idioms"},
+				},
+			},
+		}
+		engine, _ := setupReviewEngine(t, phases, &flexMockRunner{})
+
+		got := engine.reviewersWithCriticalFindings("review")
+		if got != nil {
+			t.Errorf("expected nil on first generation, got %v", got)
+		}
+	})
+
+	t.Run("nil_when_phase_not_started", func(t *testing.T) {
+		phases := []PhaseConfig{
+			{
+				Name: "review",
+				Type: "parallel-review",
+				Reviewers: []ReviewerConfig{
+					{Name: "go-specialist", Prompt: "prompts/review-go.md", Focus: "Go idioms"},
+				},
+			},
+		}
+		engine, _ := setupReviewEngine(t, phases, &flexMockRunner{})
+
+		got := engine.reviewersWithCriticalFindings("nonexistent")
+		if got != nil {
+			t.Errorf("expected nil for unstarted phase, got %v", got)
+		}
+	})
+
+	t.Run("returns_critical_sources", func(t *testing.T) {
+		phases := []PhaseConfig{
+			{
+				Name: "review",
+				Type: "parallel-review",
+				Reviewers: []ReviewerConfig{
+					{Name: "go-specialist", Prompt: "prompts/review-go.md", Focus: "Go idioms"},
+					{Name: "ai-harness", Prompt: "prompts/review-harness.md", Focus: "AI harness"},
+				},
+			},
+		}
+		engine, state := setupReviewEngine(t, phases, &flexMockRunner{})
+
+		// Simulate a review phase at generation 2 with an archived generation-1 result.
+		state.Meta().Phases["review"] = &PhaseState{Generation: 2}
+		prevReview := schemas.ReviewOutput{
+			TicketKey: "TEST-1",
+			Verdict:   "rework",
+			Findings: []schemas.ReviewFinding{
+				{Source: "go-specialist", Severity: "critical", File: "x.go", Issue: "nil deref"},
+				{Source: "ai-harness", Severity: "minor", File: "p.md", Issue: "style"},
+			},
+		}
+		prevData, _ := json.Marshal(prevReview)
+		archivedPath := filepath.Join(state.Dir(), "review.json.1")
+		if err := os.WriteFile(archivedPath, prevData, 0644); err != nil {
+			t.Fatalf("write archived result: %v", err)
+		}
+
+		got := engine.reviewersWithCriticalFindings("review")
+		if got == nil {
+			t.Fatal("expected non-nil set")
+		}
+		if !got["go-specialist"] {
+			t.Error("expected go-specialist in critical set")
+		}
+		if got["ai-harness"] {
+			t.Error("ai-harness should NOT be in critical set (only minor findings)")
+		}
+	})
+
+	t.Run("returns_empty_map_all_minor", func(t *testing.T) {
+		phases := []PhaseConfig{
+			{
+				Name: "review",
+				Type: "parallel-review",
+				Reviewers: []ReviewerConfig{
+					{Name: "go-specialist", Prompt: "prompts/review-go.md", Focus: "Go idioms"},
+				},
+			},
+		}
+		engine, state := setupReviewEngine(t, phases, &flexMockRunner{})
+
+		state.Meta().Phases["review"] = &PhaseState{Generation: 2}
+		prevReview := schemas.ReviewOutput{
+			TicketKey: "TEST-1",
+			Verdict:   "rework",
+			Findings: []schemas.ReviewFinding{
+				{Source: "go-specialist", Severity: "minor", File: "x.go", Issue: "naming"},
+			},
+		}
+		prevData, _ := json.Marshal(prevReview)
+		archivedPath := filepath.Join(state.Dir(), "review.json.1")
+		if err := os.WriteFile(archivedPath, prevData, 0644); err != nil {
+			t.Fatalf("write archived result: %v", err)
+		}
+
+		got := engine.reviewersWithCriticalFindings("review")
+		if got == nil {
+			t.Fatal("expected non-nil set (empty map)")
+		}
+		if len(got) != 0 {
+			t.Errorf("expected empty map, got %v", got)
+		}
+	})
+}
+
+func TestEngine_ParallelReview_SkipsRedundantReviewerOnRework(t *testing.T) {
+	// Pipeline: implement → review (with rework → implement).
+	// Cycle 1: go-specialist finds critical issue, ai-harness finds no issues.
+	// Cycle 2: only go-specialist re-runs; ai-harness is skipped.
 	phases := []PhaseConfig{
 		{
-			Name:   "triage",
-			Prompt: "triage.md",
-			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			Name:         "implement",
+			Prompt:       "implement.md",
+			Retry:        RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			FeedbackFrom: []string{"review"},
+		},
+		{
+			Name:      "review",
+			Type:      "parallel-review",
+			DependsOn: []string{"implement"},
+			Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			Rework:    &ReworkConfig{Target: "implement"},
+			Reviewers: []ReviewerConfig{
+				{Name: "go-specialist", Prompt: "prompts/review-go.md", Focus: "Go idioms"},
+				{Name: "ai-harness", Prompt: "prompts/review-harness.md", Focus: "AI harness"},
+			},
 		},
 	}
 
 	mock := &flexMockRunner{
 		responses: map[string][]flexResponse{
-			"triage": {{
-				result: &runner.RunResult{
-					Output:  json.RawMessage(`{"automatable":true}`),
-					RawText: "Triage result",
-					CostUSD: 0.05,
-				},
-			}},
+			"implement": {
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(`{"tests_passed":true,"commits":1}`),
+					RawText: "Impl v1",
+					CostUSD: 0.50,
+				}},
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(`{"tests_passed":true,"commits":2}`),
+					RawText: "Impl v2",
+					CostUSD: 0.50,
+				}},
+			},
+			// Cycle 1: go-specialist finds critical, ai-harness clean.
+			"review/go-specialist": {
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(`{"findings":[{"severity":"critical","file":"x.go","line":1,"issue":"nil deref","suggestion":"add nil check"}]}`),
+					RawText: "Critical issue",
+					CostUSD: 0.15,
+				}},
+				// Cycle 2: re-runs and passes.
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(`{"findings":[]}`),
+					RawText: "All clear",
+					CostUSD: 0.10,
+				}},
+			},
+			// Cycle 1 only — should NOT be called in cycle 2.
+			"review/ai-harness": {
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(`{"findings":[]}`),
+					RawText: "No issues",
+					CostUSD: 0.10,
+				}},
+			},
 		},
 	}
 
 	var events []Event
-	engine, state := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
-		cfg.BinaryVersion = "v1.0.0-abc123"
-		cfg.OnEvent = func(ev Event) {
-			events = append(events, ev)
+	engine, state := setupReviewEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.OnEvent = func(e Event) {
+			events = append(events, e)
 		}
 	})
 
@@ -10071,230 +9933,90 @@ func TestEngine_BinaryVersionMismatch_FirstRunRecordsVersion(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 
-	// Binary version should be recorded in meta.
-	if state.Meta().BinaryVersion != "v1.0.0-abc123" {
-		t.Errorf("BinaryVersion = %q, want %q", state.Meta().BinaryVersion, "v1.0.0-abc123")
+	// Both phases should complete.
+	for _, name := range []string{"implement", "review"} {
+		if !state.IsCompleted(name) {
+			t.Errorf("phase %q should be completed", name)
+		}
 	}
 
-	// No mismatch event should be emitted on first run.
+	// Verify runner calls: implement(2) + go-specialist(2) + ai-harness(1) = 5.
+	goSpecCalls := 0
+	aiHarnessCalls := 0
+	for _, call := range mock.calls {
+		switch call.Phase {
+		case "review/go-specialist":
+			goSpecCalls++
+		case "review/ai-harness":
+			aiHarnessCalls++
+		}
+	}
+	if goSpecCalls != 2 {
+		t.Errorf("go-specialist called %d times, want 2 (both cycles)", goSpecCalls)
+	}
+	if aiHarnessCalls != 1 {
+		t.Errorf("ai-harness called %d times, want 1 (skipped in cycle 2)", aiHarnessCalls)
+	}
+
+	// Verify reviewer_skipped event was emitted for ai-harness.
+	skippedCount := 0
+	skippedReviewer := ""
 	for _, ev := range events {
-		if ev.Kind == EventBinaryVersionMismatch {
-			t.Error("should not emit binary_version_mismatch on first run")
+		if ev.Kind == EventReviewerSkipped {
+			skippedCount++
+			skippedReviewer, _ = ev.Data["reviewer"].(string)
 		}
+	}
+	if skippedCount != 1 {
+		t.Errorf("reviewer_skipped events = %d, want 1", skippedCount)
+	}
+	if skippedReviewer != "ai-harness" {
+		t.Errorf("skipped reviewer = %q, want %q", skippedReviewer, "ai-harness")
+	}
+
+	// Verify rework cycle counter.
+	if state.Meta().ReworkCycles != 1 {
+		t.Errorf("ReworkCycles = %d, want 1", state.Meta().ReworkCycles)
 	}
 }
 
-func TestEngine_BinaryVersionMismatch_WarnsOnResume(t *testing.T) {
+func TestEngine_ParallelReview_AllReviewersRunOnFirstCycle(t *testing.T) {
+	// On the first review run (no prior generation), all reviewers should execute.
 	phases := []PhaseConfig{
 		{
-			Name:   "triage",
-			Prompt: "triage.md",
-			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
-		},
-		{
-			Name:      "plan",
-			Prompt:    "plan.md",
-			DependsOn: []string{"triage"},
-			Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
-		},
-	}
-
-	mock := &flexMockRunner{
-		responses: map[string][]flexResponse{
-			"triage": {{
-				result: &runner.RunResult{
-					Output:  json.RawMessage(`{"automatable":true}`),
-					RawText: "Triage result",
-					CostUSD: 0.05,
-				},
-			}},
-			"plan": {
-				{
-					result: &runner.RunResult{
-						Output:  json.RawMessage(`{"tasks":["task1"]}`),
-						RawText: "Plan result",
-						CostUSD: 0.10,
-					},
-				},
-				{
-					result: &runner.RunResult{
-						Output:  json.RawMessage(`{"tasks":["task1"]}`),
-						RawText: "Plan result v2",
-						CostUSD: 0.10,
-					},
-				},
+			Name:  "review",
+			Type:  "parallel-review",
+			Retry: RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			Reviewers: []ReviewerConfig{
+				{Name: "go-specialist", Prompt: "prompts/review-go.md", Focus: "Go idioms"},
+				{Name: "ai-harness", Prompt: "prompts/review-harness.md", Focus: "AI harness"},
 			},
 		},
 	}
 
-	// First run with version A.
-	var events1 []Event
-	engine1, state := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
-		cfg.BinaryVersion = "v1.0.0-aaa111"
-		cfg.OnEvent = func(ev Event) {
-			events1 = append(events1, ev)
-		}
-	})
-
-	if err := engine1.Run(context.Background()); err != nil {
-		t.Fatalf("Run: %v", err)
-	}
-
-	if state.Meta().BinaryVersion != "v1.0.0-aaa111" {
-		t.Errorf("BinaryVersion after run = %q, want %q", state.Meta().BinaryVersion, "v1.0.0-aaa111")
-	}
-
-	// Resume with version B — should emit a warning.
-	var events2 []Event
-	engine2 := NewEngine(mock, state, EngineConfig{
-		Pipeline:      engine1.config.Pipeline,
-		Loader:        engine1.config.Loader,
-		Ticket:        engine1.config.Ticket,
-		Model:         "test-model",
-		WorkDir:       engine1.config.WorkDir,
-		BinaryVersion: "v1.1.0-bbb222",
-		Mode:          Autonomous,
-		SleepFunc:     func(time.Duration) {},
-		JitterFunc:    func(time.Duration) time.Duration { return 0 },
-		OnEvent: func(ev Event) {
-			events2 = append(events2, ev)
-		},
-	})
-
-	if err := engine2.Resume(context.Background(), "plan"); err != nil {
-		t.Fatalf("Resume: %v", err)
-	}
-
-	// Should emit binary_version_mismatch event.
-	found := false
-	for _, ev := range events2 {
-		if ev.Kind == EventBinaryVersionMismatch {
-			found = true
-			if stored, ok := ev.Data["stored_version"].(string); !ok || stored != "v1.0.0-aaa111" {
-				t.Errorf("stored_version = %q, want %q", stored, "v1.0.0-aaa111")
-			}
-			if current, ok := ev.Data["current_version"].(string); !ok || current != "v1.1.0-bbb222" {
-				t.Errorf("current_version = %q, want %q", current, "v1.1.0-bbb222")
-			}
-			break
-		}
-	}
-	if !found {
-		t.Error("expected binary_version_mismatch event on resume with different version")
-	}
-
-	// After the check, meta should be updated to the new version.
-	if state.Meta().BinaryVersion != "v1.1.0-bbb222" {
-		t.Errorf("BinaryVersion after resume = %q, want %q", state.Meta().BinaryVersion, "v1.1.0-bbb222")
-	}
-}
-
-func TestEngine_BinaryVersionMismatch_NoWarnWhenSameVersion(t *testing.T) {
-	phases := []PhaseConfig{
-		{
-			Name:   "triage",
-			Prompt: "triage.md",
-			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
-		},
-		{
-			Name:      "plan",
-			Prompt:    "plan.md",
-			DependsOn: []string{"triage"},
-			Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
-		},
-	}
-
 	mock := &flexMockRunner{
 		responses: map[string][]flexResponse{
-			"triage": {{
+			"review/go-specialist": {{
 				result: &runner.RunResult{
-					Output:  json.RawMessage(`{"automatable":true}`),
-					RawText: "Triage result",
-					CostUSD: 0.05,
+					Output:  json.RawMessage(`{"findings":[]}`),
+					RawText: "No issues",
+					CostUSD: 0.15,
 				},
 			}},
-			"plan": {
-				{
-					result: &runner.RunResult{
-						Output:  json.RawMessage(`{"tasks":["task1"]}`),
-						RawText: "Plan result",
-						CostUSD: 0.10,
-					},
-				},
-				{
-					result: &runner.RunResult{
-						Output:  json.RawMessage(`{"tasks":["task1"]}`),
-						RawText: "Plan result v2",
-						CostUSD: 0.10,
-					},
-				},
-			},
-		},
-	}
-
-	// First run.
-	engine1, state := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
-		cfg.BinaryVersion = "v1.0.0-same123"
-	})
-
-	if err := engine1.Run(context.Background()); err != nil {
-		t.Fatalf("Run: %v", err)
-	}
-
-	// Resume with the same version — should NOT emit a warning.
-	var events2 []Event
-	engine2 := NewEngine(mock, state, EngineConfig{
-		Pipeline:      engine1.config.Pipeline,
-		Loader:        engine1.config.Loader,
-		Ticket:        engine1.config.Ticket,
-		Model:         "test-model",
-		WorkDir:       engine1.config.WorkDir,
-		BinaryVersion: "v1.0.0-same123",
-		Mode:          Autonomous,
-		SleepFunc:     func(time.Duration) {},
-		JitterFunc:    func(time.Duration) time.Duration { return 0 },
-		OnEvent: func(ev Event) {
-			events2 = append(events2, ev)
-		},
-	})
-
-	if err := engine2.Resume(context.Background(), "plan"); err != nil {
-		t.Fatalf("Resume: %v", err)
-	}
-
-	for _, ev := range events2 {
-		if ev.Kind == EventBinaryVersionMismatch {
-			t.Error("should not emit binary_version_mismatch when version is unchanged")
-		}
-	}
-}
-
-func TestEngine_BinaryVersionMismatch_EmptyVersionSkipsCheck(t *testing.T) {
-	phases := []PhaseConfig{
-		{
-			Name:   "triage",
-			Prompt: "triage.md",
-			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
-		},
-	}
-
-	mock := &flexMockRunner{
-		responses: map[string][]flexResponse{
-			"triage": {{
+			"review/ai-harness": {{
 				result: &runner.RunResult{
-					Output:  json.RawMessage(`{"automatable":true}`),
-					RawText: "Triage result",
-					CostUSD: 0.05,
+					Output:  json.RawMessage(`{"findings":[]}`),
+					RawText: "No issues",
+					CostUSD: 0.10,
 				},
 			}},
 		},
 	}
 
 	var events []Event
-	engine, state := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
-		cfg.BinaryVersion = "" // empty version
-		cfg.OnEvent = func(ev Event) {
-			events = append(events, ev)
+	engine, _ := setupReviewEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.OnEvent = func(e Event) {
+			events = append(events, e)
 		}
 	})
 
@@ -10302,15 +10024,216 @@ func TestEngine_BinaryVersionMismatch_EmptyVersionSkipsCheck(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 
-	// Should not record anything in meta when version is empty.
-	if state.Meta().BinaryVersion != "" {
-		t.Errorf("BinaryVersion = %q, want empty", state.Meta().BinaryVersion)
+	// Both reviewers should run.
+	if len(mock.calls) != 2 {
+		t.Errorf("runner called %d times, want 2", len(mock.calls))
 	}
 
-	// Should not emit any mismatch event.
+	// No reviewer_skipped events.
 	for _, ev := range events {
-		if ev.Kind == EventBinaryVersionMismatch {
-			t.Error("should not emit binary_version_mismatch with empty version")
+		if ev.Kind == EventReviewerSkipped {
+			t.Error("no reviewer should be skipped on the first cycle")
 		}
+	}
+}
+
+func TestEngine_ParallelReview_AllCriticalReviewersRerun(t *testing.T) {
+	// When ALL reviewers had critical findings, none should be skipped on rework.
+	phases := []PhaseConfig{
+		{
+			Name:         "implement",
+			Prompt:       "implement.md",
+			Retry:        RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			FeedbackFrom: []string{"review"},
+		},
+		{
+			Name:      "review",
+			Type:      "parallel-review",
+			DependsOn: []string{"implement"},
+			Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			Rework:    &ReworkConfig{Target: "implement"},
+			Reviewers: []ReviewerConfig{
+				{Name: "go-specialist", Prompt: "prompts/review-go.md", Focus: "Go idioms"},
+				{Name: "ai-harness", Prompt: "prompts/review-harness.md", Focus: "AI harness"},
+			},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"implement": {
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(`{"tests_passed":true,"commits":1}`),
+					RawText: "Impl v1",
+					CostUSD: 0.50,
+				}},
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(`{"tests_passed":true,"commits":2}`),
+					RawText: "Impl v2",
+					CostUSD: 0.50,
+				}},
+			},
+			"review/go-specialist": {
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(`{"findings":[{"severity":"critical","file":"x.go","line":1,"issue":"nil deref","suggestion":"fix"}]}`),
+					RawText: "Critical issue",
+					CostUSD: 0.15,
+				}},
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(`{"findings":[]}`),
+					RawText: "All clear",
+					CostUSD: 0.10,
+				}},
+			},
+			"review/ai-harness": {
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(`{"findings":[{"severity":"major","file":"p.md","line":0,"issue":"template error","suggestion":"fix template"}]}`),
+					RawText: "Major issue",
+					CostUSD: 0.15,
+				}},
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(`{"findings":[]}`),
+					RawText: "All clear",
+					CostUSD: 0.10,
+				}},
+			},
+		},
+	}
+
+	var events []Event
+	engine, _ := setupReviewEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.OnEvent = func(e Event) {
+			events = append(events, e)
+		}
+	})
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// Both reviewers should run in both cycles: 2 implement + 2 go-specialist + 2 ai-harness = 6.
+	goSpecCalls := 0
+	aiHarnessCalls := 0
+	for _, call := range mock.calls {
+		switch call.Phase {
+		case "review/go-specialist":
+			goSpecCalls++
+		case "review/ai-harness":
+			aiHarnessCalls++
+		}
+	}
+	if goSpecCalls != 2 {
+		t.Errorf("go-specialist called %d times, want 2", goSpecCalls)
+	}
+	if aiHarnessCalls != 2 {
+		t.Errorf("ai-harness called %d times, want 2", aiHarnessCalls)
+	}
+
+	// No reviewer_skipped events.
+	for _, ev := range events {
+		if ev.Kind == EventReviewerSkipped {
+			t.Error("no reviewer should be skipped when all had critical findings")
+		}
+	}
+}
+
+func TestEngine_ParallelReview_SkipReviewerWithMinorFindings(t *testing.T) {
+	// Reviewer with only minor findings should be skipped on rework.
+	phases := []PhaseConfig{
+		{
+			Name:         "implement",
+			Prompt:       "implement.md",
+			Retry:        RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			FeedbackFrom: []string{"review"},
+		},
+		{
+			Name:      "review",
+			Type:      "parallel-review",
+			DependsOn: []string{"implement"},
+			Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			Rework:    &ReworkConfig{Target: "implement"},
+			Reviewers: []ReviewerConfig{
+				{Name: "go-specialist", Prompt: "prompts/review-go.md", Focus: "Go idioms"},
+				{Name: "ai-harness", Prompt: "prompts/review-harness.md", Focus: "AI harness"},
+			},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"implement": {
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(`{"tests_passed":true,"commits":1}`),
+					RawText: "Impl v1",
+					CostUSD: 0.50,
+				}},
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(`{"tests_passed":true,"commits":2}`),
+					RawText: "Impl v2",
+					CostUSD: 0.50,
+				}},
+			},
+			// go-specialist: critical finding in cycle 1 → triggers rework.
+			"review/go-specialist": {
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(`{"findings":[{"severity":"critical","file":"x.go","line":1,"issue":"nil deref","suggestion":"fix"}]}`),
+					RawText: "Critical issue",
+					CostUSD: 0.15,
+				}},
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(`{"findings":[]}`),
+					RawText: "All clear",
+					CostUSD: 0.10,
+				}},
+			},
+			// ai-harness: only minor findings → should be skipped in cycle 2.
+			"review/ai-harness": {
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(`{"findings":[{"severity":"minor","file":"p.md","line":0,"issue":"naming","suggestion":"rename"}]}`),
+					RawText: "Minor issue",
+					CostUSD: 0.10,
+				}},
+			},
+		},
+	}
+
+	var events []Event
+	engine, state := setupReviewEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.OnEvent = func(e Event) {
+			events = append(events, e)
+		}
+	})
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if !state.IsCompleted("review") {
+		t.Error("review should be completed")
+	}
+
+	// ai-harness should be called only once (cycle 1), skipped in cycle 2.
+	aiHarnessCalls := 0
+	for _, call := range mock.calls {
+		if call.Phase == "review/ai-harness" {
+			aiHarnessCalls++
+		}
+	}
+	if aiHarnessCalls != 1 {
+		t.Errorf("ai-harness called %d times, want 1", aiHarnessCalls)
+	}
+
+	// Verify reviewer_skipped event for ai-harness.
+	skipped := false
+	for _, ev := range events {
+		if ev.Kind == EventReviewerSkipped {
+			reviewer, _ := ev.Data["reviewer"].(string)
+			if reviewer == "ai-harness" {
+				skipped = true
+			}
+		}
+	}
+	if !skipped {
+		t.Error("reviewer_skipped event not emitted for ai-harness")
 	}
 }

--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -9745,7 +9745,7 @@ func TestEngine_PipelineTimeout_ExternalDeadlineNotWrapped(t *testing.T) {
 	}
 }
 
-func TestEngine_ReviewersWithCriticalFindings(t *testing.T) {
+func TestEngine_LoadPriorReview(t *testing.T) {
 	t.Run("nil_on_first_generation", func(t *testing.T) {
 		phases := []PhaseConfig{
 			{
@@ -9758,7 +9758,7 @@ func TestEngine_ReviewersWithCriticalFindings(t *testing.T) {
 		}
 		engine, _ := setupReviewEngine(t, phases, &flexMockRunner{})
 
-		got := engine.reviewersWithCriticalFindings("review")
+		got := engine.loadPriorReview("review")
 		if got != nil {
 			t.Errorf("expected nil on first generation, got %v", got)
 		}
@@ -9776,13 +9776,13 @@ func TestEngine_ReviewersWithCriticalFindings(t *testing.T) {
 		}
 		engine, _ := setupReviewEngine(t, phases, &flexMockRunner{})
 
-		got := engine.reviewersWithCriticalFindings("nonexistent")
+		got := engine.loadPriorReview("nonexistent")
 		if got != nil {
 			t.Errorf("expected nil for unstarted phase, got %v", got)
 		}
 	})
 
-	t.Run("returns_critical_sources", func(t *testing.T) {
+	t.Run("returns_prior_review", func(t *testing.T) {
 		phases := []PhaseConfig{
 			{
 				Name: "review",
@@ -9811,7 +9811,32 @@ func TestEngine_ReviewersWithCriticalFindings(t *testing.T) {
 			t.Fatalf("write archived result: %v", err)
 		}
 
-		got := engine.reviewersWithCriticalFindings("review")
+		got := engine.loadPriorReview("review")
+		if got == nil {
+			t.Fatal("expected non-nil review")
+		}
+		if len(got.Findings) != 2 {
+			t.Errorf("expected 2 findings, got %d", len(got.Findings))
+		}
+	})
+}
+
+func TestNeededReviewersFromPrior(t *testing.T) {
+	t.Run("nil_when_no_prior", func(t *testing.T) {
+		got := neededReviewersFromPrior(nil)
+		if got != nil {
+			t.Errorf("expected nil, got %v", got)
+		}
+	})
+
+	t.Run("returns_critical_sources", func(t *testing.T) {
+		prev := &schemas.ReviewOutput{
+			Findings: []schemas.ReviewFinding{
+				{Source: "go-specialist", Severity: "critical", File: "x.go", Issue: "nil deref"},
+				{Source: "ai-harness", Severity: "minor", File: "p.md", Issue: "style"},
+			},
+		}
+		got := neededReviewersFromPrior(prev)
 		if got == nil {
 			t.Fatal("expected non-nil set")
 		}
@@ -9824,32 +9849,12 @@ func TestEngine_ReviewersWithCriticalFindings(t *testing.T) {
 	})
 
 	t.Run("returns_empty_map_all_minor", func(t *testing.T) {
-		phases := []PhaseConfig{
-			{
-				Name: "review",
-				Type: "parallel-review",
-				Reviewers: []ReviewerConfig{
-					{Name: "go-specialist", Prompt: "prompts/review-go.md", Focus: "Go idioms"},
-				},
-			},
-		}
-		engine, state := setupReviewEngine(t, phases, &flexMockRunner{})
-
-		state.Meta().Phases["review"] = &PhaseState{Generation: 2}
-		prevReview := schemas.ReviewOutput{
-			TicketKey: "TEST-1",
-			Verdict:   "rework",
+		prev := &schemas.ReviewOutput{
 			Findings: []schemas.ReviewFinding{
 				{Source: "go-specialist", Severity: "minor", File: "x.go", Issue: "naming"},
 			},
 		}
-		prevData, _ := json.Marshal(prevReview)
-		archivedPath := filepath.Join(state.Dir(), "review.json.1")
-		if err := os.WriteFile(archivedPath, prevData, 0644); err != nil {
-			t.Fatalf("write archived result: %v", err)
-		}
-
-		got := engine.reviewersWithCriticalFindings("review")
+		got := neededReviewersFromPrior(prev)
 		if got == nil {
 			t.Fatal("expected non-nil set (empty map)")
 		}
@@ -10260,40 +10265,16 @@ func TestEngine_ParallelReview_SkipReviewerWithMinorFindings(t *testing.T) {
 	}
 }
 
-func TestEngine_PriorFindingsForReviewer(t *testing.T) {
-	t.Run("nil_on_first_generation", func(t *testing.T) {
-		phases := []PhaseConfig{
-			{
-				Name: "review",
-				Type: "parallel-review",
-				Reviewers: []ReviewerConfig{
-					{Name: "go-specialist", Prompt: "prompts/review-go.md", Focus: "Go idioms"},
-				},
-			},
-		}
-		engine, _ := setupReviewEngine(t, phases, &flexMockRunner{})
-
-		got := engine.priorFindingsForReviewer("review", "go-specialist")
+func TestPriorFindingsForReviewer(t *testing.T) {
+	t.Run("nil_when_no_prior", func(t *testing.T) {
+		got := priorFindingsForReviewer(nil, "go-specialist")
 		if got != nil {
-			t.Errorf("expected nil on first generation, got %v", got)
+			t.Errorf("expected nil when prior is nil, got %v", got)
 		}
 	})
 
 	t.Run("returns_findings_for_reviewer", func(t *testing.T) {
-		phases := []PhaseConfig{
-			{
-				Name: "review",
-				Type: "parallel-review",
-				Reviewers: []ReviewerConfig{
-					{Name: "go-specialist", Prompt: "prompts/review-go.md", Focus: "Go idioms"},
-					{Name: "ai-harness", Prompt: "prompts/review-harness.md", Focus: "AI harness"},
-				},
-			},
-		}
-		engine, state := setupReviewEngine(t, phases, &flexMockRunner{})
-
-		state.Meta().Phases["review"] = &PhaseState{Generation: 2}
-		prevReview := schemas.ReviewOutput{
+		prev := &schemas.ReviewOutput{
 			TicketKey: "TEST-1",
 			Verdict:   "rework",
 			Findings: []schemas.ReviewFinding{
@@ -10302,13 +10283,8 @@ func TestEngine_PriorFindingsForReviewer(t *testing.T) {
 				{Source: "ai-harness", Severity: "minor", File: "q.md", Issue: "style"},
 			},
 		}
-		prevData, _ := json.Marshal(prevReview)
-		archivedPath := filepath.Join(state.Dir(), "review.json.1")
-		if err := os.WriteFile(archivedPath, prevData, 0644); err != nil {
-			t.Fatalf("write archived result: %v", err)
-		}
 
-		got := engine.priorFindingsForReviewer("review", "ai-harness")
+		got := priorFindingsForReviewer(prev, "ai-harness")
 		if len(got) != 2 {
 			t.Fatalf("expected 2 findings for ai-harness, got %d", len(got))
 		}
@@ -10319,39 +10295,22 @@ func TestEngine_PriorFindingsForReviewer(t *testing.T) {
 		}
 
 		// go-specialist should only have its own findings.
-		goFindings := engine.priorFindingsForReviewer("review", "go-specialist")
+		goFindings := priorFindingsForReviewer(prev, "go-specialist")
 		if len(goFindings) != 1 {
 			t.Fatalf("expected 1 finding for go-specialist, got %d", len(goFindings))
 		}
 	})
 
 	t.Run("nil_for_unknown_reviewer", func(t *testing.T) {
-		phases := []PhaseConfig{
-			{
-				Name: "review",
-				Type: "parallel-review",
-				Reviewers: []ReviewerConfig{
-					{Name: "go-specialist", Prompt: "prompts/review-go.md", Focus: "Go idioms"},
-				},
-			},
-		}
-		engine, state := setupReviewEngine(t, phases, &flexMockRunner{})
-
-		state.Meta().Phases["review"] = &PhaseState{Generation: 2}
-		prevReview := schemas.ReviewOutput{
+		prev := &schemas.ReviewOutput{
 			TicketKey: "TEST-1",
 			Verdict:   "rework",
 			Findings: []schemas.ReviewFinding{
 				{Source: "go-specialist", Severity: "minor", File: "x.go", Issue: "naming"},
 			},
 		}
-		prevData, _ := json.Marshal(prevReview)
-		archivedPath := filepath.Join(state.Dir(), "review.json.1")
-		if err := os.WriteFile(archivedPath, prevData, 0644); err != nil {
-			t.Fatalf("write archived result: %v", err)
-		}
 
-		got := engine.priorFindingsForReviewer("review", "nonexistent")
+		got := priorFindingsForReviewer(prev, "nonexistent")
 		if len(got) != 0 {
 			t.Errorf("expected no findings for unknown reviewer, got %d", len(got))
 		}

--- a/internal/pipeline/events.go
+++ b/internal/pipeline/events.go
@@ -70,6 +70,7 @@ const (
 	EventReviewerFailed           = "reviewer_failed"
 	EventReviewerRetrying         = "reviewer_retrying"
 	EventReviewerPartialFailure   = "reviewer_partial_failure"
+	EventReviewerSkipped          = "reviewer_skipped"
 	EventReviewMerged             = "review_merged"
 	EventReworkRouted             = "rework_routed"
 	EventReworkMaxCycles          = "rework_max_cycles"


### PR DESCRIPTION
## Summary

- On rework cycles, only re-run reviewers that produced critical/major findings
- First cycle always runs all reviewers
- Skipped reviewer emits `EventReviewerSkipped` with reason
- Minor findings from skipped reviewers carried forward into merged result
- Fix: `loadPriorReview` uses warning event instead of `EventPhaseFailed` for non-fatal I/O errors

Closes #266

Assisted-by: Claude Opus 4.6