### PR TITLE
feat(pipeline): inject code snippets into rework feedback

### DIFF
--- a/cmd/soda/embeds/prompts/implement.md
+++ b/cmd/soda/embeds/prompts/implement.md
@@ -46,6 +46,12 @@ Do NOT address multiple findings in a single edit. Fix one, verify it, then move
 ### Finding {{add $idx 1}} of {{len $.ReworkFeedback.ReviewFindings}}: {{$finding.Source}}
 - [{{$finding.Severity}}] {{$finding.File}}{{if $finding.Line}}:{{$finding.Line}}{{end}} — {{$finding.Issue}}
   Suggestion: {{$finding.Suggestion}}
+{{- if $finding.CodeSnippet}}
+  Relevant code:
+```
+{{$finding.CodeSnippet}}
+```
+{{- end}}
 → Fix this finding, then verify before proceeding.
 {{- end}}
 

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -1286,11 +1288,15 @@ func (e *Engine) extractReviewFeedback() *ReworkFeedback {
 		Source:  "review",
 	}
 
-	// Only include critical and major findings.
+	// Only include critical and major findings, enriched with code snippets.
 	for _, finding := range result.Findings {
 		sev := strings.ToLower(finding.Severity)
 		if sev == "critical" || sev == "major" {
-			fb.ReviewFindings = append(fb.ReviewFindings, finding)
+			ef := EnrichedFinding{ReviewFinding: finding}
+			if finding.File != "" && finding.Line > 0 {
+				ef.CodeSnippet = readSnippet(e.workDir(PhaseConfig{}), finding.File, finding.Line, 5)
+			}
+			fb.ReviewFindings = append(fb.ReviewFindings, ef)
 		}
 	}
 
@@ -1298,6 +1304,30 @@ func (e *Engine) extractReviewFeedback() *ReworkFeedback {
 	fb.PriorCycles = e.collectPriorReviewCycles()
 
 	return fb
+}
+
+// readSnippet reads ±context lines around the given 1-based line number
+// from file in workDir. Returns empty string on any error (missing file,
+// invalid line, etc.) — callers treat this as best-effort enrichment.
+func readSnippet(workDir, file string, line, context int) string {
+	path := filepath.Join(workDir, file)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	lines := strings.Split(string(data), "\n")
+	start := line - context - 1
+	if start < 0 {
+		start = 0
+	}
+	end := line + context
+	if end > len(lines) {
+		end = len(lines)
+	}
+	if start >= end {
+		return ""
+	}
+	return strings.Join(lines[start:end], "\n")
 }
 
 // collectPriorReviewCycles reads archived review results (review.json.1,

--- a/internal/pipeline/prompt.go
+++ b/internal/pipeline/prompt.go
@@ -61,8 +61,14 @@ type ReworkFeedback struct {
 	FailedCriteria []FailedCriterion
 	CodeIssues     []ReworkCodeIssue
 	FailedCommands []FailedCommand
-	ReviewFindings []schemas.ReviewFinding
+	ReviewFindings []EnrichedFinding
 	PriorCycles    []PriorCycle
+}
+
+// EnrichedFinding wraps a ReviewFinding with code context for rework prompts.
+type EnrichedFinding struct {
+	schemas.ReviewFinding
+	CodeSnippet string // ±5 lines around the finding's file:line; empty if unavailable
 }
 
 // PriorCycle holds a summarized snapshot of feedback from a previous

--- a/internal/pipeline/prompt_test.go
+++ b/internal/pipeline/prompt_test.go
@@ -534,8 +534,8 @@ Verdict: {{.ReworkFeedback.Verdict}}
 			ReworkFeedback: &ReworkFeedback{
 				Source:  "review",
 				Verdict: "rework",
-				ReviewFindings: []schemas.ReviewFinding{
-					{Severity: "critical", File: "x.go", Line: 1, Issue: "bad", Suggestion: "fix it", Source: "go-specialist"},
+				ReviewFindings: []EnrichedFinding{
+					{ReviewFinding: schemas.ReviewFinding{Severity: "critical", File: "x.go", Line: 1, Issue: "bad", Suggestion: "fix it", Source: "go-specialist"}},
 				},
 			},
 		}
@@ -929,8 +929,8 @@ Context: {{.}}
 			ReworkFeedback: &ReworkFeedback{
 				Source:  "review",
 				Verdict: "rework",
-				ReviewFindings: []schemas.ReviewFinding{
-					{Severity: "major", File: "handler.go", Line: 20, Issue: "missing error check", Suggestion: "add error handling", Source: "go-specialist"},
+				ReviewFindings: []EnrichedFinding{
+					{ReviewFinding: schemas.ReviewFinding{Severity: "major", File: "handler.go", Line: 20, Issue: "missing error check", Suggestion: "add error handling", Source: "go-specialist"}},
 				},
 				PriorCycles: []PriorCycle{
 					{Cycle: 1, Source: "review", Verdict: "rework", Summary: "[critical] handler.go:42 — nil deref"},
@@ -982,8 +982,8 @@ Context: {{.}}
 			ReworkFeedback: &ReworkFeedback{
 				Source:  "review",
 				Verdict: "rework",
-				ReviewFindings: []schemas.ReviewFinding{
-					{Severity: "critical", File: "x.go", Line: 1, Issue: "bad", Suggestion: "fix", Source: "go-specialist"},
+				ReviewFindings: []EnrichedFinding{
+					{ReviewFinding: schemas.ReviewFinding{Severity: "critical", File: "x.go", Line: 1, Issue: "bad", Suggestion: "fix", Source: "go-specialist"}},
 				},
 				// No PriorCycles on first rework.
 			},
@@ -1062,10 +1062,10 @@ Context: {{.}}
 			ReworkFeedback: &ReworkFeedback{
 				Source:  "review",
 				Verdict: "rework",
-				ReviewFindings: []schemas.ReviewFinding{
-					{Severity: "critical", File: "a.go", Line: 1, Issue: "issue-a", Suggestion: "fix-a", Source: "go-specialist"},
-					{Severity: "major", File: "b.go", Line: 2, Issue: "issue-b", Suggestion: "fix-b", Source: "go-specialist"},
-					{Severity: "minor", File: "c.go", Line: 3, Issue: "issue-c", Suggestion: "fix-c", Source: "go-specialist"},
+				ReviewFindings: []EnrichedFinding{
+					{ReviewFinding: schemas.ReviewFinding{Severity: "critical", File: "a.go", Line: 1, Issue: "issue-a", Suggestion: "fix-a", Source: "go-specialist"}},
+					{ReviewFinding: schemas.ReviewFinding{Severity: "major", File: "b.go", Line: 2, Issue: "issue-b", Suggestion: "fix-b", Source: "go-specialist"}},
+					{ReviewFinding: schemas.ReviewFinding{Severity: "minor", File: "c.go", Line: 3, Issue: "issue-c", Suggestion: "fix-c", Source: "go-specialist"}},
 				},
 			},
 		}


### PR DESCRIPTION
## Summary

When building rework feedback from review findings, read ±5 lines around each finding's `file:line` from the worktree and embed it in the implement prompt. The LLM sees the actual buggy code instead of having to search for it.

## Why

Raki data (n=10 sessions) showed **knowledge miss rate of 1.00** — every single rework failure was caused by the implement phase lacking code context. Both AI Harness and Go Specialist identified this as the #1 improvement.

## Changes

- `internal/pipeline/prompt.go` — `EnrichedFinding` type wrapping `ReviewFinding` with `CodeSnippet`
- `internal/pipeline/engine.go` — `readSnippet()` + enrichment in `extractReviewFeedback()`
- `cmd/soda/embeds/prompts/implement.md` — render code block when snippet present
- 55 insertions, 13 deletions

Assisted-by: Claude Opus 4.6