### PR TITLE
feat(cli): reverse scan for terminal events in follow mode [#267]

### DIFF
--- a/cmd/soda/log.go
+++ b/cmd/soda/log.go
@@ -111,10 +111,11 @@ func followEvents(w io.Writer, path string, sinceTime time.Time, phase string, l
 	}
 	// Check terminal events on the unfiltered list so that --phase filters
 	// cannot mask engine_completed / engine_failed (which have Phase="").
-	for _, ev := range events {
-		if isTerminalEvent(ev) {
-			return nil
-		}
+	// Scan backwards: only treat as terminated if the *last* terminal-or-started
+	// event is terminal. This handles resumed pipelines where the events file
+	// contains [engine_started, ..., engine_completed, engine_started, ...].
+	if isTerminatedRun(events) {
+		return nil
 	}
 
 	// Poll loop.
@@ -139,10 +140,9 @@ func followEvents(w io.Writer, path string, sinceTime time.Time, phase string, l
 				fmt.Fprintln(w, pipeline.FormatEvent(ev))
 			}
 			// Check terminal events on the unfiltered list.
-			for _, ev := range newEvents {
-				if isTerminalEvent(ev) {
-					return nil
-				}
+			// Use reverse scan to handle resumed pipelines correctly.
+			if isTerminatedRun(newEvents) {
+				return nil
 			}
 		}
 	}
@@ -235,6 +235,23 @@ func filterEvents(events []pipeline.Event, sinceTime time.Time, phase string) []
 		filtered = append(filtered, ev)
 	}
 	return filtered
+}
+
+// isTerminatedRun scans events backwards to determine if the pipeline's
+// most recent run has terminated. In an append-only events file, a resumed
+// pipeline produces [engine_started, ..., engine_completed, engine_started, ...].
+// We only treat the pipeline as terminated if the *last* terminal-or-started
+// event is a terminal event (not a new engine_started).
+func isTerminatedRun(events []pipeline.Event) bool {
+	for i := len(events) - 1; i >= 0; i-- {
+		if isTerminalEvent(events[i]) {
+			return true
+		}
+		if events[i].Kind == pipeline.EventEngineStarted {
+			return false // new run started after last terminal
+		}
+	}
+	return false
 }
 
 // isTerminalEvent returns true for events that indicate the pipeline

--- a/cmd/soda/log_test.go
+++ b/cmd/soda/log_test.go
@@ -580,6 +580,140 @@ func TestFollowEvents_ResumedPipeline(t *testing.T) {
 	}
 }
 
+func TestFollowEvents_PollLoop(t *testing.T) {
+	// Verify the core polling behavior: events arriving *after*
+	// followEvents starts are picked up and printed. This exercises the
+	// poll loop (ticker + readEventsFromOffset), which prior tests did not
+	// cover because they pre-wrote all events including the terminal event.
+	stateDir := t.TempDir()
+	ticketDir := filepath.Join(stateDir, "TEST-POLL")
+	if err := os.MkdirAll(ticketDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	ts := time.Date(2026, 4, 11, 10, 0, 0, 0, time.UTC)
+	// Write initial non-terminal events.
+	initialEvents := []pipeline.Event{
+		{Timestamp: ts, Kind: pipeline.EventEngineStarted},
+		{Timestamp: ts.Add(time.Second), Phase: "triage", Kind: pipeline.EventPhaseStarted},
+	}
+	writeTestEvents(t, ticketDir, initialEvents)
+
+	eventsPath := filepath.Join(ticketDir, "events.jsonl")
+	var buf bytes.Buffer
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- followEvents(&buf, eventsPath, time.Time{}, "", 0)
+	}()
+
+	// Wait for followEvents to read initial events and enter the poll loop,
+	// then append more events incrementally.
+	time.Sleep(200 * time.Millisecond)
+	appendTestEvent(t, eventsPath, pipeline.Event{
+		Timestamp: ts.Add(2 * time.Second),
+		Phase:     "triage",
+		Kind:      pipeline.EventPhaseCompleted,
+	})
+
+	time.Sleep(200 * time.Millisecond)
+	appendTestEvent(t, eventsPath, pipeline.Event{
+		Timestamp: ts.Add(3 * time.Second),
+		Kind:      pipeline.EventEngineCompleted,
+	})
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("followEvents: %v", err)
+		}
+	case <-ctx.Done():
+		t.Fatal("followEvents did not return after terminal event was appended")
+	}
+
+	output := buf.String()
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	// 2 initial + 2 polled = 4 events total.
+	if len(lines) != 4 {
+		t.Fatalf("expected 4 lines, got %d:\n%s", len(lines), output)
+	}
+	// Verify the initial events are printed first.
+	if !strings.Contains(lines[0], "engine_started") {
+		t.Errorf("line 0 should contain engine_started, got: %s", lines[0])
+	}
+	if !strings.Contains(lines[1], "[triage] phase_started") {
+		t.Errorf("line 1 should contain [triage] phase_started, got: %s", lines[1])
+	}
+	// Verify polled events are printed.
+	if !strings.Contains(lines[2], "[triage] phase_completed") {
+		t.Errorf("line 2 should contain [triage] phase_completed, got: %s", lines[2])
+	}
+	if !strings.Contains(lines[3], "engine_completed") {
+		t.Errorf("line 3 should contain engine_completed, got: %s", lines[3])
+	}
+}
+
+func TestFollowEvents_PollLoop_FileCreatedLater(t *testing.T) {
+	// Verify that follow mode handles the case where the events file
+	// doesn't exist yet when followEvents starts (e.g., pipeline hasn't
+	// started writing events yet). The poll loop should wait until the
+	// file appears.
+	stateDir := t.TempDir()
+	ticketDir := filepath.Join(stateDir, "TEST-NOPOLL")
+	if err := os.MkdirAll(ticketDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	eventsPath := filepath.Join(ticketDir, "events.jsonl")
+	var buf bytes.Buffer
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- followEvents(&buf, eventsPath, time.Time{}, "", 0)
+	}()
+
+	ts := time.Date(2026, 4, 11, 10, 0, 0, 0, time.UTC)
+
+	// Wait, then create the file with events.
+	time.Sleep(200 * time.Millisecond)
+	writeTestEvents(t, ticketDir, []pipeline.Event{
+		{Timestamp: ts, Kind: pipeline.EventEngineStarted},
+	})
+
+	time.Sleep(200 * time.Millisecond)
+	appendTestEvent(t, eventsPath, pipeline.Event{
+		Timestamp: ts.Add(time.Second),
+		Kind:      pipeline.EventEngineCompleted,
+	})
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("followEvents: %v", err)
+		}
+	case <-ctx.Done():
+		t.Fatal("followEvents did not return after events file was created and terminal event appended")
+	}
+
+	output := buf.String()
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d:\n%s", len(lines), output)
+	}
+	if !strings.Contains(lines[0], "engine_started") {
+		t.Errorf("line 0 should contain engine_started, got: %s", lines[0])
+	}
+	if !strings.Contains(lines[1], "engine_completed") {
+		t.Errorf("line 1 should contain engine_completed, got: %s", lines[1])
+	}
+}
+
 func TestIsTerminalEvent(t *testing.T) {
 	tests := []struct {
 		kind string

--- a/cmd/soda/log_test.go
+++ b/cmd/soda/log_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -26,6 +27,24 @@ func writeTestEvents(t *testing.T, ticketDir string, events []pipeline.Event) {
 	}
 	if err := os.WriteFile(filepath.Join(ticketDir, "events.jsonl"), buf.Bytes(), 0644); err != nil {
 		t.Fatalf("write events.jsonl: %v", err)
+	}
+}
+
+// appendTestEvent appends a single event to an existing events.jsonl file.
+func appendTestEvent(t *testing.T, eventsPath string, ev pipeline.Event) {
+	t.Helper()
+	data, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+	data = append(data, '\n')
+	f, err := os.OpenFile(eventsPath, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+	if err != nil {
+		t.Fatalf("open events.jsonl for append: %v", err)
+	}
+	defer f.Close()
+	if _, err := f.Write(data); err != nil {
+		t.Fatalf("append event: %v", err)
 	}
 }
 
@@ -413,6 +432,151 @@ func TestFollowEvents_PipelineTimeoutTerminal(t *testing.T) {
 	output := buf.String()
 	if !strings.Contains(output, "pipeline_timeout") {
 		t.Errorf("output should contain pipeline_timeout, got: %s", output)
+	}
+}
+
+func TestIsTerminatedRun(t *testing.T) {
+	tests := []struct {
+		name   string
+		events []pipeline.Event
+		want   bool
+	}{
+		{
+			name:   "empty events",
+			events: nil,
+			want:   false,
+		},
+		{
+			name: "single engine_started",
+			events: []pipeline.Event{
+				{Kind: pipeline.EventEngineStarted},
+			},
+			want: false,
+		},
+		{
+			name: "completed run",
+			events: []pipeline.Event{
+				{Kind: pipeline.EventEngineStarted},
+				{Kind: pipeline.EventEngineCompleted},
+			},
+			want: true,
+		},
+		{
+			name: "failed run",
+			events: []pipeline.Event{
+				{Kind: pipeline.EventEngineStarted},
+				{Kind: pipeline.EventEngineFailed},
+			},
+			want: true,
+		},
+		{
+			name: "resumed pipeline — new run after completed",
+			events: []pipeline.Event{
+				{Kind: pipeline.EventEngineStarted},
+				{Kind: pipeline.EventEngineCompleted},
+				{Kind: pipeline.EventEngineStarted},
+			},
+			want: false,
+		},
+		{
+			name: "resumed pipeline — second run also completed",
+			events: []pipeline.Event{
+				{Kind: pipeline.EventEngineStarted},
+				{Kind: pipeline.EventEngineCompleted},
+				{Kind: pipeline.EventEngineStarted},
+				{Kind: pipeline.EventEngineCompleted},
+			},
+			want: true,
+		},
+		{
+			name: "resumed pipeline — second run with phases, not yet terminated",
+			events: []pipeline.Event{
+				{Kind: pipeline.EventEngineStarted},
+				{Kind: pipeline.EventEngineCompleted},
+				{Kind: pipeline.EventEngineStarted},
+				{Phase: "triage", Kind: pipeline.EventPhaseStarted},
+				{Phase: "triage", Kind: pipeline.EventPhaseCompleted},
+			},
+			want: false,
+		},
+		{
+			name: "pipeline_timeout is terminal",
+			events: []pipeline.Event{
+				{Kind: pipeline.EventEngineStarted},
+				{Kind: pipeline.EventPipelineTimeout},
+			},
+			want: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isTerminatedRun(tc.events)
+			if got != tc.want {
+				t.Errorf("isTerminatedRun() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFollowEvents_ResumedPipeline(t *testing.T) {
+	// After a completed run and a Resume, the events file contains
+	// [engine_started, ..., engine_completed, engine_started, ...].
+	// Follow mode should NOT exit on the first engine_completed; it should
+	// recognize the second engine_started as the active run.
+	stateDir := t.TempDir()
+	ticketDir := filepath.Join(stateDir, "TEST-RESUME")
+	if err := os.MkdirAll(ticketDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	ts := time.Date(2026, 4, 11, 10, 0, 0, 0, time.UTC)
+	events := []pipeline.Event{
+		{Timestamp: ts, Kind: pipeline.EventEngineStarted},
+		{Timestamp: ts.Add(time.Second), Phase: "triage", Kind: pipeline.EventPhaseCompleted},
+		{Timestamp: ts.Add(2 * time.Second), Kind: pipeline.EventEngineCompleted},
+		// Pipeline was resumed:
+		{Timestamp: ts.Add(3 * time.Second), Kind: pipeline.EventEngineStarted},
+		{Timestamp: ts.Add(4 * time.Second), Phase: "plan", Kind: pipeline.EventPhaseStarted},
+	}
+	writeTestEvents(t, ticketDir, events)
+
+	eventsPath := filepath.Join(ticketDir, "events.jsonl")
+	var buf bytes.Buffer
+
+	// followEvents should NOT return immediately because the last
+	// engine_started is after the engine_completed (resumed pipeline).
+	// We use a context with timeout to avoid hanging forever.
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- followEvents(&buf, eventsPath, time.Time{}, "", 0)
+	}()
+
+	// Append a terminal event after a short delay to let follow mode
+	// enter the poll loop.
+	time.Sleep(200 * time.Millisecond)
+	appendTestEvent(t, eventsPath, pipeline.Event{
+		Timestamp: ts.Add(5 * time.Second),
+		Kind:      pipeline.EventEngineCompleted,
+	})
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("followEvents: %v", err)
+		}
+	case <-ctx.Done():
+		t.Fatal("followEvents did not return after terminal event was appended")
+	}
+
+	output := buf.String()
+	// All 6 events should be printed (5 initial + 1 appended).
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) != 6 {
+		t.Fatalf("expected 6 lines, got %d:\n%s", len(lines), output)
 	}
 }
 


### PR DESCRIPTION
## Summary
- **Fix follow mode for resumed pipelines**: Replace forward scan with backward scan (`isTerminatedRun`) so that `soda log -f` correctly tails events when a pipeline is resumed after completion. Previously, the forward scan hit the first `engine_completed` and exited immediately, ignoring the active resumed run.
- **Add comprehensive test coverage**: Add `TestIsTerminatedRun` table-driven tests, `TestFollowEvents_ResumedPipeline` integration test, and poll-loop coverage tests (`TestFollowEvents_PollLoop`, `TestFollowEvents_PollLoop_FileCreatedLater`).

## Acceptance Criteria
- [x] `soda log -f` does not exit prematurely when a pipeline is resumed (events file contains `[engine_started, ..., engine_completed, engine_started, ...]`)
- [x] `soda log -f` exits when the most recent run reaches a terminal event
- [x] Poll loop correctly picks up events written after `followEvents` starts
- [x] Follow mode handles events file that doesn't exist yet at startup

## Test Plan
- [x] `TestIsTerminatedRun` — table-driven tests for empty, single start, completed, failed, resumed, and double-resumed scenarios
- [x] `TestFollowEvents_ResumedPipeline` — verifies follow mode enters poll loop instead of exiting on first `engine_completed` when a new `engine_started` follows
- [x] `TestFollowEvents_PollLoop` — verifies events appended asynchronously are picked up by the poll loop
- [x] `TestFollowEvents_PollLoop_FileCreatedLater` — verifies follow mode waits for file creation
- [x] All existing `soda log` tests continue to pass

Assisted-by: SODA

🤖 Generated with [Claude Code](https://claude.com/claude-code)