### PR TITLE
feat(cli): soda validate — check config without running [#274]

### DIFF
--- a/cmd/soda/main.go
+++ b/cmd/soda/main.go
@@ -49,6 +49,7 @@ func newRootCmd() *cobra.Command {
 		newCleanCmd(),
 		newCostCmd(),
 		newRenderCmd(),
+		newValidateCmd(),
 		newPluginCmd(),
 		newVersionCmd(),
 	)

--- a/cmd/soda/validate.go
+++ b/cmd/soda/validate.go
@@ -1,0 +1,210 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/decko/soda/internal/config"
+	"github.com/decko/soda/internal/pipeline"
+	"github.com/decko/soda/schemas"
+	"github.com/spf13/cobra"
+)
+
+func newValidateCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "validate",
+		Short: "Check config and phases without running",
+		Long: `Validate configuration, phases, prompts, schemas, and context files
+without executing the pipeline. Exits 0 if everything is valid
+(warnings are OK), exits 1 if any validation error is found.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := loadConfig(cmd)
+			if err != nil {
+				return err
+			}
+			return runValidate(cmd.OutOrStdout(), cmd.ErrOrStderr(), cfg)
+		},
+	}
+}
+
+// validationResult accumulates errors and warnings across validation stages.
+type validationResult struct {
+	errors   []string
+	warnings []string
+}
+
+func (v *validationResult) addError(format string, args ...any) {
+	v.errors = append(v.errors, fmt.Sprintf(format, args...))
+}
+
+func (v *validationResult) addWarning(format string, args ...any) {
+	v.warnings = append(v.warnings, fmt.Sprintf(format, args...))
+}
+
+func (v *validationResult) hasErrors() bool {
+	return len(v.errors) > 0
+}
+
+// runValidate runs all validation stages in order and prints results.
+// Returns nil on success (exit 0), non-nil error on validation failure (exit 1).
+func runValidate(w io.Writer, errW io.Writer, cfg *config.Config) error {
+	result := &validationResult{}
+
+	// Stage 1: Config is already loaded (loadConfig succeeded).
+	fmt.Fprintln(w, "✓ config: valid")
+
+	// Stage 2: Phases
+	pl := validatePhases(w, result)
+
+	// Stage 3: Prompts (only if phases loaded)
+	if pl != nil {
+		validatePrompts(w, result, pl)
+	}
+
+	// Stage 4: Schemas (only if phases loaded)
+	if pl != nil {
+		validateSchemas(w, result, pl)
+	}
+
+	// Stage 5: Context files
+	validateContextFiles(w, result, cfg)
+
+	// Print summary
+	fmt.Fprintln(w)
+	for _, warn := range result.warnings {
+		fmt.Fprintf(errW, "⚠ warning: %s\n", warn)
+	}
+	for _, e := range result.errors {
+		fmt.Fprintf(errW, "✗ error: %s\n", e)
+	}
+
+	if result.hasErrors() {
+		fmt.Fprintf(w, "Validation failed: %d error(s), %d warning(s)\n", len(result.errors), len(result.warnings))
+		return fmt.Errorf("validation failed with %d error(s)", len(result.errors))
+	}
+
+	fmt.Fprintf(w, "Validation passed: %d warning(s)\n", len(result.warnings))
+	return nil
+}
+
+// validatePhases loads and validates phases.yaml (cross-references, structure).
+func validatePhases(w io.Writer, result *validationResult) *pipeline.PhasePipeline {
+	phasesPath, cleanup, err := resolvePhasesPath()
+	if err != nil {
+		result.addError("phases: %v", err)
+		return nil
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+
+	pl, err := pipeline.LoadPipeline(phasesPath)
+	if err != nil {
+		result.addError("phases: %v", err)
+		return nil
+	}
+
+	fmt.Fprintf(w, "✓ phases: %d phases loaded\n", len(pl.Phases))
+	return pl
+}
+
+// validatePrompts loads and validates each phase prompt and reviewer prompt.
+func validatePrompts(w io.Writer, result *validationResult, pl *pipeline.PhasePipeline) {
+	promptDir, err := extractEmbeddedPrompts()
+	if err != nil {
+		result.addError("prompts: extract embedded prompts: %v", err)
+		return
+	}
+	defer os.RemoveAll(promptDir)
+
+	// Build the loader with the same search order as the run command.
+	loaderDirs := []string{"."}
+	configDir, _ := os.UserConfigDir()
+	if configDir != "" {
+		loaderDirs = append([]string{filepath.Join(configDir, "soda")}, loaderDirs...)
+	}
+	loaderDirs = append(loaderDirs, promptDir)
+	loader := pipeline.NewPromptLoader(loaderDirs...)
+
+	promptErrors := 0
+	for _, phase := range pl.Phases {
+		// Phase prompt (skip parallel-review phases that have no top-level prompt).
+		if phase.Prompt != "" {
+			if err := validateSinglePrompt(loader, phase.Prompt); err != nil {
+				result.addError("prompts: phase %q: %v", phase.Name, err)
+				promptErrors++
+			}
+		}
+
+		// Reviewer prompts.
+		for _, reviewer := range phase.Reviewers {
+			if reviewer.Prompt != "" {
+				label := fmt.Sprintf("%s/%s", phase.Name, reviewer.Name)
+				if err := validateSinglePrompt(loader, reviewer.Prompt); err != nil {
+					result.addError("prompts: reviewer %q: %v", label, err)
+					promptErrors++
+				}
+			}
+		}
+	}
+
+	if promptErrors == 0 {
+		fmt.Fprintln(w, "✓ prompts: all templates valid")
+	}
+}
+
+// validateSinglePrompt loads a prompt file and validates it as a Go template.
+func validateSinglePrompt(loader *pipeline.PromptLoader, name string) error {
+	lr, err := loader.LoadWithSource(name)
+	if err != nil {
+		return fmt.Errorf("load %s: %w", name, err)
+	}
+
+	if err := pipeline.ValidateTemplate(lr.Content); err != nil {
+		return fmt.Errorf("template %s: %w", name, err)
+	}
+
+	return nil
+}
+
+// validateSchemas checks that each phase has a non-empty schema after
+// the resolution done in LoadPipeline (inline or generated).
+func validateSchemas(w io.Writer, result *validationResult, pl *pipeline.PhasePipeline) {
+	for _, phase := range pl.Phases {
+		if strings.TrimSpace(phase.Schema) == "" {
+			// Check if a generated schema exists.
+			if schemas.SchemaFor(phase.Name) == "" {
+				result.addWarning("schemas: phase %q has no schema", phase.Name)
+			}
+		}
+	}
+
+	fmt.Fprintln(w, "✓ schemas: all phases have schemas")
+}
+
+// validateContextFiles checks that each configured context file exists.
+func validateContextFiles(w io.Writer, result *validationResult, cfg *config.Config) {
+	if len(cfg.Context) == 0 {
+		fmt.Fprintln(w, "✓ context: no context files configured")
+		return
+	}
+
+	missing := 0
+	for _, path := range cfg.Context {
+		if _, err := os.Stat(path); err != nil {
+			result.addWarning("context: file %q not found", path)
+			missing++
+		}
+	}
+
+	if missing == 0 {
+		fmt.Fprintf(w, "✓ context: %d file(s) found\n", len(cfg.Context))
+	} else {
+		fmt.Fprintf(w, "✓ context: %d of %d file(s) found (%d missing)\n",
+			len(cfg.Context)-missing, len(cfg.Context), missing)
+	}
+}

--- a/cmd/soda/validate.go
+++ b/cmd/soda/validate.go
@@ -134,7 +134,7 @@ func validatePrompts(w io.Writer, result *validationResult, pl *pipeline.PhasePi
 	for _, phase := range pl.Phases {
 		// Phase prompt (skip parallel-review phases that have no top-level prompt).
 		if phase.Prompt != "" {
-			if err := validateSinglePrompt(loader, phase.Prompt); err != nil {
+			if err := validateSinglePrompt(loader, phase.Prompt, result); err != nil {
 				result.addError("prompts: phase %q: %v", phase.Name, err)
 				promptErrors++
 			}
@@ -144,7 +144,7 @@ func validatePrompts(w io.Writer, result *validationResult, pl *pipeline.PhasePi
 		for _, reviewer := range phase.Reviewers {
 			if reviewer.Prompt != "" {
 				label := fmt.Sprintf("%s/%s", phase.Name, reviewer.Name)
-				if err := validateSinglePrompt(loader, reviewer.Prompt); err != nil {
+				if err := validateSinglePrompt(loader, reviewer.Prompt, result); err != nil {
 					result.addError("prompts: reviewer %q: %v", label, err)
 					promptErrors++
 				}
@@ -158,10 +158,16 @@ func validatePrompts(w io.Writer, result *validationResult, pl *pipeline.PhasePi
 }
 
 // validateSinglePrompt loads a prompt file and validates it as a Go template.
-func validateSinglePrompt(loader *pipeline.PromptLoader, name string) error {
+// If the loader fell back from a broken override to the embedded default,
+// it records a warning so the user knows their custom file was rejected.
+func validateSinglePrompt(loader *pipeline.PromptLoader, name string, result *validationResult) error {
 	lr, err := loader.LoadWithSource(name)
 	if err != nil {
 		return fmt.Errorf("load %s: %w", name, err)
+	}
+
+	if lr.Fallback {
+		result.addWarning("prompts: %s", lr.FallbackReason)
 	}
 
 	if err := pipeline.ValidateTemplate(lr.Content); err != nil {
@@ -174,16 +180,22 @@ func validateSinglePrompt(loader *pipeline.PromptLoader, name string) error {
 // validateSchemas checks that each phase has a non-empty schema after
 // the resolution done in LoadPipeline (inline or generated).
 func validateSchemas(w io.Writer, result *validationResult, pl *pipeline.PhasePipeline) {
+	missingSchemas := 0
 	for _, phase := range pl.Phases {
 		if strings.TrimSpace(phase.Schema) == "" {
 			// Check if a generated schema exists.
 			if schemas.SchemaFor(phase.Name) == "" {
 				result.addWarning("schemas: phase %q has no schema", phase.Name)
+				missingSchemas++
 			}
 		}
 	}
 
-	fmt.Fprintln(w, "✓ schemas: all phases have schemas")
+	if missingSchemas == 0 {
+		fmt.Fprintln(w, "✓ schemas: all phases have schemas")
+	} else {
+		fmt.Fprintf(w, "⚠ schemas: %d phase(s) missing schemas\n", missingSchemas)
+	}
 }
 
 // validateContextFiles checks that each configured context file exists.

--- a/cmd/soda/validate_test.go
+++ b/cmd/soda/validate_test.go
@@ -1,0 +1,288 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/decko/soda/internal/config"
+	"github.com/decko/soda/internal/pipeline"
+)
+
+func TestValidationResult_AddErrorAndWarning(t *testing.T) {
+	result := &validationResult{}
+
+	if result.hasErrors() {
+		t.Error("new validationResult should not have errors")
+	}
+
+	result.addWarning("warn %d", 1)
+	if result.hasErrors() {
+		t.Error("warnings should not count as errors")
+	}
+	if len(result.warnings) != 1 {
+		t.Errorf("expected 1 warning, got %d", len(result.warnings))
+	}
+
+	result.addError("err %s", "test")
+	if !result.hasErrors() {
+		t.Error("expected hasErrors() to be true after addError")
+	}
+	if len(result.errors) != 1 {
+		t.Errorf("expected 1 error, got %d", len(result.errors))
+	}
+}
+
+func TestRunValidate_ValidConfig(t *testing.T) {
+	// Use a minimal valid config — the real validation stages (phases,
+	// prompts, schemas) exercise the embedded defaults.
+	cfg := &config.Config{
+		TicketSource: "github",
+		Mode:         "autonomous",
+		Model:        "claude-sonnet-4-20250514",
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := runValidate(&stdout, &stderr, cfg)
+	if err != nil {
+		t.Fatalf("runValidate() returned error: %v\nstdout: %s\nstderr: %s", err, stdout.String(), stderr.String())
+	}
+
+	output := stdout.String()
+
+	// Should contain all validation stage outputs.
+	if !strings.Contains(output, "✓ config: valid") {
+		t.Error("expected config valid message")
+	}
+	if !strings.Contains(output, "✓ phases:") {
+		t.Error("expected phases valid message")
+	}
+	if !strings.Contains(output, "✓ prompts:") {
+		t.Error("expected prompts valid message")
+	}
+	if !strings.Contains(output, "✓ schemas:") {
+		t.Error("expected schemas valid message")
+	}
+	if !strings.Contains(output, "Validation passed") {
+		t.Error("expected validation passed message")
+	}
+}
+
+func TestRunValidate_MissingContextFiles(t *testing.T) {
+	cfg := &config.Config{
+		Context: []string{"nonexistent-file.md", "also-missing.md"},
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := runValidate(&stdout, &stderr, cfg)
+
+	// Missing context files produce warnings, not errors, so validation passes.
+	if err != nil {
+		t.Fatalf("expected no error (warnings only), got: %v", err)
+	}
+
+	errOutput := stderr.String()
+	if !strings.Contains(errOutput, "nonexistent-file.md") {
+		t.Error("expected warning about nonexistent-file.md")
+	}
+	if !strings.Contains(errOutput, "also-missing.md") {
+		t.Error("expected warning about also-missing.md")
+	}
+	if !strings.Contains(errOutput, "⚠ warning") {
+		t.Error("expected warning prefix")
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "0 of 2") {
+		t.Errorf("expected '0 of 2' in context line, got: %s", output)
+	}
+}
+
+func TestRunValidate_ExistingContextFiles(t *testing.T) {
+	dir := t.TempDir()
+	ctxFile := filepath.Join(dir, "context.md")
+	if err := os.WriteFile(ctxFile, []byte("# Context"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{
+		Context: []string{ctxFile},
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := runValidate(&stdout, &stderr, cfg)
+	if err != nil {
+		t.Fatalf("runValidate() error: %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "✓ context: 1 file(s) found") {
+		t.Errorf("expected '1 file(s) found', got: %s", output)
+	}
+}
+
+func TestRunValidate_NoContextFiles(t *testing.T) {
+	cfg := &config.Config{}
+
+	var stdout, stderr bytes.Buffer
+	err := runValidate(&stdout, &stderr, cfg)
+	if err != nil {
+		t.Fatalf("runValidate() error: %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "no context files configured") {
+		t.Errorf("expected 'no context files configured', got: %s", output)
+	}
+}
+
+func TestValidateContextFiles_MixedExistAndMissing(t *testing.T) {
+	dir := t.TempDir()
+	existingFile := filepath.Join(dir, "exists.md")
+	if err := os.WriteFile(existingFile, []byte("content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{
+		Context: []string{existingFile, "missing.md"},
+	}
+
+	result := &validationResult{}
+	var buf bytes.Buffer
+	validateContextFiles(&buf, result, cfg)
+
+	if result.hasErrors() {
+		t.Error("context files should not produce errors, only warnings")
+	}
+	if len(result.warnings) != 1 {
+		t.Errorf("expected 1 warning, got %d", len(result.warnings))
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "1 of 2") {
+		t.Errorf("expected '1 of 2', got: %s", output)
+	}
+}
+
+func TestValidateSchemas_AllPhasesHaveSchemas(t *testing.T) {
+	pl := &pipeline.PhasePipeline{
+		Phases: []pipeline.PhaseConfig{
+			{Name: "triage", Schema: "{}"},
+			{Name: "plan", Schema: "{}"},
+		},
+	}
+
+	result := &validationResult{}
+	var buf bytes.Buffer
+	validateSchemas(&buf, result, pl)
+
+	if result.hasErrors() {
+		t.Error("expected no errors")
+	}
+	if len(result.warnings) > 0 {
+		t.Errorf("expected no warnings, got %v", result.warnings)
+	}
+	if !strings.Contains(buf.String(), "✓ schemas:") {
+		t.Errorf("expected schemas valid message, got: %s", buf.String())
+	}
+}
+
+func TestValidateSchemas_MissingSchemaWarning(t *testing.T) {
+	pl := &pipeline.PhasePipeline{
+		Phases: []pipeline.PhaseConfig{
+			{Name: "triage", Schema: "{}"},
+			{Name: "custom-phase", Schema: ""},
+		},
+	}
+
+	result := &validationResult{}
+	var buf bytes.Buffer
+	validateSchemas(&buf, result, pl)
+
+	if result.hasErrors() {
+		t.Error("missing schema should produce warning, not error")
+	}
+	if len(result.warnings) != 1 {
+		t.Errorf("expected 1 warning, got %d", len(result.warnings))
+	}
+	if !strings.Contains(result.warnings[0], "custom-phase") {
+		t.Errorf("warning should mention custom-phase, got: %s", result.warnings[0])
+	}
+}
+
+func TestValidateSinglePrompt_ValidTemplate(t *testing.T) {
+	dir := t.TempDir()
+	tmplPath := filepath.Join(dir, "test.md")
+	if err := os.WriteFile(tmplPath, []byte("Hello {{.Ticket.Key}}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	loader := pipeline.NewPromptLoader(dir)
+	err := validateSinglePrompt(loader, "test.md")
+	if err != nil {
+		t.Fatalf("expected no error for valid template, got: %v", err)
+	}
+}
+
+func TestValidateSinglePrompt_InvalidTemplate(t *testing.T) {
+	dir := t.TempDir()
+	tmplPath := filepath.Join(dir, "bad.md")
+	if err := os.WriteFile(tmplPath, []byte("Hello {{.Invalid"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	loader := pipeline.NewPromptLoader(dir)
+	err := validateSinglePrompt(loader, "bad.md")
+	if err == nil {
+		t.Fatal("expected error for invalid template, got nil")
+	}
+}
+
+func TestValidateSinglePrompt_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	loader := pipeline.NewPromptLoader(dir)
+	err := validateSinglePrompt(loader, "missing.md")
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error should mention 'not found', got: %v", err)
+	}
+}
+
+func TestNewValidateCmd_NoArgs(t *testing.T) {
+	cmd := newValidateCmd()
+	// Verify the command rejects args.
+	cmd.SetArgs([]string{"extra-arg"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when args provided, got nil")
+	}
+}
+
+func TestRunValidate_ErrorOutput(t *testing.T) {
+	// Test that errors go to stderr and success markers go to stdout.
+	cfg := &config.Config{
+		Context: []string{"absolutely-nonexistent-file-xyz.md"},
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := runValidate(&stdout, &stderr, cfg)
+
+	// Warnings don't cause failure.
+	if err != nil {
+		t.Fatalf("expected success (warnings only), got: %v", err)
+	}
+
+	// Warnings should go to stderr.
+	if !strings.Contains(stderr.String(), "⚠ warning") {
+		t.Error("expected warnings on stderr")
+	}
+
+	// Success markers should go to stdout.
+	if !strings.Contains(stdout.String(), "✓ config: valid") {
+		t.Error("expected config valid on stdout")
+	}
+}

--- a/cmd/soda/validate_test.go
+++ b/cmd/soda/validate_test.go
@@ -210,6 +210,14 @@ func TestValidateSchemas_MissingSchemaWarning(t *testing.T) {
 	if !strings.Contains(result.warnings[0], "custom-phase") {
 		t.Errorf("warning should mention custom-phase, got: %s", result.warnings[0])
 	}
+
+	output := buf.String()
+	if !strings.Contains(output, "⚠ schemas: 1 phase(s) missing schemas") {
+		t.Errorf("expected missing schemas summary, got: %s", output)
+	}
+	if strings.Contains(output, "all phases have schemas") {
+		t.Error("should not claim all phases have schemas when some are missing")
+	}
 }
 
 func TestValidateSinglePrompt_ValidTemplate(t *testing.T) {
@@ -220,9 +228,13 @@ func TestValidateSinglePrompt_ValidTemplate(t *testing.T) {
 	}
 
 	loader := pipeline.NewPromptLoader(dir)
-	err := validateSinglePrompt(loader, "test.md")
+	result := &validationResult{}
+	err := validateSinglePrompt(loader, "test.md", result)
 	if err != nil {
 		t.Fatalf("expected no error for valid template, got: %v", err)
+	}
+	if len(result.warnings) != 0 {
+		t.Errorf("expected no warnings, got: %v", result.warnings)
 	}
 }
 
@@ -234,7 +246,8 @@ func TestValidateSinglePrompt_InvalidTemplate(t *testing.T) {
 	}
 
 	loader := pipeline.NewPromptLoader(dir)
-	err := validateSinglePrompt(loader, "bad.md")
+	result := &validationResult{}
+	err := validateSinglePrompt(loader, "bad.md", result)
 	if err == nil {
 		t.Fatal("expected error for invalid template, got nil")
 	}
@@ -243,12 +256,39 @@ func TestValidateSinglePrompt_InvalidTemplate(t *testing.T) {
 func TestValidateSinglePrompt_MissingFile(t *testing.T) {
 	dir := t.TempDir()
 	loader := pipeline.NewPromptLoader(dir)
-	err := validateSinglePrompt(loader, "missing.md")
+	result := &validationResult{}
+	err := validateSinglePrompt(loader, "missing.md", result)
 	if err == nil {
 		t.Fatal("expected error for missing file, got nil")
 	}
 	if !strings.Contains(err.Error(), "not found") {
 		t.Errorf("error should mention 'not found', got: %v", err)
+	}
+}
+
+func TestValidateSinglePrompt_FallbackWarning(t *testing.T) {
+	// Create two dirs: "override" with a broken template, "fallback" with a valid one.
+	overrideDir := t.TempDir()
+	fallbackDir := t.TempDir()
+
+	// Broken override (invalid template syntax).
+	if err := os.WriteFile(filepath.Join(overrideDir, "plan.md"), []byte("{{.Bad"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// Valid fallback.
+	if err := os.WriteFile(filepath.Join(fallbackDir, "plan.md"), []byte("Hello {{.Ticket.Key}}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Override dir first, fallback dir second — matches real loader search order.
+	loader := pipeline.NewPromptLoader(overrideDir, fallbackDir)
+	result := &validationResult{}
+	err := validateSinglePrompt(loader, "plan.md", result)
+	if err != nil {
+		t.Fatalf("expected no error (should fall back), got: %v", err)
+	}
+	if len(result.warnings) == 0 {
+		t.Error("expected a warning about fallback, got none")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `soda validate` command that checks config, phases, prompts, schemas, and context files without executing the pipeline
- Reports errors to stderr and exits 1 on failure, exits 0 when valid (warnings are non-fatal)
- Works fully offline — no ticket key required

## Acceptance Criteria
- [x] `soda validate` reports config/phases/prompt errors
- [x] Exit 0 on valid config, exit 1 on errors
- [x] Warnings for optional missing fields (context files, schemas)
- [x] Works without a ticket key (pure offline validation)

## Changes
- `cmd/soda/validate.go` — new validate command with 5 validation stages (config, phases, prompts, schemas, context files)
- `cmd/soda/validate_test.go` — 14 test functions covering all stages, edge cases, and output separation
- `cmd/soda/main.go` — register validate subcommand

## Test plan
- [x] All 14 new tests pass (`go test ./cmd/soda/ -run TestValidate`)
- [x] All existing tests in `cmd/soda` pass (no regressions)
- [x] Manual: `soda validate` on valid project exits 0
- [x] Manual: `soda validate` with broken config exits 1 with errors on stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)