### PR TITLE
feat(cli): enhance soda status with rework cycles and cost trend [#275]

### DIFF
--- a/cmd/soda/status.go
+++ b/cmd/soda/status.go
@@ -32,6 +32,8 @@ type pipelineEntry struct {
 	cost      string
 	submitted string
 	startedAt time.Time
+	rework    int
+	costTrend string
 }
 
 func newStatusCmd() *cobra.Command {
@@ -71,6 +73,13 @@ func runStatus(stateDir string) error {
 		return fmt.Errorf("status: %w", phasesErr)
 	}
 
+	// Read the cost ledger once and compute per-ticket cost trends.
+	costEntries, costErr := pipeline.ReadCostLedger(stateDir)
+	if costErr != nil {
+		return fmt.Errorf("status: read cost ledger: %w", costErr)
+	}
+	trendMap := pipeline.CostTrendByTicket(costEntries)
+
 	// Collect pipeline entries.
 	var rows []pipelineEntry
 	for _, entry := range entries {
@@ -93,6 +102,11 @@ func runStatus(stateDir string) error {
 		elapsed := formatElapsed(meta)
 		cost := fmt.Sprintf("$%.2f", meta.TotalCost)
 
+		trend, ok := trendMap[meta.Ticket]
+		if !ok {
+			trend = "─"
+		}
+
 		rows = append(rows, pipelineEntry{
 			ticket:    meta.Ticket,
 			phase:     phase,
@@ -101,6 +115,8 @@ func runStatus(stateDir string) error {
 			cost:      cost,
 			submitted: formatSubmitted(meta.StartedAt, time.Now()),
 			startedAt: meta.StartedAt,
+			rework:    meta.ReworkCycles,
+			costTrend: trend,
 		})
 	}
 
@@ -116,10 +132,10 @@ func runStatus(stateDir string) error {
 	// Render collected entries.
 	isTTY := isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd())
 	tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
-	fmt.Fprintln(tw, "TICKET\tPHASE\tSTATUS\tSUBMITTED\tELAPSED\tCOST")
+	fmt.Fprintln(tw, "TICKET\tPHASE\tSTATUS\tSUBMITTED\tELAPSED\tCOST\tREWORK\tTREND")
 	for _, r := range rows {
 		status := colorizeStatus(r.status, isTTY)
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n", r.ticket, r.phase, status, r.submitted, r.elapsed, r.cost)
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%d\t%s\n", r.ticket, r.phase, status, r.submitted, r.elapsed, r.cost, r.rework, r.costTrend)
 	}
 
 	if err := tw.Flush(); err != nil {

--- a/cmd/soda/status_test.go
+++ b/cmd/soda/status_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -303,14 +304,11 @@ func TestRunStatus_ReworkAndTrendColumns(t *testing.T) {
 		t.Errorf("output missing TREND column header.\ngot:\n%s", output)
 	}
 
-	// Verify rework count appears in output.
-	if !strings.Contains(output, "3") {
-		t.Errorf("output missing rework count 3.\ngot:\n%s", output)
-	}
-
-	// Verify trend indicator appears in output (▲ for increasing).
-	if !strings.Contains(output, "▲") {
-		t.Errorf("output missing trend indicator ▲.\ngot:\n%s", output)
+	// Verify the TICKET-10 row has rework=3 and trend=▲ in the correct columns.
+	// REWORK and TREND are the last two columns, so we anchor to end-of-line.
+	reworkTrendRe := regexp.MustCompile(`(?m)^TICKET-10\s+.*\s+3\s+▲\s*$`)
+	if !reworkTrendRe.MatchString(output) {
+		t.Errorf("TICKET-10 row missing rework=3 and trend=▲ in correct columns.\ngot:\n%s", output)
 	}
 }
 
@@ -359,14 +357,11 @@ func TestRunStatus_DefaultTrendWhenNoLedger(t *testing.T) {
 
 	output := buf.String()
 
-	// ReworkCycles defaults to 0.
-	if !strings.Contains(output, "0") {
-		t.Errorf("output missing default rework count 0.\ngot:\n%s", output)
-	}
-
-	// Default trend should be ─.
-	if !strings.Contains(output, "─") {
-		t.Errorf("output missing default trend indicator ─.\ngot:\n%s", output)
+	// Verify the TICKET-20 row has rework=0 and trend=─ in the correct columns.
+	// REWORK and TREND are the last two columns, so we anchor to end-of-line.
+	reworkTrendRe := regexp.MustCompile(`(?m)^TICKET-20\s+.*\s+0\s+─\s*$`)
+	if !reworkTrendRe.MatchString(output) {
+		t.Errorf("TICKET-20 row missing rework=0 and trend=─ in correct columns.\ngot:\n%s", output)
 	}
 }
 

--- a/cmd/soda/status_test.go
+++ b/cmd/soda/status_test.go
@@ -237,6 +237,139 @@ func writeStatusMeta(t *testing.T, dir string, meta *pipeline.PipelineMeta) {
 	}
 }
 
+func TestRunStatus_ReworkAndTrendColumns(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a session with known rework cycles.
+	writeStatusMeta(t, filepath.Join(dir, "TICKET-10"), &pipeline.PipelineMeta{
+		Ticket:       "TICKET-10",
+		StartedAt:    time.Now().Add(-1 * time.Hour),
+		TotalCost:    5.00,
+		ReworkCycles: 3,
+		Phases: map[string]*pipeline.PhaseState{
+			"triage": {Status: pipeline.PhaseCompleted, DurationMs: 5000, Cost: 5.00},
+		},
+	})
+
+	// Add cost ledger entries so trend can be computed: increasing trend (▲).
+	if err := pipeline.AppendCostEntry(dir, pipeline.CostEntry{
+		Ticket: "TICKET-10", Cost: 1.00, Success: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := pipeline.AppendCostEntry(dir, pipeline.CostEntry{
+		Ticket: "TICKET-10", Cost: 5.00, Success: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Capture stdout.
+	oldStdout := os.Stdout
+	readPipe, writePipe, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = writePipe
+
+	runErr := runStatus(dir)
+
+	writePipe.Close()
+	os.Stdout = oldStdout
+
+	var buf strings.Builder
+	data := make([]byte, 4096)
+	for {
+		n, readErr := readPipe.Read(data)
+		if n > 0 {
+			buf.Write(data[:n])
+		}
+		if readErr != nil {
+			break
+		}
+	}
+	readPipe.Close()
+
+	if runErr != nil {
+		t.Fatalf("runStatus error: %v", runErr)
+	}
+
+	output := buf.String()
+
+	// Verify header contains new columns.
+	if !strings.Contains(output, "REWORK") {
+		t.Errorf("output missing REWORK column header.\ngot:\n%s", output)
+	}
+	if !strings.Contains(output, "TREND") {
+		t.Errorf("output missing TREND column header.\ngot:\n%s", output)
+	}
+
+	// Verify rework count appears in output.
+	if !strings.Contains(output, "3") {
+		t.Errorf("output missing rework count 3.\ngot:\n%s", output)
+	}
+
+	// Verify trend indicator appears in output (▲ for increasing).
+	if !strings.Contains(output, "▲") {
+		t.Errorf("output missing trend indicator ▲.\ngot:\n%s", output)
+	}
+}
+
+func TestRunStatus_DefaultTrendWhenNoLedger(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a session with no cost ledger entries — should get default trend ─.
+	writeStatusMeta(t, filepath.Join(dir, "TICKET-20"), &pipeline.PipelineMeta{
+		Ticket:    "TICKET-20",
+		StartedAt: time.Now().Add(-1 * time.Hour),
+		TotalCost: 1.00,
+		Phases: map[string]*pipeline.PhaseState{
+			"triage": {Status: pipeline.PhaseCompleted, DurationMs: 3000, Cost: 1.00},
+		},
+	})
+
+	// Capture stdout.
+	oldStdout := os.Stdout
+	readPipe, writePipe, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = writePipe
+
+	runErr := runStatus(dir)
+
+	writePipe.Close()
+	os.Stdout = oldStdout
+
+	var buf strings.Builder
+	data := make([]byte, 4096)
+	for {
+		n, readErr := readPipe.Read(data)
+		if n > 0 {
+			buf.Write(data[:n])
+		}
+		if readErr != nil {
+			break
+		}
+	}
+	readPipe.Close()
+
+	if runErr != nil {
+		t.Fatalf("runStatus error: %v", runErr)
+	}
+
+	output := buf.String()
+
+	// ReworkCycles defaults to 0.
+	if !strings.Contains(output, "0") {
+		t.Errorf("output missing default rework count 0.\ngot:\n%s", output)
+	}
+
+	// Default trend should be ─.
+	if !strings.Contains(output, "─") {
+		t.Errorf("output missing default trend indicator ─.\ngot:\n%s", output)
+	}
+}
+
 func TestColorizeStatus(t *testing.T) {
 	tests := []struct {
 		status string

--- a/internal/pipeline/ledger.go
+++ b/internal/pipeline/ledger.go
@@ -45,6 +45,61 @@ func ReadCostLedger(stateDir string) ([]CostEntry, error) {
 	return entries, nil
 }
 
+// CostTrendByTicket computes a per-ticket cost trend indicator from ledger
+// entries. For each ticket with at least two entries, the latest cost is
+// compared against the average of all prior entries:
+//   - "▲" if the latest cost is more than 10% above the prior average
+//   - "▼" if the latest cost is more than 10% below the prior average
+//   - "─" otherwise (stable within ±10%)
+//
+// Tickets with fewer than two entries receive "─".
+func CostTrendByTicket(entries []CostEntry) map[string]string {
+	// Group entries by ticket, preserving insertion order (which matches
+	// chronological order in the append-only ledger).
+	type ticketEntries struct {
+		costs []float64
+	}
+	byTicket := make(map[string]*ticketEntries)
+	for _, entry := range entries {
+		te, ok := byTicket[entry.Ticket]
+		if !ok {
+			te = &ticketEntries{}
+			byTicket[entry.Ticket] = te
+		}
+		te.costs = append(te.costs, entry.Cost)
+	}
+
+	trends := make(map[string]string, len(byTicket))
+	for ticket, te := range byTicket {
+		if len(te.costs) < 2 {
+			trends[ticket] = "─"
+			continue
+		}
+		latest := te.costs[len(te.costs)-1]
+		var priorSum float64
+		for _, cost := range te.costs[:len(te.costs)-1] {
+			priorSum += cost
+		}
+		priorAvg := priorSum / float64(len(te.costs)-1)
+
+		if priorAvg == 0 {
+			trends[ticket] = "─"
+			continue
+		}
+
+		ratio := latest / priorAvg
+		switch {
+		case ratio > 1.10:
+			trends[ticket] = "▲"
+		case ratio < 0.90:
+			trends[ticket] = "▼"
+		default:
+			trends[ticket] = "─"
+		}
+	}
+	return trends
+}
+
 // AppendCostEntry appends a cost entry to the persistent ledger at stateDir/cost.json.
 // The ledger file is created if it does not exist. The write is atomic.
 // An exclusive file lock (flock) protects the read-modify-write sequence so that

--- a/internal/pipeline/ledger_test.go
+++ b/internal/pipeline/ledger_test.go
@@ -94,6 +94,108 @@ func TestCostLedgerSurvivesClean(t *testing.T) {
 	}
 }
 
+func TestCostTrendByTicket_Empty(t *testing.T) {
+	trends := CostTrendByTicket(nil)
+	if len(trends) != 0 {
+		t.Errorf("expected empty map, got %v", trends)
+	}
+}
+
+func TestCostTrendByTicket_SingleEntry(t *testing.T) {
+	entries := []CostEntry{
+		{Ticket: "T-1", Cost: 5.00},
+	}
+	trends := CostTrendByTicket(entries)
+	if got := trends["T-1"]; got != "─" {
+		t.Errorf("single entry trend = %q, want \"─\"", got)
+	}
+}
+
+func TestCostTrendByTicket_Stable(t *testing.T) {
+	entries := []CostEntry{
+		{Ticket: "T-1", Cost: 1.00},
+		{Ticket: "T-1", Cost: 1.05}, // 5% above average → stable
+	}
+	trends := CostTrendByTicket(entries)
+	if got := trends["T-1"]; got != "─" {
+		t.Errorf("stable trend = %q, want \"─\"", got)
+	}
+}
+
+func TestCostTrendByTicket_Increasing(t *testing.T) {
+	entries := []CostEntry{
+		{Ticket: "T-1", Cost: 1.00},
+		{Ticket: "T-1", Cost: 1.00},
+		{Ticket: "T-1", Cost: 1.50}, // 50% above prior avg → ▲
+	}
+	trends := CostTrendByTicket(entries)
+	if got := trends["T-1"]; got != "▲" {
+		t.Errorf("increasing trend = %q, want \"▲\"", got)
+	}
+}
+
+func TestCostTrendByTicket_Decreasing(t *testing.T) {
+	entries := []CostEntry{
+		{Ticket: "T-1", Cost: 2.00},
+		{Ticket: "T-1", Cost: 2.00},
+		{Ticket: "T-1", Cost: 1.00}, // 50% below prior avg → ▼
+	}
+	trends := CostTrendByTicket(entries)
+	if got := trends["T-1"]; got != "▼" {
+		t.Errorf("decreasing trend = %q, want \"▼\"", got)
+	}
+}
+
+func TestCostTrendByTicket_MultipleTickets(t *testing.T) {
+	entries := []CostEntry{
+		{Ticket: "T-1", Cost: 1.00},
+		{Ticket: "T-2", Cost: 5.00},
+		{Ticket: "T-1", Cost: 2.00}, // ▲ (100% above prior)
+		{Ticket: "T-2", Cost: 2.00}, // ▼ (60% below prior)
+		{Ticket: "T-3", Cost: 3.00}, // single entry → ─
+	}
+	trends := CostTrendByTicket(entries)
+
+	if got := trends["T-1"]; got != "▲" {
+		t.Errorf("T-1 trend = %q, want \"▲\"", got)
+	}
+	if got := trends["T-2"]; got != "▼" {
+		t.Errorf("T-2 trend = %q, want \"▼\"", got)
+	}
+	if got := trends["T-3"]; got != "─" {
+		t.Errorf("T-3 trend = %q, want \"─\"", got)
+	}
+}
+
+func TestCostTrendByTicket_BoundaryAt10Percent(t *testing.T) {
+	// Exactly at the 10% boundary — should be stable.
+	entries := []CostEntry{
+		{Ticket: "T-UP", Cost: 1.00},
+		{Ticket: "T-UP", Cost: 1.10}, // ratio = 1.10, not > 1.10 → ─
+
+		{Ticket: "T-DOWN", Cost: 1.00},
+		{Ticket: "T-DOWN", Cost: 0.90}, // ratio = 0.90, not < 0.90 → ─
+	}
+	trends := CostTrendByTicket(entries)
+	if got := trends["T-UP"]; got != "─" {
+		t.Errorf("T-UP at boundary = %q, want \"─\"", got)
+	}
+	if got := trends["T-DOWN"]; got != "─" {
+		t.Errorf("T-DOWN at boundary = %q, want \"─\"", got)
+	}
+}
+
+func TestCostTrendByTicket_ZeroPriorAverage(t *testing.T) {
+	entries := []CostEntry{
+		{Ticket: "T-1", Cost: 0.00},
+		{Ticket: "T-1", Cost: 1.00}, // prior avg is 0 → ─
+	}
+	trends := CostTrendByTicket(entries)
+	if got := trends["T-1"]; got != "─" {
+		t.Errorf("zero prior avg trend = %q, want \"─\"", got)
+	}
+}
+
 func TestCumulativeCost_WithLedgerOnly(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
## Summary
- Add `CostTrendByTicket` helper in `internal/pipeline/ledger.go` that computes per-ticket cost trend indicators (▲/▼/─) from ledger entries using a ±10% threshold against the rolling average
- Wire **REWORK** and **TREND** columns into the `soda status` table, pulling rework cycle count from `meta.ReworkCycles` and cost trend from the new helper
- Defaults gracefully: `0` rework cycles when meta.json has no rework data, `─` trend when no ledger entries exist

## Test plan
- [x] 8 unit tests for `CostTrendByTicket` covering: nil input, single entry, stable/increasing/decreasing trends, multiple tickets, boundary (±10%), and zero-average edge case
- [x] 2 integration tests for status output: `TestRunStatus_ReworkAndTrendColumns` verifies correct column values; `TestRunStatus_DefaultTrendWhenNoLedger` verifies zero/dash defaults
- [x] All tests pass with `-race` detector
- [x] No performance regression — single `ReadCostLedger()` call, O(n) computation

## Acceptance criteria
- [x] Status table shows rework cycle count per ticket
- [x] Status table shows cost trend indicator per ticket
- [x] Graceful defaults when meta.json has no rework data (shows 0)
- [x] Graceful defaults when no ledger entries exist (shows ─)
- [x] No performance regression on status command

🤖 Generated with [Claude Code](https://claude.com/claude-code)