### PR TITLE
refactor(pipeline): move runMonitorStub to monitor_poll.go [#289]

### DIFF
--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -2577,34 +2577,6 @@ func (e *Engine) buildReviewArtifact(merged schemas.ReviewOutput) string {
 	return sb.String()
 }
 
-// runMonitorStub handles polling phases by marking them completed without
-// actually running the runner. Full monitor polling is not yet implemented.
-func (e *Engine) runMonitorStub(phase PhaseConfig) error {
-	prURL := e.extractPRURL()
-
-	if err := e.state.MarkRunning(phase.Name); err != nil {
-		return fmt.Errorf("engine: mark running %s: %w", phase.Name, err)
-	}
-	e.emit(Event{Phase: phase.Name, Kind: EventPhaseStarted, Data: map[string]any{"generation": e.state.Meta().Phases[phase.Name].Generation}})
-
-	e.emit(Event{
-		Phase: phase.Name,
-		Kind:  EventMonitorSkipped,
-		Data:  map[string]any{"pr_url": prURL, "reason": "monitor polling not yet implemented"},
-	})
-
-	if err := e.state.MarkCompleted(phase.Name); err != nil {
-		return fmt.Errorf("engine: mark completed %s: %w", phase.Name, err)
-	}
-	e.emit(Event{
-		Phase: phase.Name,
-		Kind:  EventPhaseCompleted,
-		Data:  map[string]any{"duration_ms": e.state.Meta().Phases[phase.Name].DurationMs, "cost": e.state.Meta().Phases[phase.Name].Cost},
-	})
-
-	return nil
-}
-
 // now returns the current time, using NowFunc if configured for testability.
 func (e *Engine) now() time.Time {
 	if e.config.NowFunc != nil {

--- a/internal/pipeline/monitor_poll.go
+++ b/internal/pipeline/monitor_poll.go
@@ -1045,3 +1045,31 @@ func applyProfileFilters(classified []ClassifiedComment, profile *MonitorProfile
 
 	return result
 }
+
+// runMonitorStub handles polling phases by marking them completed without
+// actually running the runner. Full monitor polling is not yet implemented.
+func (e *Engine) runMonitorStub(phase PhaseConfig) error {
+	prURL := e.extractPRURL()
+
+	if err := e.state.MarkRunning(phase.Name); err != nil {
+		return fmt.Errorf("engine: mark running %s: %w", phase.Name, err)
+	}
+	e.emit(Event{Phase: phase.Name, Kind: EventPhaseStarted, Data: map[string]any{"generation": e.state.Meta().Phases[phase.Name].Generation}})
+
+	e.emit(Event{
+		Phase: phase.Name,
+		Kind:  EventMonitorSkipped,
+		Data:  map[string]any{"pr_url": prURL, "reason": "monitor polling not yet implemented"},
+	})
+
+	if err := e.state.MarkCompleted(phase.Name); err != nil {
+		return fmt.Errorf("engine: mark completed %s: %w", phase.Name, err)
+	}
+	e.emit(Event{
+		Phase: phase.Name,
+		Kind:  EventPhaseCompleted,
+		Data:  map[string]any{"duration_ms": e.state.Meta().Phases[phase.Name].DurationMs, "cost": e.state.Meta().Phases[phase.Name].Cost},
+	})
+
+	return nil
+}


### PR DESCRIPTION
## Summary
- Moved `runMonitorStub` function (including doc comment, 28 lines) from `engine.go` to `monitor_poll.go`
- All 3 callers of `runMonitorStub` reside in `monitor_poll.go`; zero callers remain in `engine.go`
- Pure code-locality refactor — no logic changes

## Acceptance Criteria
- [x] `runMonitorStub` exists in `monitor_poll.go`
- [x] `runMonitorStub` removed from `engine.go`
- [x] All `internal/pipeline` tests pass
- [x] `go vet` clean

## Test Plan
- [x] `go test ./internal/pipeline/...` — all tests pass
- [x] `go vet ./internal/pipeline/...` — exit 0, no output
- [x] Verified byte-identical content between removed and added code

Closes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)