### PR TITLE
feat(pipeline): wire token counts through PhaseState to meta.json [#281]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -398,7 +398,7 @@ Atomic writes: always write to `.tmp` then rename. Archive on re-run (`verify.js
 16. **`ps.Cost` vs `ps.CumulativeCost`**: `Cost` resets per generation (zeroed in `MarkRunning`). `CumulativeCost` accumulates across rework/patch cycles. Budget enforcement (`checkPhaseBudget`) checks both: `MaxCostPerGeneration` against `Cost`, `MaxCostPerPhase` against `CumulativeCost`.
 17. **`EventPhaseFailed` is terminal**: the TUI and history module treat it as a hard failure. Never emit it for non-fatal warnings (e.g., failed to read archived review result) — use a warning-level event string instead.
 18. **Always use `exec.CommandContext`**: bare `exec.Command` in git/worktree operations can hang indefinitely. Use `exec.CommandContext(ctx, ...)` for any operation that could block (network, worktree removal).
-19. **Token data not persisted**: `RunResult` carries `TokensIn`/`TokensOut`/`CacheTokensIn` from the Claude CLI, but `PhaseState` in `meta.json` only stores `Cost` and `DurationMs`. Token counts are lost after the session, making raki's `token_efficiency` metric read 0.0.
+19. **Token data persisted in meta.json**: `PhaseState` stores `TokensIn`, `TokensOut`, and `CacheTokensIn` alongside `Cost` and `DurationMs`. Token counts are accumulated per-generation (zeroed on re-run) and emitted in `phase_completed` events. Legacy sessions without token data will show zero values.
 20. **`EnrichedFinding` wraps `schemas.ReviewFinding`**: defined in `prompt.go`, it adds `CodeSnippet` without changing the schema contract. Enrichment happens in `extractReviewFeedback()` only — the review phase still outputs plain `ReviewFinding`.
 
 ## Raki evaluation framework
@@ -415,7 +415,7 @@ Atomic writes: always write to `.tmp` then rename. Archive on re-run (`verify.js
 | `cost_efficiency` | Mean USD per session | $7.62 ($5.15–$11.35) |
 | `knowledge_retrieval_miss_rate` | Fraction of rework findings caused by missing context | 1.0 |
 | `phase_execution_time` | Mean wall-clock seconds per session | 847s (p50=801, p95=1309) |
-| `token_efficiency` | Mean tokens per phase | N/A (no token data) |
+| `token_efficiency` | Mean tokens per phase | available (persisted in meta.json) |
 
 ### Interpretation
 

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -660,6 +660,9 @@ func (e *Engine) runPhase(ctx context.Context, phase PhaseConfig) error {
 	if err := e.state.AccumulateCost(phase.Name, result.CostUSD); err != nil {
 		return fmt.Errorf("engine: accumulate cost for %s: %w", phase.Name, err)
 	}
+	if err := e.state.AccumulateTokens(phase.Name, result.TokensIn, result.TokensOut, result.CacheTokensIn); err != nil {
+		return fmt.Errorf("engine: accumulate tokens for %s: %w", phase.Name, err)
+	}
 
 	// Per-phase cost enforcement: abort if this phase exceeded its budget.
 	if err := e.checkPhaseBudget(phase); err != nil {
@@ -672,9 +675,19 @@ func (e *Engine) runPhase(ctx context.Context, phase PhaseConfig) error {
 	if err := e.state.MarkCompleted(phase.Name); err != nil {
 		return fmt.Errorf("engine: mark completed %s: %w", phase.Name, err)
 	}
+	ps := e.state.Meta().Phases[phase.Name]
 	completedData := map[string]any{
-		"duration_ms": e.state.Meta().Phases[phase.Name].DurationMs,
-		"cost":        e.state.Meta().Phases[phase.Name].Cost,
+		"duration_ms": ps.DurationMs,
+		"cost":        ps.Cost,
+	}
+	if ps.TokensIn > 0 {
+		completedData["tokens_in"] = ps.TokensIn
+	}
+	if ps.TokensOut > 0 {
+		completedData["tokens_out"] = ps.TokensOut
+	}
+	if ps.CacheTokensIn > 0 {
+		completedData["cache_tokens_in"] = ps.CacheTokensIn
 	}
 	if result.Output != nil {
 		if summary := progress.PhaseSummary(phase.Name, result.Output); summary != "" {

--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -98,6 +98,154 @@ func TestEngine_HappyPathAllPhasesComplete(t *testing.T) {
 	}
 }
 
+func TestEngine_TokenCountsPersistedToMeta(t *testing.T) {
+	phases := []PhaseConfig{
+		{
+			Name:   "triage",
+			Prompt: "triage.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+		{
+			Name:      "plan",
+			Prompt:    "plan.md",
+			DependsOn: []string{"triage"},
+			Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"triage": {{
+				result: &runner.RunResult{
+					Output:        json.RawMessage(`{"automatable":true}`),
+					RawText:       "Triage: automatable",
+					CostUSD:       0.10,
+					TokensIn:      12000,
+					TokensOut:     1500,
+					CacheTokensIn: 4000,
+				},
+			}},
+			"plan": {{
+				result: &runner.RunResult{
+					Output:        json.RawMessage(`{"tasks":["task1","task2"]}`),
+					RawText:       "Plan: two tasks",
+					CostUSD:       0.20,
+					TokensIn:      25000,
+					TokensOut:     3000,
+					CacheTokensIn: 8000,
+				},
+			}},
+		},
+	}
+
+	var events []Event
+	engine, state := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.OnEvent = func(e Event) {
+			events = append(events, e)
+		}
+	})
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// Verify token counts are persisted in PhaseState.
+	triagePS := state.Meta().Phases["triage"]
+	if triagePS.TokensIn != 12000 {
+		t.Errorf("triage TokensIn = %d, want 12000", triagePS.TokensIn)
+	}
+	if triagePS.TokensOut != 1500 {
+		t.Errorf("triage TokensOut = %d, want 1500", triagePS.TokensOut)
+	}
+	if triagePS.CacheTokensIn != 4000 {
+		t.Errorf("triage CacheTokensIn = %d, want 4000", triagePS.CacheTokensIn)
+	}
+
+	planPS := state.Meta().Phases["plan"]
+	if planPS.TokensIn != 25000 {
+		t.Errorf("plan TokensIn = %d, want 25000", planPS.TokensIn)
+	}
+	if planPS.TokensOut != 3000 {
+		t.Errorf("plan TokensOut = %d, want 3000", planPS.TokensOut)
+	}
+	if planPS.CacheTokensIn != 8000 {
+		t.Errorf("plan CacheTokensIn = %d, want 8000", planPS.CacheTokensIn)
+	}
+
+	// Verify token counts appear in phase_completed events.
+	for _, ev := range events {
+		if ev.Kind != EventPhaseCompleted {
+			continue
+		}
+		switch ev.Phase {
+		case "triage":
+			if tokIn := toInt64(ev.Data["tokens_in"]); tokIn != 12000 {
+				t.Errorf("triage completed event tokens_in = %d, want 12000", tokIn)
+			}
+			if tokOut := toInt64(ev.Data["tokens_out"]); tokOut != 1500 {
+				t.Errorf("triage completed event tokens_out = %d, want 1500", tokOut)
+			}
+			if cacheTok := toInt64(ev.Data["cache_tokens_in"]); cacheTok != 4000 {
+				t.Errorf("triage completed event cache_tokens_in = %d, want 4000", cacheTok)
+			}
+		case "plan":
+			if tokIn := toInt64(ev.Data["tokens_in"]); tokIn != 25000 {
+				t.Errorf("plan completed event tokens_in = %d, want 25000", tokIn)
+			}
+		}
+	}
+}
+
+func TestEngine_TokenCountsOmittedWhenZero(t *testing.T) {
+	phases := []PhaseConfig{
+		{
+			Name:   "triage",
+			Prompt: "triage.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"triage": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"automatable":true}`),
+					RawText: "Triage: automatable",
+					CostUSD: 0.10,
+					// TokensIn, TokensOut, CacheTokensIn are all zero
+				},
+			}},
+		},
+	}
+
+	var events []Event
+	engine, _ := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.OnEvent = func(e Event) {
+			events = append(events, e)
+		}
+	})
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// When tokens are zero, the keys should be absent from the event data.
+	for _, ev := range events {
+		if ev.Kind != EventPhaseCompleted {
+			continue
+		}
+		if _, ok := ev.Data["tokens_in"]; ok {
+			t.Errorf("tokens_in should be omitted when zero, got %v", ev.Data["tokens_in"])
+		}
+		if _, ok := ev.Data["tokens_out"]; ok {
+			t.Errorf("tokens_out should be omitted when zero, got %v", ev.Data["tokens_out"])
+		}
+		if _, ok := ev.Data["cache_tokens_in"]; ok {
+			t.Errorf("cache_tokens_in should be omitted when zero, got %v", ev.Data["cache_tokens_in"])
+		}
+	}
+}
+
 func TestEngine_SkipsCompletedPhases(t *testing.T) {
 	phases := []PhaseConfig{
 		{

--- a/internal/pipeline/history.go
+++ b/internal/pipeline/history.go
@@ -12,15 +12,18 @@ import (
 
 // PhaseGeneration represents a single generation (attempt) of a phase.
 type PhaseGeneration struct {
-	Phase      string
-	Generation int
-	Status     PhaseStatus
-	Cost       float64
-	DurationMs int64
-	Error      string
-	Details    string          // one-line summary from result JSON
-	FullOutput json.RawMessage // full structured output JSON (populated by LoadFullOutputs)
-	Superseded bool            // true if a later generation exists
+	Phase         string
+	Generation    int
+	Status        PhaseStatus
+	Cost          float64
+	DurationMs    int64
+	TokensIn      int64
+	TokensOut     int64
+	CacheTokensIn int64
+	Error         string
+	Details       string          // one-line summary from result JSON
+	FullOutput    json.RawMessage // full structured output JSON (populated by LoadFullOutputs)
+	Superseded    bool            // true if a later generation exists
 }
 
 // History holds the reconstructed multi-generation history for a ticket.
@@ -80,6 +83,15 @@ func BuildHistory(events []Event, stateDir string) History {
 			}
 			if v, ok := ev.Data["duration_ms"]; ok {
 				h.Entries[idx].DurationMs = toInt64(v)
+			}
+			if v, ok := ev.Data["tokens_in"]; ok {
+				h.Entries[idx].TokensIn = toInt64(v)
+			}
+			if v, ok := ev.Data["tokens_out"]; ok {
+				h.Entries[idx].TokensOut = toInt64(v)
+			}
+			if v, ok := ev.Data["cache_tokens_in"]; ok {
+				h.Entries[idx].CacheTokensIn = toInt64(v)
 			}
 			// Load details from result JSON; fall back to event-embedded summary.
 			h.Entries[idx].Details = loadPhaseDetails(ev.Phase, h.Entries[idx].Generation, stateDir)

--- a/internal/pipeline/history_test.go
+++ b/internal/pipeline/history_test.go
@@ -429,6 +429,52 @@ func TestLoadFullOutputs(t *testing.T) {
 	})
 }
 
+func TestBuildHistory_TokenCounts(t *testing.T) {
+	events := []Event{
+		{Phase: "triage", Kind: EventPhaseStarted, Data: map[string]any{"generation": float64(1)}},
+		{Phase: "triage", Kind: EventPhaseCompleted, Data: map[string]any{
+			"cost":            0.12,
+			"duration_ms":     float64(8000),
+			"tokens_in":       float64(15000),
+			"tokens_out":      float64(2500),
+			"cache_tokens_in": float64(5000),
+		}},
+		{Phase: "plan", Kind: EventPhaseStarted, Data: map[string]any{"generation": float64(1)}},
+		{Phase: "plan", Kind: EventPhaseCompleted, Data: map[string]any{
+			"cost":        0.31,
+			"duration_ms": float64(15000),
+			// No token data — should default to zero.
+		}},
+	}
+
+	h := BuildHistory(events, "")
+	if len(h.Entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(h.Entries))
+	}
+
+	// Triage should have token counts.
+	if h.Entries[0].TokensIn != 15000 {
+		t.Errorf("triage TokensIn = %d, want 15000", h.Entries[0].TokensIn)
+	}
+	if h.Entries[0].TokensOut != 2500 {
+		t.Errorf("triage TokensOut = %d, want 2500", h.Entries[0].TokensOut)
+	}
+	if h.Entries[0].CacheTokensIn != 5000 {
+		t.Errorf("triage CacheTokensIn = %d, want 5000", h.Entries[0].CacheTokensIn)
+	}
+
+	// Plan should have zero token counts (no token data in event).
+	if h.Entries[1].TokensIn != 0 {
+		t.Errorf("plan TokensIn = %d, want 0", h.Entries[1].TokensIn)
+	}
+	if h.Entries[1].TokensOut != 0 {
+		t.Errorf("plan TokensOut = %d, want 0", h.Entries[1].TokensOut)
+	}
+	if h.Entries[1].CacheTokensIn != 0 {
+		t.Errorf("plan CacheTokensIn = %d, want 0", h.Entries[1].CacheTokensIn)
+	}
+}
+
 // Ensure Event timestamp parsing works with BuildHistory.
 func TestBuildHistory_PreservesTimestamps(t *testing.T) {
 	ts := time.Date(2026, 4, 11, 10, 0, 0, 0, time.UTC)

--- a/internal/pipeline/meta.go
+++ b/internal/pipeline/meta.go
@@ -27,6 +27,9 @@ type PhaseState struct {
 	Cost           float64     `json:"cost,omitempty"`
 	CumulativeCost float64     `json:"cumulative_cost,omitempty"`
 	DurationMs     int64       `json:"duration_ms,omitempty"`
+	TokensIn       int64       `json:"tokens_in,omitempty"`
+	TokensOut      int64       `json:"tokens_out,omitempty"`
+	CacheTokensIn  int64       `json:"cache_tokens_in,omitempty"`
 	Error          string      `json:"error,omitempty"`
 	Generation     int         `json:"generation,omitempty"`
 	PlanHash       string      `json:"plan_hash,omitempty"`

--- a/internal/pipeline/meta_test.go
+++ b/internal/pipeline/meta_test.go
@@ -324,6 +324,88 @@ func TestMetaBinaryVersionOmitEmpty(t *testing.T) {
 	}
 }
 
+func TestMetaTokenCountsRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "meta.json")
+
+	original := &PipelineMeta{
+		Ticket:    "PROJ-281",
+		StartedAt: time.Now().Truncate(time.Second),
+		Phases: map[string]*PhaseState{
+			"triage": {
+				Status:        PhaseCompleted,
+				Cost:          0.12,
+				DurationMs:    8000,
+				TokensIn:      15000,
+				TokensOut:     2500,
+				CacheTokensIn: 5000,
+				Generation:    1,
+			},
+		},
+	}
+
+	if err := writeMeta(path, original); err != nil {
+		t.Fatalf("writeMeta: %v", err)
+	}
+
+	loaded, err := ReadMeta(path)
+	if err != nil {
+		t.Fatalf("ReadMeta: %v", err)
+	}
+
+	ps := loaded.Phases["triage"]
+	if ps == nil {
+		t.Fatal("triage phase missing")
+	}
+	if ps.TokensIn != 15000 {
+		t.Errorf("TokensIn = %d, want 15000", ps.TokensIn)
+	}
+	if ps.TokensOut != 2500 {
+		t.Errorf("TokensOut = %d, want 2500", ps.TokensOut)
+	}
+	if ps.CacheTokensIn != 5000 {
+		t.Errorf("CacheTokensIn = %d, want 5000", ps.CacheTokensIn)
+	}
+}
+
+func TestMetaTokenCountsOmitEmpty(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "meta.json")
+
+	original := &PipelineMeta{
+		Ticket:    "PROJ-281",
+		StartedAt: time.Now().Truncate(time.Second),
+		Phases: map[string]*PhaseState{
+			"triage": {
+				Status:     PhaseCompleted,
+				Cost:       0.12,
+				DurationMs: 8000,
+				Generation: 1,
+			},
+		},
+	}
+
+	if err := writeMeta(path, original); err != nil {
+		t.Fatalf("writeMeta: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+
+	// When token counts are zero, they should be omitted from JSON.
+	if strings.Contains(string(data), "tokens_in") {
+		t.Errorf("meta.json should omit tokens_in when zero, got:\n%s", data)
+	}
+	if strings.Contains(string(data), "tokens_out") {
+		t.Errorf("meta.json should omit tokens_out when zero, got:\n%s", data)
+	}
+	if strings.Contains(string(data), "cache_tokens_in") {
+		t.Errorf("meta.json should omit cache_tokens_in when zero, got:\n%s", data)
+	}
+}
+
 func TestPhaseStatusConstants(t *testing.T) {
 	// Verify JSON serialization matches expected strings
 	tests := []struct {

--- a/internal/pipeline/monitor_poll.go
+++ b/internal/pipeline/monitor_poll.go
@@ -703,9 +703,12 @@ func (e *Engine) respondToComments(ctx context.Context, phase PhaseConfig, class
 		return nil, fmt.Errorf("engine: monitor response round %d: %w", monState.ResponseRounds, err)
 	}
 
-	// Record cost.
+	// Record cost and tokens.
 	if err := e.state.AccumulateCost(phase.Name, result.CostUSD); err != nil {
 		return nil, fmt.Errorf("engine: accumulate monitor response cost: %w", err)
+	}
+	if err := e.state.AccumulateTokens(phase.Name, result.TokensIn, result.TokensOut, result.CacheTokensIn); err != nil {
+		return nil, fmt.Errorf("engine: accumulate monitor response tokens: %w", err)
 	}
 
 	// Parse output.

--- a/internal/pipeline/review.go
+++ b/internal/pipeline/review.go
@@ -14,10 +14,13 @@ import (
 
 // reviewerResult holds the outcome of a single reviewer subagent.
 type reviewerResult struct {
-	Name     string
-	Findings []schemas.ReviewFinding
-	Cost     float64
-	Err      error
+	Name          string
+	Findings      []schemas.ReviewFinding
+	Cost          float64
+	TokensIn      int64
+	TokensOut     int64
+	CacheTokensIn int64
+	Err           error
 }
 
 // reviewerMsg is sent from reviewer goroutines to the parent via channel.
@@ -303,14 +306,21 @@ func (e *Engine) runParallelReview(ctx context.Context, phase PhaseConfig) error
 		return fmt.Errorf("engine: write artifact for %s: %w", phase.Name, err)
 	}
 
-	// Accumulate cost from ALL reviewers (including failed ones,
+	// Accumulate cost and tokens from ALL reviewers (including failed ones,
 	// since they may have incurred partial cost before failing).
 	totalCost := 0.0
+	var totalTokensIn, totalTokensOut, totalCacheTokensIn int64
 	for _, result := range results {
 		totalCost += result.Cost
+		totalTokensIn += result.TokensIn
+		totalTokensOut += result.TokensOut
+		totalCacheTokensIn += result.CacheTokensIn
 	}
 	if err := e.state.AccumulateCost(phase.Name, totalCost); err != nil {
 		return fmt.Errorf("engine: accumulate cost for %s: %w", phase.Name, err)
+	}
+	if err := e.state.AccumulateTokens(phase.Name, totalTokensIn, totalTokensOut, totalCacheTokensIn); err != nil {
+		return fmt.Errorf("engine: accumulate tokens for %s: %w", phase.Name, err)
 	}
 
 	// Per-phase cost enforcement.
@@ -324,9 +334,19 @@ func (e *Engine) runParallelReview(ctx context.Context, phase PhaseConfig) error
 	if err := e.state.MarkCompleted(phase.Name); err != nil {
 		return fmt.Errorf("engine: mark completed %s: %w", phase.Name, err)
 	}
+	ps := e.state.Meta().Phases[phase.Name]
 	reviewCompletedData := map[string]any{
-		"duration_ms": e.state.Meta().Phases[phase.Name].DurationMs,
-		"cost":        e.state.Meta().Phases[phase.Name].Cost,
+		"duration_ms": ps.DurationMs,
+		"cost":        ps.Cost,
+	}
+	if ps.TokensIn > 0 {
+		reviewCompletedData["tokens_in"] = ps.TokensIn
+	}
+	if ps.TokensOut > 0 {
+		reviewCompletedData["tokens_out"] = ps.TokensOut
+	}
+	if ps.CacheTokensIn > 0 {
+		reviewCompletedData["cache_tokens_in"] = ps.CacheTokensIn
 	}
 	if summary := progress.PhaseSummary(phase.Name, json.RawMessage(output)); summary != "" {
 		reviewCompletedData["summary"] = summary
@@ -457,9 +477,12 @@ func (e *Engine) runReviewer(ctx context.Context, phase PhaseConfig, reviewer Re
 	})
 
 	sendResult(reviewerResult{
-		Name:     reviewer.Name,
-		Findings: findings,
-		Cost:     result.CostUSD,
+		Name:          reviewer.Name,
+		Findings:      findings,
+		Cost:          result.CostUSD,
+		TokensIn:      result.TokensIn,
+		TokensOut:     result.TokensOut,
+		CacheTokensIn: result.CacheTokensIn,
 	})
 }
 

--- a/internal/pipeline/state.go
+++ b/internal/pipeline/state.go
@@ -128,6 +128,9 @@ func (s *State) MarkRunning(phase string) error {
 	ps.Status = PhaseRunning
 	ps.Cost = 0
 	ps.DurationMs = 0
+	ps.TokensIn = 0
+	ps.TokensOut = 0
+	ps.CacheTokensIn = 0
 	ps.Error = ""
 	ps.PlanHash = ""
 	ps.startedAt = time.Now()

--- a/internal/pipeline/state.go
+++ b/internal/pipeline/state.go
@@ -194,6 +194,19 @@ func (s *State) AccumulateCost(phase string, cost float64) error {
 	return s.flushMeta()
 }
 
+// AccumulateTokens adds token counts to the phase. Phase must exist (via MarkRunning).
+// Counts are per-generation and zeroed on re-run by MarkRunning.
+func (s *State) AccumulateTokens(phase string, tokensIn, tokensOut, cacheTokensIn int64) error {
+	ps := s.meta.Phases[phase]
+	if ps == nil {
+		return fmt.Errorf("pipeline: accumulate tokens: phase %q not started", phase)
+	}
+	ps.TokensIn += tokensIn
+	ps.TokensOut += tokensOut
+	ps.CacheTokensIn += cacheTokensIn
+	return s.flushMeta()
+}
+
 // WriteArtifact writes handoff content (<phase>.md) atomically.
 func (s *State) WriteArtifact(phase string, content []byte) error {
 	path := filepath.Join(s.dir, phase+".md")

--- a/internal/pipeline/state_test.go
+++ b/internal/pipeline/state_test.go
@@ -362,6 +362,89 @@ func TestAccumulateCost(t *testing.T) {
 	})
 }
 
+func TestAccumulateTokens(t *testing.T) {
+	t.Run("accumulates_token_counts", func(t *testing.T) {
+		dir := t.TempDir()
+		state, _ := LoadOrCreate(dir, "T-TOK-1")
+
+		state.MarkRunning("triage")
+		state.AccumulateTokens("triage", 10000, 2000, 3000)
+		state.AccumulateTokens("triage", 5000, 1000, 1500)
+
+		ps := state.meta.Phases["triage"]
+		if ps.TokensIn != 15000 {
+			t.Errorf("TokensIn = %d, want 15000", ps.TokensIn)
+		}
+		if ps.TokensOut != 3000 {
+			t.Errorf("TokensOut = %d, want 3000", ps.TokensOut)
+		}
+		if ps.CacheTokensIn != 4500 {
+			t.Errorf("CacheTokensIn = %d, want 4500", ps.CacheTokensIn)
+		}
+	})
+
+	t.Run("zeroed_on_rerun", func(t *testing.T) {
+		dir := t.TempDir()
+		state, _ := LoadOrCreate(dir, "T-TOK-2")
+
+		state.MarkRunning("plan")
+		state.AccumulateTokens("plan", 10000, 2000, 3000)
+		state.MarkCompleted("plan")
+
+		// Re-run should zero token counts.
+		state.MarkRunning("plan")
+
+		ps := state.meta.Phases["plan"]
+		if ps.TokensIn != 0 {
+			t.Errorf("TokensIn after rerun = %d, want 0", ps.TokensIn)
+		}
+		if ps.TokensOut != 0 {
+			t.Errorf("TokensOut after rerun = %d, want 0", ps.TokensOut)
+		}
+		if ps.CacheTokensIn != 0 {
+			t.Errorf("CacheTokensIn after rerun = %d, want 0", ps.CacheTokensIn)
+		}
+	})
+
+	t.Run("error_on_unstarted_phase", func(t *testing.T) {
+		dir := t.TempDir()
+		state, _ := LoadOrCreate(dir, "T-TOK-3")
+
+		err := state.AccumulateTokens("nonexistent", 100, 200, 300)
+		if err == nil {
+			t.Fatal("expected error for unstarted phase")
+		}
+	})
+
+	t.Run("persists_to_disk", func(t *testing.T) {
+		dir := t.TempDir()
+		state, _ := LoadOrCreate(dir, "T-TOK-4")
+
+		state.MarkRunning("verify")
+		state.AccumulateTokens("verify", 8000, 1500, 2000)
+		state.MarkCompleted("verify")
+
+		// Reload from disk and verify tokens were persisted.
+		state2, err := LoadOrCreate(dir, "T-TOK-4")
+		if err != nil {
+			t.Fatalf("reload: %v", err)
+		}
+		ps := state2.Meta().Phases["verify"]
+		if ps == nil {
+			t.Fatal("verify phase not found after reload")
+		}
+		if ps.TokensIn != 8000 {
+			t.Errorf("TokensIn after reload = %d, want 8000", ps.TokensIn)
+		}
+		if ps.TokensOut != 1500 {
+			t.Errorf("TokensOut after reload = %d, want 1500", ps.TokensOut)
+		}
+		if ps.CacheTokensIn != 2000 {
+			t.Errorf("CacheTokensIn after reload = %d, want 2000", ps.CacheTokensIn)
+		}
+	})
+}
+
 func TestWriteReadArtifact(t *testing.T) {
 	dir := t.TempDir()
 	state, _ := LoadOrCreate(dir, "T-1")


### PR DESCRIPTION
## Summary

- Add `TokensIn`, `TokensOut`, and `CacheTokensIn` fields to `PhaseState` in `meta.go`, persisted to `meta.json` with `omitempty` for backward compatibility
- Add `AccumulateTokens` method to `State` mirroring `AccumulateCost`; token counts are zeroed on re-run via `MarkRunning`
- Wire `AccumulateTokens` calls in `engine.go` (`runPhase`), `review.go` (`runParallelReview`), and `monitor_poll.go` (`respondToComments`)
- Emit token counts in `phase_completed` events (omitted when zero)
- Propagate token data into `PhaseGeneration` in `history.go` for `soda history` and raki's `token_efficiency` metric
- Update `AGENTS.md` gotcha #19 and raki metric table to reflect token persistence

## Test plan

- [x] `TestAccumulateTokens` — accumulation, zeroing on re-run, error on unstarted phase, disk persistence
- [x] `TestMetaTokenCountsRoundTrip` — write/read cycle preserves token fields
- [x] `TestMetaTokenCountsOmitEmpty` — zero values omitted from JSON
- [x] `TestEngine_TokenCountsPersistedToMeta` — end-to-end engine run persists tokens to PhaseState and events
- [x] `TestEngine_TokenCountsOmittedWhenZero` — zero tokens not emitted in events
- [x] `TestBuildHistory_TokenCounts` — history reconstruction picks up token data from events

## Acceptance criteria

- [x] `PhaseState` in `meta.json` stores `tokens_in`, `tokens_out`, `cache_tokens_in`
- [x] Token counts accumulate per-generation and reset on re-run
- [x] `phase_completed` events include token counts when non-zero
- [x] `PhaseGeneration` in history exposes token data
- [x] Legacy sessions without token data show zero values (omitempty)
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)