### PR TITLE
feat(pipeline): inject implement diff into rework feedback [#282]

### DIFF
--- a/cmd/soda/embeds/prompts/implement.md
+++ b/cmd/soda/embeds/prompts/implement.md
@@ -21,6 +21,17 @@ Summary: {{.Ticket.Summary}}
 {{- end}}
 
 {{- if .ReworkFeedback}}
+{{- if .ReworkFeedback.ImplementDiff}}
+
+## Current Implementation Diff
+
+The following diff shows what was implemented so far (base...HEAD).
+Use this to understand what changes already exist before applying fixes.
+
+```diff
+{{.ReworkFeedback.ImplementDiff}}
+```
+{{- end}}
 {{- if .ReworkFeedback.PriorCycles}}
 
 ## Context: Prior Review Cycles

--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -279,6 +279,7 @@ func runPipeline(cmd *cobra.Command, cfg *config.Config, ticketKey string) error
 		MaxCostPerPhase:      cfg.Limits.MaxCostPerPhase,
 		MaxCostPerGeneration: cfg.Limits.MaxCostPerGeneration,
 		MaxPipelineDuration:  maxPipelineDuration,
+		MaxDiffBytes:         cfg.Limits.MaxDiffBytes,
 		Mode:                 mode,
 		PRPoller:             prPoller,
 		SelfUser:             selfUser,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -92,6 +92,7 @@ type LimitsConfig struct {
 	MaxCostPerPhase      float64 `yaml:"max_cost_per_phase"`
 	MaxCostPerGeneration float64 `yaml:"max_cost_per_generation,omitempty"` // per-attempt cost cap; 0 means disabled
 	MaxPipelineDuration  string  `yaml:"max_pipeline_duration,omitempty"`   // Go duration string (e.g., "2h", "90m"); 0 or empty means no limit
+	MaxDiffBytes         int     `yaml:"max_diff_bytes,omitempty"`          // max bytes of git diff injected into rework prompts; 0 means use default (50000)
 }
 
 // RepoConfig holds per-repo configuration.

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -558,6 +558,12 @@ func (e *Engine) runPhase(ctx context.Context, phase PhaseConfig) error {
 		promptData.DiffContext = e.computeDiffContext(ctx)
 	}
 
+	// Inject implement diff into rework feedback so the LLM can see
+	// what was previously implemented when addressing rework findings.
+	if promptData.ReworkFeedback != nil {
+		promptData.ReworkFeedback.ImplementDiff = e.computeDiffContext(ctx)
+	}
+
 	// Store plan hash for staleness guard on phases that depend on plan.
 	for _, dep := range phase.DependsOn {
 		if dep == "plan" {

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -46,6 +46,7 @@ type EngineConfig struct {
 	MaxCostPerGeneration float64       // per-generation cost cap (ps.Cost); 0 means no per-generation limit
 	MaxPipelineDuration  time.Duration // max wall-clock time for the entire pipeline; 0 means no limit
 	MaxReworkCycles      int           // max review→implement rework loops; 0 means use default (2)
+	MaxDiffBytes         int           // max bytes of git diff injected into rework prompts; 0 means use default (50000)
 	Mode                 Mode
 	OnEvent              func(Event)
 	PauseSignal          <-chan bool // receives true=pause, false=resume from TUI; nil disables
@@ -890,6 +891,10 @@ func (e *Engine) buildPromptData(phase PhaseConfig) (PromptData, error) {
 	return data, nil
 }
 
+// defaultMaxDiffBytes is the default byte limit for git diffs injected into
+// rework prompts when MaxDiffBytes is not set in EngineConfig.
+const defaultMaxDiffBytes = 50000
+
 // computeDiffContext returns the git diff of the current branch against the
 // base branch. Used by corrective phases to see what was implemented.
 // Returns an empty string on error (non-fatal).
@@ -900,7 +905,12 @@ func (e *Engine) computeDiffContext(ctx context.Context) string {
 		baseBranch = "main"
 	}
 
-	diffCtx, err := git.Diff(ctx, workDir, e.remoteName()+"/"+baseBranch, 50000)
+	maxBytes := e.config.MaxDiffBytes
+	if maxBytes == 0 {
+		maxBytes = defaultMaxDiffBytes
+	}
+
+	diffCtx, err := git.Diff(ctx, workDir, e.remoteName()+"/"+baseBranch, maxBytes)
 	if err != nil {
 		return ""
 	}

--- a/internal/pipeline/prompt.go
+++ b/internal/pipeline/prompt.go
@@ -63,6 +63,7 @@ type ReworkFeedback struct {
 	FailedCommands []FailedCommand
 	ReviewFindings []EnrichedFinding
 	PriorCycles    []PriorCycle
+	ImplementDiff  string // git diff of current branch vs base; shows what was implemented before rework
 }
 
 // EnrichedFinding wraps a ReviewFinding with code context for rework prompts.

--- a/internal/pipeline/prompt_test.go
+++ b/internal/pipeline/prompt_test.go
@@ -366,6 +366,13 @@ func TestValidateTemplate(t *testing.T) {
 		}
 	})
 
+	t.Run("valid_template_with_implement_diff", func(t *testing.T) {
+		tmpl := `{{- if .ReworkFeedback}}{{- if .ReworkFeedback.ImplementDiff}}Diff: {{.ReworkFeedback.ImplementDiff}}{{- end}}{{- end}}`
+		if err := ValidateTemplate(tmpl); err != nil {
+			t.Fatalf("ValidateTemplate should accept ImplementDiff: %v", err)
+		}
+	})
+
 	t.Run("valid_template_with_add_funcmap", func(t *testing.T) {
 		tmpl := `{{- if .ReworkFeedback}}{{range $idx, $fix := .ReworkFeedback.FixesRequired}}Finding {{add $idx 1}} of {{len $.ReworkFeedback.FixesRequired}}{{end}}{{- end}}`
 		if err := ValidateTemplate(tmpl); err != nil {
@@ -1043,6 +1050,166 @@ Context: {{.}}
 		// Should also contain current fix.
 		if !strings.Contains(result, "fix the remaining test") {
 			t.Errorf("patch prompt should contain current fix;\ngot: %s", result)
+		}
+	})
+
+	t.Run("renders_implement_prompt_with_implement_diff", func(t *testing.T) {
+		tmplBytes, err := os.ReadFile(filepath.Join("..", "..", "cmd", "soda", "embeds", "prompts", "implement.md"))
+		if err != nil {
+			t.Skipf("skipping: cannot read embedded implement.md: %v", err)
+		}
+		tmpl := string(tmplBytes)
+
+		data := PromptData{
+			Ticket:       TicketData{Key: "TEST-282", Summary: "implement diff test"},
+			WorktreePath: "/tmp/wt",
+			Branch:       "soda/TEST-282",
+			BaseBranch:   "main",
+			Config:       PromptConfigData{Formatter: "gofmt -w .", TestCommand: "go test ./..."},
+			ReworkFeedback: &ReworkFeedback{
+				Source:  "review",
+				Verdict: "rework",
+				ReviewFindings: []EnrichedFinding{
+					{ReviewFinding: schemas.ReviewFinding{Severity: "critical", File: "handler.go", Line: 42, Issue: "nil deref", Suggestion: "check nil", Source: "go-specialist"}},
+				},
+				ImplementDiff: "--- a/handler.go\n+++ b/handler.go\n@@ -40,3 +40,5 @@\n func handle() {\n+\treturn obj.Value\n }",
+			},
+		}
+
+		result, err := RenderPrompt(tmpl, data)
+		if err != nil {
+			t.Fatalf("RenderPrompt: %v", err)
+		}
+
+		// Should contain the diff section.
+		if !strings.Contains(result, "Current Implementation Diff") {
+			t.Errorf("implement prompt should contain 'Current Implementation Diff' header;\ngot: %s", result)
+		}
+		if !strings.Contains(result, "--- a/handler.go") {
+			t.Errorf("implement prompt should contain the diff content;\ngot: %s", result)
+		}
+		if !strings.Contains(result, "base...HEAD") {
+			t.Errorf("implement prompt should describe the diff as base...HEAD;\ngot: %s", result)
+		}
+		// Should also contain the review findings.
+		if !strings.Contains(result, "nil deref") {
+			t.Errorf("implement prompt should still contain review finding;\ngot: %s", result)
+		}
+	})
+
+	t.Run("omits_implement_diff_when_empty", func(t *testing.T) {
+		tmplBytes, err := os.ReadFile(filepath.Join("..", "..", "cmd", "soda", "embeds", "prompts", "implement.md"))
+		if err != nil {
+			t.Skipf("skipping: cannot read embedded implement.md: %v", err)
+		}
+		tmpl := string(tmplBytes)
+
+		data := PromptData{
+			Ticket:       TicketData{Key: "TEST-282", Summary: "no diff test"},
+			WorktreePath: "/tmp/wt",
+			Branch:       "soda/TEST-282",
+			BaseBranch:   "main",
+			Config:       PromptConfigData{Formatter: "gofmt -w .", TestCommand: "go test ./..."},
+			ReworkFeedback: &ReworkFeedback{
+				Source:  "review",
+				Verdict: "rework",
+				ReviewFindings: []EnrichedFinding{
+					{ReviewFinding: schemas.ReviewFinding{Severity: "critical", File: "x.go", Line: 1, Issue: "bad", Suggestion: "fix", Source: "go-specialist"}},
+				},
+				// ImplementDiff is empty — should be omitted from output.
+			},
+		}
+
+		result, err := RenderPrompt(tmpl, data)
+		if err != nil {
+			t.Fatalf("RenderPrompt: %v", err)
+		}
+
+		if strings.Contains(result, "Current Implementation Diff") {
+			t.Errorf("implement prompt should NOT contain diff section when ImplementDiff is empty;\ngot: %s", result)
+		}
+		// Findings should still render.
+		if !strings.Contains(result, "bad") {
+			t.Errorf("implement prompt should contain current finding;\ngot: %s", result)
+		}
+	})
+
+	t.Run("omits_implement_diff_without_rework_feedback", func(t *testing.T) {
+		tmplBytes, err := os.ReadFile(filepath.Join("..", "..", "cmd", "soda", "embeds", "prompts", "implement.md"))
+		if err != nil {
+			t.Skipf("skipping: cannot read embedded implement.md: %v", err)
+		}
+		tmpl := string(tmplBytes)
+
+		data := PromptData{
+			Ticket:       TicketData{Key: "TEST-282", Summary: "no feedback test"},
+			WorktreePath: "/tmp/wt",
+			Branch:       "soda/TEST-282",
+			BaseBranch:   "main",
+			Config:       PromptConfigData{Formatter: "gofmt -w .", TestCommand: "go test ./..."},
+			// No ReworkFeedback at all.
+		}
+
+		result, err := RenderPrompt(tmpl, data)
+		if err != nil {
+			t.Fatalf("RenderPrompt: %v", err)
+		}
+
+		if strings.Contains(result, "Current Implementation Diff") {
+			t.Errorf("implement prompt should NOT contain diff section without rework feedback;\ngot: %s", result)
+		}
+	})
+
+	t.Run("renders_implement_prompt_with_diff_and_prior_cycles", func(t *testing.T) {
+		tmplBytes, err := os.ReadFile(filepath.Join("..", "..", "cmd", "soda", "embeds", "prompts", "implement.md"))
+		if err != nil {
+			t.Skipf("skipping: cannot read embedded implement.md: %v", err)
+		}
+		tmpl := string(tmplBytes)
+
+		data := PromptData{
+			Ticket:       TicketData{Key: "TEST-282", Summary: "diff with prior cycles"},
+			WorktreePath: "/tmp/wt",
+			Branch:       "soda/TEST-282",
+			BaseBranch:   "main",
+			Config:       PromptConfigData{Formatter: "gofmt -w .", TestCommand: "go test ./..."},
+			ReworkFeedback: &ReworkFeedback{
+				Source:  "review",
+				Verdict: "rework",
+				ReviewFindings: []EnrichedFinding{
+					{ReviewFinding: schemas.ReviewFinding{Severity: "major", File: "util.go", Line: 5, Issue: "unchecked error", Suggestion: "handle err", Source: "go-specialist"}},
+				},
+				ImplementDiff: "--- a/util.go\n+++ b/util.go\n@@ -1 +1 @@\n-old\n+new",
+				PriorCycles: []PriorCycle{
+					{Cycle: 1, Source: "review", Verdict: "rework", Summary: "[critical] handler.go:42 — nil deref"},
+				},
+			},
+		}
+
+		result, err := RenderPrompt(tmpl, data)
+		if err != nil {
+			t.Fatalf("RenderPrompt: %v", err)
+		}
+
+		// Diff should appear before prior cycles.
+		diffIdx := strings.Index(result, "Current Implementation Diff")
+		priorIdx := strings.Index(result, "Prior Review Cycles")
+		findingIdx := strings.Index(result, "Specialist Review Findings")
+
+		if diffIdx < 0 {
+			t.Fatal("implement prompt should contain 'Current Implementation Diff'")
+		}
+		if priorIdx < 0 {
+			t.Fatal("implement prompt should contain 'Prior Review Cycles'")
+		}
+		if findingIdx < 0 {
+			t.Fatal("implement prompt should contain 'Specialist Review Findings'")
+		}
+		if diffIdx > priorIdx {
+			t.Error("diff section should appear before prior cycles section")
+		}
+		if priorIdx > findingIdx {
+			t.Error("prior cycles section should appear before findings section")
 		}
 	})
 


### PR DESCRIPTION
## Summary
- Add `ImplementDiff` field to `ReworkFeedback` and inject the git diff from `computeDiffContext()` when rework feedback is present, giving the LLM visibility into the current implementation before addressing review/verify findings
- Render a "Current Implementation Diff" section in the implement prompt template, guarded so it only appears during rework (not on first implement)
- Make the diff byte limit configurable via `limits.max_diff_bytes` (default 50,000 bytes), wired through `LimitsConfig` → `EngineConfig` → `computeDiffContext()`

## Acceptance Criteria
- [x] Rework prompt includes git diff of current implementation
- [x] Diff is truncated at a configurable byte limit (default 50KB)
- [x] No diff is injected on first implement (only on rework)
- [x] Tests cover diff content rendering, empty-diff omission, no-rework omission, ordering, and template validation

## Changed Files
- `internal/pipeline/prompt.go` — add `ImplementDiff` field to `ReworkFeedback`
- `internal/pipeline/engine.go` — inject diff via `computeDiffContext()` when rework feedback is present
- `cmd/soda/embeds/prompts/implement.md` — render diff section in template
- `internal/config/config.go` — add `MaxDiffBytes` to `LimitsConfig`
- `cmd/soda/run.go` — wire `MaxDiffBytes` into `EngineConfig`
- `internal/pipeline/prompt_test.go` — 5 new test cases

## Test Plan
- [x] All existing tests pass (`go test ./...`)
- [x] New tests verify diff rendering in rework prompt
- [x] New tests verify diff omission when empty or on first implement
- [x] New tests verify correct ordering (diff before prior cycles/findings)
- [x] Template validation test confirms `ImplementDiff` field is accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)