### PR TITLE
feat(pipeline): named pipelines with --pipeline flag and discovery [#300]

### DIFF
--- a/cmd/soda/history.go
+++ b/cmd/soda/history.go
@@ -184,7 +184,7 @@ func prettyJSON(data json.RawMessage) string {
 // renderMetaHistory renders a simple history table from meta.json only.
 // Used as a fallback when events.jsonl does not exist.
 func renderMetaHistory(meta *pipeline.PipelineMeta) error {
-	phasesPath, cleanup, err := resolvePhasesPath()
+	phasesPath, cleanup, err := resolvePhasesPath("")
 	if err != nil {
 		return fmt.Errorf("history: %w", err)
 	}

--- a/cmd/soda/history.go
+++ b/cmd/soda/history.go
@@ -184,7 +184,7 @@ func prettyJSON(data json.RawMessage) string {
 // renderMetaHistory renders a simple history table from meta.json only.
 // Used as a fallback when events.jsonl does not exist.
 func renderMetaHistory(meta *pipeline.PipelineMeta) error {
-	phasesPath, cleanup, err := resolvePhasesPath("")
+	phasesPath, cleanup, err := resolvePhasesPath(meta.Pipeline)
 	if err != nil {
 		return fmt.Errorf("history: %w", err)
 	}

--- a/cmd/soda/main.go
+++ b/cmd/soda/main.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/decko/soda/internal/config"
+	"github.com/decko/soda/internal/pipeline"
 	"github.com/spf13/cobra"
 )
 
@@ -109,15 +110,39 @@ func extractEmbeddedPrompts() (string, error) {
 	return tmpDir, nil
 }
 
-// resolvePhasesPath returns a path to phases.yaml.
-// Prefers a local file in the working directory; falls back to extracting
-// the embedded copy to a temp file. Caller must remove the temp file
-// if cleanup is non-nil.
-func resolvePhasesPath() (path string, cleanup func(), err error) {
-	if _, statErr := os.Stat("phases.yaml"); statErr == nil {
-		return "phases.yaml", nil, nil
+// resolvePhasesPath returns a path to a pipeline configuration file.
+// When pipelineName is empty or "default", it resolves to phases.yaml;
+// otherwise it resolves to phases-<name>.yaml. The search order is:
+//
+//  1. Working directory
+//  2. User config directory (~/.config/soda/)
+//  3. Embedded default (only for the "default" pipeline)
+//
+// Caller must remove the temp file if cleanup is non-nil.
+func resolvePhasesPath(pipelineName string) (path string, cleanup func(), err error) {
+	filename := pipeline.PipelineFilename(pipelineName)
+
+	// Check working directory.
+	if _, statErr := os.Stat(filename); statErr == nil {
+		return filename, nil, nil
 	}
 
+	// Check user config directory.
+	configDir, _ := os.UserConfigDir()
+	if configDir != "" {
+		userPath := filepath.Join(configDir, "soda", filename)
+		if _, statErr := os.Stat(userPath); statErr == nil {
+			return userPath, nil, nil
+		}
+	}
+
+	// Named pipelines have no embedded fallback.
+	if pipelineName != "" && pipelineName != "default" {
+		return "", nil, fmt.Errorf("pipeline %q not found (looked for %s in . and %s)",
+			pipelineName, filename, filepath.Join(configDir, "soda"))
+	}
+
+	// Fall back to embedded default.
 	tmpFile, tmpErr := os.CreateTemp("", "soda-phases-*.yaml")
 	if tmpErr != nil {
 		return "", nil, fmt.Errorf("create temp phases file: %w", tmpErr)

--- a/cmd/soda/main.go
+++ b/cmd/soda/main.go
@@ -51,6 +51,7 @@ func newRootCmd() *cobra.Command {
 		newCostCmd(),
 		newRenderCmd(),
 		newValidateCmd(),
+		newPipelinesCmd(),
 		newPluginCmd(),
 		newVersionCmd(),
 	)

--- a/cmd/soda/main.go
+++ b/cmd/soda/main.go
@@ -121,6 +121,9 @@ func extractEmbeddedPrompts() (string, error) {
 //
 // Caller must remove the temp file if cleanup is non-nil.
 func resolvePhasesPath(pipelineName string) (path string, cleanup func(), err error) {
+	if err := pipeline.ValidatePipelineName(pipelineName); err != nil {
+		return "", nil, err
+	}
 	filename := pipeline.PipelineFilename(pipelineName)
 
 	// Check working directory.

--- a/cmd/soda/pipelines.go
+++ b/cmd/soda/pipelines.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"text/tabwriter"
+
+	"github.com/decko/soda/internal/pipeline"
+	"github.com/spf13/cobra"
+)
+
+func newPipelinesCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "pipelines",
+		Short: "List available pipeline configurations",
+		Long: `Discover and list pipeline configuration files (phases.yaml and
+phases-<name>.yaml) from the working directory, user config directory,
+and embedded defaults.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runPipelines(cmd)
+		},
+	}
+}
+
+func runPipelines(cmd *cobra.Command) error {
+	dirs, sources := discoverDirs()
+
+	pipelines := pipeline.DiscoverPipelines(dirs, sources)
+
+	// Always include the embedded default if not already found.
+	hasDefault := false
+	for _, p := range pipelines {
+		if p.Name == "default" {
+			hasDefault = true
+			break
+		}
+	}
+	if !hasDefault {
+		pipelines = append([]pipeline.PipelineInfo{{
+			Name:   "default",
+			Path:   "(embedded)",
+			Source: "embedded",
+		}}, pipelines...)
+	}
+
+	if len(pipelines) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "No pipeline configurations found.")
+		return nil
+	}
+
+	tw := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
+	fmt.Fprintln(tw, "NAME\tSOURCE\tPATH")
+	for _, p := range pipelines {
+		fmt.Fprintf(tw, "%s\t%s\t%s\n", p.Name, p.Source, p.Path)
+	}
+	return tw.Flush()
+}
+
+// discoverDirs returns the directories and source labels to scan for
+// pipeline configuration files. The order matches the resolution
+// priority: working directory first, then user config directory.
+func discoverDirs() (dirs []string, sources []string) {
+	// Working directory.
+	cwd, err := os.Getwd()
+	if err == nil {
+		dirs = append(dirs, cwd)
+		sources = append(sources, "local")
+	}
+
+	// User config directory.
+	configDir, err := os.UserConfigDir()
+	if err == nil {
+		sodaDir := filepath.Join(configDir, "soda")
+		dirs = append(dirs, sodaDir)
+		sources = append(sources, "user")
+	}
+
+	return dirs, sources
+}

--- a/cmd/soda/pipelines_test.go
+++ b/cmd/soda/pipelines_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDiscoverDirs(t *testing.T) {
+	dirs, sources := discoverDirs()
+
+	// Should have at least the working directory.
+	if len(dirs) == 0 {
+		t.Fatal("expected at least one directory")
+	}
+	if len(dirs) != len(sources) {
+		t.Fatalf("dirs (%d) and sources (%d) length mismatch", len(dirs), len(sources))
+	}
+	if sources[0] != "local" {
+		t.Errorf("first source = %q, want %q", sources[0], "local")
+	}
+}
+
+func TestRunPipelines_EmbeddedDefault(t *testing.T) {
+	// Run from a temp dir with no pipeline files — should show embedded default.
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpDir := t.TempDir()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(origDir)
+
+	cmd := newPipelinesCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("pipelines command failed: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "default") {
+		t.Error("expected 'default' pipeline in output")
+	}
+	if !strings.Contains(output, "embedded") {
+		t.Error("expected 'embedded' source in output")
+	}
+}
+
+func TestRunPipelines_LocalPipelines(t *testing.T) {
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpDir := t.TempDir()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(origDir)
+
+	// Create local pipeline files.
+	phases := "phases:\n  - name: triage\n    prompt: prompts/triage.md\n    timeout: 1m\n"
+	if err := os.WriteFile(filepath.Join(tmpDir, "phases.yaml"), []byte(phases), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "phases-fast.yaml"), []byte(phases), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newPipelinesCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("pipelines command failed: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "default") {
+		t.Error("expected 'default' pipeline in output")
+	}
+	if !strings.Contains(output, "fast") {
+		t.Error("expected 'fast' pipeline in output")
+	}
+	if !strings.Contains(output, "local") {
+		t.Error("expected 'local' source in output")
+	}
+}
+
+func TestRunPipelines_TableHeader(t *testing.T) {
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpDir := t.TempDir()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(origDir)
+
+	cmd := newPipelinesCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("pipelines command failed: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "NAME") {
+		t.Error("expected NAME header column")
+	}
+	if !strings.Contains(output, "SOURCE") {
+		t.Error("expected SOURCE header column")
+	}
+	if !strings.Contains(output, "PATH") {
+		t.Error("expected PATH header column")
+	}
+}

--- a/cmd/soda/render.go
+++ b/cmd/soda/render.go
@@ -30,6 +30,7 @@ func newRenderCmd() *cobra.Command {
 
 	cmd.Flags().String("phase", "", "phase to render (required)")
 	cmd.Flags().String("ticket", "", "ticket key (required)")
+	cmd.Flags().String("pipeline", "", "pipeline name (default: phases.yaml)")
 	cmd.MarkFlagRequired("phase")
 	cmd.MarkFlagRequired("ticket")
 
@@ -40,7 +41,8 @@ func runRender(cmd *cobra.Command, cfg *config.Config, phaseName, ticketKey stri
 	ctx := cmd.Context()
 
 	// Load pipeline config
-	phasesPath, cleanup, err := resolvePhasesPath()
+	pipelineName, _ := cmd.Flags().GetString("pipeline")
+	phasesPath, cleanup, err := resolvePhasesPath(pipelineName)
 	if err != nil {
 		return fmt.Errorf("render: %w", err)
 	}

--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -162,6 +162,31 @@ func runPipeline(cmd *cobra.Command, cfg *config.Config, ticketKey string) error
 		return fmt.Errorf("run: %w", err)
 	}
 
+	// When resuming, check if the stored pipeline differs from the current flag.
+	fromPhaseFlag, _ := cmd.Flags().GetString("from")
+	if fromPhaseFlag != "" {
+		storedPipeline := state.Meta().Pipeline
+		if !cmd.Flags().Changed("pipeline") && storedPipeline != "" && storedPipeline != pipelineName {
+			// Auto-adopt the stored pipeline name so the resume uses the correct config.
+			fmt.Fprintf(os.Stderr, "Warning: original run used pipeline %q; adopting for resume\n", storedPipeline)
+			pipelineName = storedPipeline
+			newPhasesPath, newCleanup, reloadErr := resolvePhasesPath(pipelineName)
+			if reloadErr != nil {
+				return fmt.Errorf("run: %w", reloadErr)
+			}
+			if newCleanup != nil {
+				defer newCleanup()
+			}
+			pl, err = pipeline.LoadPipeline(newPhasesPath)
+			if err != nil {
+				return fmt.Errorf("run: %w", err)
+			}
+			pl.Name = pipelineName
+		} else if cmd.Flags().Changed("pipeline") && storedPipeline != pipelineName {
+			fmt.Fprintf(os.Stderr, "Warning: original run used pipeline %q, but resuming with %q\n", storedPipeline, pipelineName)
+		}
+	}
+
 	// Resolve mode
 	mode := pipeline.Autonomous
 	modeStr := cfg.Mode

--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -45,6 +45,7 @@ func newRunCmd() *cobra.Command {
 
 	cmd.Flags().String("mode", "", "execution mode: checkpoint or autonomous")
 	cmd.Flags().String("from", "", "resume from phase (or 'last')")
+	cmd.Flags().String("pipeline", "", "pipeline name (default: phases.yaml)")
 	cmd.Flags().Bool("dry-run", false, "render prompts without executing")
 	cmd.Flags().Bool("mock", false, "use mock runner for testing")
 	cmd.Flags().Bool("tui", false, "use interactive TUI display")
@@ -84,7 +85,8 @@ func runPipeline(cmd *cobra.Command, cfg *config.Config, ticketKey string) error
 	}
 
 	// Load pipeline config
-	phasesPath, phasesCleanup, err := resolvePhasesPath()
+	pipelineName, _ := cmd.Flags().GetString("pipeline")
+	phasesPath, phasesCleanup, err := resolvePhasesPath(pipelineName)
 	if err != nil {
 		return fmt.Errorf("run: %w", err)
 	}

--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -97,6 +97,9 @@ func runPipeline(cmd *cobra.Command, cfg *config.Config, ticketKey string) error
 	if err != nil {
 		return fmt.Errorf("run: %w", err)
 	}
+	if pipelineName != "" {
+		pl.Name = pipelineName
+	}
 
 	// Set up prompt loader
 	promptDir, err := extractEmbeddedPrompts()
@@ -273,6 +276,7 @@ func runPipeline(cmd *cobra.Command, cfg *config.Config, ticketKey string) error
 		PromptContext:        promptContext,
 		DetectedStack:        detectedStack,
 		Model:                cfg.Model,
+		PipelineName:         pipelineName,
 		BinaryVersion:        binaryVersionID(),
 		WorkDir:              workDir,
 		WorktreeBase:         filepath.Join(workDir, cfg.WorktreeDir),

--- a/cmd/soda/status.go
+++ b/cmd/soda/status.go
@@ -61,7 +61,7 @@ func runStatus(stateDir string) error {
 	}
 
 	// Load pipeline config for deterministic phase ordering.
-	phasesPath, cleanup, phasesErr := resolvePhasesPath()
+	phasesPath, cleanup, phasesErr := resolvePhasesPath("")
 	if phasesErr != nil {
 		return fmt.Errorf("status: %w", phasesErr)
 	}

--- a/cmd/soda/status.go
+++ b/cmd/soda/status.go
@@ -60,17 +60,36 @@ func runStatus(stateDir string) error {
 		return fmt.Errorf("status: read state dir: %w", err)
 	}
 
-	// Load pipeline config for deterministic phase ordering.
-	phasesPath, cleanup, phasesErr := resolvePhasesPath("")
-	if phasesErr != nil {
-		return fmt.Errorf("status: %w", phasesErr)
+	// Cache loaded pipeline configs by name to avoid redundant I/O.
+	type pipelineCache struct {
+		pl      *pipeline.PhasePipeline
+		cleanup func()
 	}
-	if cleanup != nil {
-		defer cleanup()
-	}
-	pl, phasesErr := pipeline.LoadPipeline(phasesPath)
-	if phasesErr != nil {
-		return fmt.Errorf("status: %w", phasesErr)
+	plCache := map[string]*pipelineCache{}
+	defer func() {
+		for _, c := range plCache {
+			if c.cleanup != nil {
+				c.cleanup()
+			}
+		}
+	}()
+	loadPipelineFor := func(name string) (*pipeline.PhasePipeline, error) {
+		if cached, ok := plCache[name]; ok {
+			return cached.pl, nil
+		}
+		phasesPath, cleanup, err := resolvePhasesPath(name)
+		if err != nil {
+			return nil, err
+		}
+		pl, err := pipeline.LoadPipeline(phasesPath)
+		if err != nil {
+			if cleanup != nil {
+				cleanup()
+			}
+			return nil, err
+		}
+		plCache[name] = &pipelineCache{pl: pl, cleanup: cleanup}
+		return pl, nil
 	}
 
 	// Read the cost ledger once and compute per-ticket cost trends.
@@ -91,6 +110,13 @@ func runStatus(stateDir string) error {
 
 		meta, metaErr := pipeline.ReadMeta(metaPath)
 		if metaErr != nil {
+			continue
+		}
+
+		// Use the pipeline name stored in meta to load the correct phase config.
+		pl, plErr := loadPipelineFor(meta.Pipeline)
+		if plErr != nil {
+			fmt.Fprintf(os.Stderr, "warning: could not load pipeline %q for %s: %v\n", meta.Pipeline, meta.Ticket, plErr)
 			continue
 		}
 

--- a/cmd/soda/validate.go
+++ b/cmd/soda/validate.go
@@ -14,7 +14,7 @@ import (
 )
 
 func newValidateCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "validate",
 		Short: "Check config and phases without running",
 		Long: `Validate configuration, phases, prompts, schemas, and context files
@@ -26,9 +26,14 @@ without executing the pipeline. Exits 0 if everything is valid
 			if err != nil {
 				return err
 			}
-			return runValidate(cmd.OutOrStdout(), cmd.ErrOrStderr(), cfg)
+			pipelineName, _ := cmd.Flags().GetString("pipeline")
+			return runValidate(cmd.OutOrStdout(), cmd.ErrOrStderr(), cfg, pipelineName)
 		},
 	}
+
+	cmd.Flags().String("pipeline", "", "pipeline name (default: phases.yaml)")
+
+	return cmd
 }
 
 // validationResult accumulates errors and warnings across validation stages.
@@ -51,14 +56,14 @@ func (v *validationResult) hasErrors() bool {
 
 // runValidate runs all validation stages in order and prints results.
 // Returns nil on success (exit 0), non-nil error on validation failure (exit 1).
-func runValidate(w io.Writer, errW io.Writer, cfg *config.Config) error {
+func runValidate(w io.Writer, errW io.Writer, cfg *config.Config, pipelineName string) error {
 	result := &validationResult{}
 
 	// Stage 1: Config is already loaded (loadConfig succeeded).
 	fmt.Fprintln(w, "✓ config: valid")
 
 	// Stage 2: Phases
-	pl := validatePhases(w, result)
+	pl := validatePhases(w, result, pipelineName)
 
 	// Stage 3: Prompts (only if phases loaded)
 	if pl != nil {
@@ -91,9 +96,9 @@ func runValidate(w io.Writer, errW io.Writer, cfg *config.Config) error {
 	return nil
 }
 
-// validatePhases loads and validates phases.yaml (cross-references, structure).
-func validatePhases(w io.Writer, result *validationResult) *pipeline.PhasePipeline {
-	phasesPath, cleanup, err := resolvePhasesPath()
+// validatePhases loads and validates the pipeline config (cross-references, structure).
+func validatePhases(w io.Writer, result *validationResult, pipelineName string) *pipeline.PhasePipeline {
+	phasesPath, cleanup, err := resolvePhasesPath(pipelineName)
 	if err != nil {
 		result.addError("phases: %v", err)
 		return nil

--- a/cmd/soda/validate_test.go
+++ b/cmd/soda/validate_test.go
@@ -45,7 +45,7 @@ func TestRunValidate_ValidConfig(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	err := runValidate(&stdout, &stderr, cfg)
+	err := runValidate(&stdout, &stderr, cfg, "")
 	if err != nil {
 		t.Fatalf("runValidate() returned error: %v\nstdout: %s\nstderr: %s", err, stdout.String(), stderr.String())
 	}
@@ -76,7 +76,7 @@ func TestRunValidate_MissingContextFiles(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	err := runValidate(&stdout, &stderr, cfg)
+	err := runValidate(&stdout, &stderr, cfg, "")
 
 	// Missing context files produce warnings, not errors, so validation passes.
 	if err != nil {
@@ -112,7 +112,7 @@ func TestRunValidate_ExistingContextFiles(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	err := runValidate(&stdout, &stderr, cfg)
+	err := runValidate(&stdout, &stderr, cfg, "")
 	if err != nil {
 		t.Fatalf("runValidate() error: %v", err)
 	}
@@ -127,7 +127,7 @@ func TestRunValidate_NoContextFiles(t *testing.T) {
 	cfg := &config.Config{}
 
 	var stdout, stderr bytes.Buffer
-	err := runValidate(&stdout, &stderr, cfg)
+	err := runValidate(&stdout, &stderr, cfg, "")
 	if err != nil {
 		t.Fatalf("runValidate() error: %v", err)
 	}
@@ -309,7 +309,7 @@ func TestRunValidate_ErrorOutput(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	err := runValidate(&stdout, &stderr, cfg)
+	err := runValidate(&stdout, &stderr, cfg, "")
 
 	// Warnings don't cause failure.
 	if err != nil {

--- a/internal/pipeline/discovery.go
+++ b/internal/pipeline/discovery.go
@@ -1,0 +1,101 @@
+package pipeline
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// PipelineInfo describes a discovered pipeline configuration file.
+type PipelineInfo struct {
+	Name   string // pipeline name; "default" for phases.yaml
+	Path   string // absolute or relative path to the file
+	Source string // "local", "user", or "embedded"
+}
+
+// PipelineFilename returns the expected filename for a pipeline name.
+// The default pipeline maps to "phases.yaml"; named pipelines map to
+// "phases-<name>.yaml".
+func PipelineFilename(name string) string {
+	if name == "" || name == "default" {
+		return "phases.yaml"
+	}
+	return fmt.Sprintf("phases-%s.yaml", name)
+}
+
+// PipelineNameFromFile extracts the pipeline name from a filename.
+// "phases.yaml" returns "default"; "phases-foo.yaml" returns "foo".
+// Returns empty string if the filename doesn't match the convention.
+func PipelineNameFromFile(filename string) string {
+	base := filepath.Base(filename)
+	if base == "phases.yaml" {
+		return "default"
+	}
+	if strings.HasPrefix(base, "phases-") && strings.HasSuffix(base, ".yaml") {
+		name := strings.TrimPrefix(base, "phases-")
+		name = strings.TrimSuffix(name, ".yaml")
+		if name != "" {
+			return name
+		}
+	}
+	return ""
+}
+
+// DiscoverPipelines scans directories for pipeline configuration files.
+// It looks for phases.yaml (name="default") and phases-<name>.yaml patterns.
+// Each directory is labeled with the corresponding source tag. Directories
+// are scanned in the order provided; when a pipeline name appears in
+// multiple directories, only the first occurrence is kept (higher-priority
+// source wins). The returned slice is sorted alphabetically by name, with
+// "default" always first.
+func DiscoverPipelines(dirs []string, sources []string) []PipelineInfo {
+	if len(dirs) != len(sources) {
+		return nil
+	}
+
+	seen := make(map[string]bool)
+	var pipelines []PipelineInfo
+
+	for idx, dir := range dirs {
+		source := sources[idx]
+
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
+			}
+			name := PipelineNameFromFile(entry.Name())
+			if name == "" {
+				continue
+			}
+			if seen[name] {
+				continue
+			}
+			seen[name] = true
+			pipelines = append(pipelines, PipelineInfo{
+				Name:   name,
+				Path:   filepath.Join(dir, entry.Name()),
+				Source: source,
+			})
+		}
+	}
+
+	sort.Slice(pipelines, func(i, j int) bool {
+		// "default" always first.
+		if pipelines[i].Name == "default" {
+			return true
+		}
+		if pipelines[j].Name == "default" {
+			return false
+		}
+		return pipelines[i].Name < pipelines[j].Name
+	})
+
+	return pipelines
+}

--- a/internal/pipeline/discovery.go
+++ b/internal/pipeline/discovery.go
@@ -8,6 +8,22 @@ import (
 	"strings"
 )
 
+// ValidatePipelineName checks that a pipeline name is a safe identifier.
+// It rejects names containing path separators or directory traversal
+// sequences to prevent loading arbitrary files outside the config directory.
+func ValidatePipelineName(name string) error {
+	if name == "" || name == "default" {
+		return nil
+	}
+	if strings.ContainsAny(name, `/\`) {
+		return fmt.Errorf("pipeline name %q must not contain path separators", name)
+	}
+	if strings.Contains(name, "..") {
+		return fmt.Errorf("pipeline name %q must not contain '..'", name)
+	}
+	return nil
+}
+
 // PipelineInfo describes a discovered pipeline configuration file.
 type PipelineInfo struct {
 	Name   string // pipeline name; "default" for phases.yaml

--- a/internal/pipeline/discovery_test.go
+++ b/internal/pipeline/discovery_test.go
@@ -6,6 +6,33 @@ import (
 	"testing"
 )
 
+func TestValidatePipelineName(t *testing.T) {
+	tests := []struct {
+		name    string
+		wantErr bool
+	}{
+		{"", false},
+		{"default", false},
+		{"fast", false},
+		{"ci-lite", false},
+		{"foo/bar", true},
+		{`foo\bar`, true},
+		{"foo/../bar", true},
+		{"../etc/passwd", true},
+		{"..", true},
+		{"foo/../../bar", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidatePipelineName(tt.name)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidatePipelineName(%q) error = %v, wantErr %v", tt.name, err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestPipelineFilename(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/pipeline/discovery_test.go
+++ b/internal/pipeline/discovery_test.go
@@ -1,0 +1,177 @@
+package pipeline
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPipelineFilename(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{"", "phases.yaml"},
+		{"default", "phases.yaml"},
+		{"fast", "phases-fast.yaml"},
+		{"ci-lite", "phases-ci-lite.yaml"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := PipelineFilename(tt.name)
+			if got != tt.want {
+				t.Errorf("PipelineFilename(%q) = %q, want %q", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPipelineNameFromFile(t *testing.T) {
+	tests := []struct {
+		filename string
+		want     string
+	}{
+		{"phases.yaml", "default"},
+		{"phases-fast.yaml", "fast"},
+		{"phases-ci-lite.yaml", "ci-lite"},
+		{"phases-.yaml", ""},
+		{"other.yaml", ""},
+		{"phases.yml", ""},
+		{"phases-fast.yml", ""},
+		{"dir/phases-nested.yaml", "nested"},
+		{"phases.yaml.bak", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.filename, func(t *testing.T) {
+			got := PipelineNameFromFile(tt.filename)
+			if got != tt.want {
+				t.Errorf("PipelineNameFromFile(%q) = %q, want %q", tt.filename, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDiscoverPipelines(t *testing.T) {
+	t.Run("discovers_default_and_named", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, "phases.yaml"), minimalPhasesYAML)
+		writeFile(t, filepath.Join(dir, "phases-fast.yaml"), minimalPhasesYAML)
+		writeFile(t, filepath.Join(dir, "phases-ci.yaml"), minimalPhasesYAML)
+		writeFile(t, filepath.Join(dir, "unrelated.yaml"), "key: value")
+
+		pipelines := DiscoverPipelines([]string{dir}, []string{"local"})
+
+		if len(pipelines) != 3 {
+			t.Fatalf("got %d pipelines, want 3", len(pipelines))
+		}
+
+		// default should be first
+		if pipelines[0].Name != "default" {
+			t.Errorf("first pipeline = %q, want %q", pipelines[0].Name, "default")
+		}
+		if pipelines[0].Source != "local" {
+			t.Errorf("first pipeline source = %q, want %q", pipelines[0].Source, "local")
+		}
+
+		// ci and fast should follow alphabetically
+		if pipelines[1].Name != "ci" {
+			t.Errorf("second pipeline = %q, want %q", pipelines[1].Name, "ci")
+		}
+		if pipelines[2].Name != "fast" {
+			t.Errorf("third pipeline = %q, want %q", pipelines[2].Name, "fast")
+		}
+	})
+
+	t.Run("higher_priority_source_wins", func(t *testing.T) {
+		localDir := t.TempDir()
+		userDir := t.TempDir()
+
+		writeFile(t, filepath.Join(localDir, "phases.yaml"), minimalPhasesYAML)
+		writeFile(t, filepath.Join(localDir, "phases-fast.yaml"), minimalPhasesYAML)
+		// user dir also has default and an extra pipeline
+		writeFile(t, filepath.Join(userDir, "phases.yaml"), minimalPhasesYAML)
+		writeFile(t, filepath.Join(userDir, "phases-full.yaml"), minimalPhasesYAML)
+
+		pipelines := DiscoverPipelines(
+			[]string{localDir, userDir},
+			[]string{"local", "user"},
+		)
+
+		if len(pipelines) != 3 {
+			t.Fatalf("got %d pipelines, want 3", len(pipelines))
+		}
+
+		// default should come from local (first dir)
+		if pipelines[0].Name != "default" || pipelines[0].Source != "local" {
+			t.Errorf("default pipeline source = %q, want %q", pipelines[0].Source, "local")
+		}
+
+		// fast should come from local
+		found := false
+		for _, p := range pipelines {
+			if p.Name == "fast" {
+				found = true
+				if p.Source != "local" {
+					t.Errorf("fast pipeline source = %q, want %q", p.Source, "local")
+				}
+			}
+		}
+		if !found {
+			t.Error("expected fast pipeline in results")
+		}
+
+		// full should come from user (only source)
+		found = false
+		for _, p := range pipelines {
+			if p.Name == "full" {
+				found = true
+				if p.Source != "user" {
+					t.Errorf("full pipeline source = %q, want %q", p.Source, "user")
+				}
+			}
+		}
+		if !found {
+			t.Error("expected full pipeline in results")
+		}
+	})
+
+	t.Run("empty_directory", func(t *testing.T) {
+		dir := t.TempDir()
+		pipelines := DiscoverPipelines([]string{dir}, []string{"local"})
+		if len(pipelines) != 0 {
+			t.Errorf("got %d pipelines, want 0", len(pipelines))
+		}
+	})
+
+	t.Run("nonexistent_directory", func(t *testing.T) {
+		pipelines := DiscoverPipelines([]string{"/nonexistent"}, []string{"local"})
+		if len(pipelines) != 0 {
+			t.Errorf("got %d pipelines, want 0", len(pipelines))
+		}
+	})
+
+	t.Run("mismatched_dirs_sources_returns_nil", func(t *testing.T) {
+		pipelines := DiscoverPipelines([]string{"/a", "/b"}, []string{"local"})
+		if pipelines != nil {
+			t.Errorf("expected nil for mismatched dirs/sources, got %v", pipelines)
+		}
+	})
+}
+
+const minimalPhasesYAML = `phases:
+  - name: triage
+    prompt: prompts/triage.md
+    timeout: 1m
+`
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -266,7 +266,9 @@ func (e *Engine) Run(ctx context.Context) error {
 	}
 
 	// Record pipeline name in meta for identification.
-	if e.state.Meta().Pipeline == "" && e.config.PipelineName != "" {
+	// Always update when explicitly set so re-running with a different
+	// --pipeline flag stores the correct name for future resumes.
+	if e.config.PipelineName != "" {
 		e.state.Meta().Pipeline = e.config.PipelineName
 	}
 
@@ -335,6 +337,13 @@ func (e *Engine) Resume(ctx context.Context, fromPhase string) error {
 	// Cache ticket summary in meta for soda sessions/history display.
 	if e.state.Meta().Summary == "" && e.config.Ticket.Summary != "" {
 		e.state.Meta().Summary = e.config.Ticket.Summary
+	}
+
+	// Record pipeline name in meta for identification.
+	// Always update when explicitly set so re-running with a different
+	// --pipeline flag stores the correct name for future resumes.
+	if e.config.PipelineName != "" {
+		e.state.Meta().Pipeline = e.config.PipelineName
 	}
 
 	if err := e.ensureWorktree(ctx); err != nil {

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -37,6 +37,7 @@ type EngineConfig struct {
 	PromptContext        ContextData
 	DetectedStack        DetectedStackData // auto-detected project stack info; zero value if detection was skipped
 	Model                string
+	PipelineName         string // pipeline config name (e.g. "fast"); empty means "default"
 	BinaryVersion        string // binary build identifier; recorded in meta on first run, checked for staleness on resume
 	WorkDir              string
 	WorktreeBase         string
@@ -262,6 +263,11 @@ func (e *Engine) Run(ctx context.Context) error {
 	// Cache ticket summary in meta for soda sessions/history display.
 	if e.state.Meta().Summary == "" && e.config.Ticket.Summary != "" {
 		e.state.Meta().Summary = e.config.Ticket.Summary
+	}
+
+	// Record pipeline name in meta for identification.
+	if e.state.Meta().Pipeline == "" && e.config.PipelineName != "" {
+		e.state.Meta().Pipeline = e.config.PipelineName
 	}
 
 	if err := e.ensureWorktree(ctx); err != nil {

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -284,7 +284,15 @@ func (e *Engine) Run(ctx context.Context) error {
 	e.emit(Event{Kind: EventPhaseCostsReset})
 
 	e.reranPhases = make(map[string]bool)
-	e.emit(Event{Kind: EventEngineStarted})
+	startedData := map[string]any{}
+	if e.config.PipelineName != "" {
+		startedData["pipeline"] = e.config.PipelineName
+	}
+	if len(startedData) == 0 {
+		e.emit(Event{Kind: EventEngineStarted})
+	} else {
+		e.emit(Event{Kind: EventEngineStarted, Data: startedData})
+	}
 
 	if err := e.executePhases(ctx, e.config.Pipeline.Phases, false); err != nil {
 		wrapped := e.wrapTimeoutError(ctx, err)
@@ -334,7 +342,11 @@ func (e *Engine) Resume(ctx context.Context, fromPhase string) error {
 	}
 
 	e.reranPhases = make(map[string]bool)
-	e.emit(Event{Kind: EventEngineStarted, Data: map[string]any{"resumed_from": fromPhase}})
+	resumeData := map[string]any{"resumed_from": fromPhase}
+	if e.config.PipelineName != "" {
+		resumeData["pipeline"] = e.config.PipelineName
+	}
+	e.emit(Event{Kind: EventEngineStarted, Data: resumeData})
 
 	// The fromPhase (first in slice) is always re-run, even if completed.
 	// Mark it with forceFirst=true so executePhases skips the shouldSkip check.

--- a/internal/pipeline/meta.go
+++ b/internal/pipeline/meta.go
@@ -40,6 +40,7 @@ type PhaseState struct {
 type PipelineMeta struct {
 	Ticket             string                 `json:"ticket"`
 	Summary            string                 `json:"summary,omitempty"`
+	Pipeline           string                 `json:"pipeline,omitempty"` // pipeline name used for this run; empty means "default"
 	Branch             string                 `json:"branch,omitempty"`
 	Worktree           string                 `json:"worktree,omitempty"`
 	StartedAt          time.Time              `json:"started_at"`

--- a/internal/pipeline/meta_test.go
+++ b/internal/pipeline/meta_test.go
@@ -406,6 +406,55 @@ func TestMetaTokenCountsOmitEmpty(t *testing.T) {
 	}
 }
 
+func TestMetaPipelineNameRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "meta.json")
+
+	original := &PipelineMeta{
+		Ticket:    "PROJ-300",
+		Pipeline:  "fast",
+		StartedAt: time.Now().Truncate(time.Second),
+		Phases:    map[string]*PhaseState{},
+	}
+
+	if err := writeMeta(path, original); err != nil {
+		t.Fatalf("writeMeta: %v", err)
+	}
+
+	loaded, err := ReadMeta(path)
+	if err != nil {
+		t.Fatalf("ReadMeta: %v", err)
+	}
+
+	if loaded.Pipeline != "fast" {
+		t.Errorf("Pipeline = %q, want %q", loaded.Pipeline, "fast")
+	}
+}
+
+func TestMetaPipelineNameOmitEmpty(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "meta.json")
+
+	original := &PipelineMeta{
+		Ticket:    "PROJ-300",
+		StartedAt: time.Now().Truncate(time.Second),
+		Phases:    map[string]*PhaseState{},
+	}
+
+	if err := writeMeta(path, original); err != nil {
+		t.Fatalf("writeMeta: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+
+	if strings.Contains(string(data), "pipeline") {
+		t.Errorf("meta.json should omit pipeline when empty, got:\n%s", data)
+	}
+}
+
 func TestPhaseStatusConstants(t *testing.T) {
 	// Verify JSON serialization matches expected strings
 	tests := []struct {

--- a/internal/pipeline/phase.go
+++ b/internal/pipeline/phase.go
@@ -12,6 +12,7 @@ import (
 
 // PhasePipeline holds the ordered list of phases loaded from phases.yaml.
 type PhasePipeline struct {
+	Name   string        `yaml:"-"` // pipeline name; set after loading (e.g. "default", "fast")
 	Phases []PhaseConfig `yaml:"phases"`
 }
 


### PR DESCRIPTION
## Summary

- Adds `--pipeline <name>` flag to `soda run` for selecting named pipeline definitions
- Pipeline discovery: project `pipelines/` → user config → embedded
- `./phases.yaml` backwards compatibility preserved
- Pipeline name stored in meta.json and emitted in events
- `soda validate --pipeline <name>` validates named pipelines
- `soda pipelines` command lists available pipelines

Closes #300