### PR TITLE
feat(pipeline): validate depends_on against phase list [#301]

### DIFF
--- a/internal/pipeline/phase.go
+++ b/internal/pipeline/phase.go
@@ -118,10 +118,15 @@ func LoadPipeline(path string) (*PhasePipeline, error) {
 		phaseNames[p.Name] = struct{}{}
 	}
 
-	// Validate cross-references: ReworkConfig.Target, FeedbackFrom,
-	// CorrectiveConfig.Phase, and CorrectiveConfig.EscalateTo must
-	// refer to phases that exist in the pipeline.
+	// Validate cross-references: DependsOn, ReworkConfig.Target,
+	// FeedbackFrom, CorrectiveConfig.Phase, and CorrectiveConfig.EscalateTo
+	// must refer to phases that exist in the pipeline.
 	for _, phase := range pipeline.Phases {
+		for _, dep := range phase.DependsOn {
+			if _, ok := phaseNames[dep]; !ok {
+				return nil, fmt.Errorf("pipeline: phase %q depends_on references unknown phase %q", phase.Name, dep)
+			}
+		}
 		if phase.Rework != nil {
 			if _, ok := phaseNames[phase.Rework.Target]; !ok {
 				return nil, fmt.Errorf("pipeline: phase %q rework target %q not found in pipeline", phase.Name, phase.Rework.Target)

--- a/internal/pipeline/phase_test.go
+++ b/internal/pipeline/phase_test.go
@@ -500,6 +500,68 @@ func TestLoadPipeline(t *testing.T) {
 		}
 	})
 
+	t.Run("errors_on_invalid_depends_on", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "phases.yaml")
+		content := `phases:
+  - name: triage
+    prompt: prompts/triage.md
+    timeout: 1m
+  - name: plan
+    prompt: prompts/plan.md
+    timeout: 5m
+    depends_on:
+      - triage
+      - nonexistent
+`
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+
+		_, err := LoadPipeline(path)
+		if err == nil {
+			t.Fatal("expected error for invalid depends_on")
+		}
+		if !strings.Contains(err.Error(), "depends_on") {
+			t.Errorf("error = %q, want mention of depends_on", err)
+		}
+		if !strings.Contains(err.Error(), "nonexistent") {
+			t.Errorf("error = %q, want mention of %q", err, "nonexistent")
+		}
+	})
+
+	t.Run("valid_depends_on", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "phases.yaml")
+		content := `phases:
+  - name: triage
+    prompt: prompts/triage.md
+    timeout: 1m
+  - name: plan
+    prompt: prompts/plan.md
+    timeout: 5m
+    depends_on:
+      - triage
+  - name: implement
+    prompt: prompts/implement.md
+    timeout: 10m
+    depends_on:
+      - triage
+      - plan
+`
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+
+		pipeline, err := LoadPipeline(path)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(pipeline.Phases) != 3 {
+			t.Errorf("got %d phases, want 3", len(pipeline.Phases))
+		}
+	})
+
 	t.Run("valid_corrective_config", func(t *testing.T) {
 		dir := t.TempDir()
 		path := filepath.Join(dir, "phases.yaml")


### PR DESCRIPTION
## Summary
- Add cross-reference validation for `depends_on` entries in `LoadPipeline`, rejecting references to phases that don't exist in the pipeline.
- Catches misconfigured dependencies at load time rather than at runtime, consistent with existing validation for `rework.target`, `feedback_from`, and corrective phase references.
- Two new test cases: one verifying the error on invalid `depends_on`, one confirming valid `depends_on` is accepted.

## Changes
- `internal/pipeline/phase.go` — 5 lines added to validate each `depends_on` entry against the `phaseNames` set.
- `internal/pipeline/phase_test.go` — 62 lines added with two table-driven tests (`errors_on_invalid_depends_on`, `valid_depends_on`).

## Test plan
- [x] `go test ./internal/pipeline/...` — all 18 tests pass, including the 2 new ones.
- [x] Invalid `depends_on` produces clear error naming the phase and the missing dependency.
- [x] Valid `depends_on` entries are accepted without error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)