### PR TITLE
feat(pipeline): external JSON schema file support [#303]

### DIFF
--- a/internal/pipeline/phase.go
+++ b/internal/pipeline/phase.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -179,6 +180,9 @@ func LoadPipeline(path string) (*PhasePipeline, error) {
 			schemaData, err := os.ReadFile(schemaPath)
 			if err != nil {
 				return nil, fmt.Errorf("pipeline: phase %q: read schema file %s: %w", phase.Name, phase.Schema, err)
+			}
+			if !json.Valid(schemaData) {
+				return nil, fmt.Errorf("pipeline: phase %q: schema file %s is not valid JSON", phase.Name, phase.Schema)
 			}
 			phase.Schema = string(schemaData)
 		}

--- a/internal/pipeline/phase.go
+++ b/internal/pipeline/phase.go
@@ -169,7 +169,10 @@ func LoadPipeline(path string) (*PhasePipeline, error) {
 				phase.Schema = generated
 			}
 		} else if isFilePath(phase.Schema) {
-			schemaPath := phase.Schema
+			schemaPath := filepath.Clean(phase.Schema)
+			if strings.Contains(schemaPath, "..") {
+				return nil, fmt.Errorf("pipeline: phase %q: schema path traversal rejected: %s", phase.Name, phase.Schema)
+			}
 			if !filepath.IsAbs(schemaPath) {
 				schemaPath = filepath.Join(pipelineDir, schemaPath)
 			}

--- a/internal/pipeline/phase.go
+++ b/internal/pipeline/phase.go
@@ -3,12 +3,19 @@ package pipeline
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/decko/soda/schemas"
 	"gopkg.in/yaml.v3"
 )
+
+// isFilePath returns true if s looks like a file path rather than an inline
+// JSON schema string. It checks for path separators or a .json suffix.
+func isFilePath(s string) bool {
+	return strings.ContainsAny(s, "/\\") || strings.HasSuffix(s, ".json")
+}
 
 // PhasePipeline holds the ordered list of phases loaded from phases.yaml.
 type PhasePipeline struct {
@@ -149,12 +156,24 @@ func LoadPipeline(path string) (*PhasePipeline, error) {
 
 	// Resolve schemas: if a phase has no inline schema, look up the
 	// generated schema by phase name from the schemas package.
+	// If the schema value looks like a file path, read the file contents.
+	pipelineDir := filepath.Dir(path)
 	for idx := range pipeline.Phases {
 		phase := &pipeline.Phases[idx]
 		if strings.TrimSpace(phase.Schema) == "" {
 			if generated := schemas.SchemaFor(phase.Name); generated != "" {
 				phase.Schema = generated
 			}
+		} else if isFilePath(phase.Schema) {
+			schemaPath := phase.Schema
+			if !filepath.IsAbs(schemaPath) {
+				schemaPath = filepath.Join(pipelineDir, schemaPath)
+			}
+			schemaData, err := os.ReadFile(schemaPath)
+			if err != nil {
+				return nil, fmt.Errorf("pipeline: phase %q: read schema file %s: %w", phase.Name, phase.Schema, err)
+			}
+			phase.Schema = string(schemaData)
 		}
 	}
 

--- a/internal/pipeline/phase.go
+++ b/internal/pipeline/phase.go
@@ -13,7 +13,11 @@ import (
 
 // isFilePath returns true if s looks like a file path rather than an inline
 // JSON schema string. It checks for path separators or a .json suffix.
+// Strings that start with '{' are treated as inline JSON, not file paths.
 func isFilePath(s string) bool {
+	if strings.HasPrefix(strings.TrimSpace(s), "{") {
+		return false
+	}
 	return strings.ContainsAny(s, "/\\") || strings.HasSuffix(s, ".json")
 }
 

--- a/internal/pipeline/phase_test.go
+++ b/internal/pipeline/phase_test.go
@@ -650,6 +650,36 @@ func TestLoadPipeline(t *testing.T) {
 		}
 	})
 
+	t.Run("errors_on_invalid_json_schema_file", func(t *testing.T) {
+		dir := t.TempDir()
+		schemaPath := filepath.Join(dir, "bad.json")
+		if err := os.WriteFile(schemaPath, []byte("not valid json{{{"), 0644); err != nil {
+			t.Fatalf("WriteFile schema: %v", err)
+		}
+
+		phasesPath := filepath.Join(dir, "phases.yaml")
+		content := `phases:
+  - name: custom-phase
+    prompt: prompts/custom.md
+    schema: bad.json
+    timeout: 1m
+`
+		if err := os.WriteFile(phasesPath, []byte(content), 0644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+
+		_, err := LoadPipeline(phasesPath)
+		if err == nil {
+			t.Fatal("expected error for invalid JSON schema file")
+		}
+		if !strings.Contains(err.Error(), "not valid JSON") {
+			t.Errorf("error = %q, want mention of not valid JSON", err)
+		}
+		if !strings.Contains(err.Error(), "bad.json") {
+			t.Errorf("error = %q, want mention of bad.json", err)
+		}
+	})
+
 	t.Run("errors_on_schema_path_traversal", func(t *testing.T) {
 		dir := t.TempDir()
 		phasesPath := filepath.Join(dir, "phases.yaml")

--- a/internal/pipeline/phase_test.go
+++ b/internal/pipeline/phase_test.go
@@ -531,4 +531,172 @@ func TestLoadPipeline(t *testing.T) {
 			t.Errorf("got %d phases, want 3", len(pipeline.Phases))
 		}
 	})
+
+	t.Run("schema_file_loaded", func(t *testing.T) {
+		dir := t.TempDir()
+		schemaContent := `{"type":"object","properties":{"verdict":{"type":"string"}}}`
+		schemaPath := filepath.Join(dir, "custom.json")
+		if err := os.WriteFile(schemaPath, []byte(schemaContent), 0644); err != nil {
+			t.Fatalf("WriteFile schema: %v", err)
+		}
+
+		phasesPath := filepath.Join(dir, "phases.yaml")
+		content := `phases:
+  - name: custom-phase
+    prompt: prompts/custom.md
+    schema: custom.json
+    timeout: 1m
+`
+		if err := os.WriteFile(phasesPath, []byte(content), 0644); err != nil {
+			t.Fatalf("WriteFile phases: %v", err)
+		}
+
+		pipeline, err := LoadPipeline(phasesPath)
+		if err != nil {
+			t.Fatalf("LoadPipeline: %v", err)
+		}
+
+		if pipeline.Phases[0].Schema != schemaContent {
+			t.Errorf("schema mismatch:\ngot:  %s\nwant: %s", pipeline.Phases[0].Schema, schemaContent)
+		}
+	})
+
+	t.Run("schema_file_relative_path", func(t *testing.T) {
+		dir := t.TempDir()
+		subdir := filepath.Join(dir, "schemas")
+		if err := os.MkdirAll(subdir, 0755); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		schemaContent := `{"type":"object","required":["action"]}`
+		if err := os.WriteFile(filepath.Join(subdir, "act.json"), []byte(schemaContent), 0644); err != nil {
+			t.Fatalf("WriteFile schema: %v", err)
+		}
+
+		phasesPath := filepath.Join(dir, "phases.yaml")
+		content := `phases:
+  - name: act
+    prompt: prompts/act.md
+    schema: schemas/act.json
+    timeout: 1m
+`
+		if err := os.WriteFile(phasesPath, []byte(content), 0644); err != nil {
+			t.Fatalf("WriteFile phases: %v", err)
+		}
+
+		pipeline, err := LoadPipeline(phasesPath)
+		if err != nil {
+			t.Fatalf("LoadPipeline: %v", err)
+		}
+
+		if pipeline.Phases[0].Schema != schemaContent {
+			t.Errorf("schema mismatch:\ngot:  %s\nwant: %s", pipeline.Phases[0].Schema, schemaContent)
+		}
+	})
+
+	t.Run("schema_file_overrides_generated", func(t *testing.T) {
+		dir := t.TempDir()
+		schemaContent := `{"type":"object","properties":{"custom_triage":{"type":"boolean"}}}`
+		if err := os.WriteFile(filepath.Join(dir, "triage.json"), []byte(schemaContent), 0644); err != nil {
+			t.Fatalf("WriteFile schema: %v", err)
+		}
+
+		phasesPath := filepath.Join(dir, "phases.yaml")
+		content := `phases:
+  - name: triage
+    prompt: prompts/triage.md
+    schema: triage.json
+    timeout: 1m
+`
+		if err := os.WriteFile(phasesPath, []byte(content), 0644); err != nil {
+			t.Fatalf("WriteFile phases: %v", err)
+		}
+
+		pipeline, err := LoadPipeline(phasesPath)
+		if err != nil {
+			t.Fatalf("LoadPipeline: %v", err)
+		}
+
+		// The file schema should override the generated triage schema.
+		if pipeline.Phases[0].Schema != schemaContent {
+			t.Errorf("file schema should override generated:\ngot:  %s\nwant: %s", pipeline.Phases[0].Schema, schemaContent)
+		}
+		if pipeline.Phases[0].Schema == schemas.SchemaFor("triage") {
+			t.Error("schema was not overridden — still matches generated triage schema")
+		}
+	})
+
+	t.Run("errors_on_missing_schema_file", func(t *testing.T) {
+		dir := t.TempDir()
+		phasesPath := filepath.Join(dir, "phases.yaml")
+		content := `phases:
+  - name: custom-phase
+    prompt: prompts/custom.md
+    schema: nonexistent.json
+    timeout: 1m
+`
+		if err := os.WriteFile(phasesPath, []byte(content), 0644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+
+		_, err := LoadPipeline(phasesPath)
+		if err == nil {
+			t.Fatal("expected error for missing schema file")
+		}
+		if !strings.Contains(err.Error(), "read schema file") {
+			t.Errorf("error = %q, want mention of read schema file", err)
+		}
+		if !strings.Contains(err.Error(), "nonexistent.json") {
+			t.Errorf("error = %q, want mention of nonexistent.json", err)
+		}
+	})
+
+	t.Run("inline_json_schema_not_treated_as_file", func(t *testing.T) {
+		dir := t.TempDir()
+		phasesPath := filepath.Join(dir, "phases.yaml")
+		inlineSchema := `{"type":"object","properties":{"status":{"type":"string"}}}`
+		content := `phases:
+  - name: custom-phase
+    prompt: prompts/custom.md
+    schema: '` + inlineSchema + `'
+    timeout: 1m
+`
+		if err := os.WriteFile(phasesPath, []byte(content), 0644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+
+		pipeline, err := LoadPipeline(phasesPath)
+		if err != nil {
+			t.Fatalf("LoadPipeline: %v", err)
+		}
+
+		if pipeline.Phases[0].Schema != inlineSchema {
+			t.Errorf("inline schema was modified:\ngot:  %s\nwant: %s", pipeline.Phases[0].Schema, inlineSchema)
+		}
+	})
+}
+
+func TestIsFilePath(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"schema.json", true},
+		{"./schema.json", true},
+		{"schemas/custom.json", true},
+		{"/absolute/path/schema.json", true},
+		{"relative/path/schema", true},
+		{`windows\path\schema`, true},
+		{`{"type":"object"}`, false},
+		{"plain-string", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := isFilePath(tt.input)
+			if got != tt.want {
+				t.Errorf("isFilePath(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
 }

--- a/internal/pipeline/phase_test.go
+++ b/internal/pipeline/phase_test.go
@@ -673,6 +673,32 @@ func TestLoadPipeline(t *testing.T) {
 			t.Errorf("inline schema was modified:\ngot:  %s\nwant: %s", pipeline.Phases[0].Schema, inlineSchema)
 		}
 	})
+
+	t.Run("inline_json_schema_with_slashes_not_treated_as_file", func(t *testing.T) {
+		dir := t.TempDir()
+		phasesPath := filepath.Join(dir, "phases.yaml")
+		// Inline schemas containing forward slashes (e.g. $ref or $schema URLs)
+		// must not be misidentified as file paths.
+		inlineSchema := `{"$schema":"http://json-schema.org/draft-07/schema#","$ref":"#/definitions/Foo"}`
+		content := `phases:
+  - name: custom-phase
+    prompt: prompts/custom.md
+    schema: '` + inlineSchema + `'
+    timeout: 1m
+`
+		if err := os.WriteFile(phasesPath, []byte(content), 0644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+
+		pipeline, err := LoadPipeline(phasesPath)
+		if err != nil {
+			t.Fatalf("LoadPipeline: %v", err)
+		}
+
+		if pipeline.Phases[0].Schema != inlineSchema {
+			t.Errorf("inline schema with slashes was modified:\ngot:  %s\nwant: %s", pipeline.Phases[0].Schema, inlineSchema)
+		}
+	})
 }
 
 func TestIsFilePath(t *testing.T) {
@@ -687,6 +713,8 @@ func TestIsFilePath(t *testing.T) {
 		{"relative/path/schema", true},
 		{`windows\path\schema`, true},
 		{`{"type":"object"}`, false},
+		{`{"$ref":"#/definitions/Foo"}`, false},
+		{`{"$schema":"http://json-schema.org/draft-07/schema#"}`, false},
 		{"plain-string", false},
 		{"", false},
 	}

--- a/internal/pipeline/phase_test.go
+++ b/internal/pipeline/phase_test.go
@@ -650,6 +650,28 @@ func TestLoadPipeline(t *testing.T) {
 		}
 	})
 
+	t.Run("errors_on_schema_path_traversal", func(t *testing.T) {
+		dir := t.TempDir()
+		phasesPath := filepath.Join(dir, "phases.yaml")
+		content := `phases:
+  - name: custom-phase
+    prompt: prompts/custom.md
+    schema: ../../etc/passwd
+    timeout: 1m
+`
+		if err := os.WriteFile(phasesPath, []byte(content), 0644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+
+		_, err := LoadPipeline(phasesPath)
+		if err == nil {
+			t.Fatal("expected error for path traversal in schema")
+		}
+		if !strings.Contains(err.Error(), "path traversal rejected") {
+			t.Errorf("error = %q, want mention of path traversal rejected", err)
+		}
+	})
+
 	t.Run("inline_json_schema_not_treated_as_file", func(t *testing.T) {
 		dir := t.TempDir()
 		phasesPath := filepath.Join(dir, "phases.yaml")


### PR DESCRIPTION
## Summary

- Add external JSON schema file support for custom pipeline phases — the `schema` field in `phases.yaml` now accepts a file path (e.g. `schemas/custom.json`) in addition to inline JSON strings
- File paths are resolved relative to the pipeline directory, with path traversal (`..`) rejected for security
- Schema files are validated as valid JSON at load time (fail-fast)
- Inline JSON schemas (starting with `{`) continue to work unchanged, even when they contain forward slashes (e.g. `$ref`, `$schema` URLs)

## Test plan

- [x] Unit tests for `isFilePath` helper covering file paths, inline JSON, and edge cases
- [x] Integration tests for `LoadPipeline` covering:
  - Schema file loading (happy path with `.json` file)
  - Relative path resolution via subdirectory (`schemas/act.json`)
  - File-based schema overrides generated schemas for known phases (e.g. `triage`)
  - Error on missing schema file
  - Error on invalid JSON in schema file
  - Error on path traversal attempts (`../../etc/passwd`)
  - Backwards compatibility for inline JSON strings
  - Inline JSON with slashes not misidentified as file paths

## Acceptance criteria

- [x] `schema: custom.json` in phases.yaml loads the file contents as the schema
- [x] Relative paths resolved against the pipeline file's directory
- [x] Path traversal (`..`) is rejected with a clear error
- [x] Invalid JSON in schema files is caught at load time
- [x] Inline JSON schemas (starting with `{`) are not treated as file paths
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)