### PR TITLE
feat(pipeline): Extras artifact map for custom phase output [#302]

### DIFF
--- a/cmd/soda/render.go
+++ b/cmd/soda/render.go
@@ -99,7 +99,7 @@ func runRender(cmd *cobra.Command, cfg *config.Config, phaseName, ticketKey stri
 	if stateDir != "" {
 		state, stateErr := pipeline.LoadOrCreate(stateDir, ticketKey)
 		if stateErr == nil {
-			loadArtifacts(state, &promptData)
+			loadArtifacts(state, &promptData, pl)
 		}
 	}
 
@@ -253,7 +253,17 @@ func buildJiraExtractors(cfg *config.Config) []ticket.ArtifactExtractor {
 	return extractors
 }
 
-func loadArtifacts(state *pipeline.State, data *pipeline.PromptData) {
+func loadArtifacts(state *pipeline.State, data *pipeline.PromptData, pl *pipeline.PhasePipeline) {
+	builtins := map[string]bool{
+		"triage":    true,
+		"plan":      true,
+		"implement": true,
+		"verify":    true,
+		"review":    true,
+		"patch":     true,
+		"submit":    true,
+	}
+
 	if artifact, err := state.ReadArtifact("triage"); err == nil {
 		data.Artifacts.Triage = string(artifact)
 	}
@@ -268,5 +278,20 @@ func loadArtifacts(state *pipeline.State, data *pipeline.PromptData) {
 	}
 	if artifact, err := state.ReadArtifact("review"); err == nil {
 		data.Artifacts.Review = string(artifact)
+	}
+
+	// Populate Extras for custom (non-built-in) phase artifacts referenced
+	// in DependsOn lists, so templates can access {{.Artifacts.Extras}}.
+	for _, phase := range pl.Phases {
+		for _, dep := range phase.DependsOn {
+			if !builtins[dep] {
+				if artifact, err := state.ReadArtifact(dep); err == nil {
+					if data.Artifacts.Extras == nil {
+						data.Artifacts.Extras = make(map[string]string)
+					}
+					data.Artifacts.Extras[dep] = string(artifact)
+				}
+			}
+		}
 	}
 }

--- a/cmd/soda/render.go
+++ b/cmd/soda/render.go
@@ -254,6 +254,7 @@ func buildJiraExtractors(cfg *config.Config) []ticket.ArtifactExtractor {
 }
 
 func loadArtifacts(state *pipeline.State, data *pipeline.PromptData, pl *pipeline.PhasePipeline) {
+	data.Artifacts.Extras = make(map[string]string)
 	builtins := map[string]bool{
 		"triage":    true,
 		"plan":      true,
@@ -286,9 +287,6 @@ func loadArtifacts(state *pipeline.State, data *pipeline.PromptData, pl *pipelin
 		for _, dep := range phase.DependsOn {
 			if !builtins[dep] {
 				if artifact, err := state.ReadArtifact(dep); err == nil {
-					if data.Artifacts.Extras == nil {
-						data.Artifacts.Extras = make(map[string]string)
-					}
 					data.Artifacts.Extras[dep] = string(artifact)
 				}
 			}

--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -779,7 +779,7 @@ func runDryRun(cfg *config.Config, pl *pipeline.PhasePipeline, loader *pipeline.
 	if cfg.StateDir != "" {
 		state, err := pipeline.LoadOrCreate(cfg.StateDir, ticketData.Key)
 		if err == nil {
-			loadArtifacts(state, &promptData)
+			loadArtifacts(state, &promptData, pl)
 		}
 	}
 

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -871,6 +871,7 @@ func (e *Engine) buildPromptData(phase PhaseConfig) (PromptData, error) {
 		WorktreePath:  e.state.Meta().Worktree,
 		Branch:        e.state.Meta().Branch,
 		BaseBranch:    e.config.BaseBranch,
+		Artifacts:     ArtifactData{Extras: make(map[string]string)},
 	}
 
 	for _, dep := range phase.DependsOn {
@@ -899,9 +900,6 @@ func (e *Engine) buildPromptData(phase PhaseConfig) (PromptData, error) {
 		default:
 			// Custom/user-defined phase: store in Extras map so
 			// templates can access via {{index .Artifacts.Extras "name"}}.
-			if data.Artifacts.Extras == nil {
-				data.Artifacts.Extras = make(map[string]string)
-			}
 			data.Artifacts.Extras[dep] = content
 		}
 	}

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -896,6 +896,13 @@ func (e *Engine) buildPromptData(phase PhaseConfig) (PromptData, error) {
 			data.Artifacts.Patch = content
 		case "submit":
 			data.Artifacts.Submit.PRURL = e.extractPRURL()
+		default:
+			// Custom/user-defined phase: store in Extras map so
+			// templates can access via {{index .Artifacts.Extras "name"}}.
+			if data.Artifacts.Extras == nil {
+				data.Artifacts.Extras = make(map[string]string)
+			}
+			data.Artifacts.Extras[dep] = content
 		}
 	}
 

--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -5133,3 +5133,284 @@ func TestEngine_PipelineTimeout_ExternalDeadlineNotWrapped(t *testing.T) {
 		t.Error("external context deadline should not be wrapped as PipelineTimeoutError")
 	}
 }
+
+func TestEngine_ExtrasArtifactForCustomPhase(t *testing.T) {
+	// A pipeline with a custom phase ("lint") whose artifact should be
+	// available to a downstream phase via Artifacts.Extras["lint"].
+	phases := []PhaseConfig{
+		{
+			Name:   "lint",
+			Prompt: "lint.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+		{
+			Name:      "implement",
+			Prompt:    "implement.md",
+			DependsOn: []string{"lint"},
+			Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+	}
+
+	lintArtifact := "Lint passed: no issues found in 42 files"
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"lint": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"passed":true}`),
+					RawText: lintArtifact,
+					CostUSD: 0.02,
+				},
+			}},
+			"implement": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"tests_passed":true}`),
+					RawText: "Implementation done",
+					CostUSD: 0.10,
+				},
+			}},
+		},
+	}
+
+	stateDir := t.TempDir()
+	promptDir := t.TempDir()
+	workDir := t.TempDir()
+
+	templates := map[string]string{
+		"lint.md":      "Phase: lint\nTicket: {{.Ticket.Key}}\n",
+		"implement.md": "Phase: implement\nTicket: {{.Ticket.Key}}\n{{- if .Artifacts.Extras}}Lint output: {{index .Artifacts.Extras \"lint\"}}{{- end}}\n",
+	}
+	for name, content := range templates {
+		if err := os.WriteFile(filepath.Join(promptDir, name), []byte(content), 0644); err != nil {
+			t.Fatalf("write template %s: %v", name, err)
+		}
+	}
+
+	state, err := LoadOrCreate(stateDir, "TEST-302")
+	if err != nil {
+		t.Fatalf("LoadOrCreate: %v", err)
+	}
+
+	engine := NewEngine(mock, state, EngineConfig{
+		Pipeline:   &PhasePipeline{Phases: phases},
+		Loader:     NewPromptLoader(promptDir),
+		Ticket:     TicketData{Key: "TEST-302", Summary: "Extras test"},
+		Model:      "test-model",
+		WorkDir:    workDir,
+		MaxCostUSD: 0,
+		Mode:       Autonomous,
+		SleepFunc:  func(time.Duration) {},
+		JitterFunc: func(time.Duration) time.Duration { return 0 },
+	})
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// Both phases should be completed.
+	if !state.IsCompleted("lint") {
+		t.Error("lint phase should be completed")
+	}
+	if !state.IsCompleted("implement") {
+		t.Error("implement phase should be completed")
+	}
+
+	// The implement phase prompt should contain the lint artifact via Extras.
+	if len(mock.calls) != 2 {
+		t.Fatalf("runner called %d times, want 2", len(mock.calls))
+	}
+
+	implementPrompt := mock.calls[1].SystemPrompt
+	if !strings.Contains(implementPrompt, lintArtifact) {
+		t.Errorf("implement prompt should contain lint artifact via Extras;\nprompt: %q\nwanted: %q",
+			implementPrompt, lintArtifact)
+	}
+}
+
+func TestEngine_ExtrasMultipleCustomPhases(t *testing.T) {
+	// Multiple custom phases should all appear in Extras for a downstream phase.
+	phases := []PhaseConfig{
+		{
+			Name:   "lint",
+			Prompt: "lint.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+		{
+			Name:   "security",
+			Prompt: "security.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+		{
+			Name:      "implement",
+			Prompt:    "implement.md",
+			DependsOn: []string{"lint", "security"},
+			Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+	}
+
+	lintArtifact := "Lint: all clear"
+	securityArtifact := "Security: no vulnerabilities"
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"lint": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"passed":true}`),
+					RawText: lintArtifact,
+					CostUSD: 0.01,
+				},
+			}},
+			"security": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"passed":true}`),
+					RawText: securityArtifact,
+					CostUSD: 0.01,
+				},
+			}},
+			"implement": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"tests_passed":true}`),
+					RawText: "Done",
+					CostUSD: 0.10,
+				},
+			}},
+		},
+	}
+
+	stateDir := t.TempDir()
+	promptDir := t.TempDir()
+	workDir := t.TempDir()
+
+	templates := map[string]string{
+		"lint.md":      "Phase: lint\n",
+		"security.md":  "Phase: security\n",
+		"implement.md": "Phase: implement\n{{- if .Artifacts.Extras}}{{range $name, $content := .Artifacts.Extras}}\n{{$name}}: {{$content}}{{end}}{{- end}}\n",
+	}
+	for name, content := range templates {
+		if err := os.WriteFile(filepath.Join(promptDir, name), []byte(content), 0644); err != nil {
+			t.Fatalf("write template %s: %v", name, err)
+		}
+	}
+
+	state, err := LoadOrCreate(stateDir, "TEST-302M")
+	if err != nil {
+		t.Fatalf("LoadOrCreate: %v", err)
+	}
+
+	engine := NewEngine(mock, state, EngineConfig{
+		Pipeline:   &PhasePipeline{Phases: phases},
+		Loader:     NewPromptLoader(promptDir),
+		Ticket:     TicketData{Key: "TEST-302M", Summary: "Multi extras test"},
+		Model:      "test-model",
+		WorkDir:    workDir,
+		MaxCostUSD: 0,
+		Mode:       Autonomous,
+		SleepFunc:  func(time.Duration) {},
+		JitterFunc: func(time.Duration) time.Duration { return 0 },
+	})
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// All three phases should be completed.
+	for _, name := range []string{"lint", "security", "implement"} {
+		if !state.IsCompleted(name) {
+			t.Errorf("phase %q should be completed", name)
+		}
+	}
+
+	// The implement prompt should contain both custom artifacts.
+	implementPrompt := mock.calls[2].SystemPrompt
+	if !strings.Contains(implementPrompt, lintArtifact) {
+		t.Errorf("implement prompt should contain lint artifact;\nprompt: %q", implementPrompt)
+	}
+	if !strings.Contains(implementPrompt, securityArtifact) {
+		t.Errorf("implement prompt should contain security artifact;\nprompt: %q", implementPrompt)
+	}
+}
+
+func TestEngine_ExtrasNotUsedForBuiltinPhases(t *testing.T) {
+	// Built-in phase names (triage, plan) should use the named fields,
+	// not Extras. This test verifies the named fields still work and
+	// Extras is empty when only built-in phases are in the pipeline.
+	phases := []PhaseConfig{
+		{
+			Name:   "triage",
+			Prompt: "triage.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+		{
+			Name:      "plan",
+			Prompt:    "plan.md",
+			DependsOn: []string{"triage"},
+			Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"triage": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"automatable":true}`),
+					RawText: "Triage result here",
+					CostUSD: 0.05,
+				},
+			}},
+			"plan": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"tasks":[{"id":"T1","description":"do stuff"}]}`),
+					RawText: "Plan output",
+					CostUSD: 0.10,
+				},
+			}},
+		},
+	}
+
+	stateDir := t.TempDir()
+	promptDir := t.TempDir()
+	workDir := t.TempDir()
+
+	// The plan template uses the named Triage field and checks Extras is empty.
+	templates := map[string]string{
+		"triage.md": "Phase: triage\n",
+		"plan.md":   "Phase: plan\nTriage: {{.Artifacts.Triage}}\n{{- if .Artifacts.Extras}}HAS_EXTRAS{{- end}}\n",
+	}
+	for name, content := range templates {
+		if err := os.WriteFile(filepath.Join(promptDir, name), []byte(content), 0644); err != nil {
+			t.Fatalf("write template %s: %v", name, err)
+		}
+	}
+
+	state, err := LoadOrCreate(stateDir, "TEST-302B")
+	if err != nil {
+		t.Fatalf("LoadOrCreate: %v", err)
+	}
+
+	engine := NewEngine(mock, state, EngineConfig{
+		Pipeline:   &PhasePipeline{Phases: phases},
+		Loader:     NewPromptLoader(promptDir),
+		Ticket:     TicketData{Key: "TEST-302B", Summary: "Builtin test"},
+		Model:      "test-model",
+		WorkDir:    workDir,
+		MaxCostUSD: 0,
+		Mode:       Autonomous,
+		SleepFunc:  func(time.Duration) {},
+		JitterFunc: func(time.Duration) time.Duration { return 0 },
+	})
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// The plan prompt should contain the triage artifact via named field.
+	planPrompt := mock.calls[1].SystemPrompt
+	if !strings.Contains(planPrompt, "Triage result here") {
+		t.Errorf("plan prompt should contain triage artifact via named field;\nprompt: %q", planPrompt)
+	}
+
+	// The plan prompt should NOT contain HAS_EXTRAS marker — built-in
+	// deps should not populate Extras.
+	if strings.Contains(planPrompt, "HAS_EXTRAS") {
+		t.Error("plan prompt should not have Extras populated for built-in phase deps")
+	}
+}

--- a/internal/pipeline/prompt.go
+++ b/internal/pipeline/prompt.go
@@ -149,6 +149,10 @@ type RepoConfig struct {
 }
 
 // ArtifactData holds rendered artifacts from previous phases.
+// The named fields cover the built-in pipeline phases. Extras holds
+// artifacts from custom (user-defined) phases keyed by phase name,
+// enabling config-driven pipelines to pass data between phases that
+// SODA doesn't know about at compile time.
 type ArtifactData struct {
 	Triage    string
 	Plan      string
@@ -157,6 +161,7 @@ type ArtifactData struct {
 	Review    string
 	Patch     string
 	Submit    SubmitArtifact
+	Extras    map[string]string
 }
 
 // SubmitArtifact holds parsed fields from the submit phase output.

--- a/internal/pipeline/prompt_test.go
+++ b/internal/pipeline/prompt_test.go
@@ -379,6 +379,20 @@ func TestValidateTemplate(t *testing.T) {
 			t.Fatalf("ValidateTemplate should accept add FuncMap: %v", err)
 		}
 	})
+
+	t.Run("valid_template_with_extras", func(t *testing.T) {
+		tmpl := `{{- if .Artifacts.Extras}}{{range $name, $content := .Artifacts.Extras}}Phase {{$name}}: {{$content}}{{end}}{{- end}}`
+		if err := ValidateTemplate(tmpl); err != nil {
+			t.Fatalf("ValidateTemplate should accept Extras: %v", err)
+		}
+	})
+
+	t.Run("valid_template_with_extras_index", func(t *testing.T) {
+		tmpl := `{{- if .Artifacts.Extras}}{{index .Artifacts.Extras "lint"}}{{- end}}`
+		if err := ValidateTemplate(tmpl); err != nil {
+			t.Fatalf("ValidateTemplate should accept Extras index: %v", err)
+		}
+	})
 }
 
 func TestRenderPrompt(t *testing.T) {
@@ -1252,6 +1266,77 @@ Context: {{.}}
 		count := strings.Count(result, "Fix this finding, then verify before proceeding")
 		if count != 3 {
 			t.Errorf("expected 3 verify instructions, got %d;\nresult: %s", count, result)
+		}
+	})
+
+	t.Run("renders_extras_artifact_with_range", func(t *testing.T) {
+		tmpl := `{{- if .Artifacts.Extras}}{{range $name, $content := .Artifacts.Extras}}Custom({{$name}}): {{$content}}
+{{end}}{{- end}}`
+		data := PromptData{
+			Artifacts: ArtifactData{
+				Extras: map[string]string{
+					"lint":     "All lint checks passed.",
+					"security": "No vulnerabilities found.",
+				},
+			},
+		}
+
+		result, err := RenderPrompt(tmpl, data)
+		if err != nil {
+			t.Fatalf("RenderPrompt: %v", err)
+		}
+		if !strings.Contains(result, "Custom(lint): All lint checks passed.") {
+			t.Errorf("result should contain lint extra, got: %s", result)
+		}
+		if !strings.Contains(result, "Custom(security): No vulnerabilities found.") {
+			t.Errorf("result should contain security extra, got: %s", result)
+		}
+	})
+
+	t.Run("renders_extras_artifact_with_index", func(t *testing.T) {
+		tmpl := `{{- if .Artifacts.Extras}}Lint: {{index .Artifacts.Extras "lint"}}{{- end}}`
+		data := PromptData{
+			Artifacts: ArtifactData{
+				Extras: map[string]string{
+					"lint": "All checks passed.",
+				},
+			},
+		}
+
+		result, err := RenderPrompt(tmpl, data)
+		if err != nil {
+			t.Fatalf("RenderPrompt: %v", err)
+		}
+		if !strings.Contains(result, "Lint: All checks passed.") {
+			t.Errorf("result should contain lint value via index, got: %s", result)
+		}
+	})
+
+	t.Run("omits_extras_when_nil", func(t *testing.T) {
+		tmpl := `{{- if .Artifacts.Extras}}Extras present{{- end}}`
+		data := PromptData{}
+		result, err := RenderPrompt(tmpl, data)
+		if err != nil {
+			t.Fatalf("RenderPrompt: %v", err)
+		}
+		if strings.Contains(result, "Extras present") {
+			t.Errorf("result should not contain extras when nil, got: %s", result)
+		}
+	})
+
+	t.Run("omits_extras_when_empty_map", func(t *testing.T) {
+		tmpl := `{{- if .Artifacts.Extras}}Extras present{{- end}}`
+		data := PromptData{
+			Artifacts: ArtifactData{
+				Extras: map[string]string{},
+			},
+		}
+		result, err := RenderPrompt(tmpl, data)
+		if err != nil {
+			t.Fatalf("RenderPrompt: %v", err)
+		}
+		if strings.Contains(result, "Extras present") {
+			t.Errorf("result should not contain extras when empty map, got: %s", result)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- Add `Extras map[string]string` field to `ArtifactData` struct so custom (user-defined) pipeline phases can pass artifacts to downstream phases via prompt templates
- Wire Extras population in `buildPromptData` (engine path) and `loadArtifacts` (CLI render/dry-run paths), storing non-built-in phase artifacts by phase name
- Eagerly initialize the Extras map at struct creation time so templates using `{{if .Artifacts.Extras}}` never encounter a nil map
- Built-in phases (triage, plan, implement, verify, review, patch, submit) continue to use their dedicated named fields

## Test plan

- [x] `TestEngine_ExtrasArtifactForCustomPhase` — single custom phase artifact flows to downstream via Extras
- [x] `TestEngine_ExtrasMultipleCustomPhases` — multiple custom phases populate Extras correctly
- [x] `TestEngine_ExtrasNotUsedForBuiltinPhases` — built-in deps use named fields, Extras stays empty
- [x] `TestValidateTemplate` — templates with `{{range .Artifacts.Extras}}` and `{{index .Artifacts.Extras "name"}}` pass validation
- [x] `TestRenderPrompt` — Extras renders with range, index, nil, and empty map cases
- [ ] Manual: `soda render-prompt` with a custom pipeline that has non-built-in phases

## Acceptance criteria

- [x] AC1: `ArtifactData.Extras` field exists as `map[string]string`
- [x] AC2: Custom phase artifacts stored in Extras by phase name in both engine and CLI paths
- [x] AC3: Extras is eagerly initialized (never nil) so template conditionals work correctly
- [x] AC4: Built-in phases are unaffected — they use named fields, not Extras

🤖 Generated with [Claude Code](https://claude.com/claude-code)