### PR TITLE
feat(pipeline): built-in quick-fix and docs-only pipeline examples [#304]

### DIFF
--- a/cmd/soda/embeds/pipelines/docs-only.yaml
+++ b/cmd/soda/embeds/pipelines/docs-only.yaml
@@ -7,7 +7,7 @@ phases:
   - name: implement
     prompt: prompts/docs-implement.md
     schema: |
-      {"type":"object","properties":{"ticket_key":{"type":"string"},"branch":{"type":"string"},"commits":{"type":"array","items":{"type":"object","properties":{"hash":{"type":"string"},"message":{"type":"string"},"task_id":{"type":"string"}},"required":["hash","message","task_id"]}},"files_changed":{"type":"array","items":{"type":"object","properties":{"path":{"type":"string"},"action":{"type":"string"}},"required":["path","action"]}},"task_results":{"type":"array","items":{"type":"object","properties":{"task_id":{"type":"string"},"status":{"type":"string"},"reason":{"type":"string"}},"required":["task_id","status"]}},"tests_passed":{"type":"boolean"},"test_output":{"type":"string"},"deviations":{"type":"array","items":{"type":"string"}}},"required":["ticket_key","branch","commits","files_changed","task_results","tests_passed"]}
+      {"type":"object","properties":{"ticket_key":{"type":"string"},"branch":{"type":"string"},"commits":{"type":"array","items":{"type":"object","properties":{"hash":{"type":"string"},"message":{"type":"string"},"task_id":{"type":"string"}},"required":["hash","message","task_id"]}},"files_changed":{"type":"array","items":{"type":"object","properties":{"path":{"type":"string"},"action":{"type":"string"}},"required":["path","action"]}},"task_results":{"type":"array","items":{"type":"object","properties":{"task_id":{"type":"string"},"status":{"type":"string"},"reason":{"type":"string"}},"required":["task_id","status"]}},"tests_passed":{"type":"boolean"},"test_output":{"type":"string"},"deviations":{"type":"array","items":{"type":"string"}}},"required":["ticket_key","branch","commits","files_changed"]}
     tools:
       - Read
       - Write

--- a/cmd/soda/embeds/pipelines/docs-only.yaml
+++ b/cmd/soda/embeds/pipelines/docs-only.yaml
@@ -1,0 +1,39 @@
+# SODA Docs-Only Pipeline
+#
+# A minimal pipeline for documentation-only changes that skip triage,
+# planning, and verification. Two phases: implement → submit.
+
+phases:
+  - name: implement
+    prompt: prompts/docs-implement.md
+    schema: |
+      {"type":"object","properties":{"ticket_key":{"type":"string"},"branch":{"type":"string"},"commits":{"type":"array","items":{"type":"object","properties":{"hash":{"type":"string"},"message":{"type":"string"},"task_id":{"type":"string"}},"required":["hash","message","task_id"]}},"files_changed":{"type":"array","items":{"type":"object","properties":{"path":{"type":"string"},"action":{"type":"string"}},"required":["path","action"]}},"task_results":{"type":"array","items":{"type":"object","properties":{"task_id":{"type":"string"},"status":{"type":"string"},"reason":{"type":"string"}},"required":["task_id","status"]}},"tests_passed":{"type":"boolean"},"test_output":{"type":"string"},"deviations":{"type":"array","items":{"type":"string"}}},"required":["ticket_key","branch","commits","files_changed","task_results","tests_passed"]}
+    tools:
+      - Read
+      - Write
+      - Edit
+      - Glob
+      - Grep
+      - Bash
+    timeout: 10m
+    retry:
+      transient: 2
+      parse: 1
+      semantic: 0
+    depends_on: []
+
+  - name: submit
+    prompt: prompts/submit.md
+    schema: |
+      {"type":"object","properties":{"ticket_key":{"type":"string"},"pr_url":{"type":"string"},"pr_number":{"type":"integer"},"title":{"type":"string"},"branch":{"type":"string"},"target":{"type":"string"},"forge":{"type":"string"}},"required":["ticket_key","pr_url","pr_number","title","branch","target","forge"]}
+    tools:
+      - Bash(git:*)
+      - Bash(gh:*)
+      - Bash(glab:*)
+    timeout: 3m
+    retry:
+      transient: 2
+      parse: 1
+      semantic: 0
+    depends_on:
+      - implement

--- a/cmd/soda/embeds/pipelines/quick-fix.yaml
+++ b/cmd/soda/embeds/pipelines/quick-fix.yaml
@@ -1,0 +1,57 @@
+# SODA Quick-Fix Pipeline
+#
+# A shortened pipeline for small, well-understood fixes that skip
+# triage and planning. Three phases: implement → verify → submit.
+
+phases:
+  - name: implement
+    prompt: prompts/quick-fix-implement.md
+    schema: |
+      {"type":"object","properties":{"ticket_key":{"type":"string"},"branch":{"type":"string"},"commits":{"type":"array","items":{"type":"object","properties":{"hash":{"type":"string"},"message":{"type":"string"},"task_id":{"type":"string"}},"required":["hash","message","task_id"]}},"files_changed":{"type":"array","items":{"type":"object","properties":{"path":{"type":"string"},"action":{"type":"string"}},"required":["path","action"]}},"task_results":{"type":"array","items":{"type":"object","properties":{"task_id":{"type":"string"},"status":{"type":"string"},"reason":{"type":"string"}},"required":["task_id","status"]}},"tests_passed":{"type":"boolean"},"test_output":{"type":"string"},"deviations":{"type":"array","items":{"type":"string"}}},"required":["ticket_key","branch","commits","files_changed","task_results","tests_passed"]}
+    tools:
+      - Read
+      - Write
+      - Edit
+      - Glob
+      - Grep
+      - Bash
+    timeout: 15m
+    retry:
+      transient: 2
+      parse: 1
+      semantic: 0
+    depends_on: []
+
+  - name: verify
+    prompt: prompts/verify.md
+    schema: |
+      {"type":"object","properties":{"ticket_key":{"type":"string"},"verdict":{"type":"string"},"criteria_results":{"type":"array","items":{"type":"object","properties":{"criterion":{"type":"string"},"passed":{"type":"boolean"},"evidence":{"type":"string"}},"required":["criterion","passed","evidence"]}},"command_results":{"type":"array","items":{"type":"object","properties":{"command":{"type":"string"},"exit_code":{"type":"integer"},"output":{"type":"string"},"passed":{"type":"boolean"}},"required":["command","exit_code","output","passed"]}},"code_issues":{"type":"array","items":{"type":"object","properties":{"file":{"type":"string"},"line":{"type":"integer"},"severity":{"type":"string"},"issue":{"type":"string"},"suggested_fix":{"type":"string"}},"required":["file","severity","issue"]}},"fixes_required":{"type":"array","items":{"type":"string"}}},"required":["ticket_key","verdict","criteria_results","command_results"]}
+    tools:
+      - Read
+      - Glob
+      - Grep
+      - Bash
+    timeout: 8m
+    retry:
+      transient: 2
+      parse: 1
+      semantic: 1
+    depends_on:
+      - implement
+
+  - name: submit
+    prompt: prompts/submit.md
+    schema: |
+      {"type":"object","properties":{"ticket_key":{"type":"string"},"pr_url":{"type":"string"},"pr_number":{"type":"integer"},"title":{"type":"string"},"branch":{"type":"string"},"target":{"type":"string"},"forge":{"type":"string"}},"required":["ticket_key","pr_url","pr_number","title","branch","target","forge"]}
+    tools:
+      - Bash(git:*)
+      - Bash(gh:*)
+      - Bash(glab:*)
+    timeout: 3m
+    retry:
+      transient: 2
+      parse: 1
+      semantic: 0
+    depends_on:
+      - implement
+      - verify

--- a/cmd/soda/embeds/prompts/docs-implement.md
+++ b/cmd/soda/embeds/prompts/docs-implement.md
@@ -1,0 +1,64 @@
+You are a technical writer updating documentation for a project.
+
+## Ticket
+
+Key: {{.Ticket.Key}}
+Summary: {{.Ticket.Summary}}
+
+### Description
+{{.Ticket.Description}}
+
+{{- if .Ticket.AcceptanceCriteria}}
+
+### Acceptance Criteria
+{{range .Ticket.AcceptanceCriteria}}- {{.}}
+{{end}}
+{{- end}}
+
+{{- if .Ticket.ExistingSpec}}
+
+## Existing Spec
+{{.Ticket.ExistingSpec}}
+{{- end}}
+
+{{- if .Ticket.ExistingPlan}}
+
+## Existing Plan
+{{.Ticket.ExistingPlan}}
+{{- end}}
+
+{{- if .Context.ProjectContext}}
+
+## Project Context
+{{.Context.ProjectContext}}
+{{- end}}
+
+{{- if .Context.RepoConventions}}
+
+## Repo Conventions
+{{.Context.RepoConventions}}
+{{- end}}
+
+## Working Directory
+
+You are working in a git worktree at: {{.WorktreePath}}
+Branch: {{.Branch}}
+Base: {{.BaseBranch}}
+
+## Your Task
+
+This is a docs-only pipeline — only documentation files should be changed.
+Do NOT modify source code, tests, or configuration files.
+
+1. **Read the existing documentation** to understand the current state.
+2. **Make the documentation changes** described in the ticket.
+3. **Follow existing documentation style** — formatting, tone, structure.
+4. **Check for broken links or references** if applicable.
+5. **Commit** with a descriptive message referencing the ticket key.
+
+After implementation:
+
+- List every file you created, modified, or deleted.
+- List every commit you made (hash + message).
+- Report any deviations and why.
+- Confirm that only documentation files were changed.

--- a/cmd/soda/embeds/prompts/quick-fix-implement.md
+++ b/cmd/soda/embeds/prompts/quick-fix-implement.md
@@ -1,0 +1,73 @@
+You are a software engineer applying a quick fix to a codebase.
+
+## Ticket
+
+Key: {{.Ticket.Key}}
+Summary: {{.Ticket.Summary}}
+
+### Description
+{{.Ticket.Description}}
+
+{{- if .Ticket.AcceptanceCriteria}}
+
+### Acceptance Criteria
+{{range .Ticket.AcceptanceCriteria}}- {{.}}
+{{end}}
+{{- end}}
+
+{{- if .Ticket.ExistingSpec}}
+
+## Existing Spec
+{{.Ticket.ExistingSpec}}
+{{- end}}
+
+{{- if .Ticket.ExistingPlan}}
+
+## Existing Plan
+{{.Ticket.ExistingPlan}}
+{{- end}}
+
+{{- if .Context.ProjectContext}}
+
+## Project Context
+{{.Context.ProjectContext}}
+{{- end}}
+
+{{- if .Context.RepoConventions}}
+
+## Repo Conventions
+{{.Context.RepoConventions}}
+{{- end}}
+
+{{- if .Context.Gotchas}}
+
+## Known Gotchas
+{{.Context.Gotchas}}
+{{- end}}
+
+## Working Directory
+
+You are working in a git worktree at: {{.WorktreePath}}
+Branch: {{.Branch}}
+Base: {{.BaseBranch}}
+
+## Your Task
+
+This is a quick-fix pipeline — there is no separate triage or plan phase.
+You must triage the ticket, decide on an approach, and implement it directly.
+
+1. **Read the relevant codebase** — identify the files and areas that need changes.
+2. **Assess the scope** — this pipeline is for small, well-understood changes.
+   If the change is too large or complex, note it in deviations.
+3. **Implement the fix** — make the changes, following repo conventions.
+4. **Write or update tests** as needed.
+5. **Run the formatter** if configured: `{{.Config.Formatter}}`
+6. **Run the tests** if configured: `{{.Config.TestCommand}}`
+7. **Commit** with a descriptive message referencing the ticket key.
+
+After implementation:
+
+- List every file you created, modified, or deleted.
+- List every commit you made (hash + message).
+- Report any deviations and why.
+- Report any test failures and whether they were resolved.

--- a/cmd/soda/embeds/prompts/submit.md
+++ b/cmd/soda/embeds/prompts/submit.md
@@ -8,8 +8,11 @@ Summary: {{.Ticket.Summary}}
 ## Implementation Report
 {{.Artifacts.Implement}}
 
+{{- if .Artifacts.Verify}}
+
 ## Verification Report
 {{.Artifacts.Verify}}
+{{- end}}
 
 ## Repo Configuration
 

--- a/cmd/soda/embeds/prompts/verify.md
+++ b/cmd/soda/embeds/prompts/verify.md
@@ -1,4 +1,4 @@
-You are a quality engineer verifying an implementation against its plan and acceptance criteria.
+You are a quality engineer verifying an implementation against its acceptance criteria.
 
 ## Ticket
 
@@ -12,8 +12,11 @@ Summary: {{.Ticket.Summary}}
 {{end}}
 {{- end}}
 
+{{- if .Artifacts.Plan}}
+
 ## Implementation Plan
 {{.Artifacts.Plan}}
+{{- end}}
 
 ## Implementation Report
 {{.Artifacts.Implement}}
@@ -45,7 +48,7 @@ For each acceptance criterion, verify it is met. Read the actual code, not just 
 - Does it follow repo conventions?
 - Are there obvious bugs, edge cases, or security issues?
 - Are tests adequate? Do they cover the acceptance criteria?
-- Does it match the plan? If deviations exist, are they justified?
+- If a plan was provided, does the implementation match it? If deviations exist, are they justified? If no plan was provided, verify against the ticket requirements and acceptance criteria.
 - For each code issue found, include a `suggested_fix` describing the concrete change needed (e.g., "add nil check before dereferencing", "rename variable X to Y"). This helps the patch phase apply targeted fixes.
 
 ### 4. Check for regressions

--- a/cmd/soda/main.go
+++ b/cmd/soda/main.go
@@ -18,6 +18,16 @@ var embeddedPrompts embed.FS
 //go:embed embeds/phases.yaml
 var embeddedPhases []byte
 
+//go:embed all:embeds/pipelines
+var embeddedPipelines embed.FS
+
+// knownEmbeddedPipelines maps pipeline names to their embedded file paths
+// within the embeddedPipelines filesystem.
+var knownEmbeddedPipelines = map[string]string{
+	"quick-fix": "embeds/pipelines/quick-fix.yaml",
+	"docs-only": "embeds/pipelines/docs-only.yaml",
+}
+
 var version = "dev"
 
 func main() {
@@ -140,10 +150,28 @@ func resolvePhasesPath(pipelineName string) (path string, cleanup func(), err er
 		}
 	}
 
-	// Named pipelines have no embedded fallback.
+	// Check known embedded pipelines.
 	if pipelineName != "" && pipelineName != "default" {
-		return "", nil, fmt.Errorf("pipeline %q not found (looked for %s in . and %s)",
-			pipelineName, filename, filepath.Join(configDir, "soda"))
+		embeddedPath, ok := knownEmbeddedPipelines[pipelineName]
+		if !ok {
+			return "", nil, fmt.Errorf("pipeline %q not found (looked for %s in . and %s)",
+				pipelineName, filename, filepath.Join(configDir, "soda"))
+		}
+		data, readErr := fs.ReadFile(embeddedPipelines, embeddedPath)
+		if readErr != nil {
+			return "", nil, fmt.Errorf("read embedded pipeline %q: %w", pipelineName, readErr)
+		}
+		tmpFile, tmpErr := os.CreateTemp("", "soda-phases-*.yaml")
+		if tmpErr != nil {
+			return "", nil, fmt.Errorf("create temp phases file: %w", tmpErr)
+		}
+		if _, writeErr := tmpFile.Write(data); writeErr != nil {
+			tmpFile.Close()
+			os.Remove(tmpFile.Name())
+			return "", nil, fmt.Errorf("write embedded phases: %w", writeErr)
+		}
+		tmpFile.Close()
+		return tmpFile.Name(), func() { os.Remove(tmpFile.Name()) }, nil
 	}
 
 	// Fall back to embedded default.

--- a/cmd/soda/pipelines.go
+++ b/cmd/soda/pipelines.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"text/tabwriter"
 
 	"github.com/decko/soda/internal/pipeline"
@@ -29,21 +30,42 @@ func runPipelines(cmd *cobra.Command) error {
 
 	pipelines := pipeline.DiscoverPipelines(dirs, sources)
 
-	// Always include the embedded default if not already found.
-	hasDefault := false
+	// Always include embedded pipelines if not already discovered on disk.
+	discovered := make(map[string]bool, len(pipelines))
 	for _, p := range pipelines {
-		if p.Name == "default" {
-			hasDefault = true
-			break
-		}
+		discovered[p.Name] = true
 	}
-	if !hasDefault {
+
+	// Embedded default pipeline.
+	if !discovered["default"] {
 		pipelines = append([]pipeline.PipelineInfo{{
 			Name:   "default",
 			Path:   "(embedded)",
 			Source: "embedded",
 		}}, pipelines...)
 	}
+
+	// Known embedded alternative pipelines.
+	for name := range knownEmbeddedPipelines {
+		if !discovered[name] {
+			pipelines = append(pipelines, pipeline.PipelineInfo{
+				Name:   name,
+				Path:   "(embedded)",
+				Source: "embedded",
+			})
+		}
+	}
+
+	// Re-sort: "default" first, then alphabetical.
+	sort.Slice(pipelines, func(i, j int) bool {
+		if pipelines[i].Name == "default" {
+			return true
+		}
+		if pipelines[j].Name == "default" {
+			return false
+		}
+		return pipelines[i].Name < pipelines[j].Name
+	})
 
 	if len(pipelines) == 0 {
 		fmt.Fprintln(cmd.OutOrStdout(), "No pipeline configurations found.")

--- a/cmd/soda/pipelines_test.go
+++ b/cmd/soda/pipelines_test.go
@@ -28,15 +28,7 @@ func TestDiscoverDirs(t *testing.T) {
 
 func TestRunPipelines_EmbeddedDefault(t *testing.T) {
 	// Run from a temp dir with no pipeline files — should show embedded default.
-	origDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	tmpDir := t.TempDir()
-	if err := os.Chdir(tmpDir); err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(origDir)
+	t.Chdir(t.TempDir())
 
 	cmd := newPipelinesCmd()
 	var buf bytes.Buffer
@@ -56,15 +48,8 @@ func TestRunPipelines_EmbeddedDefault(t *testing.T) {
 }
 
 func TestRunPipelines_LocalPipelines(t *testing.T) {
-	origDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
 	tmpDir := t.TempDir()
-	if err := os.Chdir(tmpDir); err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(origDir)
+	t.Chdir(tmpDir)
 
 	// Create local pipeline files.
 	phases := "phases:\n  - name: triage\n    prompt: prompts/triage.md\n    timeout: 1m\n"
@@ -98,15 +83,7 @@ func TestRunPipelines_LocalPipelines(t *testing.T) {
 func TestRunPipelines_EmbeddedAlternativePipelines(t *testing.T) {
 	// Run from a temp dir with no pipeline files — should show all embedded
 	// pipelines including quick-fix and docs-only.
-	origDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	tmpDir := t.TempDir()
-	if err := os.Chdir(tmpDir); err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(origDir)
+	t.Chdir(t.TempDir())
 
 	cmd := newPipelinesCmd()
 	var buf bytes.Buffer
@@ -127,15 +104,8 @@ func TestRunPipelines_EmbeddedAlternativePipelines(t *testing.T) {
 func TestRunPipelines_LocalOverrideHidesEmbedded(t *testing.T) {
 	// When a local phases-quick-fix.yaml exists, it should show "local"
 	// source rather than "embedded".
-	origDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
 	tmpDir := t.TempDir()
-	if err := os.Chdir(tmpDir); err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(origDir)
+	t.Chdir(tmpDir)
 
 	// Create a local quick-fix pipeline file.
 	phases := "phases:\n  - name: implement\n    prompt: prompts/implement.md\n    timeout: 1m\n"
@@ -282,15 +252,7 @@ func TestKnownEmbeddedPipelines_AllDiscoverable(t *testing.T) {
 }
 
 func TestRunPipelines_TableHeader(t *testing.T) {
-	origDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	tmpDir := t.TempDir()
-	if err := os.Chdir(tmpDir); err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(origDir)
+	t.Chdir(t.TempDir())
 
 	cmd := newPipelinesCmd()
 	var buf bytes.Buffer

--- a/cmd/soda/pipelines_test.go
+++ b/cmd/soda/pipelines_test.go
@@ -4,8 +4,11 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
+
+	"github.com/decko/soda/internal/pipeline"
 )
 
 func TestDiscoverDirs(t *testing.T) {
@@ -89,6 +92,192 @@ func TestRunPipelines_LocalPipelines(t *testing.T) {
 	}
 	if !strings.Contains(output, "local") {
 		t.Error("expected 'local' source in output")
+	}
+}
+
+func TestRunPipelines_EmbeddedAlternativePipelines(t *testing.T) {
+	// Run from a temp dir with no pipeline files — should show all embedded
+	// pipelines including quick-fix and docs-only.
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpDir := t.TempDir()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(origDir)
+
+	cmd := newPipelinesCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("pipelines command failed: %v", err)
+	}
+
+	output := buf.String()
+	for _, name := range []string{"default", "quick-fix", "docs-only"} {
+		if !strings.Contains(output, name) {
+			t.Errorf("expected %q pipeline in output, got:\n%s", name, output)
+		}
+	}
+}
+
+func TestRunPipelines_LocalOverrideHidesEmbedded(t *testing.T) {
+	// When a local phases-quick-fix.yaml exists, it should show "local"
+	// source rather than "embedded".
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpDir := t.TempDir()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(origDir)
+
+	// Create a local quick-fix pipeline file.
+	phases := "phases:\n  - name: implement\n    prompt: prompts/implement.md\n    timeout: 1m\n"
+	if err := os.WriteFile(filepath.Join(tmpDir, "phases-quick-fix.yaml"), []byte(phases), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newPipelinesCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("pipelines command failed: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "quick-fix") {
+		t.Error("expected quick-fix in output")
+	}
+	// The quick-fix entry should show "local" source, not "embedded".
+	lines := strings.Split(output, "\n")
+	quickFixLines := 0
+	for _, line := range lines {
+		// Match lines where quick-fix appears as the pipeline name (first column).
+		if strings.HasPrefix(strings.TrimSpace(line), "quick-fix") {
+			quickFixLines++
+			if !strings.Contains(line, "local") {
+				t.Errorf("expected 'local' source for quick-fix, got: %s", line)
+			}
+		}
+	}
+	if quickFixLines != 1 {
+		t.Errorf("expected exactly 1 quick-fix row, got %d", quickFixLines)
+	}
+}
+
+func TestResolvePhasesPath_EmbeddedQuickFix(t *testing.T) {
+	path, cleanup, err := resolvePhasesPath("quick-fix")
+	if err != nil {
+		t.Fatalf("resolvePhasesPath(quick-fix) failed: %v", err)
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+
+	pl, err := pipeline.LoadPipeline(path)
+	if err != nil {
+		t.Fatalf("LoadPipeline failed: %v", err)
+	}
+
+	if len(pl.Phases) != 3 {
+		t.Errorf("quick-fix: expected 3 phases, got %d", len(pl.Phases))
+	}
+
+	// Verify phase names and order.
+	wantNames := []string{"implement", "verify", "submit"}
+	for i, want := range wantNames {
+		if pl.Phases[i].Name != want {
+			t.Errorf("phase[%d] = %q, want %q", i, pl.Phases[i].Name, want)
+		}
+	}
+}
+
+func TestResolvePhasesPath_EmbeddedDocsOnly(t *testing.T) {
+	path, cleanup, err := resolvePhasesPath("docs-only")
+	if err != nil {
+		t.Fatalf("resolvePhasesPath(docs-only) failed: %v", err)
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+
+	pl, err := pipeline.LoadPipeline(path)
+	if err != nil {
+		t.Fatalf("LoadPipeline failed: %v", err)
+	}
+
+	if len(pl.Phases) != 2 {
+		t.Errorf("docs-only: expected 2 phases, got %d", len(pl.Phases))
+	}
+
+	// Verify phase names and order.
+	wantNames := []string{"implement", "submit"}
+	for i, want := range wantNames {
+		if pl.Phases[i].Name != want {
+			t.Errorf("phase[%d] = %q, want %q", i, pl.Phases[i].Name, want)
+		}
+	}
+}
+
+func TestResolvePhasesPath_UnknownPipeline(t *testing.T) {
+	_, _, err := resolvePhasesPath("nonexistent-pipeline")
+	if err == nil {
+		t.Fatal("expected error for unknown pipeline, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error should mention 'not found', got: %v", err)
+	}
+}
+
+func TestResolvePhasesPath_DependsOnValidation(t *testing.T) {
+	// Verify that both embedded pipelines pass depends_on cross-reference
+	// validation (which happens inside LoadPipeline).
+	for _, name := range []string{"quick-fix", "docs-only"} {
+		t.Run(name, func(t *testing.T) {
+			path, cleanup, err := resolvePhasesPath(name)
+			if err != nil {
+				t.Fatalf("resolvePhasesPath(%s) failed: %v", name, err)
+			}
+			if cleanup != nil {
+				defer cleanup()
+			}
+
+			_, err = pipeline.LoadPipeline(path)
+			if err != nil {
+				t.Fatalf("LoadPipeline(%s) failed depends_on validation: %v", name, err)
+			}
+		})
+	}
+}
+
+func TestKnownEmbeddedPipelines_AllDiscoverable(t *testing.T) {
+	// Verify every entry in knownEmbeddedPipelines is resolvable.
+	var names []string
+	for name := range knownEmbeddedPipelines {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) {
+			path, cleanup, err := resolvePhasesPath(name)
+			if err != nil {
+				t.Fatalf("resolvePhasesPath(%s) failed: %v", name, err)
+			}
+			if cleanup != nil {
+				defer cleanup()
+			}
+			if path == "" {
+				t.Fatalf("resolvePhasesPath(%s) returned empty path", name)
+			}
+		})
 	}
 }
 

--- a/cmd/soda/pipelines_test.go
+++ b/cmd/soda/pipelines_test.go
@@ -143,6 +143,7 @@ func TestRunPipelines_LocalOverrideHidesEmbedded(t *testing.T) {
 }
 
 func TestResolvePhasesPath_EmbeddedQuickFix(t *testing.T) {
+	t.Chdir(t.TempDir())
 	path, cleanup, err := resolvePhasesPath("quick-fix")
 	if err != nil {
 		t.Fatalf("resolvePhasesPath(quick-fix) failed: %v", err)
@@ -157,7 +158,7 @@ func TestResolvePhasesPath_EmbeddedQuickFix(t *testing.T) {
 	}
 
 	if len(pl.Phases) != 3 {
-		t.Errorf("quick-fix: expected 3 phases, got %d", len(pl.Phases))
+		t.Fatalf("quick-fix: expected 3 phases, got %d", len(pl.Phases))
 	}
 
 	// Verify phase names and order.
@@ -170,6 +171,7 @@ func TestResolvePhasesPath_EmbeddedQuickFix(t *testing.T) {
 }
 
 func TestResolvePhasesPath_EmbeddedDocsOnly(t *testing.T) {
+	t.Chdir(t.TempDir())
 	path, cleanup, err := resolvePhasesPath("docs-only")
 	if err != nil {
 		t.Fatalf("resolvePhasesPath(docs-only) failed: %v", err)
@@ -184,7 +186,7 @@ func TestResolvePhasesPath_EmbeddedDocsOnly(t *testing.T) {
 	}
 
 	if len(pl.Phases) != 2 {
-		t.Errorf("docs-only: expected 2 phases, got %d", len(pl.Phases))
+		t.Fatalf("docs-only: expected 2 phases, got %d", len(pl.Phases))
 	}
 
 	// Verify phase names and order.
@@ -197,6 +199,7 @@ func TestResolvePhasesPath_EmbeddedDocsOnly(t *testing.T) {
 }
 
 func TestResolvePhasesPath_UnknownPipeline(t *testing.T) {
+	t.Chdir(t.TempDir())
 	_, _, err := resolvePhasesPath("nonexistent-pipeline")
 	if err == nil {
 		t.Fatal("expected error for unknown pipeline, got nil")

--- a/cmd/soda/validate_test.go
+++ b/cmd/soda/validate_test.go
@@ -302,6 +302,56 @@ func TestNewValidateCmd_NoArgs(t *testing.T) {
 	}
 }
 
+func TestRunValidate_QuickFixPipeline(t *testing.T) {
+	cfg := &config.Config{
+		TicketSource: "github",
+		Mode:         "autonomous",
+		Model:        "claude-sonnet-4-20250514",
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := runValidate(&stdout, &stderr, cfg, "quick-fix")
+	if err != nil {
+		t.Fatalf("runValidate(quick-fix) returned error: %v\nstdout: %s\nstderr: %s", err, stdout.String(), stderr.String())
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "✓ phases:") {
+		t.Error("expected phases valid message for quick-fix")
+	}
+	if !strings.Contains(output, "3 phases loaded") {
+		t.Errorf("expected '3 phases loaded' for quick-fix, got: %s", output)
+	}
+	if !strings.Contains(output, "Validation passed") {
+		t.Error("expected validation passed for quick-fix")
+	}
+}
+
+func TestRunValidate_DocsOnlyPipeline(t *testing.T) {
+	cfg := &config.Config{
+		TicketSource: "github",
+		Mode:         "autonomous",
+		Model:        "claude-sonnet-4-20250514",
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := runValidate(&stdout, &stderr, cfg, "docs-only")
+	if err != nil {
+		t.Fatalf("runValidate(docs-only) returned error: %v\nstdout: %s\nstderr: %s", err, stdout.String(), stderr.String())
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "✓ phases:") {
+		t.Error("expected phases valid message for docs-only")
+	}
+	if !strings.Contains(output, "2 phases loaded") {
+		t.Errorf("expected '2 phases loaded' for docs-only, got: %s", output)
+	}
+	if !strings.Contains(output, "Validation passed") {
+		t.Error("expected validation passed for docs-only")
+	}
+}
+
 func TestRunValidate_ErrorOutput(t *testing.T) {
 	// Test that errors go to stderr and success markers go to stdout.
 	cfg := &config.Config{


### PR DESCRIPTION
## Summary

- Ships `quick-fix` pipeline (implement → verify → submit) and `docs-only` pipeline (implement → submit)
- Custom prompts that don't reference missing artifacts
- Both pass `soda validate --pipeline <name>`
- Discoverable via `soda pipelines`

Closes #304