### PR TITLE
docs: update plugin commands for --pipeline and --purge

### DIFF
--- a/cmd/soda/embeds/plugin/agents/pipeline-architect.md
+++ b/cmd/soda/embeds/plugin/agents/pipeline-architect.md
@@ -8,17 +8,20 @@ allowed_tools:
   - Bash(git:*)
 ---
 
-You are the Pipeline Architect — a design-only agent that analyzes the current project and proposes a `phases.yaml` configuration for the SODA pipeline.
+You are the Pipeline Architect — a design-only agent that analyzes the current project and proposes pipeline configurations for SODA.
 
 ## Your task
 
 1. Read the project structure and detect the tech stack (language, framework, test tools, linters)
-2. Propose a `phases.yaml` with appropriate:
+2. Propose named pipeline definitions as YAML files (e.g., `default.yaml`, `quick-fix.yaml`, `docs-only.yaml`) with appropriate:
    - Review specialists for the detected stack
    - Phase-specific context files
    - Timeout and retry settings calibrated for the project size
+   - Per-phase model selection (cheaper models for classification, stronger for implementation)
 3. Suggest `soda.yaml` project configuration entries
-4. Output the proposed configuration for user review
+4. Output the proposed configurations for user review
+
+Pipelines are placed in `./pipelines/` (project-level) or `~/.config/soda/pipelines/` (user-level). Run `soda pipelines` to list available pipelines and `soda run <ticket> --pipeline <name>` to select one.
 
 ## Rules
 

--- a/cmd/soda/embeds/plugin/commands/clean.md
+++ b/cmd/soda/embeds/plugin/commands/clean.md
@@ -1,8 +1,8 @@
 ---
-description: Clean completed/failed pipeline state and worktrees
+description: Clean completed/failed pipeline worktrees and branches
 ---
 
-Clean completed or failed SODA pipeline state and worktrees:
+Clean completed or failed SODA pipeline worktrees and branches:
 
 ```bash
 soda clean $ARGUMENTS
@@ -10,4 +10,4 @@ soda clean $ARGUMENTS
 
 If no ticket key is provided, ask the user for one or suggest using `--all` to clean all terminal pipelines.
 
-This removes worktrees, branches, and state directories for pipelines that have completed or failed.
+By default, this removes worktrees and branches but **preserves session data** (`.soda/<ticket>/`) for raki metrics. Use `--purge` to remove everything including session data.

--- a/cmd/soda/embeds/plugin/commands/run.md
+++ b/cmd/soda/embeds/plugin/commands/run.md
@@ -11,3 +11,5 @@ soda run $ARGUMENTS
 If no ticket key is provided, ask the user for one.
 
 This will execute all pipeline phases: triage → plan → implement → verify → review → submit.
+
+Use `--pipeline <name>` to select a named pipeline (e.g., `quick-fix`, `docs-only`). Run `soda pipelines` to list available pipelines.

--- a/cmd/soda/embeds/plugin/skills/soda-pipeline/RUNBOOK.md
+++ b/cmd/soda/embeds/plugin/skills/soda-pipeline/RUNBOOK.md
@@ -254,7 +254,7 @@ grep '"reviewer_completed"' .soda/<ticket>/events.jsonl
 
 **Fix:**
 1. List worktrees: `git worktree list`
-2. Clean stale worktrees: `soda clean <ticket>` (removes worktree + state)
+2. Clean stale worktrees: `soda clean <ticket>` (removes worktree, preserves session data)
 3. Clean all: `soda clean --all`
 4. Manual cleanup if soda clean fails:
    ```bash
@@ -323,16 +323,20 @@ grep '"phase_retrying"' .soda/<ticket>/events.jsonl
 ## Cleaning up
 
 ```bash
-soda clean <ticket>              # remove state + worktree for one ticket
-soda clean --all                 # clean all completed/failed sessions
+soda clean <ticket>              # remove worktree + branches, preserve session data
+soda clean <ticket> --purge      # remove everything including .soda/<ticket>/
+soda clean --all                 # clean all worktrees, preserve session data
+soda clean --all --purge         # clean everything including all session data
 soda clean --all --dry-run       # preview what would be cleaned
 ```
 
 Cleanup removes:
-- `.soda/<ticket>/` state directory
 - `.worktrees/soda/<ticket>/` worktree
 - Local `soda/<ticket>` branch
+- Remote `origin/soda/<ticket>` branch (with `--force`)
+
+Cleanup preserves (unless `--purge`):
+- `.soda/<ticket>/` session data (meta, events, artifacts — used by raki metrics)
 
 Cleanup does **not** remove:
-- Remote branches (push cleanup is manual)
-- Cost ledger entries (`.soda/cost.json` is preserved)
+- Cost ledger entries (`.soda/cost.json` is always preserved)


### PR DESCRIPTION
Update plugin slash commands, pipeline architect agent, and RUNBOOK to reflect named pipelines and clean --purge behavior.