### PR TITLE
feat(tui): ticket picker — select a ticket and trigger pipeline [#54]

### DIFF
--- a/cmd/soda/main.go
+++ b/cmd/soda/main.go
@@ -53,6 +53,7 @@ func newRootCmd() *cobra.Command {
 	cmd.AddCommand(
 		newInitCmd(),
 		newRunCmd(),
+		newPickCmd(),
 		newStatusCmd(),
 		newSessionsCmd(),
 		newHistoryCmd(),

--- a/cmd/soda/pick.go
+++ b/cmd/soda/pick.go
@@ -79,6 +79,7 @@ func runPick(cmd *cobra.Command, cfg *config.Config) error {
 
 	// Trigger the pipeline for the selected ticket.
 	fmt.Printf("Selected: %s — %s\n", result.Ticket.Key, result.Ticket.Summary)
+	cancel() // release signal handler before runPipeline creates its own
 	return runPipeline(cmd, cfg, result.Ticket.Key)
 }
 

--- a/cmd/soda/pick.go
+++ b/cmd/soda/pick.go
@@ -55,8 +55,17 @@ func runPick(cmd *cobra.Command, cfg *config.Config) error {
 	// Convert to TUI model data.
 	infos := ticketsToPickerInfo(tickets)
 
+	// Build refresh function so the user can press 'r' to reload the list.
+	refreshFn := func() ([]tui.TicketInfo, error) {
+		ts, listErr := source.List(ctx, query)
+		if listErr != nil {
+			return nil, listErr
+		}
+		return ticketsToPickerInfo(ts), nil
+	}
+
 	// Launch the picker TUI.
-	model := tui.NewPickerModel(infos)
+	model := tui.NewPickerModelWithRefresh(infos, refreshFn)
 	program := tea.NewProgram(model, tea.WithAltScreen())
 	finalModel, err := program.Run()
 	if err != nil {

--- a/cmd/soda/pick.go
+++ b/cmd/soda/pick.go
@@ -80,7 +80,18 @@ func runPick(cmd *cobra.Command, cfg *config.Config) error {
 	// Trigger the pipeline for the selected ticket.
 	fmt.Printf("Selected: %s — %s\n", result.Ticket.Key, result.Ticket.Summary)
 	cancel() // release signal handler before runPipeline creates its own
-	return runPipeline(cmd, cfg, result.Ticket.Key)
+
+	pipelineName, _ := cmd.Flags().GetString("pipeline")
+	mode, _ := cmd.Flags().GetString("mode")
+	useMock, _ := cmd.Flags().GetBool("mock")
+	return runPipeline(cfg, pipelineOpts{
+		ticketKey:       result.Ticket.Key,
+		pipelineName:    pipelineName,
+		pipelineChanged: cmd.Flags().Changed("pipeline"),
+		mode:            mode,
+		modeChanged:     cmd.Flags().Changed("mode"),
+		useMock:         useMock,
+	})
 }
 
 // ticketsToPickerInfo converts ticket.Ticket slices to tui.TicketInfo slices.

--- a/cmd/soda/pick.go
+++ b/cmd/soda/pick.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/decko/soda/internal/config"
+	"github.com/decko/soda/internal/ticket"
+	"github.com/decko/soda/internal/tui"
+	"github.com/spf13/cobra"
+)
+
+func newPickCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "pick",
+		Short: "Select a ticket interactively and trigger pipeline",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := loadConfig(cmd)
+			if err != nil {
+				return err
+			}
+			return runPick(cmd, cfg)
+		},
+	}
+
+	cmd.Flags().String("query", "", "search filter for listing tickets")
+	cmd.Flags().String("pipeline", "", "pipeline name (default: phases.yaml)")
+	cmd.Flags().String("mode", "", "execution mode: checkpoint or autonomous")
+	cmd.Flags().Bool("mock", false, "use mock runner for testing")
+
+	return cmd
+}
+
+func runPick(cmd *cobra.Command, cfg *config.Config) error {
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	// Build ticket source from config.
+	source, err := createTicketSource(cfg)
+	if err != nil {
+		return fmt.Errorf("pick: %w", err)
+	}
+
+	// Fetch ticket list.
+	query, _ := cmd.Flags().GetString("query")
+	tickets, err := source.List(ctx, query)
+	if err != nil {
+		return fmt.Errorf("pick: list tickets: %w", err)
+	}
+
+	// Convert to TUI model data.
+	infos := ticketsToPickerInfo(tickets)
+
+	// Launch the picker TUI.
+	model := tui.NewPickerModel(infos)
+	program := tea.NewProgram(model, tea.WithAltScreen())
+	finalModel, err := program.Run()
+	if err != nil {
+		return fmt.Errorf("pick: TUI error: %w", err)
+	}
+
+	pm, ok := finalModel.(tui.PickerModel)
+	if !ok {
+		return fmt.Errorf("pick: unexpected model type %T", finalModel)
+	}
+	result := pm.Result()
+	if result == nil {
+		// User quit without selecting.
+		return nil
+	}
+
+	if result.Action != tui.PickerActionRun {
+		return nil
+	}
+
+	// Trigger the pipeline for the selected ticket.
+	fmt.Printf("Selected: %s — %s\n", result.Ticket.Key, result.Ticket.Summary)
+	return runPipeline(cmd, cfg, result.Ticket.Key)
+}
+
+// ticketsToPickerInfo converts ticket.Ticket slices to tui.TicketInfo slices.
+func ticketsToPickerInfo(tickets []ticket.Ticket) []tui.TicketInfo {
+	infos := make([]tui.TicketInfo, 0, len(tickets))
+	for _, t := range tickets {
+		infos = append(infos, tui.TicketInfo{
+			Key:      t.Key,
+			Summary:  t.Summary,
+			Type:     t.Type,
+			Priority: t.Priority,
+			Status:   t.Status,
+			Labels:   t.Labels,
+		})
+	}
+	return infos
+}

--- a/cmd/soda/pick_test.go
+++ b/cmd/soda/pick_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/decko/soda/internal/ticket"
+	"github.com/decko/soda/internal/tui"
+)
+
+func TestNewPickCmd_Exists(t *testing.T) {
+	cmd := newPickCmd()
+	if cmd == nil {
+		t.Fatal("newPickCmd() returned nil")
+	}
+	if cmd.Use != "pick" {
+		t.Errorf("expected Use='pick', got %q", cmd.Use)
+	}
+}
+
+func TestNewPickCmd_Flags(t *testing.T) {
+	cmd := newPickCmd()
+
+	queryFlag := cmd.Flags().Lookup("query")
+	if queryFlag == nil {
+		t.Fatal("--query flag not found")
+	}
+	if queryFlag.DefValue != "" {
+		t.Errorf("--query default = %q, want empty", queryFlag.DefValue)
+	}
+
+	pipelineFlag := cmd.Flags().Lookup("pipeline")
+	if pipelineFlag == nil {
+		t.Fatal("--pipeline flag not found")
+	}
+
+	modeFlag := cmd.Flags().Lookup("mode")
+	if modeFlag == nil {
+		t.Fatal("--mode flag not found")
+	}
+
+	mockFlag := cmd.Flags().Lookup("mock")
+	if mockFlag == nil {
+		t.Fatal("--mock flag not found")
+	}
+}
+
+func TestTicketsToPickerInfo(t *testing.T) {
+	tickets := []ticket.Ticket{
+		{
+			Key:      "42",
+			Summary:  "Add validation",
+			Type:     "Feature",
+			Priority: "High",
+			Status:   "Open",
+			Labels:   []string{"enhancement"},
+		},
+		{
+			Key:      "58",
+			Summary:  "Fix login bug",
+			Type:     "Bug",
+			Priority: "Critical",
+			Status:   "In Progress",
+			Labels:   nil,
+		},
+	}
+
+	infos := ticketsToPickerInfo(tickets)
+
+	if len(infos) != 2 {
+		t.Fatalf("expected 2 infos, got %d", len(infos))
+	}
+
+	if infos[0].Key != "42" {
+		t.Errorf("infos[0].Key = %q, want %q", infos[0].Key, "42")
+	}
+	if infos[0].Summary != "Add validation" {
+		t.Errorf("infos[0].Summary = %q, want %q", infos[0].Summary, "Add validation")
+	}
+	if infos[0].Type != "Feature" {
+		t.Errorf("infos[0].Type = %q, want %q", infos[0].Type, "Feature")
+	}
+	if infos[0].Priority != "High" {
+		t.Errorf("infos[0].Priority = %q, want %q", infos[0].Priority, "High")
+	}
+	if infos[0].Status != "Open" {
+		t.Errorf("infos[0].Status = %q, want %q", infos[0].Status, "Open")
+	}
+	if len(infos[0].Labels) != 1 || infos[0].Labels[0] != "enhancement" {
+		t.Errorf("infos[0].Labels = %v, want [enhancement]", infos[0].Labels)
+	}
+
+	if infos[1].Key != "58" {
+		t.Errorf("infos[1].Key = %q, want %q", infos[1].Key, "58")
+	}
+	if infos[1].Priority != "Critical" {
+		t.Errorf("infos[1].Priority = %q, want %q", infos[1].Priority, "Critical")
+	}
+	if infos[1].Labels != nil {
+		t.Errorf("infos[1].Labels = %v, want nil", infos[1].Labels)
+	}
+}
+
+func TestTicketsToPickerInfo_Empty(t *testing.T) {
+	infos := ticketsToPickerInfo(nil)
+	if len(infos) != 0 {
+		t.Errorf("expected 0 infos for nil input, got %d", len(infos))
+	}
+}
+
+func TestPickerResultToTicketKey(t *testing.T) {
+	result := &tui.PickerResult{
+		Ticket: tui.TicketInfo{
+			Key:     "PROJ-99",
+			Summary: "Test ticket",
+		},
+		Action: tui.PickerActionRun,
+	}
+
+	if result.Ticket.Key != "PROJ-99" {
+		t.Errorf("expected key 'PROJ-99', got %q", result.Ticket.Key)
+	}
+}

--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -29,6 +29,43 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// pipelineOpts holds all flag-driven parameters for runPipeline so callers
+// don't need to register or pass a *cobra.Command with the right flags.
+type pipelineOpts struct {
+	ticketKey       string
+	pipelineName    string
+	pipelineChanged bool // true when --pipeline was explicitly passed
+	mode            string
+	modeChanged     bool // true when --mode was explicitly passed
+	fromPhase       string
+	dryRun          bool
+	useMock         bool
+	useTUI          bool
+}
+
+// pipelineOptsFromCmd extracts pipelineOpts from Cobra flags registered on the
+// run command.
+func pipelineOptsFromCmd(cmd *cobra.Command, ticketKey string) pipelineOpts {
+	pipelineName, _ := cmd.Flags().GetString("pipeline")
+	mode, _ := cmd.Flags().GetString("mode")
+	fromPhase, _ := cmd.Flags().GetString("from")
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	useMock, _ := cmd.Flags().GetBool("mock")
+	useTUI, _ := cmd.Flags().GetBool("tui")
+
+	return pipelineOpts{
+		ticketKey:       ticketKey,
+		pipelineName:    pipelineName,
+		pipelineChanged: cmd.Flags().Changed("pipeline"),
+		mode:            mode,
+		modeChanged:     cmd.Flags().Changed("mode"),
+		fromPhase:       fromPhase,
+		dryRun:          dryRun,
+		useMock:         useMock,
+		useTUI:          useTUI,
+	}
+}
+
 func newRunCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "run <ticket>",
@@ -39,7 +76,7 @@ func newRunCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return runPipeline(cmd, cfg, args[0])
+			return runPipeline(cfg, pipelineOptsFromCmd(cmd, args[0]))
 		},
 	}
 
@@ -53,11 +90,12 @@ func newRunCmd() *cobra.Command {
 	return cmd
 }
 
-func runPipeline(cmd *cobra.Command, cfg *config.Config, ticketKey string) error {
+func runPipeline(cfg *config.Config, opts pipelineOpts) error {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 
-	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	ticketKey := opts.ticketKey
+	dryRun := opts.dryRun
 
 	// Fetch ticket
 	source, err := createTicketSource(cfg)
@@ -85,7 +123,7 @@ func runPipeline(cmd *cobra.Command, cfg *config.Config, ticketKey string) error
 	}
 
 	// Load pipeline config
-	pipelineName, _ := cmd.Flags().GetString("pipeline")
+	pipelineName := opts.pipelineName
 	phasesPath, phasesCleanup, err := resolvePhasesPath(pipelineName)
 	if err != nil {
 		return fmt.Errorf("run: %w", err)
@@ -163,10 +201,10 @@ func runPipeline(cmd *cobra.Command, cfg *config.Config, ticketKey string) error
 	}
 
 	// When resuming, check if the stored pipeline differs from the current flag.
-	fromPhaseFlag, _ := cmd.Flags().GetString("from")
+	fromPhaseFlag := opts.fromPhase
 	if fromPhaseFlag != "" {
 		storedPipeline := state.Meta().Pipeline
-		if !cmd.Flags().Changed("pipeline") && storedPipeline != "" && storedPipeline != pipelineName {
+		if !opts.pipelineChanged && storedPipeline != "" && storedPipeline != pipelineName {
 			// Auto-adopt the stored pipeline name so the resume uses the correct config.
 			fmt.Fprintf(os.Stderr, "Warning: original run used pipeline %q; adopting for resume\n", storedPipeline)
 			pipelineName = storedPipeline
@@ -182,7 +220,7 @@ func runPipeline(cmd *cobra.Command, cfg *config.Config, ticketKey string) error
 				return fmt.Errorf("run: %w", err)
 			}
 			pl.Name = pipelineName
-		} else if cmd.Flags().Changed("pipeline") && storedPipeline != pipelineName {
+		} else if opts.pipelineChanged && storedPipeline != pipelineName {
 			fmt.Fprintf(os.Stderr, "Warning: original run used pipeline %q, but resuming with %q\n", storedPipeline, pipelineName)
 		}
 	}
@@ -190,8 +228,8 @@ func runPipeline(cmd *cobra.Command, cfg *config.Config, ticketKey string) error
 	// Resolve mode
 	mode := pipeline.Autonomous
 	modeStr := cfg.Mode
-	if cmd.Flags().Changed("mode") {
-		modeStr, _ = cmd.Flags().GetString("mode")
+	if opts.modeChanged {
+		modeStr = opts.mode
 	}
 	switch modeStr {
 	case "checkpoint":
@@ -204,7 +242,7 @@ func runPipeline(cmd *cobra.Command, cfg *config.Config, ticketKey string) error
 
 	// Build runner
 	var r runner.Runner
-	useMock, _ := cmd.Flags().GetBool("mock")
+	useMock := opts.useMock
 	if useMock {
 		r = buildMockRunner()
 	} else {
@@ -231,7 +269,7 @@ func runPipeline(cmd *cobra.Command, cfg *config.Config, ticketKey string) error
 	promptContext := buildPromptContext(cfg)
 
 	// Check if TUI mode is requested.
-	useTUI, _ := cmd.Flags().GetBool("tui")
+	useTUI := opts.useTUI
 
 	// Set up progress display (used in non-TUI mode).
 	isTTY := isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd())
@@ -346,7 +384,7 @@ func runPipeline(cmd *cobra.Command, cfg *config.Config, ticketKey string) error
 	costBefore := state.Meta().TotalCost
 
 	// Run or resume
-	fromPhase, _ := cmd.Flags().GetString("from")
+	fromPhase := opts.fromPhase
 	startTime := time.Now()
 
 	var runErr error

--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -68,13 +68,16 @@ func pipelineOptsFromCmd(cmd *cobra.Command, ticketKey string) pipelineOpts {
 
 func newRunCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "run <ticket>",
-		Short: "Run the pipeline for a ticket",
-		Args:  cobra.ExactArgs(1),
+		Use:   "run [ticket]",
+		Short: "Run the pipeline for a ticket (or pick one interactively)",
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := loadConfig(cmd)
 			if err != nil {
 				return err
+			}
+			if len(args) == 0 {
+				return runPick(cmd, cfg)
 			}
 			return runPipeline(cfg, pipelineOptsFromCmd(cmd, args[0]))
 		},
@@ -86,6 +89,7 @@ func newRunCmd() *cobra.Command {
 	cmd.Flags().Bool("dry-run", false, "render prompts without executing")
 	cmd.Flags().Bool("mock", false, "use mock runner for testing")
 	cmd.Flags().Bool("tui", false, "use interactive TUI display")
+	cmd.Flags().String("query", "", "search filter for listing tickets (picker mode)")
 
 	return cmd
 }

--- a/internal/tui/picker.go
+++ b/internal/tui/picker.go
@@ -11,12 +11,13 @@ import (
 // TicketInfo holds the data needed to render a single ticket row
 // in the TUI ticket picker.
 type TicketInfo struct {
-	Key      string
-	Summary  string
-	Type     string
-	Priority string
-	Status   string
-	Labels   []string
+	Key         string
+	Summary     string
+	Type        string
+	Priority    string
+	Status      string
+	Labels      []string
+	Description string
 }
 
 // PickerAction represents an action the user selected on a ticket.
@@ -214,17 +215,25 @@ func (m PickerModel) View() string {
 		filterLine = stylePending.Render("filter: ") + m.filter + "\n\n"
 	}
 
-	var lines []string
+	var listLines []string
 	for idx, ticket := range filtered {
-		lines = append(lines, renderTicketRow(ticket, idx == m.cursor))
+		listLines = append(listLines, renderTicketRow(ticket, idx == m.cursor))
 	}
 	if len(filtered) == 0 {
-		lines = []string{stylePending.Render("No matches.")}
+		listLines = []string{stylePending.Render("No matches.")}
+	}
+	listBody := strings.Join(listLines, "\n")
+
+	// Preview panel for the highlighted ticket.
+	var body string
+	if len(filtered) > 0 {
+		preview := renderPreviewPanel(filtered[m.cursor])
+		body = lipgloss.JoinHorizontal(lipgloss.Top, listBody, "  ", preview)
+	} else {
+		body = listBody
 	}
 
-	content := filterLine + strings.Join(lines, "\n")
-	content += "\n\n" + m.pickerHelpBar()
-
+	content := filterLine + body + "\n\n" + m.pickerHelpBar()
 	return renderPickerFrame(content, m.width)
 }
 
@@ -276,6 +285,29 @@ func ticketPriorityStyle(priority string) lipgloss.Style {
 	default:
 		return stylePending
 	}
+}
+
+// renderPreviewPanel returns a compact detail view for the given ticket,
+// shown to the right of the ticket list.
+func renderPreviewPanel(t TicketInfo) string {
+	lines := []string{
+		styleHeader.Render(t.Key),
+		"",
+		stylePending.Render("Type:     ") + t.Type,
+		stylePending.Render("Status:   ") + t.Status,
+		stylePending.Render("Priority: ") + t.Priority,
+	}
+	if len(t.Labels) > 0 {
+		lines = append(lines, stylePending.Render("Labels:   ")+strings.Join(t.Labels, ", "))
+	}
+	if t.Description != "" {
+		desc := t.Description
+		if runes := []rune(desc); len(runes) > 80 {
+			desc = string(runes[:77]) + "..."
+		}
+		lines = append(lines, "", stylePending.Render("Desc:"), desc)
+	}
+	return strings.Join(lines, "\n")
 }
 
 // pageSize returns the number of rows to skip on pg up/pg down.

--- a/internal/tui/picker.go
+++ b/internal/tui/picker.go
@@ -1,0 +1,221 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// TicketInfo holds the data needed to render a single ticket row
+// in the TUI ticket picker.
+type TicketInfo struct {
+	Key      string
+	Summary  string
+	Type     string
+	Priority string
+	Status   string
+	Labels   []string
+}
+
+// PickerAction represents an action the user selected on a ticket.
+type PickerAction int
+
+const (
+	// PickerActionNone means no action was taken.
+	PickerActionNone PickerAction = iota
+	// PickerActionRun means the user selected a ticket to run.
+	PickerActionRun
+)
+
+// PickerResult is returned when the user selects a ticket.
+type PickerResult struct {
+	Ticket TicketInfo
+	Action PickerAction
+}
+
+// PickerModel is a bubbletea model for browsing and selecting tickets.
+type PickerModel struct {
+	tickets  []TicketInfo
+	cursor   int
+	width    int
+	height   int
+	result   *PickerResult
+	quitting bool
+}
+
+// NewPickerModel creates a new ticket picker model.
+func NewPickerModel(tickets []TicketInfo) PickerModel {
+	return PickerModel{
+		tickets: tickets,
+	}
+}
+
+// Result returns the selected ticket action, or nil if the user quit.
+func (m PickerModel) Result() *PickerResult {
+	return m.result
+}
+
+// Init implements tea.Model.
+func (m PickerModel) Init() tea.Cmd {
+	return nil
+}
+
+// Update implements tea.Model.
+func (m PickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		return m, nil
+
+	case tea.KeyMsg:
+		return m.handleKey(msg)
+	}
+
+	return m, nil
+}
+
+func (m PickerModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if len(m.tickets) == 0 {
+		switch msg.String() {
+		case "q", "ctrl+c", "esc":
+			m.quitting = true
+			return m, tea.Quit
+		}
+		return m, nil
+	}
+
+	switch msg.String() {
+	case "q", "ctrl+c", "esc":
+		m.quitting = true
+		return m, tea.Quit
+
+	case "up", "k":
+		if m.cursor > 0 {
+			m.cursor--
+		}
+		return m, nil
+
+	case "down", "j":
+		if m.cursor < len(m.tickets)-1 {
+			m.cursor++
+		}
+		return m, nil
+
+	case "enter":
+		ticket := m.tickets[m.cursor]
+		m.result = &PickerResult{
+			Ticket: ticket,
+			Action: PickerActionRun,
+		}
+		return m, tea.Quit
+	}
+
+	return m, nil
+}
+
+// View implements tea.Model.
+func (m PickerModel) View() string {
+	if m.quitting {
+		return ""
+	}
+
+	if len(m.tickets) == 0 {
+		return renderPickerFrame("No tickets found.\n\n"+m.pickerHelpBar(), m.width)
+	}
+
+	var lines []string
+	for idx, ticket := range m.tickets {
+		lines = append(lines, renderTicketRow(ticket, idx == m.cursor))
+	}
+
+	content := strings.Join(lines, "\n")
+	content += "\n\n" + m.pickerHelpBar()
+
+	return renderPickerFrame(content, m.width)
+}
+
+func renderTicketRow(ticket TicketInfo, selected bool) string {
+	cursor := "  "
+	if selected {
+		cursor = "> "
+	}
+
+	key := padRight(ticket.Key, 10)
+	summary := ticket.Summary
+	summaryRunes := []rune(summary)
+	if len(summaryRunes) > 40 {
+		summary = string(summaryRunes[:37]) + "..."
+	}
+	summary = padRight(summary, 40)
+
+	priority := padRight(ticket.Priority, 10)
+
+	labels := ""
+	if len(ticket.Labels) > 0 {
+		labels = stylePending.Render("[" + strings.Join(ticket.Labels, ", ") + "]")
+	}
+
+	line := stylePending.Render(key) + "  " +
+		stylePending.Render(summary) + "  " +
+		ticketPriorityStyle(ticket.Priority).Render(priority)
+
+	if labels != "" {
+		line += "  " + labels
+	}
+
+	if selected {
+		return styleRunning.Render(cursor) + line
+	}
+	return stylePending.Render(cursor) + line
+}
+
+func ticketPriorityStyle(priority string) lipgloss.Style {
+	switch strings.ToLower(priority) {
+	case "critical", "highest":
+		return styleFailed
+	case "high":
+		return styleRunning
+	case "medium":
+		return stylePending
+	case "low", "lowest":
+		return stylePending
+	default:
+		return stylePending
+	}
+}
+
+func (m PickerModel) pickerHelpBar() string {
+	bindings := []struct{ key, label string }{
+		{"↑/↓", "navigate"},
+		{"Enter", "select"},
+		{"q", "quit"},
+	}
+	var parts []string
+	for _, b := range bindings {
+		parts = append(parts, fmt.Sprintf("%s %s",
+			styleKey.Render(b.key),
+			stylePending.Render(b.label),
+		))
+	}
+	return strings.Join(parts, "  ")
+}
+
+func renderPickerFrame(content string, width int) string {
+	title := styleHeader.Render("Pick a ticket")
+	body := title + "\n\n" + content
+
+	if width < 1 {
+		return body
+	}
+
+	frameWidth := width - 2
+	if frameWidth < 1 {
+		frameWidth = 1
+	}
+	return styleBorder.
+		Width(frameWidth).
+		Render(lipgloss.NewStyle().Padding(0, 1).Render(body))
+}

--- a/internal/tui/picker.go
+++ b/internal/tui/picker.go
@@ -104,6 +104,25 @@ func (m PickerModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
+	case "pgup":
+		pageSize := m.pageSize()
+		if m.cursor > pageSize {
+			m.cursor -= pageSize
+		} else {
+			m.cursor = 0
+		}
+		return m, nil
+
+	case "pgdown":
+		pageSize := m.pageSize()
+		last := len(m.tickets) - 1
+		if m.cursor+pageSize < last {
+			m.cursor += pageSize
+		} else {
+			m.cursor = last
+		}
+		return m, nil
+
 	case "enter":
 		ticket := m.tickets[m.cursor]
 		m.result = &PickerResult{
@@ -185,6 +204,14 @@ func ticketPriorityStyle(priority string) lipgloss.Style {
 	default:
 		return stylePending
 	}
+}
+
+// pageSize returns the number of rows to skip on pg up/pg down.
+func (m PickerModel) pageSize() int {
+	if m.height > 6 {
+		return m.height - 6
+	}
+	return 10
 }
 
 func (m PickerModel) pickerHelpBar() string {

--- a/internal/tui/picker.go
+++ b/internal/tui/picker.go
@@ -160,6 +160,15 @@ func (m PickerModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case "q", "ctrl+c", "esc":
 			m.quitting = true
 			return m, tea.Quit
+		case "r":
+			if m.refreshFunc != nil && !m.loading {
+				m.loading = true
+				fn := m.refreshFunc
+				return m, func() tea.Msg {
+					tickets, err := fn()
+					return ticketsRefreshedMsg{tickets: tickets, err: err}
+				}
+			}
 		}
 		return m, nil
 	}

--- a/internal/tui/picker.go
+++ b/internal/tui/picker.go
@@ -36,16 +36,25 @@ type PickerResult struct {
 	Action PickerAction
 }
 
+// ticketsRefreshedMsg carries the result of a background ticket refresh.
+type ticketsRefreshedMsg struct {
+	tickets []TicketInfo
+	err     error
+}
+
 // PickerModel is a bubbletea model for browsing and selecting tickets.
 type PickerModel struct {
-	tickets   []TicketInfo
-	cursor    int
-	width     int
-	height    int
-	result    *PickerResult
-	quitting  bool
-	filter    string
-	filtering bool
+	tickets     []TicketInfo
+	cursor      int
+	width       int
+	height      int
+	result      *PickerResult
+	quitting    bool
+	filter      string
+	filtering   bool
+	refreshFunc func() ([]TicketInfo, error)
+	refreshErr  string
+	loading     bool
 }
 
 // NewPickerModel creates a new ticket picker model.
@@ -53,6 +62,14 @@ func NewPickerModel(tickets []TicketInfo) PickerModel {
 	return PickerModel{
 		tickets: tickets,
 	}
+}
+
+// NewPickerModelWithRefresh creates a picker model that supports refreshing
+// the ticket list by pressing 'r'. refreshFn is called in the background.
+func NewPickerModelWithRefresh(tickets []TicketInfo, refreshFn func() ([]TicketInfo, error)) PickerModel {
+	m := NewPickerModel(tickets)
+	m.refreshFunc = refreshFn
+	return m
 }
 
 // Result returns the selected ticket action, or nil if the user quit.
@@ -75,6 +92,17 @@ func (m PickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.KeyMsg:
 		return m.handleKey(msg)
+
+	case ticketsRefreshedMsg:
+		m.loading = false
+		if msg.err != nil {
+			m.refreshErr = msg.err.Error()
+		} else {
+			m.refreshErr = ""
+			m.tickets = msg.tickets
+			m.cursor = 0
+		}
+		return m, nil
 	}
 
 	return m, nil
@@ -147,6 +175,17 @@ func (m PickerModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.filtering = true
 		return m, nil
 
+	case "r":
+		if m.refreshFunc != nil && !m.loading {
+			m.loading = true
+			fn := m.refreshFunc
+			return m, func() tea.Msg {
+				tickets, err := fn()
+				return ticketsRefreshedMsg{tickets: tickets, err: err}
+			}
+		}
+		return m, nil
+
 	case "up", "k":
 		if m.cursor > 0 {
 			m.cursor--
@@ -200,6 +239,14 @@ func (m PickerModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 func (m PickerModel) View() string {
 	if m.quitting {
 		return ""
+	}
+
+	if m.loading {
+		return renderPickerFrame(stylePending.Render("Refreshing…")+"\n\n"+m.pickerHelpBar(), m.width)
+	}
+
+	if m.refreshErr != "" {
+		return renderPickerFrame(styleFailed.Render("Error: "+m.refreshErr)+"\n\n"+m.pickerHelpBar(), m.width)
 	}
 
 	if len(m.tickets) == 0 {
@@ -322,6 +369,7 @@ func (m PickerModel) pickerHelpBar() string {
 	bindings := []struct{ key, label string }{
 		{"↑/↓", "navigate"},
 		{"/", "filter"},
+		{"r", "refresh"},
 		{"Enter", "select"},
 		{"q", "quit"},
 	}

--- a/internal/tui/picker.go
+++ b/internal/tui/picker.go
@@ -37,12 +37,14 @@ type PickerResult struct {
 
 // PickerModel is a bubbletea model for browsing and selecting tickets.
 type PickerModel struct {
-	tickets  []TicketInfo
-	cursor   int
-	width    int
-	height   int
-	result   *PickerResult
-	quitting bool
+	tickets   []TicketInfo
+	cursor    int
+	width     int
+	height    int
+	result    *PickerResult
+	quitting  bool
+	filter    string
+	filtering bool
 }
 
 // NewPickerModel creates a new ticket picker model.
@@ -77,7 +79,53 @@ func (m PickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+// filteredTickets returns the subset of tickets whose Key or Summary
+// contains the current filter string (case-insensitive substring match).
+// When filter is empty all tickets are returned.
+func (m PickerModel) filteredTickets() []TicketInfo {
+	if m.filter == "" {
+		return m.tickets
+	}
+	lower := strings.ToLower(m.filter)
+	var result []TicketInfo
+	for _, t := range m.tickets {
+		if strings.Contains(strings.ToLower(t.Key), lower) ||
+			strings.Contains(strings.ToLower(t.Summary), lower) {
+			result = append(result, t)
+		}
+	}
+	return result
+}
+
 func (m PickerModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	// Filter input mode: capture runes for the filter string.
+	if m.filtering {
+		switch msg.String() {
+		case "esc":
+			m.filtering = false
+			m.filter = ""
+			m.cursor = 0
+		case "enter":
+			m.filtering = false
+		case "backspace":
+			if len(m.filter) > 0 {
+				runes := []rune(m.filter)
+				m.filter = string(runes[:len(runes)-1])
+			}
+			if filtered := m.filteredTickets(); m.cursor >= len(filtered) && len(filtered) > 0 {
+				m.cursor = len(filtered) - 1
+			}
+		default:
+			if msg.Type == tea.KeyRunes {
+				m.filter += string(msg.Runes)
+				if filtered := m.filteredTickets(); m.cursor >= len(filtered) && len(filtered) > 0 {
+					m.cursor = len(filtered) - 1
+				}
+			}
+		}
+		return m, nil
+	}
+
 	if len(m.tickets) == 0 {
 		switch msg.String() {
 		case "q", "ctrl+c", "esc":
@@ -87,10 +135,16 @@ func (m PickerModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
+	filtered := m.filteredTickets()
+
 	switch msg.String() {
 	case "q", "ctrl+c", "esc":
 		m.quitting = true
 		return m, tea.Quit
+
+	case "/":
+		m.filtering = true
+		return m, nil
 
 	case "up", "k":
 		if m.cursor > 0 {
@@ -99,7 +153,7 @@ func (m PickerModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case "down", "j":
-		if m.cursor < len(m.tickets)-1 {
+		if m.cursor < len(filtered)-1 {
 			m.cursor++
 		}
 		return m, nil
@@ -115,7 +169,10 @@ func (m PickerModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	case "pgdown":
 		pageSize := m.pageSize()
-		last := len(m.tickets) - 1
+		last := len(filtered) - 1
+		if last < 0 {
+			last = 0
+		}
 		if m.cursor+pageSize < last {
 			m.cursor += pageSize
 		} else {
@@ -124,7 +181,10 @@ func (m PickerModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case "enter":
-		ticket := m.tickets[m.cursor]
+		if len(filtered) == 0 {
+			return m, nil
+		}
+		ticket := filtered[m.cursor]
 		m.result = &PickerResult{
 			Ticket: ticket,
 			Action: PickerActionRun,
@@ -145,12 +205,24 @@ func (m PickerModel) View() string {
 		return renderPickerFrame("No tickets found.\n\n"+m.pickerHelpBar(), m.width)
 	}
 
-	var lines []string
-	for idx, ticket := range m.tickets {
-		lines = append(lines, renderTicketRow(ticket, idx == m.cursor))
+	filtered := m.filteredTickets()
+
+	var filterLine string
+	if m.filtering {
+		filterLine = styleKey.Render("/") + " " + m.filter + "▋\n\n"
+	} else if m.filter != "" {
+		filterLine = stylePending.Render("filter: ") + m.filter + "\n\n"
 	}
 
-	content := strings.Join(lines, "\n")
+	var lines []string
+	for idx, ticket := range filtered {
+		lines = append(lines, renderTicketRow(ticket, idx == m.cursor))
+	}
+	if len(filtered) == 0 {
+		lines = []string{stylePending.Render("No matches.")}
+	}
+
+	content := filterLine + strings.Join(lines, "\n")
 	content += "\n\n" + m.pickerHelpBar()
 
 	return renderPickerFrame(content, m.width)
@@ -217,6 +289,7 @@ func (m PickerModel) pageSize() int {
 func (m PickerModel) pickerHelpBar() string {
 	bindings := []struct{ key, label string }{
 		{"↑/↓", "navigate"},
+		{"/", "filter"},
 		{"Enter", "select"},
 		{"q", "quit"},
 	}

--- a/internal/tui/picker_test.go
+++ b/internal/tui/picker_test.go
@@ -1,0 +1,315 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func testTickets() []TicketInfo {
+	return []TicketInfo{
+		{Key: "42", Summary: "Add validation to user input", Type: "Feature", Priority: "High", Status: "Open", Labels: []string{"enhancement"}},
+		{Key: "58", Summary: "Fix login timeout error", Type: "Bug", Priority: "Critical", Status: "Open", Labels: []string{"bug"}},
+		{Key: "64", Summary: "Update documentation for API", Type: "Task", Priority: "Low", Status: "In Progress", Labels: []string{"docs"}},
+		{Key: "99", Summary: "Refactor config loading", Type: "Task", Priority: "Medium", Status: "Open", Labels: []string{}},
+	}
+}
+
+func TestPickerModel_InitialState(t *testing.T) {
+	tickets := testTickets()
+	model := NewPickerModel(tickets)
+
+	if model.cursor != 0 {
+		t.Errorf("expected cursor at 0, got %d", model.cursor)
+	}
+	if model.result != nil {
+		t.Error("expected nil result initially")
+	}
+}
+
+func TestPickerModel_NavigateDown(t *testing.T) {
+	model := NewPickerModel(testTickets())
+
+	model2, _ := model.handleKey(tea.KeyMsg{Type: tea.KeyDown})
+	m := model2.(PickerModel)
+	if m.cursor != 1 {
+		t.Errorf("expected cursor at 1 after down, got %d", m.cursor)
+	}
+
+	// Navigate to last
+	m2, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyDown})
+	m3, _ := m2.(PickerModel).handleKey(tea.KeyMsg{Type: tea.KeyDown})
+	mm := m3.(PickerModel)
+	if mm.cursor != 3 {
+		t.Errorf("expected cursor at 3, got %d", mm.cursor)
+	}
+
+	// Cannot go past last
+	m4, _ := mm.handleKey(tea.KeyMsg{Type: tea.KeyDown})
+	if m4.(PickerModel).cursor != 3 {
+		t.Errorf("expected cursor still at 3, got %d", m4.(PickerModel).cursor)
+	}
+}
+
+func TestPickerModel_NavigateUp(t *testing.T) {
+	model := NewPickerModel(testTickets())
+	model.cursor = 2
+
+	model2, _ := model.handleKey(tea.KeyMsg{Type: tea.KeyUp})
+	m := model2.(PickerModel)
+	if m.cursor != 1 {
+		t.Errorf("expected cursor at 1 after up, got %d", m.cursor)
+	}
+
+	// Navigate to first
+	m2, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyUp})
+	if m2.(PickerModel).cursor != 0 {
+		t.Errorf("expected cursor at 0, got %d", m2.(PickerModel).cursor)
+	}
+
+	// Cannot go past first
+	m3, _ := m2.(PickerModel).handleKey(tea.KeyMsg{Type: tea.KeyUp})
+	if m3.(PickerModel).cursor != 0 {
+		t.Errorf("expected cursor still at 0, got %d", m3.(PickerModel).cursor)
+	}
+}
+
+func TestPickerModel_NavigateWithKJ(t *testing.T) {
+	model := NewPickerModel(testTickets())
+
+	// j moves down
+	model2, _ := model.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	if model2.(PickerModel).cursor != 1 {
+		t.Errorf("expected cursor at 1 after j, got %d", model2.(PickerModel).cursor)
+	}
+
+	// k moves up
+	model3, _ := model2.(PickerModel).handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("k")})
+	if model3.(PickerModel).cursor != 0 {
+		t.Errorf("expected cursor at 0 after k, got %d", model3.(PickerModel).cursor)
+	}
+}
+
+func TestPickerModel_EnterSelectsTicket(t *testing.T) {
+	model := NewPickerModel(testTickets())
+	model.cursor = 1
+
+	model2, cmd := model.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	m := model2.(PickerModel)
+
+	if m.result == nil {
+		t.Fatal("expected result after Enter")
+	}
+	if m.result.Ticket.Key != "58" {
+		t.Errorf("expected ticket 58, got %q", m.result.Ticket.Key)
+	}
+	if m.result.Action != PickerActionRun {
+		t.Errorf("expected PickerActionRun, got %d", m.result.Action)
+	}
+	if cmd == nil {
+		t.Error("expected quit command after Enter")
+	}
+}
+
+func TestPickerModel_Quit(t *testing.T) {
+	model := NewPickerModel(testTickets())
+
+	model2, cmd := model.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	m := model2.(PickerModel)
+
+	if !m.quitting {
+		t.Error("expected quitting true after q")
+	}
+	if m.result != nil {
+		t.Error("expected nil result on quit")
+	}
+	if cmd == nil {
+		t.Error("expected quit command")
+	}
+}
+
+func TestPickerModel_EscQuits(t *testing.T) {
+	model := NewPickerModel(testTickets())
+
+	model2, cmd := model.handleKey(tea.KeyMsg{Type: tea.KeyEsc})
+	m := model2.(PickerModel)
+
+	if !m.quitting {
+		t.Error("expected quitting true after esc")
+	}
+	if m.result != nil {
+		t.Error("expected nil result on esc")
+	}
+	if cmd == nil {
+		t.Error("expected quit command")
+	}
+}
+
+func TestPickerModel_CtrlCQuits(t *testing.T) {
+	model := NewPickerModel(testTickets())
+
+	model2, cmd := model.handleKey(tea.KeyMsg{Type: tea.KeyCtrlC})
+	m := model2.(PickerModel)
+
+	if !m.quitting {
+		t.Error("expected quitting true after ctrl+c")
+	}
+	if cmd == nil {
+		t.Error("expected quit command")
+	}
+}
+
+func TestPickerModel_ViewContent(t *testing.T) {
+	model := NewPickerModel(testTickets())
+	model.width = 80
+	model.height = 24
+
+	view := model.View()
+
+	// Should show title
+	if !strings.Contains(view, "Pick a ticket") {
+		t.Error("view missing title")
+	}
+
+	// Should show ticket keys
+	for _, key := range []string{"42", "58", "64", "99"} {
+		if !strings.Contains(view, key) {
+			t.Errorf("view missing ticket %q", key)
+		}
+	}
+
+	// Should show summaries
+	if !strings.Contains(view, "Add validation") {
+		t.Error("view missing ticket summary")
+	}
+
+	// Should show cursor on first item
+	if !strings.Contains(view, ">") {
+		t.Error("view missing cursor '>'")
+	}
+
+	// Should show help bar
+	if !strings.Contains(view, "select") {
+		t.Error("view missing 'select' in help bar")
+	}
+	if !strings.Contains(view, "quit") {
+		t.Error("view missing 'quit' in help bar")
+	}
+}
+
+func TestPickerModel_ViewEmpty(t *testing.T) {
+	model := NewPickerModel(nil)
+	model.width = 80
+
+	view := model.View()
+	if !strings.Contains(view, "No tickets found") {
+		t.Error("empty view should show 'No tickets found'")
+	}
+}
+
+func TestPickerModel_ViewQuitting(t *testing.T) {
+	model := NewPickerModel(testTickets())
+	model.quitting = true
+
+	view := model.View()
+	if view != "" {
+		t.Errorf("expected empty view when quitting, got %q", view)
+	}
+}
+
+func TestPickerModel_EmptyListQuit(t *testing.T) {
+	model := NewPickerModel(nil)
+
+	model2, cmd := model.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	m := model2.(PickerModel)
+
+	if !m.quitting {
+		t.Error("expected quitting true after q on empty list")
+	}
+	if cmd == nil {
+		t.Error("expected quit command")
+	}
+}
+
+func TestPickerModel_PriorityDisplay(t *testing.T) {
+	model := NewPickerModel(testTickets())
+	model.width = 80
+
+	view := model.View()
+	if !strings.Contains(view, "High") {
+		t.Error("view missing priority 'High'")
+	}
+}
+
+func TestPickerModel_WindowSize(t *testing.T) {
+	model := NewPickerModel(testTickets())
+
+	updatedModel, _ := model.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m := updatedModel.(PickerModel)
+
+	if m.width != 120 {
+		t.Errorf("expected width 120, got %d", m.width)
+	}
+	if m.height != 40 {
+		t.Errorf("expected height 40, got %d", m.height)
+	}
+}
+
+func TestPickerModel_ResultReturnsSelection(t *testing.T) {
+	model := NewPickerModel(testTickets())
+	model.cursor = 2
+
+	model2, _ := model.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	m := model2.(PickerModel)
+
+	result := m.Result()
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.Ticket.Key != "64" {
+		t.Errorf("expected ticket key '64', got %q", result.Ticket.Key)
+	}
+	if result.Ticket.Summary != "Update documentation for API" {
+		t.Errorf("expected summary, got %q", result.Ticket.Summary)
+	}
+}
+
+func TestPickerModel_ResultNilOnQuit(t *testing.T) {
+	model := NewPickerModel(testTickets())
+
+	model2, _ := model.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	m := model2.(PickerModel)
+
+	if m.Result() != nil {
+		t.Error("expected nil result after quit")
+	}
+}
+
+func TestPickerModel_EnterOnFirstTicket(t *testing.T) {
+	model := NewPickerModel(testTickets())
+
+	model2, _ := model.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	m := model2.(PickerModel)
+
+	result := m.Result()
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.Ticket.Key != "42" {
+		t.Errorf("expected ticket key '42', got %q", result.Ticket.Key)
+	}
+	if result.Action != PickerActionRun {
+		t.Errorf("expected PickerActionRun, got %d", result.Action)
+	}
+}
+
+func TestPickerModel_LabelsShown(t *testing.T) {
+	model := NewPickerModel(testTickets())
+	model.width = 120
+
+	view := model.View()
+	if !strings.Contains(view, "enhancement") {
+		t.Error("view missing label 'enhancement'")
+	}
+}


### PR DESCRIPTION
## Summary

- `soda run` with no ticket arg shows interactive ticket picker
- Hand-rolled list with j/k, up/down, pg up/pg down navigation
- Client-side filter (/ to search, substring on key + summary)
- Preview panel showing ticket details
- Source pre-flight validation before TUI entry
- `r` to refresh ticket list
- Sequential `tea.NewProgram` pattern (matches `SessionsModel`)

Closes #54