### PR TITLE
feat(pipeline): live pipeline streaming — broadcast layer + soda attach [#234] [#235]

### DIFF
--- a/cmd/soda/attach.go
+++ b/cmd/soda/attach.go
@@ -1,0 +1,243 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"github.com/decko/soda/internal/pipeline"
+	"github.com/spf13/cobra"
+)
+
+func newAttachCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "attach <ticket>",
+		Short: "Stream live output from a running pipeline",
+		Long:  "Connect to a running pipeline and stream its output, like docker logs -f.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := loadConfig(cmd)
+			if err != nil {
+				return err
+			}
+			fromStart, _ := cmd.Flags().GetBool("from-start")
+			showEvents, _ := cmd.Flags().GetBool("events")
+			return runAttach(cmd.OutOrStdout(), cmd.ErrOrStderr(), cfg.StateDir, args[0], fromStart, showEvents)
+		},
+	}
+
+	cmd.Flags().Bool("from-start", false, "replay event history before live stream")
+	cmd.Flags().Bool("events", false, "show phase-level events (not just output chunks)")
+
+	return cmd
+}
+
+func runAttach(stdout, stderr io.Writer, stateDir, ticketKey string, fromStart, showEvents bool) error {
+	ticketDir := filepath.Join(stateDir, ticketKey)
+
+	if _, err := os.Stat(ticketDir); os.IsNotExist(err) {
+		return fmt.Errorf("attach: no pipeline state for ticket %q (run 'soda run %s' first)", ticketKey, ticketKey)
+	}
+
+	lockPath := filepath.Join(ticketDir, "lock")
+	info, err := pipeline.ReadLockInfo(lockPath)
+	if err != nil || !info.IsAlive {
+		return attachNotRunning(stdout, ticketDir, ticketKey)
+	}
+
+	sockPath := filepath.Join(ticketDir, "stream.sock")
+	if _, err := os.Stat(sockPath); os.IsNotExist(err) {
+		return fmt.Errorf("attach: pipeline is running (PID %d) but broadcast socket not found — binary may be outdated", info.PID)
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	if fromStart {
+		if replayErr := replayHistory(stdout, ticketDir, showEvents); replayErr != nil {
+			fmt.Fprintf(stderr, "Warning: could not replay history: %v\n", replayErr)
+		}
+	}
+
+	fmt.Fprintf(stderr, "Attached to pipeline for %s (PID %d)\n", ticketKey, info.PID)
+
+	conn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		return fmt.Errorf("attach: connect to socket: %w", err)
+	}
+	defer conn.Close()
+
+	return streamFromSocket(ctx, stdout, conn, showEvents)
+}
+
+func attachNotRunning(stdout io.Writer, ticketDir, ticketKey string) error {
+	metaPath := filepath.Join(ticketDir, "meta.json")
+	meta, err := pipeline.ReadMeta(metaPath)
+	if err != nil {
+		return fmt.Errorf("attach: pipeline for %q is not running and no metadata found", ticketKey)
+	}
+
+	fmt.Fprintf(stdout, "Pipeline for %s is not running.\n", ticketKey)
+
+	lastPhase := ""
+	lastStatus := ""
+	for phase, ps := range meta.Phases {
+		if ps.Status != "" {
+			lastPhase = phase
+			lastStatus = string(ps.Status)
+		}
+	}
+	if lastPhase != "" {
+		fmt.Fprintf(stdout, "Last phase: %s (%s)\n", lastPhase, lastStatus)
+	}
+	if meta.TotalCost > 0 {
+		fmt.Fprintf(stdout, "Total cost: $%.2f\n", meta.TotalCost)
+	}
+
+	return fmt.Errorf("pipeline not running")
+}
+
+func replayHistory(stdout io.Writer, ticketDir string, showEvents bool) error {
+	events, err := pipeline.ReadEvents(ticketDir)
+	if err != nil {
+		return err
+	}
+
+	for _, ev := range events {
+		if showEvents {
+			fmt.Fprintln(stdout, pipeline.FormatEvent(ev))
+		} else if ev.Kind == pipeline.EventOutputChunk {
+			printChunkLine(stdout, ev)
+		}
+	}
+
+	if len(events) > 0 {
+		fmt.Fprintln(stdout, strings.Repeat("─", 40))
+	}
+
+	return nil
+}
+
+func streamFromSocket(ctx context.Context, stdout io.Writer, conn net.Conn, showEvents bool) error {
+	scanner := bufio.NewScanner(conn)
+
+	lineCh := make(chan string)
+	errCh := make(chan error, 1)
+	go func() {
+		for scanner.Scan() {
+			lineCh <- scanner.Text()
+		}
+		if err := scanner.Err(); err != nil {
+			errCh <- err
+		}
+		close(lineCh)
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case err := <-errCh:
+			if errors.Is(err, net.ErrClosed) {
+				return nil
+			}
+			return fmt.Errorf("attach: read error: %w", err)
+		case line, ok := <-lineCh:
+			if !ok {
+				fmt.Fprintln(stdout, "\nPipeline finished.")
+				return nil
+			}
+
+			var msg pipeline.BroadcastMessage
+			if err := json.Unmarshal([]byte(line), &msg); err != nil {
+				continue
+			}
+
+			switch msg.Type {
+			case "chunk":
+				var ev pipeline.Event
+				if err := json.Unmarshal(msg.Data, &ev); err != nil {
+					continue
+				}
+				printChunkLine(stdout, ev)
+
+			case "event":
+				if !showEvents {
+					var ev pipeline.Event
+					if err := json.Unmarshal(msg.Data, &ev); err != nil {
+						continue
+					}
+					if isPhaseTransition(ev) {
+						printPhaseHeader(stdout, ev)
+					}
+					if isTerminalEvent(ev) {
+						printTerminal(stdout, ev)
+						return nil
+					}
+					continue
+				}
+				var ev pipeline.Event
+				if err := json.Unmarshal(msg.Data, &ev); err != nil {
+					continue
+				}
+				fmt.Fprintln(stdout, pipeline.FormatEvent(ev))
+				if isTerminalEvent(ev) {
+					return nil
+				}
+			}
+		}
+	}
+}
+
+func printChunkLine(w io.Writer, ev pipeline.Event) {
+	if line, ok := ev.Data["line"].(string); ok {
+		fmt.Fprint(w, line)
+	}
+}
+
+func isPhaseTransition(ev pipeline.Event) bool {
+	switch ev.Kind {
+	case pipeline.EventPhaseStarted, pipeline.EventPhaseCompleted, pipeline.EventPhaseFailed:
+		return true
+	}
+	return false
+}
+
+func printPhaseHeader(w io.Writer, ev pipeline.Event) {
+	switch ev.Kind {
+	case pipeline.EventPhaseStarted:
+		fmt.Fprintf(w, "\n── %s ──\n", ev.Phase)
+	case pipeline.EventPhaseCompleted:
+		fmt.Fprintf(w, "\n✓ %s completed\n", ev.Phase)
+	case pipeline.EventPhaseFailed:
+		errMsg := ""
+		if e, ok := ev.Data["error"].(string); ok {
+			errMsg = ": " + e
+		}
+		fmt.Fprintf(w, "\n✗ %s failed%s\n", ev.Phase, errMsg)
+	}
+}
+
+func printTerminal(w io.Writer, ev pipeline.Event) {
+	switch ev.Kind {
+	case pipeline.EventEngineCompleted:
+		fmt.Fprintln(w, "\nPipeline completed successfully.")
+	case pipeline.EventEngineFailed:
+		errMsg := ""
+		if e, ok := ev.Data["error"].(string); ok {
+			errMsg = ": " + e
+		}
+		fmt.Fprintf(w, "\nPipeline failed%s\n", errMsg)
+	case pipeline.EventPipelineTimeout:
+		fmt.Fprintln(w, "\nPipeline timed out.")
+	}
+}

--- a/cmd/soda/attach_test.go
+++ b/cmd/soda/attach_test.go
@@ -1,0 +1,220 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/decko/soda/internal/pipeline"
+)
+
+func TestAttach_NonExistentTicket(t *testing.T) {
+	stateDir := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	err := runAttach(&stdout, &stderr, stateDir, "GHOST-999", false, false)
+	if err == nil {
+		t.Fatal("expected error for non-existent ticket")
+	}
+	if !strings.Contains(err.Error(), "no pipeline state") {
+		t.Errorf("error = %q, want to contain 'no pipeline state'", err.Error())
+	}
+}
+
+func TestAttach_CompletedPipeline(t *testing.T) {
+	stateDir := t.TempDir()
+	ticketDir := filepath.Join(stateDir, "TEST-1")
+	if err := os.MkdirAll(ticketDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	meta := &pipeline.PipelineMeta{
+		Ticket: "TEST-1",
+		Phases: map[string]*pipeline.PhaseState{
+			"triage": {Status: pipeline.PhaseCompleted},
+		},
+		TotalCost: 1.25,
+	}
+	metaData, _ := json.Marshal(meta)
+	os.WriteFile(filepath.Join(ticketDir, "meta.json"), metaData, 0644)
+
+	// Write a lock file with a dead PID.
+	lockInfo := pipeline.LockInfo{PID: 999999, AcquiredAt: time.Now().Add(-time.Hour)}
+	lockData, _ := json.Marshal(lockInfo)
+	os.WriteFile(filepath.Join(ticketDir, "lock"), lockData, 0644)
+
+	var stdout, stderr bytes.Buffer
+	err := runAttach(&stdout, &stderr, stateDir, "TEST-1", false, false)
+	if err == nil {
+		t.Fatal("expected error for completed pipeline")
+	}
+	if !strings.Contains(err.Error(), "pipeline not running") {
+		t.Errorf("error = %q, want to contain 'pipeline not running'", err.Error())
+	}
+	if !strings.Contains(stdout.String(), "not running") {
+		t.Errorf("stdout = %q, want to contain 'not running'", stdout.String())
+	}
+}
+
+func TestAttach_FromStartReplay(t *testing.T) {
+	stateDir := t.TempDir()
+	ticketDir := filepath.Join(stateDir, "TEST-2")
+	if err := os.MkdirAll(ticketDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write events to replay.
+	events := []pipeline.Event{
+		{Timestamp: time.Now(), Kind: pipeline.EventEngineStarted},
+		{Timestamp: time.Now(), Phase: "triage", Kind: pipeline.EventPhaseStarted},
+		{Timestamp: time.Now(), Phase: "triage", Kind: pipeline.EventPhaseCompleted},
+	}
+	var eventLines bytes.Buffer
+	for _, ev := range events {
+		data, _ := json.Marshal(ev)
+		eventLines.Write(data)
+		eventLines.WriteByte('\n')
+	}
+	os.WriteFile(filepath.Join(ticketDir, "events.jsonl"), eventLines.Bytes(), 0644)
+
+	var stdout bytes.Buffer
+	err := replayHistory(&stdout, ticketDir, true)
+	if err != nil {
+		t.Fatalf("replayHistory: %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "engine_started") {
+		t.Errorf("output missing engine_started: %q", output)
+	}
+	if !strings.Contains(output, "phase_started") {
+		t.Errorf("output missing phase_started: %q", output)
+	}
+	if !strings.Contains(output, "───") || !strings.Contains(output, "─") {
+		t.Errorf("output missing separator: %q", output)
+	}
+}
+
+func TestAttach_StreamFromSocket(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "test.sock")
+
+	broadcaster, err := pipeline.NewBroadcaster(sockPath)
+	if err != nil {
+		t.Fatalf("NewBroadcaster: %v", err)
+	}
+	defer broadcaster.Close()
+
+	conn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	// Wait for the broadcaster to register the client.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if broadcaster.ClientCount() >= 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// Broadcast events in a goroutine (including a terminal event to end streaming).
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		broadcaster.Broadcast(pipeline.Event{
+			Kind:  pipeline.EventPhaseStarted,
+			Phase: "implement",
+		})
+		broadcaster.Broadcast(pipeline.Event{
+			Kind:  pipeline.EventOutputChunk,
+			Phase: "implement",
+			Data:  map[string]any{"line": "writing code...\n"},
+		})
+		broadcaster.Broadcast(pipeline.Event{
+			Kind: pipeline.EventEngineCompleted,
+		})
+	}()
+
+	var stdout bytes.Buffer
+	ctx, cancel := contextWithTimeout(t, 5*time.Second)
+	defer cancel()
+
+	err = streamFromSocket(ctx, &stdout, conn, false)
+	if err != nil {
+		t.Fatalf("streamFromSocket: %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "implement") {
+		t.Errorf("output missing phase header: %q", output)
+	}
+	if !strings.Contains(output, "writing code...") {
+		t.Errorf("output missing chunk content: %q", output)
+	}
+	if !strings.Contains(output, "completed successfully") {
+		t.Errorf("output missing terminal message: %q", output)
+	}
+}
+
+func TestAttach_StreamWithEvents(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "test.sock")
+
+	broadcaster, err := pipeline.NewBroadcaster(sockPath)
+	if err != nil {
+		t.Fatalf("NewBroadcaster: %v", err)
+	}
+	defer broadcaster.Close()
+
+	conn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if broadcaster.ClientCount() >= 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		broadcaster.Broadcast(pipeline.Event{
+			Kind:  pipeline.EventPhaseStarted,
+			Phase: "triage",
+		})
+		broadcaster.Broadcast(pipeline.Event{
+			Kind: pipeline.EventEngineCompleted,
+		})
+	}()
+
+	var stdout bytes.Buffer
+	ctx, cancel := contextWithTimeout(t, 5*time.Second)
+	defer cancel()
+
+	err = streamFromSocket(ctx, &stdout, conn, true)
+	if err != nil {
+		t.Fatalf("streamFromSocket: %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "phase_started") {
+		t.Errorf("output missing formatted event: %q", output)
+	}
+	if !strings.Contains(output, "engine_completed") {
+		t.Errorf("output missing terminal event: %q", output)
+	}
+}
+
+func contextWithTimeout(t *testing.T, d time.Duration) (context.Context, context.CancelFunc) {
+	t.Helper()
+	return context.WithTimeout(context.Background(), d)
+}

--- a/cmd/soda/main.go
+++ b/cmd/soda/main.go
@@ -54,6 +54,7 @@ func newRootCmd() *cobra.Command {
 		newInitCmd(),
 		newRunCmd(),
 		newPickCmd(),
+		newAttachCmd(),
 		newStatusCmd(),
 		newSessionsCmd(),
 		newHistoryCmd(),

--- a/internal/pipeline/broadcast.go
+++ b/internal/pipeline/broadcast.go
@@ -1,0 +1,195 @@
+package pipeline
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"sync"
+	"time"
+)
+
+// MaxBroadcastClients is the maximum number of concurrent attach clients.
+const MaxBroadcastClients = 8
+
+// broadcastClientBufSize is the per-client event buffer depth.
+// Events are dropped if a client falls behind.
+const broadcastClientBufSize = 64
+
+// broadcastWriteTimeout is the deadline for writing a single message to a client.
+const broadcastWriteTimeout = 2 * time.Second
+
+// BroadcastMessage is the typed JSON envelope sent over the socket.
+type BroadcastMessage struct {
+	Type string          `json:"type"`
+	Data json.RawMessage `json:"data"`
+}
+
+// Broadcaster manages a Unix domain socket listener and fans out events
+// to all connected clients. Non-blocking: slow clients are dropped.
+type Broadcaster struct {
+	listener net.Listener
+	sockPath string
+
+	mu      sync.Mutex
+	clients map[*broadcastClient]struct{}
+	closed  bool
+	wg      sync.WaitGroup
+}
+
+type broadcastClient struct {
+	conn net.Conn
+	ch   chan []byte
+}
+
+// NewBroadcaster creates a Unix domain socket at sockPath and starts
+// accepting connections. If a stale socket file exists from a dead
+// process, it is removed.
+func NewBroadcaster(sockPath string) (*Broadcaster, error) {
+	if err := cleanStaleSock(sockPath); err != nil {
+		return nil, fmt.Errorf("broadcast: clean stale socket: %w", err)
+	}
+
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		return nil, fmt.Errorf("broadcast: listen %s: %w", sockPath, err)
+	}
+
+	b := &Broadcaster{
+		listener: ln,
+		sockPath: sockPath,
+		clients:  make(map[*broadcastClient]struct{}),
+	}
+
+	b.wg.Add(1)
+	go b.acceptLoop()
+
+	return b, nil
+}
+
+// Broadcast sends an event to all connected clients. Non-blocking:
+// if a client's buffer is full, the event is dropped for that client.
+func (b *Broadcaster) Broadcast(event Event) {
+	data, err := json.Marshal(event)
+	if err != nil {
+		return
+	}
+
+	msgType := "event"
+	if event.Kind == EventOutputChunk {
+		msgType = "chunk"
+	}
+
+	msg := BroadcastMessage{
+		Type: msgType,
+		Data: json.RawMessage(data),
+	}
+	line, err := json.Marshal(msg)
+	if err != nil {
+		return
+	}
+	line = append(line, '\n')
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.closed {
+		return
+	}
+
+	for c := range b.clients {
+		select {
+		case c.ch <- line:
+		default:
+			// Slow client — drop this event.
+		}
+	}
+}
+
+// ClientCount returns the number of connected clients.
+func (b *Broadcaster) ClientCount() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.clients)
+}
+
+// Close shuts down the listener, disconnects all clients, and removes
+// the socket file.
+func (b *Broadcaster) Close() error {
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		return nil
+	}
+	b.closed = true
+
+	for c := range b.clients {
+		close(c.ch)
+		c.conn.Close()
+		delete(b.clients, c)
+	}
+	b.mu.Unlock()
+
+	err := b.listener.Close()
+	b.wg.Wait()
+	os.Remove(b.sockPath)
+	return err
+}
+
+func (b *Broadcaster) acceptLoop() {
+	defer b.wg.Done()
+	for {
+		conn, err := b.listener.Accept()
+		if err != nil {
+			return
+		}
+
+		b.mu.Lock()
+		if b.closed || len(b.clients) >= MaxBroadcastClients {
+			b.mu.Unlock()
+			conn.Close()
+			continue
+		}
+
+		c := &broadcastClient{
+			conn: conn,
+			ch:   make(chan []byte, broadcastClientBufSize),
+		}
+		b.clients[c] = struct{}{}
+		b.mu.Unlock()
+
+		b.wg.Add(1)
+		go b.writeLoop(c)
+	}
+}
+
+func (b *Broadcaster) writeLoop(c *broadcastClient) {
+	defer b.wg.Done()
+	defer func() {
+		b.mu.Lock()
+		delete(b.clients, c)
+		b.mu.Unlock()
+		c.conn.Close()
+	}()
+
+	for line := range c.ch {
+		c.conn.SetWriteDeadline(time.Now().Add(broadcastWriteTimeout))
+		if _, err := c.conn.Write(line); err != nil {
+			return
+		}
+	}
+}
+
+// cleanStaleSock removes an existing socket file if it exists and no
+// process holds the corresponding lock. This handles the case where a
+// previous pipeline crashed and left the socket behind.
+func cleanStaleSock(sockPath string) error {
+	_, err := os.Stat(sockPath)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	return os.Remove(sockPath)
+}

--- a/internal/pipeline/broadcast_test.go
+++ b/internal/pipeline/broadcast_test.go
@@ -1,0 +1,343 @@
+package pipeline
+
+import (
+	"bufio"
+	"encoding/json"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestBroadcasterSingleClient(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "stream.sock")
+	b, err := NewBroadcaster(sockPath)
+	if err != nil {
+		t.Fatalf("NewBroadcaster: %v", err)
+	}
+	defer b.Close()
+
+	conn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	waitForClients(t, b, 1)
+
+	event := Event{
+		Timestamp: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		Phase:     "triage",
+		Kind:      EventPhaseStarted,
+	}
+	b.Broadcast(event)
+
+	msg := readMessage(t, conn, 2*time.Second)
+	if msg.Type != "event" {
+		t.Errorf("type = %q, want %q", msg.Type, "event")
+	}
+
+	var got Event
+	if err := json.Unmarshal(msg.Data, &got); err != nil {
+		t.Fatalf("unmarshal event: %v", err)
+	}
+	if got.Phase != "triage" {
+		t.Errorf("phase = %q, want %q", got.Phase, "triage")
+	}
+	if got.Kind != EventPhaseStarted {
+		t.Errorf("kind = %q, want %q", got.Kind, EventPhaseStarted)
+	}
+}
+
+func TestBroadcasterChunkType(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "stream.sock")
+	b, err := NewBroadcaster(sockPath)
+	if err != nil {
+		t.Fatalf("NewBroadcaster: %v", err)
+	}
+	defer b.Close()
+
+	conn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	waitForClients(t, b, 1)
+
+	b.Broadcast(Event{Kind: EventOutputChunk, Phase: "implement", Data: map[string]any{"text": "hello"}})
+
+	msg := readMessage(t, conn, 2*time.Second)
+	if msg.Type != "chunk" {
+		t.Errorf("type = %q, want %q", msg.Type, "chunk")
+	}
+}
+
+func TestBroadcasterFanOut(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "stream.sock")
+	b, err := NewBroadcaster(sockPath)
+	if err != nil {
+		t.Fatalf("NewBroadcaster: %v", err)
+	}
+	defer b.Close()
+
+	const numClients = 4
+	conns := make([]net.Conn, numClients)
+	for i := range conns {
+		conn, dialErr := net.Dial("unix", sockPath)
+		if dialErr != nil {
+			t.Fatalf("dial client %d: %v", i, dialErr)
+		}
+		defer conn.Close()
+		conns[i] = conn
+	}
+
+	waitForClients(t, b, numClients)
+
+	event := Event{Kind: EventPhaseCompleted, Phase: "plan"}
+	b.Broadcast(event)
+
+	for i, conn := range conns {
+		msg := readMessage(t, conn, 2*time.Second)
+		if msg.Type != "event" {
+			t.Errorf("client %d: type = %q, want %q", i, msg.Type, "event")
+		}
+	}
+}
+
+func TestBroadcasterSlowClientDoesNotBlock(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "stream.sock")
+	b, err := NewBroadcaster(sockPath)
+	if err != nil {
+		t.Fatalf("NewBroadcaster: %v", err)
+	}
+	defer b.Close()
+
+	// The slow client connects but never reads.
+	slowConn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("dial slow: %v", err)
+	}
+	defer slowConn.Close()
+
+	waitForClients(t, b, 1)
+
+	// Broadcast many events — this must complete quickly even though the
+	// slow client never reads. If the broadcaster blocked on writes,
+	// this would hang past the deadline.
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < broadcastClientBufSize*3; i++ {
+			b.Broadcast(Event{Kind: EventPhaseStarted, Phase: "fill"})
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Broadcasts completed without blocking — pass.
+	case <-time.After(3 * time.Second):
+		t.Fatal("Broadcast blocked on slow client")
+	}
+}
+
+func TestBroadcasterClientDisconnect(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "stream.sock")
+	b, err := NewBroadcaster(sockPath)
+	if err != nil {
+		t.Fatalf("NewBroadcaster: %v", err)
+	}
+	defer b.Close()
+
+	conn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+
+	waitForClients(t, b, 1)
+
+	conn.Close()
+
+	// Broadcast after disconnect — should not panic.
+	b.Broadcast(Event{Kind: EventPhaseStarted, Phase: "triage"})
+
+	// Give the write loop time to notice the closed connection.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if b.ClientCount() == 0 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Error("disconnected client was not removed")
+}
+
+func TestBroadcasterClose(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "stream.sock")
+	b, err := NewBroadcaster(sockPath)
+	if err != nil {
+		t.Fatalf("NewBroadcaster: %v", err)
+	}
+
+	conn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	waitForClients(t, b, 1)
+
+	if err := b.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Socket file should be removed.
+	if _, err := os.Stat(sockPath); !os.IsNotExist(err) {
+		t.Error("socket file still exists after Close")
+	}
+
+	// Client should get EOF.
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	buf := make([]byte, 1)
+	_, readErr := conn.Read(buf)
+	if readErr == nil {
+		t.Error("expected EOF or error on closed connection, got nil")
+	}
+}
+
+func TestBroadcasterStaleSockCleanup(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "stream.sock")
+
+	// Create a stale socket file.
+	if err := os.WriteFile(sockPath, []byte("stale"), 0644); err != nil {
+		t.Fatalf("write stale: %v", err)
+	}
+
+	b, err := NewBroadcaster(sockPath)
+	if err != nil {
+		t.Fatalf("NewBroadcaster should succeed with stale socket: %v", err)
+	}
+	defer b.Close()
+
+	// Should be able to connect.
+	conn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	conn.Close()
+}
+
+func TestBroadcasterMaxClients(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "stream.sock")
+	b, err := NewBroadcaster(sockPath)
+	if err != nil {
+		t.Fatalf("NewBroadcaster: %v", err)
+	}
+	defer b.Close()
+
+	conns := make([]net.Conn, MaxBroadcastClients)
+	for i := range conns {
+		conn, dialErr := net.Dial("unix", sockPath)
+		if dialErr != nil {
+			t.Fatalf("dial client %d: %v", i, dialErr)
+		}
+		defer conn.Close()
+		conns[i] = conn
+	}
+
+	waitForClients(t, b, MaxBroadcastClients)
+
+	// One more connection should be immediately closed by the server.
+	extra, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("dial extra: %v", err)
+	}
+	defer extra.Close()
+
+	// The extra connection should get closed (EOF on read).
+	extra.SetReadDeadline(time.Now().Add(2 * time.Second))
+	buf := make([]byte, 1)
+	_, readErr := extra.Read(buf)
+	if readErr == nil {
+		t.Error("extra client beyond max was not rejected")
+	}
+}
+
+func TestBroadcasterConcurrentBroadcast(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "stream.sock")
+	b, err := NewBroadcaster(sockPath)
+	if err != nil {
+		t.Fatalf("NewBroadcaster: %v", err)
+	}
+	defer b.Close()
+
+	conn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	waitForClients(t, b, 1)
+
+	const numGoroutines = 10
+	const eventsPerGoroutine = 5
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+	for g := range numGoroutines {
+		go func(id int) {
+			defer wg.Done()
+			for e := range eventsPerGoroutine {
+				b.Broadcast(Event{
+					Kind:  EventPhaseStarted,
+					Phase: "concurrent",
+					Data:  map[string]any{"goroutine": id, "event": e},
+				})
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	// Read all events from the connection.
+	received := 0
+	conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	scanner := bufio.NewScanner(conn)
+	for scanner.Scan() {
+		received++
+		if received >= numGoroutines*eventsPerGoroutine {
+			break
+		}
+	}
+	if received != numGoroutines*eventsPerGoroutine {
+		t.Errorf("received %d events, want %d", received, numGoroutines*eventsPerGoroutine)
+	}
+}
+
+// readMessage reads a single newline-delimited JSON message from conn.
+func readMessage(t *testing.T, conn net.Conn, timeout time.Duration) BroadcastMessage {
+	t.Helper()
+	conn.SetReadDeadline(time.Now().Add(timeout))
+	scanner := bufio.NewScanner(conn)
+	if !scanner.Scan() {
+		t.Fatalf("read message: %v", scanner.Err())
+	}
+	var msg BroadcastMessage
+	if err := json.Unmarshal(scanner.Bytes(), &msg); err != nil {
+		t.Fatalf("unmarshal message: %v (raw: %s)", err, scanner.Text())
+	}
+	return msg
+}
+
+// waitForClients polls until the broadcaster has the expected number of clients.
+func waitForClients(t *testing.T, b *Broadcaster, expected int) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if b.ClientCount() >= expected {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d clients, have %d", expected, b.ClientCount())
+}

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -86,6 +86,7 @@ type Engine struct {
 	runner           runner.Runner
 	config           EngineConfig
 	state            *State
+	broadcaster      *Broadcaster
 	apiSem           *Semaphore // limits concurrent runner.Run calls; nil means unlimited
 	confirmCh        chan struct{}
 	reranPhases      map[string]bool // phases that ran (not skipped) in this execution
@@ -254,6 +255,10 @@ func (e *Engine) Run(ctx context.Context) error {
 	}
 	defer e.state.ReleaseLock()
 
+	// Start broadcast socket for live streaming to attach clients.
+	e.startBroadcaster()
+	defer e.stopBroadcaster()
+
 	// Apply pipeline-level timeout if configured.
 	ctx, cancel := e.applyPipelineTimeout(ctx)
 	defer cancel()
@@ -327,6 +332,10 @@ func (e *Engine) Resume(ctx context.Context, fromPhase string) error {
 		return fmt.Errorf("engine: %w", err)
 	}
 	defer e.state.ReleaseLock()
+
+	// Start broadcast socket for live streaming to attach clients.
+	e.startBroadcaster()
+	defer e.stopBroadcaster()
 
 	// Apply pipeline-level timeout if configured.
 	ctx, cancel := e.applyPipelineTimeout(ctx)
@@ -1046,19 +1055,46 @@ func (e *Engine) makeOnChunk(ctx context.Context, phase string) func(string) {
 }
 
 // emit logs an event to state and calls the OnEvent callback if set.
+// Also broadcasts to any attached clients via the Unix socket.
 func (e *Engine) emit(event Event) {
 	_ = e.state.LogEvent(event)
 	if e.config.OnEvent != nil {
 		e.config.OnEvent(event)
+	}
+	if e.broadcaster != nil {
+		e.broadcaster.Broadcast(event)
+	}
+}
+
+// startBroadcaster creates the broadcast Unix socket for live streaming.
+// Errors are silently ignored — broadcast is best-effort and must not
+// prevent the pipeline from running.
+func (e *Engine) startBroadcaster() {
+	b, err := NewBroadcaster(e.state.SocketPath())
+	if err != nil {
+		return
+	}
+	e.broadcaster = b
+}
+
+// stopBroadcaster closes the broadcast socket and cleans up.
+func (e *Engine) stopBroadcaster() {
+	if e.broadcaster != nil {
+		e.broadcaster.Close()
+		e.broadcaster = nil
 	}
 }
 
 // emitChunk forwards an event to the OnEvent callback without writing it
 // to events.jsonl. Output chunks are high-frequency, transient streaming
 // data that would inflate the durable log with no diagnostic value.
+// Also broadcasts to any attached clients via the Unix socket.
 func (e *Engine) emitChunk(event Event) {
 	if e.config.OnEvent != nil {
 		e.config.OnEvent(event)
+	}
+	if e.broadcaster != nil {
+		e.broadcaster.Broadcast(event)
 	}
 }
 

--- a/internal/pipeline/state.go
+++ b/internal/pipeline/state.go
@@ -75,6 +75,11 @@ func (s *State) Dir() string {
 	return s.dir
 }
 
+// SocketPath returns the path to the broadcast Unix socket.
+func (s *State) SocketPath() string {
+	return filepath.Join(s.dir, "stream.sock")
+}
+
 // Meta returns the in-memory pipeline metadata. Callers should treat as read-only.
 func (s *State) Meta() *PipelineMeta {
 	return s.meta


### PR DESCRIPTION
## Summary

- Add Unix socket broadcast layer (`internal/pipeline/broadcast.go`) that fans out pipeline events to connected clients as newline-delimited JSON. Non-blocking writes with per-client buffered channels ensure slow clients never block the engine.
- Add `soda attach <ticket>` CLI command that connects to a running pipeline and streams live output. Supports `--from-start` (replay history) and `--events` (include phase-level events).
- Wire broadcaster lifecycle into `Engine.Run()` and `Engine.Resume()` — created after lock, closed before release.
- Add `State.SocketPath()` helper.

## Test plan

- [x] 9 broadcaster tests: single client, fan-out, slow client non-blocking, disconnect, close/cleanup, stale socket, max clients, concurrent broadcast
- [x] 5 attach tests: non-existent ticket, completed pipeline, from-start replay, socket streaming, streaming with events flag
- [x] Full test suite passes (`go test ./...`)
- [x] `go vet ./...` clean

Closes #234, closes #235