### PR TITLE
feat(proxy): LLM proxy integration for sandbox credential isolation [#29]

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -38,6 +38,17 @@ sandbox:
     cpu_percent: 200
     max_pids: 256
 
+  # LLM proxy — route API calls through a host-side proxy for
+  # credential isolation, token metering, and budget enforcement.
+  # When enabled, the sandbox uses full network isolation (UseNetNS: true)
+  # and API calls are bridged through a Unix socket.
+  proxy:
+    enabled: false
+    # upstream_url: https://api.anthropic.com  # default; or set ANTHROPIC_BASE_URL
+    # max_input_tokens: 500000   # per-session input token budget; 0 = unlimited
+    # max_output_tokens: 200000  # per-session output token budget; 0 = unlimited
+    # log_dir: .soda/proxy-logs  # request/response audit log directory
+
 # Budget and duration limits
 limits:
   max_cost_per_ticket: 30.00

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -74,9 +74,21 @@ type ExtractionStrategy struct {
 
 // SandboxConfig holds sandbox execution settings.
 type SandboxConfig struct {
-	Enabled bool          `yaml:"enabled"`
-	Binary  string        `yaml:"binary"`
-	Limits  SandboxLimits `yaml:"limits"`
+	Enabled bool               `yaml:"enabled"`
+	Binary  string             `yaml:"binary"`
+	Limits  SandboxLimits      `yaml:"limits"`
+	Proxy   SandboxProxyConfig `yaml:"proxy"`
+}
+
+// SandboxProxyConfig holds LLM proxy settings for sandboxed execution.
+// When enabled, API calls are routed through a host-side proxy for
+// credential isolation, token metering, and budget enforcement.
+type SandboxProxyConfig struct {
+	Enabled         bool   `yaml:"enabled"`
+	UpstreamURL     string `yaml:"upstream_url,omitempty"`      // defaults to ANTHROPIC_BASE_URL or https://api.anthropic.com
+	MaxInputTokens  int64  `yaml:"max_input_tokens,omitempty"`  // per-session budget; 0 = unlimited
+	MaxOutputTokens int64  `yaml:"max_output_tokens,omitempty"` // per-session budget; 0 = unlimited
+	LogDir          string `yaml:"log_dir,omitempty"`           // request/response log directory; empty = no logging
 }
 
 // SandboxLimits holds resource limits for sandboxed execution.

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1,0 +1,230 @@
+package proxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Config holds the proxy server configuration.
+type Config struct {
+	SocketPath      string // Unix socket path to listen on
+	UpstreamURL     string // Real API base URL
+	APIKey          string // API key to inject into requests
+	MaxInputTokens  int64  // Budget cap; 0 = unlimited
+	MaxOutputTokens int64  // Budget cap; 0 = unlimited
+	LogDir          string // Directory for request/response logs; empty = no logging
+}
+
+// Stats holds cumulative metering data.
+type Stats struct {
+	Requests     int64
+	InputTokens  int64
+	OutputTokens int64
+}
+
+// Proxy is an HTTP reverse proxy that listens on a Unix domain socket,
+// injects credentials, meters token usage, and enforces budget limits.
+type Proxy struct {
+	listener net.Listener
+	server   *http.Server
+	sockPath string
+	config   Config
+
+	// metering
+	requests     atomic.Int64
+	inputTokens  atomic.Int64
+	outputTokens atomic.Int64
+
+	// logging
+	logMu  sync.Mutex
+	logSeq int64
+}
+
+// New creates and starts the proxy server on the configured Unix socket.
+func New(cfg Config) (*Proxy, error) {
+	if cfg.SocketPath == "" {
+		return nil, fmt.Errorf("proxy: socket path is required")
+	}
+	if cfg.UpstreamURL == "" {
+		return nil, fmt.Errorf("proxy: upstream URL is required")
+	}
+
+	// Clean up stale socket.
+	os.Remove(cfg.SocketPath)
+
+	upstream, err := url.Parse(cfg.UpstreamURL)
+	if err != nil {
+		return nil, fmt.Errorf("proxy: parse upstream URL: %w", err)
+	}
+
+	ln, err := net.Listen("unix", cfg.SocketPath)
+	if err != nil {
+		return nil, fmt.Errorf("proxy: listen %s: %w", cfg.SocketPath, err)
+	}
+
+	proxy := &Proxy{
+		listener: ln,
+		sockPath: cfg.SocketPath,
+		config:   cfg,
+	}
+
+	reverseProxy := &httputil.ReverseProxy{
+		Director: func(req *http.Request) {
+			req.URL.Scheme = upstream.Scheme
+			req.URL.Host = upstream.Host
+			req.Host = upstream.Host
+
+			// Inject real credentials — the sandbox sees a fake nonce.
+			if cfg.APIKey != "" {
+				req.Header.Set("Authorization", "Bearer "+cfg.APIKey)
+				req.Header.Set("x-api-key", cfg.APIKey)
+			}
+		},
+		ModifyResponse: proxy.meterResponse,
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if proxy.overBudget() {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(429)
+			json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]any{
+					"type":    "budget_exceeded",
+					"message": fmt.Sprintf("budget exceeded: %d input tokens, %d output tokens used", proxy.inputTokens.Load(), proxy.outputTokens.Load()),
+				},
+			})
+			return
+		}
+		reverseProxy.ServeHTTP(w, r)
+	})
+
+	proxy.server = &http.Server{Handler: mux}
+	go proxy.server.Serve(ln)
+
+	return proxy, nil
+}
+
+// Stats returns the current cumulative metering data.
+func (p *Proxy) Stats() Stats {
+	return Stats{
+		Requests:     p.requests.Load(),
+		InputTokens:  p.inputTokens.Load(),
+		OutputTokens: p.outputTokens.Load(),
+	}
+}
+
+// Close shuts down the proxy server and removes the socket file.
+func (p *Proxy) Close() error {
+	err := p.server.Close()
+	os.Remove(p.sockPath)
+	return err
+}
+
+// overBudget returns true if cumulative token usage exceeds configured limits.
+// Checked before forwarding to upstream — prevents the call from being made.
+func (p *Proxy) overBudget() bool {
+	if p.config.MaxInputTokens > 0 && p.inputTokens.Load() >= p.config.MaxInputTokens {
+		return true
+	}
+	if p.config.MaxOutputTokens > 0 && p.outputTokens.Load() >= p.config.MaxOutputTokens {
+		return true
+	}
+	return false
+}
+
+// meterResponse is called by the reverse proxy after receiving the upstream
+// response. It reads the response body, extracts token usage, updates
+// cumulative counts, optionally logs, and replaces the body for the client.
+func (p *Proxy) meterResponse(resp *http.Response) error {
+	if resp.Body == nil {
+		return nil
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return fmt.Errorf("proxy: read response body: %w", err)
+	}
+
+	// Replace the body so the client can read it.
+	resp.Body = io.NopCloser(bytes.NewReader(body))
+	resp.ContentLength = int64(len(body))
+
+	// Meter tokens from response.
+	p.requests.Add(1)
+	usage := extractUsage(body)
+	p.inputTokens.Add(usage.inputTokens)
+	p.outputTokens.Add(usage.outputTokens)
+
+	// Log if configured.
+	if p.config.LogDir != "" {
+		go p.logEntry(resp.Request, body, usage)
+	}
+
+	return nil
+}
+
+type tokenUsage struct {
+	inputTokens  int64
+	outputTokens int64
+}
+
+// extractUsage parses the Anthropic API response for token usage.
+func extractUsage(body []byte) tokenUsage {
+	var resp struct {
+		Usage struct {
+			InputTokens  int64 `json:"input_tokens"`
+			OutputTokens int64 `json:"output_tokens"`
+		} `json:"usage"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return tokenUsage{}
+	}
+	return tokenUsage{
+		inputTokens:  resp.Usage.InputTokens,
+		outputTokens: resp.Usage.OutputTokens,
+	}
+}
+
+func (p *Proxy) logEntry(req *http.Request, responseBody []byte, usage tokenUsage) {
+	p.logMu.Lock()
+	p.logSeq++
+	seq := p.logSeq
+	p.logMu.Unlock()
+
+	entry := map[string]any{
+		"seq":           seq,
+		"timestamp":     time.Now().UTC().Format(time.RFC3339),
+		"method":        req.Method,
+		"path":          req.URL.Path,
+		"input_tokens":  usage.inputTokens,
+		"output_tokens": usage.outputTokens,
+	}
+
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return
+	}
+	data = append(data, '\n')
+
+	os.MkdirAll(p.config.LogDir, 0755)
+	logPath := filepath.Join(p.config.LogDir, "proxy.jsonl")
+	fd, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return
+	}
+	defer fd.Close()
+	fd.Write(data)
+}

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1,0 +1,308 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestProxy_ForwardsRequests(t *testing.T) {
+	var receivedAuth string
+	var receivedBody string
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("Authorization")
+		body, _ := io.ReadAll(r.Body)
+		receivedBody = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		json.NewEncoder(w).Encode(map[string]any{
+			"content": []map[string]any{{"type": "text", "text": "hello"}},
+			"usage":   map[string]any{"input_tokens": 100, "output_tokens": 50},
+		})
+	}))
+	defer upstream.Close()
+
+	sockPath := filepath.Join(t.TempDir(), "proxy.sock")
+	proxy, err := New(Config{
+		SocketPath:  sockPath,
+		UpstreamURL: upstream.URL,
+		APIKey:      "sk-test-key-123",
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer proxy.Close()
+
+	client := unixClient(sockPath)
+	resp, err := client.Post("http://localhost/v1/messages", "application/json", strings.NewReader(`{"model":"claude-3","messages":[]}`))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	if receivedAuth != "Bearer sk-test-key-123" {
+		t.Errorf("upstream auth = %q, want 'Bearer sk-test-key-123'", receivedAuth)
+	}
+	if receivedBody != `{"model":"claude-3","messages":[]}` {
+		t.Errorf("upstream body = %q", receivedBody)
+	}
+}
+
+func TestProxy_CredentialIsolation(t *testing.T) {
+	var headers http.Header
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		headers = r.Header.Clone()
+		w.WriteHeader(200)
+		w.Write([]byte(`{"usage":{"input_tokens":0,"output_tokens":0}}`))
+	}))
+	defer upstream.Close()
+
+	sockPath := filepath.Join(t.TempDir(), "proxy.sock")
+	proxy, err := New(Config{
+		SocketPath:  sockPath,
+		UpstreamURL: upstream.URL,
+		APIKey:      "sk-real-key",
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer proxy.Close()
+
+	client := unixClient(sockPath)
+	req, _ := http.NewRequest("POST", "http://localhost/v1/messages", strings.NewReader("{}"))
+	req.Header.Set("Authorization", "Bearer sk-fake-nonce")
+	req.Header.Set("x-api-key", "should-be-replaced")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	resp.Body.Close()
+
+	if got := headers.Get("Authorization"); got != "Bearer sk-real-key" {
+		t.Errorf("upstream Authorization = %q, want 'Bearer sk-real-key'", got)
+	}
+	if got := headers.Get("x-api-key"); got != "sk-real-key" {
+		t.Errorf("upstream x-api-key = %q, want 'sk-real-key'", got)
+	}
+}
+
+func TestProxy_TokenMetering(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"usage": map[string]any{
+				"input_tokens":  200,
+				"output_tokens": 100,
+			},
+		})
+	}))
+	defer upstream.Close()
+
+	sockPath := filepath.Join(t.TempDir(), "proxy.sock")
+	proxy, err := New(Config{
+		SocketPath:  sockPath,
+		UpstreamURL: upstream.URL,
+		APIKey:      "sk-test",
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer proxy.Close()
+
+	client := unixClient(sockPath)
+	for range 3 {
+		resp, reqErr := client.Post("http://localhost/v1/messages", "application/json", strings.NewReader("{}"))
+		if reqErr != nil {
+			t.Fatalf("request: %v", reqErr)
+		}
+		resp.Body.Close()
+	}
+
+	stats := proxy.Stats()
+	if stats.Requests != 3 {
+		t.Errorf("requests = %d, want 3", stats.Requests)
+	}
+	if stats.InputTokens != 600 {
+		t.Errorf("input_tokens = %d, want 600", stats.InputTokens)
+	}
+	if stats.OutputTokens != 300 {
+		t.Errorf("output_tokens = %d, want 300", stats.OutputTokens)
+	}
+}
+
+func TestProxy_BudgetEnforcement(t *testing.T) {
+	callCount := int32(0)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&callCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"usage": map[string]any{
+				"input_tokens":  1000,
+				"output_tokens": 500,
+			},
+		})
+	}))
+	defer upstream.Close()
+
+	sockPath := filepath.Join(t.TempDir(), "proxy.sock")
+	proxy, err := New(Config{
+		SocketPath:      sockPath,
+		UpstreamURL:     upstream.URL,
+		APIKey:          "sk-test",
+		MaxInputTokens:  500,
+		MaxOutputTokens: 400,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer proxy.Close()
+
+	client := unixClient(sockPath)
+
+	// First request: 1000 in, 500 out — within budget.
+	resp, err := client.Post("http://localhost/v1/messages", "application/json", strings.NewReader("{}"))
+	if err != nil {
+		t.Fatalf("req 1: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("req 1 status = %d, want 200", resp.StatusCode)
+	}
+
+	// Second request: would exceed budget (2000 in > 1500 max).
+	resp2, err := client.Post("http://localhost/v1/messages", "application/json", strings.NewReader("{}"))
+	if err != nil {
+		t.Fatalf("req 2: %v", err)
+	}
+	defer resp2.Body.Close()
+
+	if resp2.StatusCode != 429 {
+		t.Errorf("req 2 status = %d, want 429", resp2.StatusCode)
+	}
+
+	body, _ := io.ReadAll(resp2.Body)
+	if !strings.Contains(string(body), "budget exceeded") {
+		t.Errorf("body = %q, want to contain 'budget exceeded'", string(body))
+	}
+
+	// Upstream should have been called only once.
+	if got := atomic.LoadInt32(&callCount); got != 1 {
+		t.Errorf("upstream calls = %d, want 1", got)
+	}
+}
+
+func TestProxy_RequestLogging(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"content": []map[string]any{{"type": "text", "text": "ok"}},
+			"usage":   map[string]any{"input_tokens": 10, "output_tokens": 5},
+		})
+	}))
+	defer upstream.Close()
+
+	logDir := t.TempDir()
+	sockPath := filepath.Join(t.TempDir(), "proxy.sock")
+	proxy, err := New(Config{
+		SocketPath:  sockPath,
+		UpstreamURL: upstream.URL,
+		APIKey:      "sk-test",
+		LogDir:      logDir,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer proxy.Close()
+
+	client := unixClient(sockPath)
+	resp, err := client.Post("http://localhost/v1/messages", "application/json", strings.NewReader(`{"model":"test"}`))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	resp.Body.Close()
+
+	// Give the async log writer time to flush.
+	time.Sleep(100 * time.Millisecond)
+
+	entries, readErr := os.ReadDir(logDir)
+	if readErr != nil {
+		t.Fatalf("readdir: %v", readErr)
+	}
+	if len(entries) == 0 {
+		t.Error("no log files written")
+	}
+}
+
+func TestProxy_UpstreamError(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		w.Write([]byte(`{"error":{"message":"internal server error"}}`))
+	}))
+	defer upstream.Close()
+
+	sockPath := filepath.Join(t.TempDir(), "proxy.sock")
+	proxy, err := New(Config{
+		SocketPath:  sockPath,
+		UpstreamURL: upstream.URL,
+		APIKey:      "sk-test",
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer proxy.Close()
+
+	client := unixClient(sockPath)
+	resp, err := client.Post("http://localhost/v1/messages", "application/json", strings.NewReader("{}"))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 500 {
+		t.Errorf("status = %d, want 500", resp.StatusCode)
+	}
+}
+
+func TestProxy_Close(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "proxy.sock")
+	proxy, err := New(Config{
+		SocketPath:  sockPath,
+		UpstreamURL: "http://localhost:0",
+		APIKey:      "sk-test",
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if err := proxy.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+
+	if _, err := os.Stat(sockPath); !os.IsNotExist(err) {
+		t.Error("socket file not cleaned up")
+	}
+}
+
+// unixClient creates an HTTP client that dials a Unix socket.
+func unixClient(sockPath string) *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("unix", sockPath)
+			},
+		},
+	}
+}

--- a/internal/sandbox/config.go
+++ b/internal/sandbox/config.go
@@ -10,4 +10,18 @@ type Config struct {
 	ExtraReadPaths  []string // additional read-only paths
 	ExtraWritePaths []string // additional write paths beyond WorkDir
 	ClaudeBinary    string   // empty = exec.LookPath("claude")
+	Proxy           ProxyConfig
+}
+
+// ProxyConfig holds LLM proxy settings.
+// When Enabled, the sandbox runner starts an LLM proxy on a Unix socket,
+// routes Claude Code API calls through it (via NetworkProxySocket),
+// and enables full network isolation (UseNetNS is forced to true).
+type ProxyConfig struct {
+	Enabled         bool   // start proxy and enable network isolation
+	UpstreamURL     string // real API base URL (default: from ANTHROPIC_BASE_URL or https://api.anthropic.com)
+	APIKey          string // API key for upstream; empty = read from ANTHROPIC_API_KEY env
+	MaxInputTokens  int64  // per-session input token budget; 0 = unlimited
+	MaxOutputTokens int64  // per-session output token budget; 0 = unlimited
+	LogDir          string // proxy request/response log directory; empty = no logging
 }

--- a/internal/sandbox/resolve.go
+++ b/internal/sandbox/resolve.go
@@ -98,7 +98,11 @@ func systemReadPaths() []string {
 }
 
 // claudeEnv builds the environment for a sandboxed Claude Code process.
-func claudeEnv(tmpDir string, opts runner.RunOpts, claudeBin string) []string {
+// When useProxy is true, real credentials are NOT passed to the sandbox.
+// Instead, a fake API key is set and ANTHROPIC_BASE_URL points to the
+// proxy's in-sandbox bridge (http://127.0.0.1:8080). The proxy injects
+// real credentials on the host side.
+func claudeEnv(tmpDir string, opts runner.RunOpts, claudeBin string, useProxy bool) []string {
 	env := []string{
 		"HOME=" + tmpDir,
 		"TMPDIR=" + tmpDir,
@@ -120,20 +124,28 @@ func claudeEnv(tmpDir string, opts runner.RunOpts, claudeBin string) []string {
 		env = append(env, "NODE_PATH="+nodePath)
 	}
 
-	// Credentials: pass through real API key or Vertex vars for v1.
-	// v2 (#29) will use a fake nonce with LLM proxy.
-	credentialVars := []string{
-		"ANTHROPIC_API_KEY",
-		"CLAUDE_CODE_USE_VERTEX",
-		"VERTEXAI_PROJECT",
-		"VERTEXAI_LOCATION",
-		"CLOUD_ML_REGION",
-		"GOOGLE_APPLICATION_CREDENTIALS",
-		"GOOGLE_CLOUD_PROJECT",
-	}
-	for _, key := range credentialVars {
-		if val := os.Getenv(key); val != "" {
-			env = append(env, key+"="+val)
+	if useProxy {
+		// Proxy mode: fake API key + base URL pointing to the in-sandbox
+		// bridge that arapuca sets up from NetworkProxySocket.
+		env = append(env,
+			"ANTHROPIC_API_KEY=sk-proxy-nonce",
+			"ANTHROPIC_BASE_URL=http://127.0.0.1:8080",
+		)
+	} else {
+		// Direct mode: pass through real credentials.
+		credentialVars := []string{
+			"ANTHROPIC_API_KEY",
+			"CLAUDE_CODE_USE_VERTEX",
+			"VERTEXAI_PROJECT",
+			"VERTEXAI_LOCATION",
+			"CLOUD_ML_REGION",
+			"GOOGLE_APPLICATION_CREDENTIALS",
+			"GOOGLE_CLOUD_PROJECT",
+		}
+		for _, key := range credentialVars {
+			if val := os.Getenv(key); val != "" {
+				env = append(env, key+"="+val)
+			}
 		}
 	}
 

--- a/internal/sandbox/resolve_test.go
+++ b/internal/sandbox/resolve_test.go
@@ -38,7 +38,7 @@ func TestClaudeEnv(t *testing.T) {
 	t.Setenv("LANG", "en_US.UTF-8")
 
 	opts := runner.RunOpts{Phase: "triage", WorkDir: "/work"}
-	env := claudeEnv("/tmp/sandbox", opts, "/usr/local/bin/claude")
+	env := claudeEnv("/tmp/sandbox", opts, "/usr/local/bin/claude", false)
 
 	envMap := make(map[string]string)
 	for _, entry := range env {
@@ -69,7 +69,7 @@ func TestClaudeEnvVertexPassthrough(t *testing.T) {
 	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "/path/to/creds.json")
 
 	opts := runner.RunOpts{Phase: "plan", WorkDir: "/work"}
-	env := claudeEnv("/tmp/sb", opts, "/usr/bin/claude")
+	env := claudeEnv("/tmp/sb", opts, "/usr/bin/claude", false)
 
 	envMap := make(map[string]string)
 	for _, entry := range env {
@@ -97,7 +97,7 @@ func TestClaudeEnvNoKeyMeansNoEntry(t *testing.T) {
 	t.Setenv("CLAUDE_CODE_USE_VERTEX", "")
 
 	opts := runner.RunOpts{Phase: "plan", WorkDir: "/work"}
-	env := claudeEnv("/tmp/sb", opts, "/usr/bin/claude")
+	env := claudeEnv("/tmp/sb", opts, "/usr/bin/claude", false)
 
 	for _, entry := range env {
 		if strings.HasPrefix(entry, "ANTHROPIC_API_KEY=") {
@@ -106,6 +106,32 @@ func TestClaudeEnvNoKeyMeansNoEntry(t *testing.T) {
 		if strings.HasPrefix(entry, "CLAUDE_CODE_USE_VERTEX=") {
 			t.Error("CLAUDE_CODE_USE_VERTEX should not be present when empty")
 		}
+	}
+}
+
+func TestClaudeEnvProxyMode(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-real-key")
+
+	opts := runner.RunOpts{Phase: "implement", WorkDir: "/work"}
+	env := claudeEnv("/tmp/sb", opts, "/usr/bin/claude", true)
+
+	envMap := make(map[string]string)
+	for _, entry := range env {
+		parts := strings.SplitN(entry, "=", 2)
+		if len(parts) == 2 {
+			envMap[parts[0]] = parts[1]
+		}
+	}
+
+	if envMap["ANTHROPIC_API_KEY"] != "sk-proxy-nonce" {
+		t.Errorf("ANTHROPIC_API_KEY = %q, want 'sk-proxy-nonce'", envMap["ANTHROPIC_API_KEY"])
+	}
+	if envMap["ANTHROPIC_BASE_URL"] != "http://127.0.0.1:8080" {
+		t.Errorf("ANTHROPIC_BASE_URL = %q, want 'http://127.0.0.1:8080'", envMap["ANTHROPIC_BASE_URL"])
+	}
+	// Real credentials should NOT be present.
+	if _, ok := envMap["GOOGLE_APPLICATION_CREDENTIALS"]; ok {
+		t.Error("GOOGLE_APPLICATION_CREDENTIALS should not be present in proxy mode")
 	}
 }
 

--- a/internal/sandbox/runner.go
+++ b/internal/sandbox/runner.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 
 	"github.com/decko/soda/internal/claude"
+	"github.com/decko/soda/internal/proxy"
 	"github.com/decko/soda/internal/runner"
 	arapuca "github.com/sergio-correia/go-arapuca"
 )
@@ -125,6 +126,54 @@ func (r *Runner) Run(ctx context.Context, opts runner.RunOpts) (*runner.RunResul
 	readPaths = append(readPaths, tmpDir)
 	writePaths = append(writePaths, tmpDir)
 
+	useNetNS := r.config.UseNetNS
+	var networkProxySocket string
+	var llmProxy *proxy.Proxy
+
+	// Start LLM proxy if configured. This enables full network isolation:
+	// Claude Code API calls are routed through the proxy Unix socket,
+	// and arapuca bridges it into the sandbox via NetworkProxySocket.
+	if r.config.Proxy.Enabled {
+		useNetNS = true // force network isolation when proxy is active
+
+		socketDir, socketErr := arapuca.MakeSocketDir()
+		if socketErr != nil {
+			return nil, fmt.Errorf("sandbox: create socket dir for proxy: %w", socketErr)
+		}
+		defer os.RemoveAll(socketDir)
+
+		sockPath := filepath.Join(socketDir, "llm.sock")
+		readPaths = append(readPaths, socketDir)
+
+		apiKey := r.config.Proxy.APIKey
+		if apiKey == "" {
+			apiKey = os.Getenv("ANTHROPIC_API_KEY")
+		}
+		upstreamURL := r.config.Proxy.UpstreamURL
+		if upstreamURL == "" {
+			upstreamURL = os.Getenv("ANTHROPIC_BASE_URL")
+		}
+		if upstreamURL == "" {
+			upstreamURL = "https://api.anthropic.com"
+		}
+
+		var proxyErr error
+		llmProxy, proxyErr = proxy.New(proxy.Config{
+			SocketPath:      sockPath,
+			UpstreamURL:     upstreamURL,
+			APIKey:          apiKey,
+			MaxInputTokens:  r.config.Proxy.MaxInputTokens,
+			MaxOutputTokens: r.config.Proxy.MaxOutputTokens,
+			LogDir:          r.config.Proxy.LogDir,
+		})
+		if proxyErr != nil {
+			return nil, fmt.Errorf("sandbox: start LLM proxy: %w", proxyErr)
+		}
+		defer llmProxy.Close()
+
+		networkProxySocket = sockPath
+	}
+
 	profile := arapuca.Profile{
 		ReadPaths:     readPaths,
 		WritePaths:    writePaths,
@@ -132,7 +181,7 @@ func (r *Runner) Run(ctx context.Context, opts runner.RunOpts) (*runner.RunResul
 		MaxCPUPct:     r.config.CPUPercent,
 		MaxPIDs:       r.config.MaxPIDs,
 		MaxFileSizeMB: r.config.MaxFileSizeMB,
-		UseNetNS:      r.config.UseNetNS,
+		UseNetNS:      useNetNS,
 	}
 
 	// Set up stdout/stderr pipes. Defer closing both ends as safety net
@@ -152,18 +201,19 @@ func (r *Runner) Run(ctx context.Context, opts runner.RunOpts) (*runner.RunResul
 	defer stderrW.Close()
 
 	cfg := arapuca.Config{
-		Profile: profile,
-		TaskID:  opts.Phase,
-		Phase:   opts.Phase,
-		WorkDir: opts.WorkDir,
-		Stdout:  stdoutW,
-		Stderr:  stderrW,
+		Profile:            profile,
+		TaskID:             opts.Phase,
+		Phase:              opts.Phase,
+		WorkDir:            opts.WorkDir,
+		Stdout:             stdoutW,
+		Stderr:             stderrW,
+		NetworkProxySocket: networkProxySocket,
 	}
 
 	// Serialize env mutation + Launch to prevent races if multiple Runners
 	// are used concurrently. Restore env immediately after Launch returns —
 	// no need to keep sandbox env vars set during subprocess execution.
-	env := claudeEnv(tmpDir, opts, r.claudeBin)
+	env := claudeEnv(tmpDir, opts, r.claudeBin, r.config.Proxy.Enabled)
 	launchMu.Lock()
 	restore := setEnvForLaunch(env)
 	proc, launchErr := r.sandbox.Launch(ctx, cfg, r.claudeBin, args, nil)


### PR DESCRIPTION
## Summary

- Add `internal/proxy/` package: HTTP reverse proxy on a Unix domain socket that forwards API calls to the real Anthropic endpoint, injecting credentials on the host side. The sandboxed process never sees real API keys.
- Token metering: parses every API response for `usage.input_tokens`/`output_tokens`, tracks cumulative counts.
- Budget enforcement: rejects requests with HTTP 429 when cumulative token usage exceeds configured limits — prevents runaway costs before the call reaches the API.
- JSONL audit logging of all proxied requests (method, path, tokens per call).
- Wire proxy into sandbox runner: starts proxy before launch, sets `NetworkProxySocket` on arapuca config, forces `UseNetNS: true` for full network isolation, passes fake `ANTHROPIC_API_KEY` and `ANTHROPIC_BASE_URL` to sandbox.
- Add `SandboxProxyConfig` to `soda.yaml` config with upstream URL, per-session token budgets, and log directory.

## Test plan

- [x] 7 proxy tests: request forwarding, credential injection, token metering, budget enforcement (429), audit logging, upstream errors, close/cleanup
- [x] 1 new sandbox test: proxy mode env (fake API key, base URL, no real credentials)
- [x] All existing sandbox tests updated for new `claudeEnv` signature
- [x] Full test suite passes (`go test ./...`)
- [x] `go vet ./...` clean

Closes #29