### PR TITLE
fix(config): add prompts_path for custom prompt template directory

### DIFF
--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -150,11 +150,14 @@ func runPipeline(cfg *config.Config, opts pipelineOpts) error {
 	}
 	defer os.RemoveAll(promptDir)
 
-	// Search order: user config dir > working dir > embedded.
+	// Search order: user config dir > prompts_path from config > working dir > embedded.
 	// phases.yaml references prompts with the "prompts/" prefix
 	// (e.g. "prompts/triage.md"), so the base dirs should NOT
 	// include "prompts/" — the loader joins base + name.
 	loaderDirs := []string{"."}
+	if cfg.PromptsPath != "" {
+		loaderDirs = append([]string{cfg.PromptsPath}, loaderDirs...)
+	}
 	configDir, _ := os.UserConfigDir()
 	if configDir != "" {
 		loaderDirs = append([]string{filepath.Join(configDir, "soda")}, loaderDirs...)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,7 +18,8 @@ type Config struct {
 	Model        string              `yaml:"model"`
 	Sandbox      SandboxConfig       `yaml:"sandbox"`
 	Limits       LimitsConfig        `yaml:"limits"`
-	PhasesPath   string              `yaml:"phases_path"` // explicit path to pipeline YAML; overrides CWD discovery
+	PhasesPath   string              `yaml:"phases_path"`  // explicit path to pipeline YAML; overrides CWD discovery
+	PromptsPath  string              `yaml:"prompts_path"` // base directory for prompt templates; overrides CWD discovery
 	WorktreeDir  string              `yaml:"worktree_dir"`
 	StateDir     string              `yaml:"state_dir"`
 	Context      []string            `yaml:"context"`


### PR DESCRIPTION
## Summary

Projects that store prompts outside CWD (e.g. `docs/soda/prompts/`) were not discoverable by the prompt loader. It only searched `~/.config/soda`, CWD, and embedded defaults.

Adds `prompts_path` config field that inserts a custom base directory into the prompt loader search order:

```
~/.config/soda > prompts_path > CWD > embedded
```

### Usage in soda.yaml

```yaml
phases_path: docs/soda/phases.yaml
prompts_path: docs/soda
```

This resolves the "could not load template for review: is a directory" error when running soda from a repo that stores its pipeline config under a subdirectory.

## Test plan

- [x] Full test suite passes
- [x] `go vet` clean
