### PR TITLE
feat(pipeline): expand rework feedback context from ±5 lines to full-file [#326]

### DIFF
--- a/internal/pipeline/feedback.go
+++ b/internal/pipeline/feedback.go
@@ -133,6 +133,10 @@ func (e *Engine) extractVerifyFeedback() *ReworkFeedback {
 	return fb
 }
 
+// maxFeedbackContextBytes is the total byte budget for file content injected
+// into rework feedback across all findings. Prevents context bloat.
+const maxFeedbackContextBytes = 30 * 1024 // 30KB
+
 // extractReviewFeedback reads the review result and returns structured
 // feedback when the verdict is "rework". Returns nil if no review result
 // exists or the verdict is not "rework".
@@ -142,6 +146,10 @@ func (e *Engine) extractVerifyFeedback() *ReworkFeedback {
 // (review.json.1, review.json.2, ...) so the LLM has context about
 // what was previously reported. Only critical/major findings are
 // included to keep prompt context focused.
+//
+// Each finding is enriched with file content: full-file when budget allows,
+// falling back to ±5 lines when budget is exhausted. Same-file findings
+// share the cached content to avoid duplicate reads.
 func (e *Engine) extractReviewFeedback() *ReworkFeedback {
 	raw, err := e.state.ReadResult("review")
 	if err != nil {
@@ -161,22 +169,84 @@ func (e *Engine) extractReviewFeedback() *ReworkFeedback {
 		Source:  "review",
 	}
 
-	// Only include critical and major findings, enriched with code snippets.
+	workDir := e.workDir(PhaseConfig{})
+	budgetRemaining := maxFeedbackContextBytes
+	fileCache := make(map[string]string) // file path → cached content
+
+	// Only include critical and major findings, enriched with code context.
 	for _, finding := range result.Findings {
 		sev := strings.ToLower(finding.Severity)
-		if sev == "critical" || sev == "major" {
-			ef := EnrichedFinding{ReviewFinding: finding}
-			if finding.File != "" && finding.Line > 0 {
-				ef.CodeSnippet = readSnippet(e.workDir(PhaseConfig{}), finding.File, finding.Line, 5)
-			}
-			fb.ReviewFindings = append(fb.ReviewFindings, ef)
+		if sev != "critical" && sev != "major" {
+			continue
 		}
+
+		ef := EnrichedFinding{ReviewFinding: finding}
+		if finding.File != "" {
+			ef.CodeSnippet = readFileForFinding(workDir, finding.File, finding.Line, &budgetRemaining, fileCache)
+		}
+		fb.ReviewFindings = append(fb.ReviewFindings, ef)
 	}
 
 	// Collect prior cycle context from archived review results.
 	fb.PriorCycles = e.collectPriorReviewCycles()
 
 	return fb
+}
+
+// readFileForFinding returns file content for a review finding. It tries
+// full-file injection first (if budget allows), falling back to ±5 lines.
+// Same-file findings reuse cached content without consuming extra budget.
+func readFileForFinding(workDir, file string, line int, budgetRemaining *int, cache map[string]string) string {
+	// Check cache first — same file referenced by multiple findings.
+	if cached, ok := cache[file]; ok {
+		return cached
+	}
+
+	resolved := filepath.Clean(filepath.Join(workDir, file))
+	if !strings.HasPrefix(resolved, filepath.Clean(workDir)+string(filepath.Separator)) {
+		return ""
+	}
+
+	data, err := os.ReadFile(resolved)
+	if err != nil {
+		return ""
+	}
+
+	content := string(data)
+
+	// If the full file fits within budget, use it.
+	if len(data) <= *budgetRemaining {
+		*budgetRemaining -= len(data)
+		cache[file] = content
+		return content
+	}
+
+	// Budget exhausted for full file — fall back to ±5 lines snippet.
+	if line > 0 {
+		snippet := extractSnippet(content, line, 5)
+		cache[file] = snippet
+		return snippet
+	}
+
+	return ""
+}
+
+// extractSnippet returns ±context lines around the given 1-based line number
+// from the provided content string.
+func extractSnippet(content string, line, context int) string {
+	lines := strings.Split(content, "\n")
+	start := line - context - 1
+	if start < 0 {
+		start = 0
+	}
+	end := line + context
+	if end > len(lines) {
+		end = len(lines)
+	}
+	if start >= end {
+		return ""
+	}
+	return strings.Join(lines[start:end], "\n")
 }
 
 // readSnippet reads ±context lines around the given 1-based line number
@@ -192,19 +262,7 @@ func readSnippet(workDir, file string, line, context int) string {
 	if err != nil {
 		return ""
 	}
-	lines := strings.Split(string(data), "\n")
-	start := line - context - 1
-	if start < 0 {
-		start = 0
-	}
-	end := line + context
-	if end > len(lines) {
-		end = len(lines)
-	}
-	if start >= end {
-		return ""
-	}
-	return strings.Join(lines[start:end], "\n")
+	return extractSnippet(string(data), line, context)
 }
 
 // collectPriorReviewCycles reads archived review results (review.json.1,

--- a/internal/pipeline/feedback_test.go
+++ b/internal/pipeline/feedback_test.go
@@ -520,3 +520,143 @@ func TestReadSnippet(t *testing.T) {
 		}
 	})
 }
+
+func TestReadFileForFinding(t *testing.T) {
+	writeFile := func(t *testing.T, dir, name, content string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Run("full_file_within_budget", func(t *testing.T) {
+		dir := t.TempDir()
+		content := "line1\nline2\nline3\nline4\nline5\n"
+		writeFile(t, dir, "small.go", content)
+
+		budget := 1000
+		cache := make(map[string]string)
+		got := readFileForFinding(dir, "small.go", 3, &budget, cache)
+
+		if got != content {
+			t.Errorf("got %q, want full file content", got)
+		}
+		if budget != 1000-len(content) {
+			t.Errorf("budget = %d, want %d", budget, 1000-len(content))
+		}
+	})
+
+	t.Run("falls_back_to_snippet_when_over_budget", func(t *testing.T) {
+		dir := t.TempDir()
+		// 20-line file — snippet at line 10 with ±5 context = 11 lines, not all 20.
+		var longLines []string
+		for i := 1; i <= 20; i++ {
+			longLines = append(longLines, strings.Repeat("x", 10))
+		}
+		content := strings.Join(longLines, "\n")
+		writeFile(t, dir, "big.go", content)
+
+		budget := 50 // too small for full file (~220 bytes)
+		cache := make(map[string]string)
+		got := readFileForFinding(dir, "big.go", 10, &budget, cache)
+
+		if got == content {
+			t.Error("should NOT return full file when over budget")
+		}
+		if got == "" {
+			t.Error("should return snippet fallback, not empty")
+		}
+		// Snippet should be a subset of lines.
+		snippetLines := strings.Split(got, "\n")
+		if len(snippetLines) >= 20 {
+			t.Errorf("snippet has %d lines, should be fewer than 20", len(snippetLines))
+		}
+	})
+
+	t.Run("deduplicates_same_file", func(t *testing.T) {
+		dir := t.TempDir()
+		content := "func A() {}\nfunc B() {}\n"
+		writeFile(t, dir, "shared.go", content)
+
+		budget := 1000
+		cache := make(map[string]string)
+
+		got1 := readFileForFinding(dir, "shared.go", 1, &budget, cache)
+		budgetAfterFirst := budget
+		got2 := readFileForFinding(dir, "shared.go", 2, &budget, cache)
+
+		if got1 != got2 {
+			t.Errorf("same file should return same content: %q vs %q", got1, got2)
+		}
+		if budget != budgetAfterFirst {
+			t.Errorf("second read should not consume budget: %d vs %d", budget, budgetAfterFirst)
+		}
+	})
+
+	t.Run("budget_exhaustion_across_files", func(t *testing.T) {
+		dir := t.TempDir()
+		file1Content := strings.Repeat("a", 100) + "\n"
+		// 20-line file so snippet (±5 around line 15) is shorter than full file.
+		var file2Lines []string
+		for i := 1; i <= 20; i++ {
+			file2Lines = append(file2Lines, strings.Repeat("b", 10))
+		}
+		file2Content := strings.Join(file2Lines, "\n")
+		writeFile(t, dir, "first.go", file1Content)
+		writeFile(t, dir, "second.go", file2Content)
+
+		budget := 120 // enough for first file (101 bytes) but not second (~220 bytes)
+		cache := make(map[string]string)
+
+		got1 := readFileForFinding(dir, "first.go", 1, &budget, cache)
+		if got1 != file1Content {
+			t.Error("first file should get full content")
+		}
+
+		got2 := readFileForFinding(dir, "second.go", 15, &budget, cache)
+		if got2 == file2Content {
+			t.Error("second file should NOT get full content (over budget)")
+		}
+		if got2 == "" {
+			t.Error("second file should get snippet fallback")
+		}
+	})
+
+	t.Run("nonexistent_file_returns_empty", func(t *testing.T) {
+		dir := t.TempDir()
+		budget := 1000
+		cache := make(map[string]string)
+		got := readFileForFinding(dir, "nope.go", 1, &budget, cache)
+		if got != "" {
+			t.Errorf("expected empty for nonexistent file, got: %q", got)
+		}
+	})
+
+	t.Run("path_traversal_blocked", func(t *testing.T) {
+		dir := t.TempDir()
+		parentFile := filepath.Join(filepath.Dir(dir), "secret.txt")
+		os.WriteFile(parentFile, []byte("secret"), 0644)
+		defer os.Remove(parentFile)
+
+		budget := 1000
+		cache := make(map[string]string)
+		got := readFileForFinding(dir, "../secret.txt", 1, &budget, cache)
+		if got != "" {
+			t.Errorf("expected empty for path traversal, got: %q", got)
+		}
+	})
+}
+
+func TestExtractSnippet(t *testing.T) {
+	content := "line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\n"
+
+	got := extractSnippet(content, 5, 2)
+	if !strings.Contains(got, "line3") || !strings.Contains(got, "line7") {
+		t.Errorf("snippet should contain lines 3-7, got: %q", got)
+	}
+
+	got2 := extractSnippet(content, 1, 2)
+	if !strings.Contains(got2, "line1") {
+		t.Errorf("snippet near start should contain line1, got: %q", got2)
+	}
+}

--- a/internal/pipeline/prompt.go
+++ b/internal/pipeline/prompt.go
@@ -70,7 +70,7 @@ type ReworkFeedback struct {
 // EnrichedFinding wraps a ReviewFinding with code context for rework prompts.
 type EnrichedFinding struct {
 	schemas.ReviewFinding
-	CodeSnippet string // ±5 lines around the finding's file:line; empty if unavailable
+	CodeSnippet string // full file content (budget-controlled) or ±5 lines fallback; empty if unavailable
 }
 
 // PriorCycle holds a summarized snapshot of feedback from a previous


### PR DESCRIPTION
## Summary

Replace the ±5 line snippet window with full-file injection for review finding code context. Directly attacks `knowledge_miss_rate=1.0` — the agent always fixes rework findings (`self_correction_rate=1.0`) but wastes tokens reading surrounding code. Full-file context eliminates that retrieval step.

### Changes

- `readFileForFinding()` — reads full file when budget allows, falls back to ±5 lines when exhausted
- Same-file deduplication: multiple findings in the same file share cached content (no budget double-counting)
- 30KB total cap across all findings (`maxFeedbackContextBytes`)
- `extractSnippet()` extracted from `readSnippet()` for reuse
- `readSnippet()` kept for backward compatibility, now delegates to `extractSnippet()`

## Test plan

- [x] 6 new tests: full file within budget, snippet fallback on over-budget, deduplication, budget exhaustion across files, nonexistent file, path traversal
- [x] 2 new tests: `extractSnippet` basic behavior
- [x] All existing `readSnippet` tests pass unchanged
- [x] Full test suite green, `go vet` clean

Closes #326
