### PR TITLE
feat(pipeline): deep context injection — full function bodies for plan files [#327]

### DIFF
--- a/internal/pipeline/siblings.go
+++ b/internal/pipeline/siblings.go
@@ -215,10 +215,68 @@ func exprString(expr ast.Expr) string {
 	}
 }
 
+// FunctionBody holds a Go function/method name and its full source text.
+type FunctionBody struct {
+	Name string // e.g. "Run" or "(e *Engine) Run"
+	Body string // full source text including signature line
+}
+
+// ExtractGoFunctionBodies parses a Go source file and returns full
+// function/method bodies. Returns nil for non-Go files, test files,
+// or parse errors (best-effort).
+func ExtractGoFunctionBodies(filePath string) ([]FunctionBody, error) {
+	if !strings.HasSuffix(filePath, ".go") {
+		return nil, nil
+	}
+	if strings.HasSuffix(filePath, "_test.go") {
+		return nil, nil
+	}
+
+	src, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("siblings: read %s: %w", filePath, err)
+	}
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, filePath, src, 0)
+	if err != nil {
+		return nil, fmt.Errorf("siblings: parse %s: %w", filePath, err)
+	}
+
+	lines := strings.Split(string(src), "\n")
+	var bodies []FunctionBody
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
+
+		startLine := fset.Position(fn.Pos()).Line - 1 // 0-based
+		endLine := fset.Position(fn.End()).Line       // 1-based, inclusive
+
+		if startLine < 0 {
+			startLine = 0
+		}
+		if endLine > len(lines) {
+			endLine = len(lines)
+		}
+
+		body := strings.Join(lines[startLine:endLine], "\n")
+		bodies = append(bodies, FunctionBody{
+			Name: formatFuncSignature(fn),
+			Body: body,
+		})
+	}
+	return bodies, nil
+}
+
 // BuildSiblingContext reads the plan result from state, extracts the
-// referenced files, and returns a formatted string of function
-// signatures grouped by file. Returns an empty string if the plan
-// result is unavailable or contains no Go files.
+// referenced files, and returns a formatted context string grouped by file.
+//
+// For Go source files, full function bodies are injected so the implement
+// phase sees the actual code it needs to modify. When a file's bodies would
+// exceed the remaining budget, the function falls back to signatures only.
+// Test files always get signatures (bodies are less useful for context).
 //
 // maxBytes limits the total size of the returned string. When maxBytes
 // is 0, the default limit (maxSiblingContextBytes) is used.
@@ -236,8 +294,6 @@ func BuildSiblingContext(workDir string, planResult json.RawMessage, maxBytes in
 	totalBytes := 0
 	for _, relPath := range files {
 		absPath := filepath.Join(workDir, relPath)
-		// Validate resolved path stays within workDir to prevent path traversal
-		// from LLM-generated plan file paths.
 		absResolved, err := filepath.Abs(absPath)
 		if err != nil {
 			continue
@@ -253,30 +309,14 @@ func BuildSiblingContext(workDir string, planResult json.RawMessage, maxBytes in
 			continue
 		}
 
-		var sigs []string
-		if strings.HasSuffix(relPath, "_test.go") {
-			sigs, err = ExtractGoTestPatterns(absPath)
-		} else {
-			sigs, err = ExtractGoSignatures(absPath)
-		}
-		if err != nil || len(sigs) == 0 {
+		section := buildFileSection(absPath, relPath, maxBytes-totalBytes)
+		if section == "" {
 			continue
 		}
 
-		var b strings.Builder
-		b.WriteString("### ")
-		b.WriteString(relPath)
-		b.WriteByte('\n')
-		for _, sig := range sigs {
-			b.WriteString("- `")
-			b.WriteString(sig)
-			b.WriteString("`\n")
-		}
-
-		section := b.String()
 		sepCost := 0
 		if len(sections) > 0 {
-			sepCost = 1 // for the "\n" between previous section and this one
+			sepCost = 1
 		}
 		if totalBytes+sepCost+len(section) > maxBytes {
 			break
@@ -289,4 +329,68 @@ func BuildSiblingContext(workDir string, planResult json.RawMessage, maxBytes in
 		return ""
 	}
 	return strings.Join(sections, "\n")
+}
+
+// buildFileSection returns a formatted context section for a single file.
+// For non-test Go files, it tries full function bodies first and falls
+// back to signatures if bodies exceed remainingBudget. Test files and
+// non-Go files always use signatures.
+func buildFileSection(absPath, relPath string, remainingBudget int) string {
+	isTest := strings.HasSuffix(relPath, "_test.go")
+
+	// Try full bodies for non-test Go files.
+	if !isTest && strings.HasSuffix(relPath, ".go") {
+		bodies, err := ExtractGoFunctionBodies(absPath)
+		if err == nil && len(bodies) > 0 {
+			section := formatBodiesSection(relPath, bodies)
+			if len(section) <= remainingBudget {
+				return section
+			}
+			// Bodies too large — fall through to signatures.
+		}
+	}
+
+	// Signatures as fallback (or primary for test files).
+	var sigs []string
+	var err error
+	if isTest {
+		sigs, err = ExtractGoTestPatterns(absPath)
+	} else {
+		sigs, err = ExtractGoSignatures(absPath)
+	}
+	if err != nil || len(sigs) == 0 {
+		return ""
+	}
+	return formatSignaturesSection(relPath, sigs)
+}
+
+// formatBodiesSection renders a file section with full function bodies.
+func formatBodiesSection(relPath string, bodies []FunctionBody) string {
+	var b strings.Builder
+	b.WriteString("### ")
+	b.WriteString(relPath)
+	b.WriteString("\n```go\n")
+	for i, body := range bodies {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(body.Body)
+		b.WriteByte('\n')
+	}
+	b.WriteString("```\n")
+	return b.String()
+}
+
+// formatSignaturesSection renders a file section with function signatures.
+func formatSignaturesSection(relPath string, sigs []string) string {
+	var b strings.Builder
+	b.WriteString("### ")
+	b.WriteString(relPath)
+	b.WriteByte('\n')
+	for _, sig := range sigs {
+		b.WriteString("- `")
+		b.WriteString(sig)
+		b.WriteString("`\n")
+	}
+	return b.String()
 }

--- a/internal/pipeline/siblings_test.go
+++ b/internal/pipeline/siblings_test.go
@@ -448,3 +448,167 @@ func TestFoo(t *testing.T) {}
 		}
 	})
 }
+
+func TestExtractGoFunctionBodies(t *testing.T) {
+	t.Run("extracts_function_bodies", func(t *testing.T) {
+		dir := t.TempDir()
+		src := `package main
+
+func Add(a, b int) int {
+	return a + b
+}
+
+func Multiply(a, b int) int {
+	result := a * b
+	return result
+}
+`
+		path := filepath.Join(dir, "math.go")
+		os.WriteFile(path, []byte(src), 0644)
+
+		bodies, err := ExtractGoFunctionBodies(path)
+		if err != nil {
+			t.Fatalf("ExtractGoFunctionBodies: %v", err)
+		}
+		if len(bodies) != 2 {
+			t.Fatalf("got %d bodies, want 2", len(bodies))
+		}
+		if !strings.Contains(bodies[0].Body, "return a + b") {
+			t.Errorf("first body missing 'return a + b': %q", bodies[0].Body)
+		}
+		if !strings.Contains(bodies[1].Body, "result := a * b") {
+			t.Errorf("second body missing 'result := a * b': %q", bodies[1].Body)
+		}
+	})
+
+	t.Run("extracts_method_bodies", func(t *testing.T) {
+		dir := t.TempDir()
+		src := `package main
+
+type Server struct{}
+
+func (s *Server) Start() error {
+	return nil
+}
+`
+		path := filepath.Join(dir, "server.go")
+		os.WriteFile(path, []byte(src), 0644)
+
+		bodies, err := ExtractGoFunctionBodies(path)
+		if err != nil {
+			t.Fatalf("ExtractGoFunctionBodies: %v", err)
+		}
+		if len(bodies) != 1 {
+			t.Fatalf("got %d bodies, want 1", len(bodies))
+		}
+		if !strings.Contains(bodies[0].Name, "Server") {
+			t.Errorf("name should contain receiver: %q", bodies[0].Name)
+		}
+		if !strings.Contains(bodies[0].Body, "return nil") {
+			t.Errorf("body missing 'return nil': %q", bodies[0].Body)
+		}
+	})
+
+	t.Run("skips_test_files", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "math_test.go")
+		os.WriteFile(path, []byte("package main\nfunc TestAdd(t *testing.T) {}\n"), 0644)
+
+		bodies, err := ExtractGoFunctionBodies(path)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if bodies != nil {
+			t.Error("expected nil for test files")
+		}
+	})
+
+	t.Run("skips_non_go_files", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "readme.md")
+		os.WriteFile(path, []byte("# Readme"), 0644)
+
+		bodies, err := ExtractGoFunctionBodies(path)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if bodies != nil {
+			t.Error("expected nil for non-Go files")
+		}
+	})
+}
+
+func TestBuildSiblingContext_BodiesInjected(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, "pkg"), 0755)
+
+	src := `package pkg
+
+func Process(data string) error {
+	if data == "" {
+		return fmt.Errorf("empty")
+	}
+	return nil
+}
+
+func helper() string {
+	return "ok"
+}
+`
+	os.WriteFile(filepath.Join(dir, "pkg", "process.go"), []byte(src), 0644)
+
+	plan := `{
+		"ticket_key": "TEST-1",
+		"approach": "fix",
+		"tasks": [{"id":"T1","description":"fix process","files":["pkg/process.go"],"done_when":"ok"}],
+		"verification": {"commands":["go test"]}
+	}`
+
+	ctx := BuildSiblingContext(dir, json.RawMessage(plan), 0)
+	if ctx == "" {
+		t.Fatal("expected non-empty context")
+	}
+	// Should contain full function bodies, not just signatures.
+	if !strings.Contains(ctx, "return fmt.Errorf") {
+		t.Errorf("context should contain function body, got:\n%s", ctx)
+	}
+	if !strings.Contains(ctx, "return \"ok\"") {
+		t.Errorf("context should contain helper body, got:\n%s", ctx)
+	}
+	// Should be wrapped in code fence.
+	if !strings.Contains(ctx, "```go") {
+		t.Errorf("context should contain code fence, got:\n%s", ctx)
+	}
+}
+
+func TestBuildSiblingContext_FallsBackToSignatures(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a file with enough functions that bodies exceed a small budget.
+	var src strings.Builder
+	src.WriteString("package main\n\n")
+	for i := 0; i < 20; i++ {
+		src.WriteString(fmt.Sprintf("func Func%d() {\n\t// body line %d\n}\n\n", i, i))
+	}
+	os.WriteFile(filepath.Join(dir, "big.go"), []byte(src.String()), 0644)
+
+	plan := `{
+		"ticket_key": "TEST-1",
+		"approach": "x",
+		"tasks": [{"id":"T1","description":"x","files":["big.go"],"done_when":"x"}],
+		"verification": {"commands":[]}
+	}`
+
+	// Budget that fits signatures but not full bodies.
+	ctx := BuildSiblingContext(dir, json.RawMessage(plan), 500)
+	if ctx == "" {
+		t.Fatal("expected non-empty context (signatures fallback)")
+	}
+	// Should have signatures (backtick-quoted), not code fences.
+	if strings.Contains(ctx, "```go") {
+		t.Error("should have fallen back to signatures, but got code fence (bodies)")
+	}
+	if !strings.Contains(ctx, "Func0") {
+		t.Errorf("context should contain function names: %s", ctx)
+	}
+}


### PR DESCRIPTION
## Summary

`BuildSiblingContext` now injects full Go function/method bodies for files referenced in the plan, instead of just signatures. The implement phase sees the actual code it needs to modify, eliminating the retrieval gap that causes all rework (`knowledge_miss_rate=1.0`).

### How it works

- `ExtractGoFunctionBodies()` — parses Go source with `go/ast`, returns function name + full source text (signature through closing brace)
- `buildFileSection()` — tries bodies first, falls back to signatures if bodies exceed remaining budget
- Test files always get signatures (bodies are less useful for context)
- Budget-controlled: respects `MaxSiblingContextBytes` (default 20KB)
- Output wrapped in markdown code fences for LLM readability

### Expected metric impact

Target: `rework_cycles` from 0.73 → ≤0.40, `knowledge_miss_rate` below 0.5

## Test plan

- [x] 4 new tests: `ExtractGoFunctionBodies` (functions, methods, test file skip, non-Go skip)
- [x] 2 new integration tests: bodies injected for plan files, fallback to signatures on budget exhaustion
- [x] All 6 existing `BuildSiblingContext` tests pass unchanged
- [x] Full test suite green, `go vet` clean

Closes #327
