### PR TITLE
feat(tui): attach mode — connect TUI to external running pipeline [#236]

### DIFF
--- a/cmd/soda/attach.go
+++ b/cmd/soda/attach.go
@@ -14,7 +14,9 @@ import (
 	"strings"
 	"syscall"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/decko/soda/internal/pipeline"
+	"github.com/decko/soda/internal/tui"
 	"github.com/spf13/cobra"
 )
 
@@ -31,17 +33,19 @@ func newAttachCmd() *cobra.Command {
 			}
 			fromStart, _ := cmd.Flags().GetBool("from-start")
 			showEvents, _ := cmd.Flags().GetBool("events")
-			return runAttach(cmd.OutOrStdout(), cmd.ErrOrStderr(), cfg.StateDir, args[0], fromStart, showEvents)
+			useTUI, _ := cmd.Flags().GetBool("tui")
+			return runAttach(cmd.OutOrStdout(), cmd.ErrOrStderr(), cfg.StateDir, args[0], fromStart, showEvents, useTUI)
 		},
 	}
 
 	cmd.Flags().Bool("from-start", false, "replay event history before live stream")
 	cmd.Flags().Bool("events", false, "show phase-level events (not just output chunks)")
+	cmd.Flags().Bool("tui", false, "launch full TUI in read-only attached mode")
 
 	return cmd
 }
 
-func runAttach(stdout, stderr io.Writer, stateDir, ticketKey string, fromStart, showEvents bool) error {
+func runAttach(stdout, stderr io.Writer, stateDir, ticketKey string, fromStart, showEvents, useTUI bool) error {
 	ticketDir := filepath.Join(stateDir, ticketKey)
 
 	if _, err := os.Stat(ticketDir); os.IsNotExist(err) {
@@ -76,7 +80,64 @@ func runAttach(stdout, stderr io.Writer, stateDir, ticketKey string, fromStart, 
 	}
 	defer conn.Close()
 
+	if useTUI {
+		return runAttachTUI(conn, ticketKey, ticketDir)
+	}
+
 	return streamFromSocket(ctx, stdout, conn, showEvents)
+}
+
+// runAttachTUI launches the full TUI in read-only mode, bridging the
+// socket connection to the TUI's event channel.
+func runAttachTUI(conn net.Conn, ticketKey, ticketDir string) error {
+	eventCh := make(chan pipeline.Event, 64)
+
+	// Discover phase names from meta if available.
+	phases := discoverPhases(ticketDir)
+
+	model := tui.NewAttach(ticketKey, phases, eventCh)
+
+	// Bridge socket → event channel in background.
+	go bridgeSocketToChannel(conn, eventCh)
+
+	p := tea.NewProgram(model, tea.WithAltScreen())
+	if _, err := p.Run(); err != nil {
+		return fmt.Errorf("attach: TUI error: %w", err)
+	}
+	return nil
+}
+
+// bridgeSocketToChannel reads broadcast messages from the socket and
+// sends parsed events to the channel. Closes the channel on EOF or error.
+func bridgeSocketToChannel(conn net.Conn, eventCh chan<- pipeline.Event) {
+	defer close(eventCh)
+	scanner := bufio.NewScanner(conn)
+	for scanner.Scan() {
+		var msg pipeline.BroadcastMessage
+		if err := json.Unmarshal(scanner.Bytes(), &msg); err != nil {
+			continue
+		}
+		var ev pipeline.Event
+		if err := json.Unmarshal(msg.Data, &ev); err != nil {
+			continue
+		}
+		eventCh <- ev
+	}
+}
+
+// discoverPhases reads meta.json and returns phase names in order.
+// Falls back to a default list if meta is unavailable.
+func discoverPhases(ticketDir string) []string {
+	metaPath := filepath.Join(ticketDir, "meta.json")
+	meta, err := pipeline.ReadMeta(metaPath)
+	if err != nil || len(meta.Phases) == 0 {
+		return []string{"triage", "plan", "implement", "verify", "review", "submit"}
+	}
+	var phases []string
+	for name := range meta.Phases {
+		phases = append(phases, name)
+	}
+	return phases
 }
 
 func attachNotRunning(stdout io.Writer, ticketDir, ticketKey string) error {

--- a/cmd/soda/attach_test.go
+++ b/cmd/soda/attach_test.go
@@ -17,7 +17,7 @@ import (
 func TestAttach_NonExistentTicket(t *testing.T) {
 	stateDir := t.TempDir()
 	var stdout, stderr bytes.Buffer
-	err := runAttach(&stdout, &stderr, stateDir, "GHOST-999", false, false)
+	err := runAttach(&stdout, &stderr, stateDir, "GHOST-999", false, false, false)
 	if err == nil {
 		t.Fatal("expected error for non-existent ticket")
 	}
@@ -49,7 +49,7 @@ func TestAttach_CompletedPipeline(t *testing.T) {
 	os.WriteFile(filepath.Join(ticketDir, "lock"), lockData, 0644)
 
 	var stdout, stderr bytes.Buffer
-	err := runAttach(&stdout, &stderr, stateDir, "TEST-1", false, false)
+	err := runAttach(&stdout, &stderr, stateDir, "TEST-1", false, false, false)
 	if err == nil {
 		t.Fatal("expected error for completed pipeline")
 	}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -31,6 +31,7 @@ type Model struct {
 	buffered    []pipeline.Event
 	detailMode  bool
 	paused      bool
+	readOnly    bool // attached mode: no engine control
 	engineDone  bool
 	width       int
 	height      int
@@ -51,6 +52,24 @@ func New(t ticket.Ticket, phases []string, events <-chan pipeline.Event, pauseSi
 		events:      events,
 		pauseSignal: pauseSignal,
 		pauseG:      &pauseGuard{},
+	}
+}
+
+// NewAttach creates a TUI model in read-only attached mode. The TUI
+// displays live output from an external pipeline but cannot control it
+// (pause/resume/confirm are disabled).
+func NewAttach(ticketKey string, phases []string, events <-chan pipeline.Event) Model {
+	t := ticket.Ticket{Key: ticketKey}
+	return Model{
+		ticket:   newTicketView(t),
+		pipeline: newPipelineView(phases),
+		output:   newOutputView(),
+		stats:    newStatsView(),
+		keys:     newKeysView(),
+		phases:   phases,
+		events:   events,
+		readOnly: true,
+		pauseG:   &pauseGuard{},
 	}
 }
 
@@ -187,6 +206,10 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case "p":
+		if m.readOnly {
+			m.keys.flash = "read-only: cannot pause"
+			return m, clearFlashAfter()
+		}
 		m.paused = !m.paused
 		m.keys.paused = m.paused
 		m.sendPauseSignal(m.paused)
@@ -217,6 +240,9 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, clearFlashAfter()
 
 	case "enter":
+		if m.readOnly {
+			return m, nil
+		}
 		if m.paused {
 			m.paused = false
 			m.keys.paused = false
@@ -275,6 +301,7 @@ func (m *Model) layout() {
 	m.pipeline.width = w
 	m.stats.width = w
 	m.keys.width = w
+	m.keys.readOnly = m.readOnly
 
 	// Calculate output viewport height: total height minus other components
 	// ticket ~5 lines + border, pipeline ~8 lines + border, stats 3 lines, keys 1 line, gaps

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -576,3 +576,96 @@ func TestEnterResumeSignalSent(t *testing.T) {
 		t.Error("no resume signal received on Enter")
 	}
 }
+
+func testAttachModel() Model {
+	phases := []string{"triage", "plan", "implement"}
+	events := make(chan pipeline.Event, 10)
+	return NewAttach("TEST-ATTACH", phases, events)
+}
+
+func TestAttachModelIsReadOnly(t *testing.T) {
+	m := testAttachModel()
+	if !m.readOnly {
+		t.Error("attached model should be read-only")
+	}
+	if m.pauseSignal != nil {
+		t.Error("attached model should have nil pauseSignal")
+	}
+}
+
+func TestAttachPauseKeyDisabled(t *testing.T) {
+	m := testAttachModel()
+	m.handleEvent(pipeline.Event{Kind: pipeline.EventPhaseStarted, Phase: "triage"})
+	m2, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("p")})
+	mm := m2.(Model)
+	if mm.paused {
+		t.Error("pause should be disabled in read-only mode")
+	}
+	if mm.keys.flash != "read-only: cannot pause" {
+		t.Errorf("expected read-only flash, got %q", mm.keys.flash)
+	}
+}
+
+func TestAttachEnterKeyDisabled(t *testing.T) {
+	m := testAttachModel()
+	m.paused = true // simulate checkpoint
+	m2, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	mm := m2.(Model)
+	if !mm.paused {
+		t.Error("enter should not unpause in read-only mode")
+	}
+}
+
+func TestAttachReceivesEvents(t *testing.T) {
+	m := testAttachModel()
+	m.handleEvent(pipeline.Event{Kind: pipeline.EventPhaseStarted, Phase: "triage"})
+	if m.pipeline.info["triage"].status != pipeline.PhaseRunning {
+		t.Errorf("expected running, got %s", m.pipeline.info["triage"].status)
+	}
+	m.handleEvent(pipeline.Event{
+		Kind: pipeline.EventOutputChunk,
+		Data: map[string]any{"line": "attached output"},
+	})
+	if len(m.output.lines) != 1 || m.output.lines[0] != "attached output" {
+		t.Errorf("expected output line, got %v", m.output.lines)
+	}
+}
+
+func TestAttachKeysViewShowsAttached(t *testing.T) {
+	m := testAttachModel()
+	m.width = 80
+	m.height = 40
+	m.layout()
+	v := m.keys.View()
+	if !strings.Contains(v, "ATTACHED") {
+		t.Error("keys view should show ATTACHED indicator")
+	}
+	if strings.Contains(v, "[p]") {
+		t.Error("keys view should NOT show pause key in read-only mode")
+	}
+	if !strings.Contains(v, "[d]") {
+		t.Error("keys view should show detail key")
+	}
+	if !strings.Contains(v, "[q]") {
+		t.Error("keys view should show quit key")
+	}
+}
+
+func TestAttachQuitStillWorks(t *testing.T) {
+	m := testAttachModel()
+	_, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	if cmd == nil {
+		t.Error("quit should still work in read-only mode")
+	}
+}
+
+func TestAttachDetailToggleWorks(t *testing.T) {
+	m := testAttachModel()
+	m.width = 80
+	m.height = 24
+	m.layout()
+	m2, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")})
+	if !m2.(Model).detailMode {
+		t.Error("detail toggle should work in read-only mode")
+	}
+}

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -9,9 +9,10 @@ import (
 )
 
 type keysView struct {
-	paused bool
-	flash  string
-	width  int
+	paused   bool
+	readOnly bool
+	flash    string
+	width    int
 }
 
 func newKeysView() keysView {
@@ -19,12 +20,20 @@ func newKeysView() keysView {
 }
 
 func (v keysView) View() string {
-	bindings := []struct{ key, label string }{
-		{"p", pauseLabel(v.paused)},
-		{"s", "steer"},
-		{"d", "detail"},
-		{"r", "retry"},
-		{"q", "quit"},
+	var bindings []struct{ key, label string }
+	if v.readOnly {
+		bindings = []struct{ key, label string }{
+			{"d", "detail"},
+			{"q", "quit"},
+		}
+	} else {
+		bindings = []struct{ key, label string }{
+			{"p", pauseLabel(v.paused)},
+			{"s", "steer"},
+			{"d", "detail"},
+			{"r", "retry"},
+			{"q", "quit"},
+		}
 	}
 	var parts []string
 	for _, b := range bindings {
@@ -35,6 +44,9 @@ func (v keysView) View() string {
 	}
 
 	bar := lipgloss.JoinHorizontal(lipgloss.Top, joinWith(parts, "  "))
+	if v.readOnly {
+		bar = styleFlash.Render("ATTACHED (read-only)") + "  " + bar
+	}
 	if v.flash != "" {
 		bar += "  " + styleFlash.Render(v.flash)
 	}


### PR DESCRIPTION
## Summary

Add read-only TUI mode that connects to a running pipeline via the broadcast socket and displays live output in the full TUI interface.

- `NewAttach()` constructor — creates a Model with `readOnly=true`, no pause signal
- `--tui` flag on `soda attach` — launches full TUI instead of raw stdout streaming  
- Socket-to-channel bridge in background goroutine
- Pause/resume/confirm keys disabled with "read-only: cannot pause" flash
- Keys bar shows "ATTACHED (read-only)" indicator, hides interactive keys (p/s/r)
- Detail toggle and quit still work
- Phase names discovered from meta.json with fallback to defaults

### Usage

```bash
soda attach TICKET-1 --tui          # full TUI, read-only
soda attach TICKET-1                # raw stdout (existing behavior)
soda attach TICKET-1 --from-start   # replay history first
```

## Test plan

- [x] 7 new TUI tests: read-only model, pause disabled, enter disabled, event handling, ATTACHED indicator, quit works, detail toggle works
- [x] All existing TUI tests pass unchanged
- [x] All existing attach tests updated
- [x] Full suite green, `go vet` clean

Closes #236
Closes the **Live Pipeline Streaming** milestone (#9).
