### PR TITLE
feat(sandbox): end-to-end sandbox integration with TCP proxy and Vertex AI

### DIFF
--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -22,6 +22,7 @@ import (
 	"github.com/decko/soda/internal/pipeline"
 	"github.com/decko/soda/internal/progress"
 	"github.com/decko/soda/internal/runner"
+	"github.com/decko/soda/internal/sandbox"
 	"github.com/decko/soda/internal/ticket"
 	"github.com/decko/soda/internal/tui"
 	"github.com/decko/soda/schemas"
@@ -252,6 +253,26 @@ func runPipeline(cfg *config.Config, opts pipelineOpts) error {
 	useMock := opts.useMock
 	if useMock {
 		r = buildMockRunner()
+	} else if cfg.Sandbox.Enabled {
+		sbCfg := sandbox.Config{
+			MemoryMB:     uint64(cfg.Sandbox.Limits.MemoryMB),
+			CPUPercent:   uint32(cfg.Sandbox.Limits.CPUPercent),
+			MaxPIDs:      uint32(cfg.Sandbox.Limits.MaxPIDs),
+			ClaudeBinary: cfg.Sandbox.Binary,
+			Proxy: sandbox.ProxyConfig{
+				Enabled:         cfg.Sandbox.Proxy.Enabled,
+				UpstreamURL:     cfg.Sandbox.Proxy.UpstreamURL,
+				MaxInputTokens:  cfg.Sandbox.Proxy.MaxInputTokens,
+				MaxOutputTokens: cfg.Sandbox.Proxy.MaxOutputTokens,
+				LogDir:          cfg.Sandbox.Proxy.LogDir,
+			},
+		}
+		sbRunner, err := sandbox.New(sbCfg)
+		if err != nil {
+			return fmt.Errorf("run: create sandbox runner: %w", err)
+		}
+		defer sbRunner.Close()
+		r = sbRunner
 	} else {
 		claudeRunner, err := runner.NewClaudeRunner("claude", cfg.Model, workDir)
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -36,4 +36,4 @@ require (
 	golang.org/x/text v0.3.8 // indirect
 )
 
-replace github.com/sergio-correia/go-arapuca => github.com/decko/go-arapuca v0.1.0
+replace github.com/sergio-correia/go-arapuca => github.com/decko/go-arapuca v0.1.1-0.20260421121428-18be6a8cdc3f

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/clipperhouse/stringish v0.1.1/go.mod h1:v/WhFtE1q0ovMta2+m+UbpZ+2/HEX
 github.com/clipperhouse/uax29/v2 v2.5.0 h1:x7T0T4eTHDONxFJsL94uKNKPHrclyFI0lm7+w94cO8U=
 github.com/clipperhouse/uax29/v2 v2.5.0/go.mod h1:Wn1g7MK6OoeDT0vL+Q0SQLDz/KpfsVRgg6W7ihQeh4g=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
-github.com/decko/go-arapuca v0.1.0 h1:pBzlTr8OnOOLFbC+Xp/BcqzHXsL7NXSqmBiqq+a3TwA=
-github.com/decko/go-arapuca v0.1.0/go.mod h1:n3QwYrcRa8hGT5Xc6T1OAogHNzn/lTm5XaQmQhOJhuM=
+github.com/decko/go-arapuca v0.1.1-0.20260421121428-18be6a8cdc3f h1:+NkeKYHOTo5cRs44i2qjP4vz7/dwZQLV1bjzmtQxQKU=
+github.com/decko/go-arapuca v0.1.1-0.20260421121428-18be6a8cdc3f/go.mod h1:n3QwYrcRa8hGT5Xc6T1OAogHNzn/lTm5XaQmQhOJhuM=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -18,12 +19,14 @@ import (
 
 // Config holds the proxy server configuration.
 type Config struct {
-	SocketPath      string // Unix socket path to listen on
-	UpstreamURL     string // Real API base URL
-	APIKey          string // API key to inject into requests
-	MaxInputTokens  int64  // Budget cap; 0 = unlimited
-	MaxOutputTokens int64  // Budget cap; 0 = unlimited
-	LogDir          string // Directory for request/response logs; empty = no logging
+	SocketPath      string        // Unix socket path to listen on (used when ListenAddr is empty)
+	ListenAddr      string        // TCP address to listen on (e.g. "127.0.0.1:0"); takes precedence over SocketPath
+	UpstreamURL     string        // Real API base URL
+	APIKey          string        // API key to inject into requests (Anthropic direct)
+	TokenFunc       func() string // returns a Bearer token (Vertex OAuth); takes precedence over APIKey
+	MaxInputTokens  int64         // Budget cap; 0 = unlimited
+	MaxOutputTokens int64         // Budget cap; 0 = unlimited
+	LogDir          string        // Directory for request/response logs; empty = no logging
 }
 
 // Stats holds cumulative metering data.
@@ -51,26 +54,33 @@ type Proxy struct {
 	logSeq int64
 }
 
-// New creates and starts the proxy server on the configured Unix socket.
+// New creates and starts the proxy server. When ListenAddr is set, the
+// proxy listens on TCP; otherwise it listens on the Unix socket at SocketPath.
 func New(cfg Config) (*Proxy, error) {
-	if cfg.SocketPath == "" {
-		return nil, fmt.Errorf("proxy: socket path is required")
+	if cfg.ListenAddr == "" && cfg.SocketPath == "" {
+		return nil, fmt.Errorf("proxy: either ListenAddr or SocketPath is required")
 	}
 	if cfg.UpstreamURL == "" {
 		return nil, fmt.Errorf("proxy: upstream URL is required")
 	}
-
-	// Clean up stale socket.
-	os.Remove(cfg.SocketPath)
 
 	upstream, err := url.Parse(cfg.UpstreamURL)
 	if err != nil {
 		return nil, fmt.Errorf("proxy: parse upstream URL: %w", err)
 	}
 
-	ln, err := net.Listen("unix", cfg.SocketPath)
-	if err != nil {
-		return nil, fmt.Errorf("proxy: listen %s: %w", cfg.SocketPath, err)
+	var ln net.Listener
+	if cfg.ListenAddr != "" {
+		ln, err = net.Listen("tcp", cfg.ListenAddr)
+		if err != nil {
+			return nil, fmt.Errorf("proxy: listen %s: %w", cfg.ListenAddr, err)
+		}
+	} else {
+		os.Remove(cfg.SocketPath)
+		ln, err = net.Listen("unix", cfg.SocketPath)
+		if err != nil {
+			return nil, fmt.Errorf("proxy: listen %s: %w", cfg.SocketPath, err)
+		}
 	}
 
 	proxy := &Proxy{
@@ -85,8 +95,20 @@ func New(cfg Config) (*Proxy, error) {
 			req.URL.Host = upstream.Host
 			req.Host = upstream.Host
 
-			// Inject real credentials — the sandbox sees a fake nonce.
-			if cfg.APIKey != "" {
+			// Prepend the upstream's path prefix (e.g. "/v1") to the
+			// incoming request path. This is needed for Vertex AI where
+			// the base URL is https://REGION-aiplatform.googleapis.com/v1
+			// and the client sends /projects/.../rawPredict.
+			if upstream.Path != "" && upstream.Path != "/" {
+				req.URL.Path = singleJoiningSlash(upstream.Path, req.URL.Path)
+			}
+
+			// Inject credentials — the sandbox sees a fake nonce.
+			if cfg.TokenFunc != nil {
+				if token := cfg.TokenFunc(); token != "" {
+					req.Header.Set("Authorization", "Bearer "+token)
+				}
+			} else if cfg.APIKey != "" {
 				req.Header.Set("Authorization", "Bearer "+cfg.APIKey)
 				req.Header.Set("x-api-key", cfg.APIKey)
 			}
@@ -125,10 +147,18 @@ func (p *Proxy) Stats() Stats {
 	}
 }
 
-// Close shuts down the proxy server and removes the socket file.
+// Addr returns the listener's network address. For TCP listeners,
+// use this to discover the assigned port (e.g. when using ":0").
+func (p *Proxy) Addr() net.Addr {
+	return p.listener.Addr()
+}
+
+// Close shuts down the proxy server and removes the socket file (if any).
 func (p *Proxy) Close() error {
 	err := p.server.Close()
-	os.Remove(p.sockPath)
+	if p.sockPath != "" {
+		os.Remove(p.sockPath)
+	}
 	return err
 }
 
@@ -170,7 +200,7 @@ func (p *Proxy) meterResponse(resp *http.Response) error {
 
 	// Log if configured.
 	if p.config.LogDir != "" {
-		go p.logEntry(resp.Request, body, usage)
+		go p.logEntry(resp.Request, body, usage, resp.StatusCode)
 	}
 
 	return nil
@@ -198,19 +228,26 @@ func extractUsage(body []byte) tokenUsage {
 	}
 }
 
-func (p *Proxy) logEntry(req *http.Request, responseBody []byte, usage tokenUsage) {
+func (p *Proxy) logEntry(req *http.Request, responseBody []byte, usage tokenUsage, statusCode int) {
 	p.logMu.Lock()
 	p.logSeq++
 	seq := p.logSeq
 	p.logMu.Unlock()
+
+	bodyExcerpt := string(responseBody)
+	if len(bodyExcerpt) > 200 {
+		bodyExcerpt = bodyExcerpt[:200]
+	}
 
 	entry := map[string]any{
 		"seq":           seq,
 		"timestamp":     time.Now().UTC().Format(time.RFC3339),
 		"method":        req.Method,
 		"path":          req.URL.Path,
+		"status":        statusCode,
 		"input_tokens":  usage.inputTokens,
 		"output_tokens": usage.outputTokens,
+		"body_excerpt":  bodyExcerpt,
 	}
 
 	data, err := json.Marshal(entry)
@@ -227,4 +264,17 @@ func (p *Proxy) logEntry(req *http.Request, responseBody []byte, usage tokenUsag
 	}
 	defer fd.Close()
 	fd.Write(data)
+}
+
+// singleJoiningSlash joins two URL path segments with exactly one slash.
+func singleJoiningSlash(a, b string) string {
+	aSlash := strings.HasSuffix(a, "/")
+	bSlash := strings.HasPrefix(b, "/")
+	switch {
+	case aSlash && bSlash:
+		return a + b[1:]
+	case !aSlash && !bSlash:
+		return a + "/" + b
+	}
+	return a + b
 }

--- a/internal/proxy/vertex.go
+++ b/internal/proxy/vertex.go
@@ -1,0 +1,111 @@
+package proxy
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// adcCredentials represents the Application Default Credentials file format
+// used by Google Cloud SDK (gcloud auth application-default login).
+type adcCredentials struct {
+	Type         string `json:"type"`
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+	RefreshToken string `json:"refresh_token"`
+}
+
+// cachedToken holds a Google OAuth2 access token with its expiry.
+type cachedToken struct {
+	accessToken string
+	expiresAt   time.Time
+}
+
+// VertexTokenSource returns a TokenFunc that exchanges Google ADC
+// credentials for access tokens. Tokens are cached and refreshed
+// automatically when within 60 seconds of expiry.
+//
+// adcPath is the path to the ADC JSON file. If empty, it defaults
+// to ~/.config/gcloud/application_default_credentials.json.
+func VertexTokenSource(adcPath string) (func() string, error) {
+	if adcPath == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("proxy: user home dir: %w", err)
+		}
+		adcPath = filepath.Join(home, ".config", "gcloud", "application_default_credentials.json")
+	}
+
+	data, err := os.ReadFile(adcPath)
+	if err != nil {
+		return nil, fmt.Errorf("proxy: read ADC %s: %w", adcPath, err)
+	}
+
+	var creds adcCredentials
+	if err := json.Unmarshal(data, &creds); err != nil {
+		return nil, fmt.Errorf("proxy: parse ADC %s: %w", adcPath, err)
+	}
+
+	if creds.RefreshToken == "" || creds.ClientID == "" || creds.ClientSecret == "" {
+		return nil, fmt.Errorf("proxy: ADC missing required fields (refresh_token, client_id, client_secret)")
+	}
+
+	var mu sync.Mutex
+	var cached cachedToken
+
+	return func() string {
+		mu.Lock()
+		defer mu.Unlock()
+
+		if cached.accessToken != "" && time.Now().Before(cached.expiresAt.Add(-60*time.Second)) {
+			return cached.accessToken
+		}
+
+		token, expiresIn, err := exchangeRefreshToken(creds)
+		if err != nil {
+			return cached.accessToken // return stale token on error
+		}
+
+		cached.accessToken = token
+		cached.expiresAt = time.Now().Add(time.Duration(expiresIn) * time.Second)
+		return token
+	}, nil
+}
+
+// exchangeRefreshToken performs the OAuth2 token exchange against Google's
+// token endpoint. Returns the access token and its TTL in seconds.
+func exchangeRefreshToken(creds adcCredentials) (token string, expiresIn int, err error) {
+	resp, err := http.PostForm("https://oauth2.googleapis.com/token", url.Values{
+		"client_id":     {creds.ClientID},
+		"client_secret": {creds.ClientSecret},
+		"refresh_token": {creds.RefreshToken},
+		"grant_type":    {"refresh_token"},
+	})
+	if err != nil {
+		return "", 0, fmt.Errorf("proxy: token exchange: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return "", 0, fmt.Errorf("proxy: token exchange returned %d", resp.StatusCode)
+	}
+
+	var result struct {
+		AccessToken string `json:"access_token"`
+		ExpiresIn   int    `json:"expires_in"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", 0, fmt.Errorf("proxy: parse token response: %w", err)
+	}
+
+	if result.AccessToken == "" {
+		return "", 0, fmt.Errorf("proxy: empty access token in response")
+	}
+
+	return result.AccessToken, result.ExpiresIn, nil
+}

--- a/internal/sandbox/resolve.go
+++ b/internal/sandbox/resolve.go
@@ -98,11 +98,10 @@ func systemReadPaths() []string {
 }
 
 // claudeEnv builds the environment for a sandboxed Claude Code process.
-// When useProxy is true, real credentials are NOT passed to the sandbox.
-// Instead, a fake API key is set and ANTHROPIC_BASE_URL points to the
-// proxy's in-sandbox bridge (http://127.0.0.1:8080). The proxy injects
-// real credentials on the host side.
-func claudeEnv(tmpDir string, opts runner.RunOpts, claudeBin string, useProxy bool) []string {
+// When proxyURL is non-empty, real credentials are NOT passed to the sandbox.
+// Instead, a fake API key is set and the base URL points to the proxy.
+// The proxy injects real credentials on the host side.
+func claudeEnv(tmpDir string, opts runner.RunOpts, claudeBin, proxyURL string) []string {
 	env := []string{
 		"HOME=" + tmpDir,
 		"TMPDIR=" + tmpDir,
@@ -124,13 +123,29 @@ func claudeEnv(tmpDir string, opts runner.RunOpts, claudeBin string, useProxy bo
 		env = append(env, "NODE_PATH="+nodePath)
 	}
 
-	if useProxy {
-		// Proxy mode: fake API key + base URL pointing to the in-sandbox
-		// bridge that arapuca sets up from NetworkProxySocket.
-		env = append(env,
-			"ANTHROPIC_API_KEY=sk-proxy-nonce",
-			"ANTHROPIC_BASE_URL=http://127.0.0.1:8080",
-		)
+	if proxyURL != "" {
+		// Proxy mode: the proxy on the host side handles authentication.
+		if os.Getenv("CLAUDE_CODE_USE_VERTEX") != "" {
+			// Vertex mode: pass through Vertex config (project, location)
+			// but route API calls through the proxy and skip Vertex auth
+			// (the proxy injects Google OAuth tokens on the host side).
+			env = append(env,
+				"CLAUDE_CODE_USE_VERTEX=1",
+				"ANTHROPIC_VERTEX_BASE_URL="+proxyURL,
+				"CLAUDE_CODE_SKIP_VERTEX_AUTH=1",
+			)
+			for _, key := range []string{"VERTEXAI_PROJECT", "VERTEXAI_LOCATION", "CLOUD_ML_REGION", "ANTHROPIC_VERTEX_PROJECT_ID"} {
+				if val := os.Getenv(key); val != "" {
+					env = append(env, key+"="+val)
+				}
+			}
+		} else {
+			// Direct Anthropic mode: fake API key + base URL.
+			env = append(env,
+				"ANTHROPIC_API_KEY=sk-proxy-nonce",
+				"ANTHROPIC_BASE_URL="+proxyURL,
+			)
+		}
 	} else {
 		// Direct mode: pass through real credentials.
 		credentialVars := []string{

--- a/internal/sandbox/resolve_test.go
+++ b/internal/sandbox/resolve_test.go
@@ -38,7 +38,7 @@ func TestClaudeEnv(t *testing.T) {
 	t.Setenv("LANG", "en_US.UTF-8")
 
 	opts := runner.RunOpts{Phase: "triage", WorkDir: "/work"}
-	env := claudeEnv("/tmp/sandbox", opts, "/usr/local/bin/claude", false)
+	env := claudeEnv("/tmp/sandbox", opts, "/usr/local/bin/claude", "")
 
 	envMap := make(map[string]string)
 	for _, entry := range env {
@@ -69,7 +69,7 @@ func TestClaudeEnvVertexPassthrough(t *testing.T) {
 	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "/path/to/creds.json")
 
 	opts := runner.RunOpts{Phase: "plan", WorkDir: "/work"}
-	env := claudeEnv("/tmp/sb", opts, "/usr/bin/claude", false)
+	env := claudeEnv("/tmp/sb", opts, "/usr/bin/claude", "")
 
 	envMap := make(map[string]string)
 	for _, entry := range env {
@@ -97,7 +97,7 @@ func TestClaudeEnvNoKeyMeansNoEntry(t *testing.T) {
 	t.Setenv("CLAUDE_CODE_USE_VERTEX", "")
 
 	opts := runner.RunOpts{Phase: "plan", WorkDir: "/work"}
-	env := claudeEnv("/tmp/sb", opts, "/usr/bin/claude", false)
+	env := claudeEnv("/tmp/sb", opts, "/usr/bin/claude", "")
 
 	for _, entry := range env {
 		if strings.HasPrefix(entry, "ANTHROPIC_API_KEY=") {
@@ -111,9 +111,10 @@ func TestClaudeEnvNoKeyMeansNoEntry(t *testing.T) {
 
 func TestClaudeEnvProxyMode(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "sk-real-key")
+	t.Setenv("CLAUDE_CODE_USE_VERTEX", "") // ensure non-Vertex for this test
 
 	opts := runner.RunOpts{Phase: "implement", WorkDir: "/work"}
-	env := claudeEnv("/tmp/sb", opts, "/usr/bin/claude", true)
+	env := claudeEnv("/tmp/sb", opts, "/usr/bin/claude", "http://127.0.0.1:8080")
 
 	envMap := make(map[string]string)
 	for _, entry := range env {
@@ -129,9 +130,42 @@ func TestClaudeEnvProxyMode(t *testing.T) {
 	if envMap["ANTHROPIC_BASE_URL"] != "http://127.0.0.1:8080" {
 		t.Errorf("ANTHROPIC_BASE_URL = %q, want 'http://127.0.0.1:8080'", envMap["ANTHROPIC_BASE_URL"])
 	}
-	// Real credentials should NOT be present.
 	if _, ok := envMap["GOOGLE_APPLICATION_CREDENTIALS"]; ok {
 		t.Error("GOOGLE_APPLICATION_CREDENTIALS should not be present in proxy mode")
+	}
+}
+
+func TestClaudeEnvProxyModeVertex(t *testing.T) {
+	t.Setenv("CLAUDE_CODE_USE_VERTEX", "1")
+	t.Setenv("VERTEXAI_PROJECT", "my-project")
+	t.Setenv("VERTEXAI_LOCATION", "us-east5")
+
+	opts := runner.RunOpts{Phase: "implement", WorkDir: "/work"}
+	env := claudeEnv("/tmp/sb", opts, "/usr/bin/claude", "http://127.0.0.1:8080")
+
+	envMap := make(map[string]string)
+	for _, entry := range env {
+		parts := strings.SplitN(entry, "=", 2)
+		if len(parts) == 2 {
+			envMap[parts[0]] = parts[1]
+		}
+	}
+
+	if envMap["CLAUDE_CODE_USE_VERTEX"] != "1" {
+		t.Errorf("CLAUDE_CODE_USE_VERTEX = %q, want '1'", envMap["CLAUDE_CODE_USE_VERTEX"])
+	}
+	if envMap["ANTHROPIC_VERTEX_BASE_URL"] != "http://127.0.0.1:8080" {
+		t.Errorf("ANTHROPIC_VERTEX_BASE_URL = %q, want 'http://127.0.0.1:8080'", envMap["ANTHROPIC_VERTEX_BASE_URL"])
+	}
+	if envMap["CLAUDE_CODE_SKIP_VERTEX_AUTH"] != "1" {
+		t.Errorf("CLAUDE_CODE_SKIP_VERTEX_AUTH = %q, want '1'", envMap["CLAUDE_CODE_SKIP_VERTEX_AUTH"])
+	}
+	if envMap["VERTEXAI_PROJECT"] != "my-project" {
+		t.Errorf("VERTEXAI_PROJECT = %q, want 'my-project'", envMap["VERTEXAI_PROJECT"])
+	}
+	// Should NOT have ANTHROPIC_API_KEY in Vertex proxy mode.
+	if _, ok := envMap["ANTHROPIC_API_KEY"]; ok {
+		t.Error("ANTHROPIC_API_KEY should not be present in Vertex proxy mode")
 	}
 }
 

--- a/internal/sandbox/runner.go
+++ b/internal/sandbox/runner.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/decko/soda/internal/claude"
@@ -72,7 +73,10 @@ func (r *Runner) Run(ctx context.Context, opts runner.RunOpts) (*runner.RunResul
 	}
 
 	// Create sandbox temp dir first — used for system prompt file and HOME/TMPDIR.
-	tmpDir, err := arapuca.MakeTmpDir(opts.Phase)
+	// Sanitize phase name: replace slashes with dashes since MakeTmpDir uses
+	// the name in a path (e.g. "review/go-specialist" → "review-go-specialist").
+	tmpPhase := strings.ReplaceAll(opts.Phase, "/", "-")
+	tmpDir, err := arapuca.MakeTmpDir(tmpPhase)
 	if err != nil {
 		return nil, fmt.Errorf("sandbox: create temp dir: %w", err)
 	}
@@ -127,51 +131,60 @@ func (r *Runner) Run(ctx context.Context, opts runner.RunOpts) (*runner.RunResul
 	writePaths = append(writePaths, tmpDir)
 
 	useNetNS := r.config.UseNetNS
-	var networkProxySocket string
 	var llmProxy *proxy.Proxy
+	var proxyBaseURL string
 
-	// Start LLM proxy if configured. This enables full network isolation:
-	// Claude Code API calls are routed through the proxy Unix socket,
-	// and arapuca bridges it into the sandbox via NetworkProxySocket.
+	// Start LLM proxy if configured. The proxy listens on TCP localhost
+	// and the sandbox process connects to it via ANTHROPIC_BASE_URL or
+	// ANTHROPIC_VERTEX_BASE_URL. Network namespace isolation is deferred
+	// until go-arapuca implements the NetworkProxySocket bridge.
 	if r.config.Proxy.Enabled {
-		useNetNS = true // force network isolation when proxy is active
-
-		socketDir, socketErr := arapuca.MakeSocketDir()
-		if socketErr != nil {
-			return nil, fmt.Errorf("sandbox: create socket dir for proxy: %w", socketErr)
-		}
-		defer os.RemoveAll(socketDir)
-
-		sockPath := filepath.Join(socketDir, "llm.sock")
-		readPaths = append(readPaths, socketDir)
-
-		apiKey := r.config.Proxy.APIKey
-		if apiKey == "" {
-			apiKey = os.Getenv("ANTHROPIC_API_KEY")
-		}
-		upstreamURL := r.config.Proxy.UpstreamURL
-		if upstreamURL == "" {
-			upstreamURL = os.Getenv("ANTHROPIC_BASE_URL")
-		}
-		if upstreamURL == "" {
-			upstreamURL = "https://api.anthropic.com"
-		}
-
-		var proxyErr error
-		llmProxy, proxyErr = proxy.New(proxy.Config{
-			SocketPath:      sockPath,
-			UpstreamURL:     upstreamURL,
-			APIKey:          apiKey,
+		proxyCfg := proxy.Config{
+			ListenAddr:      "127.0.0.1:0",
 			MaxInputTokens:  r.config.Proxy.MaxInputTokens,
 			MaxOutputTokens: r.config.Proxy.MaxOutputTokens,
 			LogDir:          r.config.Proxy.LogDir,
-		})
+		}
+
+		if os.Getenv("CLAUDE_CODE_USE_VERTEX") != "" {
+			// Vertex mode: resolve upstream URL and token source from ADC.
+			region := os.Getenv("CLOUD_ML_REGION")
+			if region == "" {
+				region = os.Getenv("VERTEXAI_LOCATION")
+			}
+			if region == "" {
+				region = "us-east5"
+			}
+			proxyCfg.UpstreamURL = fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1", region)
+
+			tokenFunc, tokenErr := proxy.VertexTokenSource("")
+			if tokenErr != nil {
+				return nil, fmt.Errorf("sandbox: vertex token source: %w", tokenErr)
+			}
+			proxyCfg.TokenFunc = tokenFunc
+		} else {
+			// Direct Anthropic mode.
+			proxyCfg.APIKey = r.config.Proxy.APIKey
+			if proxyCfg.APIKey == "" {
+				proxyCfg.APIKey = os.Getenv("ANTHROPIC_API_KEY")
+			}
+			proxyCfg.UpstreamURL = r.config.Proxy.UpstreamURL
+			if proxyCfg.UpstreamURL == "" {
+				proxyCfg.UpstreamURL = os.Getenv("ANTHROPIC_BASE_URL")
+			}
+			if proxyCfg.UpstreamURL == "" {
+				proxyCfg.UpstreamURL = "https://api.anthropic.com"
+			}
+		}
+
+		var proxyErr error
+		llmProxy, proxyErr = proxy.New(proxyCfg)
 		if proxyErr != nil {
 			return nil, fmt.Errorf("sandbox: start LLM proxy: %w", proxyErr)
 		}
 		defer llmProxy.Close()
 
-		networkProxySocket = sockPath
+		proxyBaseURL = fmt.Sprintf("http://%s", llmProxy.Addr().String())
 	}
 
 	profile := arapuca.Profile{
@@ -201,24 +214,26 @@ func (r *Runner) Run(ctx context.Context, opts runner.RunOpts) (*runner.RunResul
 	defer stderrW.Close()
 
 	cfg := arapuca.Config{
-		Profile:            profile,
-		TaskID:             opts.Phase,
-		Phase:              opts.Phase,
-		WorkDir:            opts.WorkDir,
-		Stdout:             stdoutW,
-		Stderr:             stderrW,
-		NetworkProxySocket: networkProxySocket,
+		Profile: profile,
+		TaskID:  tmpPhase,
+		Phase:   tmpPhase,
+		WorkDir: opts.WorkDir,
+		Stdout:  stdoutW,
+		Stderr:  stderrW,
 	}
 
-	// Serialize env mutation + Launch to prevent races if multiple Runners
-	// are used concurrently. Restore env immediately after Launch returns —
-	// no need to keep sandbox env vars set during subprocess execution.
-	env := claudeEnv(tmpDir, opts, r.claudeBin, r.config.Proxy.Enabled)
-	launchMu.Lock()
-	restore := setEnvForLaunch(env)
+	// Build env vars for the sandboxed process. go-arapuca v0.1.1+ passes
+	// these directly to the subprocess via Config.Env, avoiding the racy
+	// setEnvForLaunch pattern that mutated the host process env.
+	envSlice := claudeEnv(tmpDir, opts, r.claudeBin, proxyBaseURL)
+	envMap := make(map[string]string, len(envSlice))
+	for _, entry := range envSlice {
+		k, v, _ := parseEnvEntry(entry)
+		envMap[k] = v
+	}
+	cfg.Env = envMap
+
 	proc, launchErr := r.sandbox.Launch(ctx, cfg, r.claudeBin, args, nil)
-	restore()
-	launchMu.Unlock()
 
 	if launchErr != nil {
 		return nil, fmt.Errorf("sandbox: launch: %w", launchErr)


### PR DESCRIPTION
## Summary

Wire the sandbox runner into the pipeline so `soda run` executes Claude Code inside arapuca with OS-level isolation when `sandbox.enabled: true`.

### What this enables

- **Landlock filesystem isolation**: Claude Code can only read/write allowed paths
- **cgroup resource limits**: memory, CPU, PID caps
- **seccomp syscall filtering**: restricted syscall set
- **Credential isolation**: real API tokens never enter the sandbox — the TCP proxy injects Google OAuth tokens on the host side

### Key changes

- **go-arapuca v0.1.1**: `Config.Env` for direct env var passthrough (fixes the broken `setEnvForLaunch` pattern)
- **TCP proxy mode**: `ListenAddr` field + `Addr()` method for port discovery (Unix socket bridge not yet implemented in arapuca)
- **Vertex AI proxy**: `vertex.go` exchanges Google ADC refresh tokens for access tokens, cached with 60s expiry buffer
- **Vertex env wiring**: `ANTHROPIC_VERTEX_BASE_URL` → proxy, `CLAUDE_CODE_SKIP_VERTEX_AUTH=1`, project/location passthrough
- **Path prefix support**: proxy prepends upstream path (e.g. `/v1`) for Vertex AI URLs
- **Phase name sanitization**: slashes in reviewer phase names (e.g. `review/go-specialist`) replaced with dashes for arapuca temp dirs and task IDs
- **run.go wiring**: creates `sandbox.Runner` when `sandbox.enabled: true`, with proxy config from `soda.yaml`

### Validated end-to-end

`soda run 324` completed all 7 phases inside the sandbox with Vertex AI proxy:

| Phase | Status | Cost |
|-------|--------|------|
| triage | ✓ | $0.38 |
| plan | ✓ | $0.83 |
| implement | ✓ (3 rework cycles) | $1.67 |
| verify | ✓ PASS | $0.74 |
| review | ✓ pass-with-follow-ups | $0.98 |
| submit | ✓ PR #333 | $0.34 |
| **Total** | | **$14.41** |

### Config

```yaml
sandbox:
  enabled: true
  limits:
    memory_mb: 2048
    cpu_percent: 200
    max_pids: 256
  proxy:
    enabled: true
    log_dir: .soda/proxy-logs
```

## Test plan

- [x] All unit tests pass (CGO_ENABLED=0 and CGO_ENABLED=1)
- [x] Vertex proxy env test added (proxy mode + non-proxy mode)
- [x] `go vet` clean
- [x] Full pipeline run completed inside sandbox (PR #333)
- [x] Concurrent reviewers work with phase name sanitization
