### PR TITLE
fix(pipeline): monitor phase works without self_user — passive by default [#336]

### DIFF
--- a/cmd/soda/embeds/phases.yaml
+++ b/cmd/soda/embeds/phases.yaml
@@ -185,6 +185,8 @@ phases:
       escalate_after: 30m
       max_duration: 4h
       max_response_rounds: 3
+      respond_to_comments: false  # enable to classify and respond to PR comments (requires self_user)
+      auto_merge: false           # enable to auto-merge when CI green + approved (see #338)
     retry:
       transient: 2
       parse: 1

--- a/internal/pipeline/monitor_poll.go
+++ b/internal/pipeline/monitor_poll.go
@@ -28,20 +28,18 @@ func (e *Engine) runMonitor(ctx context.Context, phase PhaseConfig) error {
 		return e.runMonitorStub(phase)
 	}
 
-	// Require SelfUser so the classifier can filter out the bot's own comments.
-	// Use TrimSpace to be consistent with NewCommentClassifier, which also
-	// rejects whitespace-only values. Without this, a whitespace-only SelfUser
-	// would pass this guard but fail classifier construction on every poll,
-	// causing comments to be silently dropped.
-	if strings.TrimSpace(e.config.SelfUser) == "" {
+	// Determine whether comment response is enabled.
+	// Requires both the config flag and self_user to be set.
+	respondToComments := phase.Polling != nil && phase.Polling.RespondToComments
+	if respondToComments && strings.TrimSpace(e.config.SelfUser) == "" {
 		e.emit(Event{
 			Phase: phase.Name,
 			Kind:  EventMonitorWarning,
 			Data: map[string]any{
-				"warning": "self_user not configured; falling back to stub (required for comment classification)",
+				"warning": "respond_to_comments enabled but self_user not configured; comment response disabled",
 			},
 		})
-		return e.runMonitorStub(phase)
+		respondToComments = false
 	}
 
 	polling := phase.Polling
@@ -202,73 +200,75 @@ func (e *Engine) runMonitor(ctx context.Context, phase PhaseConfig) error {
 			return nil
 		}
 
-		// 2. Check for new comments.
-		classified := e.checkNewComments(ctx, phase.Name, monState)
+		// 2. Check for new comments and respond (only when enabled).
+		if respondToComments {
+			classified := e.checkNewComments(ctx, phase.Name, monState)
 
-		// Apply profile behavior filters to classified comments.
-		classified = applyProfileFilters(classified, profile)
+			// Apply profile behavior filters to classified comments.
+			classified = applyProfileFilters(classified, profile)
 
-		// 2a. Post canned acknowledgment for non-authoritative comments.
-		e.postAcknowledgments(ctx, phase.Name, classified, monState)
+			// 2a. Post canned acknowledgment for non-authoritative comments.
+			e.postAcknowledgments(ctx, phase.Name, classified, monState)
 
-		// 2b. Response execution: run a Claude session for actionable comments.
-		if HasActionable(classified) {
-			if e.runner == nil {
-				// No runner configured; count the round to avoid infinite loops,
-				// but only for fix attempts, not reply-only sessions.
-				if !isReplyOnly(classified) {
-					monState.ResponseRounds++
-				}
-			} else if e.config.MaxCostUSD > 0 && e.state.Meta().TotalCost >= e.config.MaxCostUSD {
-				// Budget exceeded — do not consume a response round since no
-				// work is performed. This prevents premature MaxRounds
-				// termination when all rounds are budget-skipped.
-				e.emit(Event{
-					Phase: phase.Name,
-					Kind:  EventBudgetWarning,
-					Data: map[string]any{
-						"total_cost": e.state.Meta().TotalCost,
-						"limit":      e.config.MaxCostUSD,
-						"skipping":   "monitor_response",
-					},
-				})
-			} else if e.config.MaxCostPerPhase > 0 && e.state.Meta().Phases[phase.Name] != nil && e.state.Meta().Phases[phase.Name].CumulativeCost >= e.config.MaxCostPerPhase {
-				// Per-phase budget exceeded — skip response, same as global budget.
-				e.emit(Event{
-					Phase: phase.Name,
-					Kind:  EventPhaseBudgetExceeded,
-					Data: map[string]any{
-						"phase_cost": e.state.Meta().Phases[phase.Name].CumulativeCost,
-						"limit":      e.config.MaxCostPerPhase,
-						"skipping":   "monitor_response",
-					},
-				})
-			} else {
-				output, err := e.respondToComments(ctx, phase, classified, monState)
-				if err != nil {
-					// Non-fatal: log and continue polling. Do not increment
-					// ResponseRounds so transient failures don't consume the budget.
-					e.emit(Event{
-						Phase: phase.Name,
-						Kind:  EventMonitorResponseFailed,
-						Data: map[string]any{
-							"response_round": monState.ResponseRounds,
-							"error":          err.Error(),
-						},
-					})
-				} else if output != nil {
-					// Increment the appropriate counter after a successful response.
-					if isReplyOnly(classified) {
-						monState.ReplyRounds++
-					} else {
+			// 2b. Response execution: run a Claude session for actionable comments.
+			if HasActionable(classified) {
+				if e.runner == nil {
+					// No runner configured; count the round to avoid infinite loops,
+					// but only for fix attempts, not reply-only sessions.
+					if !isReplyOnly(classified) {
 						monState.ResponseRounds++
 					}
-					// Programmatic verify gate: when files were changed,
-					// check tests_passed to decide whether to allow push.
-					e.gateMonitorResponse(ctx, phase, output, monState)
+				} else if e.config.MaxCostUSD > 0 && e.state.Meta().TotalCost >= e.config.MaxCostUSD {
+					// Budget exceeded — do not consume a response round since no
+					// work is performed. This prevents premature MaxRounds
+					// termination when all rounds are budget-skipped.
+					e.emit(Event{
+						Phase: phase.Name,
+						Kind:  EventBudgetWarning,
+						Data: map[string]any{
+							"total_cost": e.state.Meta().TotalCost,
+							"limit":      e.config.MaxCostUSD,
+							"skipping":   "monitor_response",
+						},
+					})
+				} else if e.config.MaxCostPerPhase > 0 && e.state.Meta().Phases[phase.Name] != nil && e.state.Meta().Phases[phase.Name].CumulativeCost >= e.config.MaxCostPerPhase {
+					// Per-phase budget exceeded — skip response, same as global budget.
+					e.emit(Event{
+						Phase: phase.Name,
+						Kind:  EventPhaseBudgetExceeded,
+						Data: map[string]any{
+							"phase_cost": e.state.Meta().Phases[phase.Name].CumulativeCost,
+							"limit":      e.config.MaxCostPerPhase,
+							"skipping":   "monitor_response",
+						},
+					})
+				} else {
+					output, err := e.respondToComments(ctx, phase, classified, monState)
+					if err != nil {
+						// Non-fatal: log and continue polling. Do not increment
+						// ResponseRounds so transient failures don't consume the budget.
+						e.emit(Event{
+							Phase: phase.Name,
+							Kind:  EventMonitorResponseFailed,
+							Data: map[string]any{
+								"response_round": monState.ResponseRounds,
+								"error":          err.Error(),
+							},
+						})
+					} else if output != nil {
+						// Increment the appropriate counter after a successful response.
+						if isReplyOnly(classified) {
+							monState.ReplyRounds++
+						} else {
+							monState.ResponseRounds++
+						}
+						// Programmatic verify gate: when files were changed,
+						// check tests_passed to decide whether to allow push.
+						e.gateMonitorResponse(ctx, phase, output, monState)
 
-					// Post a summary reply to the PR.
-					e.postResponseSummary(ctx, phase.Name, output, monState)
+						// Post a summary reply to the PR.
+						e.postResponseSummary(ctx, phase.Name, output, monState)
+					}
 				}
 			}
 		}
@@ -280,31 +280,33 @@ func (e *Engine) runMonitor(ctx context.Context, phase PhaseConfig) error {
 		autoRebase := profile == nil || profile.ShouldAutoRebase()
 		e.checkMergeConflicts(ctx, phase.Name, monState, autoRebase)
 
-		// 5. Check max response rounds (fix + reply combined).
-		totalRounds := monState.ResponseRounds + monState.ReplyRounds
-		if totalRounds >= monState.MaxResponseRounds {
-			monState.Status = MonitorMaxRounds
-			_ = e.state.WriteMonitorState(monState)
-			e.emit(Event{
-				Phase: phase.Name,
-				Kind:  EventMonitorMaxRounds,
-				Data: map[string]any{
-					"response_rounds":     monState.ResponseRounds,
-					"max_response_rounds": monState.MaxResponseRounds,
-				},
-			})
-			if err := e.state.MarkCompleted(phase.Name); err != nil {
-				return fmt.Errorf("engine: mark completed %s: %w", phase.Name, err)
+		// 5. Check max response rounds (only relevant when comment response is enabled).
+		if respondToComments {
+			totalRounds := monState.ResponseRounds + monState.ReplyRounds
+			if totalRounds >= monState.MaxResponseRounds {
+				monState.Status = MonitorMaxRounds
+				_ = e.state.WriteMonitorState(monState)
+				e.emit(Event{
+					Phase: phase.Name,
+					Kind:  EventMonitorMaxRounds,
+					Data: map[string]any{
+						"response_rounds":     monState.ResponseRounds,
+						"max_response_rounds": monState.MaxResponseRounds,
+					},
+				})
+				if err := e.state.MarkCompleted(phase.Name); err != nil {
+					return fmt.Errorf("engine: mark completed %s: %w", phase.Name, err)
+				}
+				e.emit(Event{
+					Phase: phase.Name,
+					Kind:  EventPhaseCompleted,
+					Data: map[string]any{
+						"duration_ms": e.state.Meta().Phases[phase.Name].DurationMs,
+						"reason":      "max_rounds_reached",
+					},
+				})
+				return nil
 			}
-			e.emit(Event{
-				Phase: phase.Name,
-				Kind:  EventPhaseCompleted,
-				Data: map[string]any{
-					"duration_ms": e.state.Meta().Phases[phase.Name].DurationMs,
-					"reason":      "max_rounds_reached",
-				},
-			})
-			return nil
 		}
 
 		// Persist state after each poll cycle.

--- a/internal/pipeline/monitor_poll_test.go
+++ b/internal/pipeline/monitor_poll_test.go
@@ -143,6 +143,7 @@ func setupMonitorEngineWithRunner(t *testing.T, r runner.Runner, poller PRPoller
 			EscalateAfter:     Duration{Duration: 10 * time.Millisecond},
 			MaxDuration:       Duration{Duration: 100 * time.Millisecond},
 			MaxResponseRounds: 3,
+			RespondToComments: true,
 		}
 	}
 
@@ -348,6 +349,7 @@ func TestMonitor_MaxRoundsReached(t *testing.T) {
 		EscalateAfter:     Duration{Duration: 10 * time.Millisecond},
 		MaxDuration:       Duration{Duration: 1 * time.Second},
 		MaxResponseRounds: 3,
+		RespondToComments: true,
 	}
 
 	engine, state, events := setupMonitorEngine(t, poller, pollingCfg)
@@ -443,6 +445,7 @@ func TestMonitor_MaxDurationTimeout(t *testing.T) {
 		EscalateAfter:     Duration{Duration: 10 * time.Minute},
 		MaxDuration:       Duration{Duration: 1 * time.Hour},
 		MaxResponseRounds: 3,
+		RespondToComments: true,
 	}
 
 	engine, state, events := setupMonitorEngine(t, poller, pollingCfg, func(cfg *EngineConfig) {
@@ -533,8 +536,9 @@ func TestMonitor_PollCountIncremented(t *testing.T) {
 	}
 }
 
-func TestMonitor_FallbackToStubWithoutSelfUser(t *testing.T) {
-	// When SelfUser is empty, should emit a warning and fall back to stub.
+func TestMonitor_NoSelfUserDisablesCommentResponse(t *testing.T) {
+	// When SelfUser is empty and respond_to_comments is true, comment response
+	// should be disabled but the monitor should still poll and complete normally.
 	poller := &mockPRPoller{
 		statusResponses: []mockPRStatusResponse{
 			{status: &PRStatus{State: "open", Approved: true}},
@@ -550,39 +554,33 @@ func TestMonitor_FallbackToStubWithoutSelfUser(t *testing.T) {
 	}
 
 	if !state.IsCompleted("monitor") {
-		t.Error("monitor should be completed via stub fallback")
+		t.Error("monitor should be completed (passive polling)")
 	}
 
 	hasWarning := false
-	hasMonitorSkipped := false
 	for _, e := range *events {
 		if e.Kind == EventMonitorWarning {
-			if w, _ := e.Data["warning"].(string); strings.Contains(w, "self_user not configured") {
+			if w, _ := e.Data["warning"].(string); strings.Contains(w, "respond_to_comments") {
 				hasWarning = true
 			}
 		}
-		if e.Kind == EventMonitorSkipped {
-			hasMonitorSkipped = true
-		}
 	}
 	if !hasWarning {
-		t.Error("monitor_warning event about self_user not emitted")
-	}
-	if !hasMonitorSkipped {
-		t.Error("monitor_skipped event not emitted for stub fallback")
+		t.Error("should emit warning about respond_to_comments + missing self_user")
 	}
 
-	// Should NOT have entered the polling loop.
-	_, err := state.ReadMonitorState()
-	if err == nil {
-		t.Error("monitor state should not exist (stub does not write it)")
+	// Should have entered the polling loop (monitor state exists).
+	monState, err := state.ReadMonitorState()
+	if err != nil {
+		t.Fatalf("expected monitor state to exist: %v", err)
+	}
+	if monState.PollCount == 0 {
+		t.Error("expected at least one poll cycle")
 	}
 }
 
-func TestMonitor_FallbackToStubWithWhitespaceSelfUser(t *testing.T) {
-	// Whitespace-only SelfUser should be treated the same as empty —
-	// fall back to stub rather than entering the polling loop where
-	// every classifier construction would fail.
+func TestMonitor_WhitespaceSelfUserDisablesCommentResponse(t *testing.T) {
+	// Whitespace-only SelfUser should be treated the same as empty.
 	poller := &mockPRPoller{
 		statusResponses: []mockPRStatusResponse{
 			{status: &PRStatus{State: "open", Approved: true}},
@@ -598,32 +596,19 @@ func TestMonitor_FallbackToStubWithWhitespaceSelfUser(t *testing.T) {
 	}
 
 	if !state.IsCompleted("monitor") {
-		t.Error("monitor should be completed via stub fallback")
+		t.Error("monitor should be completed (passive polling)")
 	}
 
 	hasWarning := false
-	hasMonitorSkipped := false
 	for _, e := range *events {
 		if e.Kind == EventMonitorWarning {
-			if w, _ := e.Data["warning"].(string); strings.Contains(w, "self_user not configured") {
+			if w, _ := e.Data["warning"].(string); strings.Contains(w, "respond_to_comments") {
 				hasWarning = true
 			}
 		}
-		if e.Kind == EventMonitorSkipped {
-			hasMonitorSkipped = true
-		}
 	}
 	if !hasWarning {
-		t.Error("monitor_warning event about self_user not emitted")
-	}
-	if !hasMonitorSkipped {
-		t.Error("monitor_skipped event not emitted for stub fallback")
-	}
-
-	// Should NOT have entered the polling loop.
-	_, err := state.ReadMonitorState()
-	if err == nil {
-		t.Error("monitor state should not exist (stub does not write it)")
+		t.Error("should emit warning about respond_to_comments + missing self_user")
 	}
 }
 

--- a/internal/pipeline/phase.go
+++ b/internal/pipeline/phase.go
@@ -86,7 +86,9 @@ type PollingConfig struct {
 	EscalateAfter     Duration           `yaml:"escalate_after"`
 	MaxDuration       Duration           `yaml:"max_duration"`
 	MaxResponseRounds int                `yaml:"max_response_rounds"`
-	Profile           MonitorProfileName `yaml:"profile,omitempty"` // preset profile name (conservative, smart, aggressive)
+	Profile           MonitorProfileName `yaml:"profile,omitempty"`             // preset profile name (conservative, smart, aggressive)
+	RespondToComments bool               `yaml:"respond_to_comments,omitempty"` // enable comment classification + response (requires self_user)
+	AutoMerge         bool               `yaml:"auto_merge,omitempty"`          // merge PR when checks green + approved (see #338 for safeguards)
 }
 
 // Duration wraps time.Duration for YAML unmarshaling.


### PR DESCRIPTION
## Summary

The monitor phase no longer requires `self_user` to function. Previously, missing `self_user` caused the entire monitor to fall back to a no-op stub. Now the monitor runs as a **passive watcher** by default — polling PR status, detecting CI failures, detecting merge conflicts — without requiring any config.

### Behavior change

| Before | After |
|--------|-------|
| Missing `self_user` → entire monitor is a no-op | Missing `self_user` → monitor polls, reports, but skips comment response |
| Comment response always attempted | Comment response is opt-in via `respond_to_comments: true` |
| No `auto_merge` option | `auto_merge: false` field added (safeguards in #338) |

### New config fields in PollingConfig

```yaml
monitor:
  polling:
    respond_to_comments: false  # opt-in: classify and respond to PR comments (requires self_user)
    auto_merge: false           # opt-in: merge when CI green + approved (see #338)
```

### Default monitor (zero config)

Poll → report PR status → detect CI failures → detect merge conflicts → exit when approved/merged/closed. No `self_user` needed.

## Test plan

- [x] Existing monitor tests updated for new behavior (RespondToComments: true in test configs)
- [x] New tests: missing self_user disables comment response but monitor still polls
- [x] New tests: whitespace-only self_user treated same as empty
- [x] Stub fallback without poller test unchanged
- [x] Full suite green, `go vet` clean

Closes #336
