### PR TITLE
fix(pipeline): detect comments in passive monitor mode [#336]

### DIFF
--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -746,6 +746,13 @@ func handleEvent(ctx context.Context, cancel context.CancelFunc, engine *pipelin
 		}
 		prog.Message(fmt.Sprintf("  ⏹  Monitor timeout after %s", duration))
 
+	case pipeline.EventMonitorNotifyUser:
+		var reason string
+		if r, ok := event.Data["reason"].(string); ok {
+			reason = r
+		}
+		prog.Message(fmt.Sprintf("  👤 %s", reason))
+
 	case pipeline.EventCorrectiveSkipped:
 		prog.PhaseSkipped(event.Phase)
 

--- a/internal/pipeline/monitor_poll.go
+++ b/internal/pipeline/monitor_poll.go
@@ -200,7 +200,12 @@ func (e *Engine) runMonitor(ctx context.Context, phase PhaseConfig) error {
 			return nil
 		}
 
-		// 2. Check for new comments and respond (only when enabled).
+		// 2. Check for new comments.
+		// In passive mode (respondToComments=false), we still detect and log
+		// new comments so the user knows human feedback arrived.
+		if !respondToComments {
+			e.checkNewCommentsPassive(ctx, phase.Name, monState)
+		}
 		if respondToComments {
 			classified := e.checkNewComments(ctx, phase.Name, monState)
 
@@ -461,6 +466,71 @@ func (e *Engine) checkNewComments(ctx context.Context, phaseName string, monStat
 	})
 
 	return classified
+}
+
+// checkNewCommentsPassive detects new comments without classifying or responding.
+// Used in passive mode (no self_user / respondToComments=false) to log that
+// human feedback arrived so the user knows action is needed.
+func (e *Engine) checkNewCommentsPassive(ctx context.Context, phaseName string, monState *MonitorState) {
+	if e.config.PRPoller == nil {
+		return
+	}
+
+	comments, err := e.config.PRPoller.GetNewComments(ctx, monState.PRURL, monState.LastCommentID)
+	if err != nil {
+		e.emit(Event{
+			Phase: phaseName,
+			Kind:  EventMonitorWarning,
+			Data:  map[string]any{"warning": fmt.Sprintf("get new comments: %v", err)},
+		})
+		return
+	}
+
+	if len(comments) == 0 {
+		return
+	}
+
+	// Advance LastCommentID so we don't re-report the same comments.
+	monState.LastCommentID = comments[len(comments)-1].ID
+
+	// Build comment summaries for the event.
+	commentSummaries := make([]map[string]any, 0, len(comments))
+	for _, comment := range comments {
+		commentSummaries = append(commentSummaries, map[string]any{
+			"id":     comment.ID,
+			"author": comment.Author,
+			"path":   comment.Path,
+		})
+	}
+
+	e.emit(Event{
+		Phase: phaseName,
+		Kind:  EventMonitorNewComments,
+		Data: map[string]any{
+			"count":    len(comments),
+			"passive":  true,
+			"comments": commentSummaries,
+		},
+	})
+
+	// Notify the user that comments need attention.
+	authors := make([]string, 0, len(comments))
+	seen := map[string]bool{}
+	for _, comment := range comments {
+		if !seen[comment.Author] {
+			authors = append(authors, comment.Author)
+			seen[comment.Author] = true
+		}
+	}
+	e.emit(Event{
+		Phase: phaseName,
+		Kind:  EventMonitorNotifyUser,
+		Data: map[string]any{
+			"reason":  fmt.Sprintf("%d new comment(s) detected — manual review needed (comment response not enabled)", len(comments)),
+			"count":   len(comments),
+			"authors": authors,
+		},
+	})
 }
 
 // checkCIStatus polls CI status and emits events on status changes.

--- a/internal/pipeline/monitor_poll_test.go
+++ b/internal/pipeline/monitor_poll_test.go
@@ -579,6 +579,162 @@ func TestMonitor_NoSelfUserDisablesCommentResponse(t *testing.T) {
 	}
 }
 
+func TestMonitor_PassiveMode_DetectsNewComments(t *testing.T) {
+	// In passive mode (respondToComments=false), the monitor should still
+	// detect new comments and emit EventMonitorNewComments + EventMonitorNotifyUser
+	// so the user knows human feedback arrived, even though it won't respond.
+	poller := &mockPRPoller{
+		statusResponses: []mockPRStatusResponse{
+			{status: &PRStatus{State: "open", Approved: false}},
+			{status: &PRStatus{State: "open", Approved: true}},
+		},
+		commentResponses: []mockCommentResponse{
+			{comments: []PRComment{
+				{ID: "c1", Author: "reviewer", Body: "Please add a Go-specific section"},
+			}},
+		},
+	}
+
+	pollingCfg := &PollingConfig{
+		InitialInterval:   Duration{Duration: 1 * time.Millisecond},
+		MaxInterval:       Duration{Duration: 2 * time.Millisecond},
+		EscalateAfter:     Duration{Duration: 10 * time.Millisecond},
+		MaxDuration:       Duration{Duration: 100 * time.Millisecond},
+		MaxResponseRounds: 3,
+		RespondToComments: false, // passive mode
+	}
+
+	engine, state, events := setupMonitorEngine(t, poller, pollingCfg, func(cfg *EngineConfig) {
+		cfg.SelfUser = "" // no self_user
+	})
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if !state.IsCompleted("monitor") {
+		t.Error("monitor should be completed (passive polling)")
+	}
+
+	hasNewComments := false
+	hasNotifyUser := false
+	var notifyReason string
+	var commentCount int
+	for _, evt := range *events {
+		if evt.Kind == EventMonitorNewComments {
+			hasNewComments = true
+			if c, ok := evt.Data["count"].(int); ok {
+				commentCount = c
+			}
+		}
+		if evt.Kind == EventMonitorNotifyUser {
+			hasNotifyUser = true
+			if r, ok := evt.Data["reason"].(string); ok {
+				notifyReason = r
+			}
+		}
+	}
+	if !hasNewComments {
+		t.Error("passive mode should emit monitor_new_comments event")
+	}
+	if commentCount != 1 {
+		t.Errorf("comment count = %d, want 1", commentCount)
+	}
+	if !hasNotifyUser {
+		t.Error("passive mode should emit monitor_notify_user event")
+	}
+	if !strings.Contains(notifyReason, "comment") {
+		t.Errorf("notify reason = %q, want it to mention comments", notifyReason)
+	}
+
+	// Verify the poller was actually called for comments.
+	poller.mu.Lock()
+	commentCalls := poller.commentCallCount
+	poller.mu.Unlock()
+	if commentCalls == 0 {
+		t.Error("GetNewComments should be called even in passive mode")
+	}
+}
+
+func TestMonitor_PassiveMode_NoCommentsNoNotify(t *testing.T) {
+	// When no new comments exist, passive mode should NOT emit notify_user.
+	poller := &mockPRPoller{
+		statusResponses: []mockPRStatusResponse{
+			{status: &PRStatus{State: "open", Approved: true}},
+		},
+		// No comment responses — GetNewComments returns nil
+	}
+
+	pollingCfg := &PollingConfig{
+		InitialInterval:   Duration{Duration: 1 * time.Millisecond},
+		MaxInterval:       Duration{Duration: 2 * time.Millisecond},
+		EscalateAfter:     Duration{Duration: 10 * time.Millisecond},
+		MaxDuration:       Duration{Duration: 100 * time.Millisecond},
+		MaxResponseRounds: 3,
+		RespondToComments: false,
+	}
+
+	engine, _, events := setupMonitorEngine(t, poller, pollingCfg, func(cfg *EngineConfig) {
+		cfg.SelfUser = ""
+	})
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	for _, evt := range *events {
+		if evt.Kind == EventMonitorNotifyUser {
+			t.Error("should NOT emit monitor_notify_user when no comments")
+		}
+	}
+}
+
+func TestMonitor_PassiveMode_GetCommentsErrorNonFatal(t *testing.T) {
+	// GetNewComments error in passive mode should emit warning, not crash.
+	poller := &mockPRPoller{
+		statusResponses: []mockPRStatusResponse{
+			{status: &PRStatus{State: "open", Approved: false}},
+			{status: &PRStatus{State: "open", Approved: true}},
+		},
+		commentResponses: []mockCommentResponse{
+			{err: fmt.Errorf("API rate limited")},
+		},
+	}
+
+	pollingCfg := &PollingConfig{
+		InitialInterval:   Duration{Duration: 1 * time.Millisecond},
+		MaxInterval:       Duration{Duration: 2 * time.Millisecond},
+		EscalateAfter:     Duration{Duration: 10 * time.Millisecond},
+		MaxDuration:       Duration{Duration: 100 * time.Millisecond},
+		MaxResponseRounds: 3,
+		RespondToComments: false,
+	}
+
+	engine, state, events := setupMonitorEngine(t, poller, pollingCfg, func(cfg *EngineConfig) {
+		cfg.SelfUser = ""
+	})
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if !state.IsCompleted("monitor") {
+		t.Error("monitor should complete despite comment fetch error")
+	}
+
+	hasWarning := false
+	for _, evt := range *events {
+		if evt.Kind == EventMonitorWarning {
+			if w, _ := evt.Data["warning"].(string); strings.Contains(w, "get new comments") {
+				hasWarning = true
+			}
+		}
+	}
+	if !hasWarning {
+		t.Error("should emit warning when passive comment fetch fails")
+	}
+}
+
 func TestMonitor_WhitespaceSelfUserDisablesCommentResponse(t *testing.T) {
 	// Whitespace-only SelfUser should be treated the same as empty.
 	poller := &mockPRPoller{


### PR DESCRIPTION
## Summary

- In passive monitor mode (no `self_user` / `respond_to_comments` disabled), the polling loop now fetches new PR comments and emits `monitor_new_comments` + `monitor_notify_user` events so the user knows human feedback arrived
- Previously, passive mode was completely blind to comments — no indication that reviewers had posted feedback
- Also adds CLI rendering for `monitor_notify_user` events (was silently ignored)

## Test plan

- [x] `TestMonitor_PassiveMode_DetectsNewComments` — verifies events emitted when comments detected
- [x] `TestMonitor_PassiveMode_NoCommentsNoNotify` — no false notifications when no comments
- [x] `TestMonitor_PassiveMode_GetCommentsErrorNonFatal` — error handling doesn't crash polling
- [x] All existing monitor tests pass (no regressions)
- [x] `go vet ./...` clean
- [x] Validated end-to-end: ran ticket #342 through full pipeline, monitor detected merge in passive mode

Closes #336