### PR TITLE
chore(cli): use /loop for non-blocking pipeline monitoring in commands

### DIFF
--- a/cmd/soda/embeds/claude-code/commands/soda-resume.md
+++ b/cmd/soda/embeds/claude-code/commands/soda-resume.md
@@ -6,9 +6,15 @@ argument-hint: <ticket-key> [--from <phase>]
 Resume a SODA pipeline from the last failed or interrupted phase:
 
 ```bash
-soda run $ARGUMENTS --from last
+nohup soda run $ARGUMENTS --from last > /tmp/soda-<ticket>.log 2>&1 &
 ```
 
-If a specific phase is provided in $ARGUMENTS, use it as the `--from` value instead of `last`.
+Replace `<ticket>` with the actual ticket key. If a specific phase is provided in $ARGUMENTS, use it as the `--from` value instead of `last`.
+
+The pipeline runs in the background. **Do not block waiting for it.** Instead, poll progress:
+
+```
+/loop 2m soda status
+```
 
 If no ticket key is provided, ask the user for one. You can check `soda status` or `soda sessions` to find recent tickets.

--- a/cmd/soda/embeds/claude-code/commands/soda-run.md
+++ b/cmd/soda/embeds/claude-code/commands/soda-run.md
@@ -6,8 +6,18 @@ argument-hint: <ticket-key> [--pipeline <name>] [--from <phase>] [--mode checkpo
 Run the SODA pipeline for a ticket:
 
 ```bash
-soda run $ARGUMENTS
+nohup soda run $ARGUMENTS > /tmp/soda-<ticket>.log 2>&1 &
 ```
+
+Replace `<ticket>` with the actual ticket key in the log path.
+
+The pipeline runs in the background. **Do not block waiting for it.** Instead, set up a polling loop to check progress:
+
+```
+/loop 2m soda status
+```
+
+Or use `soda log <ticket> -f` in a separate terminal. Use `soda attach <ticket>` to observe in real-time.
 
 If no ticket key is provided, ask the user for one.
 


### PR DESCRIPTION
## Summary

- Update soda-run and soda-resume commands to run the pipeline in the background (`nohup ... &`) and use `/loop 2m soda status` for non-blocking progress polling
- Previously these commands would run soda inline, blocking the Claude Code agent until the pipeline completed

## Test plan

- [x] `go test ./cmd/soda/` passes
- [x] Binary builds cleanly