### PR TITLE
fix(cli): status column alignment and stale lock masking completed pipelines

### DIFF
--- a/cmd/soda/status.go
+++ b/cmd/soda/status.go
@@ -204,17 +204,10 @@ func currentPhaseStatus(meta *pipeline.PipelineMeta, phases []pipeline.PhaseConf
 }
 
 // pipelineStatus computes a pipeline-level status from lock info and phase state.
-// Priority: lock alive → "running", lock stale → "stale", any phase failed → "failed",
-// all phases completed → "completed", otherwise fall back to the most advanced phase status.
+// Phase states take priority over lock state: a pipeline with all phases
+// completed/failed is terminal even if a stale lock file remains on disk.
 func pipelineStatus(meta *pipeline.PipelineMeta, lockInfo *pipeline.LockInfo) string {
-	if lockInfo != nil {
-		if lockInfo.IsAlive {
-			return "running"
-		}
-		return "stale"
-	}
-
-	// No lock file — derive status from phase states.
+	// Derive terminal status from phase states first.
 	hasFailed := false
 	hasNonCompleted := false
 	hasAny := false
@@ -232,6 +225,14 @@ func pipelineStatus(meta *pipeline.PipelineMeta, lockInfo *pipeline.LockInfo) st
 	}
 	if hasAny && !hasNonCompleted {
 		return "completed"
+	}
+
+	// Not terminal — check lock state for active/stale.
+	if lockInfo != nil {
+		if lockInfo.IsAlive {
+			return "running"
+		}
+		return "stale"
 	}
 
 	// Fallback: use the most advanced phase's status.
@@ -275,23 +276,27 @@ func statusGroup(status string) int {
 }
 
 // colorizeStatus wraps the status string in ANSI color codes when isTTY is true.
+// The status is padded to a fixed width BEFORE adding color codes so that
+// tabwriter sees consistent column widths (ANSI escapes are invisible but
+// counted as characters by tabwriter).
 func colorizeStatus(status string, isTTY bool) string {
+	padded := fmt.Sprintf("%-10s", status)
 	if !isTTY {
-		return status
+		return padded
 	}
 	switch status {
 	case "running":
-		return statusColorGreen + status + statusColorReset
+		return statusColorGreen + padded + statusColorReset
 	case "completed":
-		return statusColorGreen + status + statusColorReset
+		return statusColorGreen + padded + statusColorReset
 	case "failed":
-		return statusColorRed + status + statusColorReset
+		return statusColorRed + padded + statusColorReset
 	case "stale":
-		return statusColorYellow + status + statusColorReset
+		return statusColorYellow + padded + statusColorReset
 	case "retrying":
-		return statusColorYellow + status + statusColorReset
+		return statusColorYellow + padded + statusColorReset
 	default:
-		return statusColorDim + status + statusColorReset
+		return statusColorDim + padded + statusColorReset
 	}
 }
 
@@ -311,14 +316,14 @@ func phaseRank(status pipeline.PhaseStatus) int {
 }
 
 // formatSubmitted returns a human-friendly timestamp: time-only for today,
-// date+time for older entries.
+// date+time for older entries. Both are padded to consistent width.
 func formatSubmitted(startedAt, now time.Time) string {
 	sy, sm, sd := startedAt.Date()
 	ny, nm, nd := now.Date()
 	if sy == ny && sm == nm && sd == nd {
-		return fmt.Sprintf("%12s", startedAt.Format("15:04"))
+		return fmt.Sprintf("%-12s", startedAt.Format("15:04"))
 	}
-	return startedAt.Format("Jan 02 15:04")
+	return fmt.Sprintf("%-12s", startedAt.Format("Jan 02 15:04"))
 }
 
 func formatElapsed(meta *pipeline.PipelineMeta) string {

--- a/cmd/soda/status_test.go
+++ b/cmd/soda/status_test.go
@@ -26,10 +26,28 @@ func TestPipelineStatus(t *testing.T) {
 			want:     "running",
 		},
 		{
-			name:     "lock dead → stale",
+			name:     "lock dead, no phases → stale",
 			meta:     &pipeline.PipelineMeta{Phases: map[string]*pipeline.PhaseState{}},
 			lockInfo: &pipeline.LockInfo{IsAlive: false},
 			want:     "stale",
+		},
+		{
+			name: "lock dead, all completed → completed (not stale)",
+			meta: &pipeline.PipelineMeta{Phases: map[string]*pipeline.PhaseState{
+				"triage":    {Status: pipeline.PhaseCompleted},
+				"implement": {Status: pipeline.PhaseCompleted},
+			}},
+			lockInfo: &pipeline.LockInfo{IsAlive: false},
+			want:     "completed",
+		},
+		{
+			name: "lock dead, any failed → failed (not stale)",
+			meta: &pipeline.PipelineMeta{Phases: map[string]*pipeline.PhaseState{
+				"triage":    {Status: pipeline.PhaseCompleted},
+				"implement": {Status: pipeline.PhaseFailed},
+			}},
+			lockInfo: &pipeline.LockInfo{IsAlive: false},
+			want:     "failed",
 		},
 		{
 			name: "no lock, all completed → completed",
@@ -140,7 +158,7 @@ func TestFormatSubmitted(t *testing.T) {
 			name:      "same day → time only",
 			startedAt: time.Date(2025, 6, 15, 9, 5, 0, 0, time.UTC),
 			now:       now,
-			want:      "       09:05",
+			want:      "09:05       ",
 		},
 		{
 			name:      "yesterday → date + time",
@@ -371,20 +389,20 @@ func TestColorizeStatus(t *testing.T) {
 		isTTY  bool
 		want   string
 	}{
-		// Non-TTY: no colors.
-		{"running", false, "running"},
-		{"completed", false, "completed"},
-		{"failed", false, "failed"},
-		{"stale", false, "stale"},
-		{"pending", false, "pending"},
+		// Non-TTY: padded, no colors.
+		{"running", false, "running   "},
+		{"completed", false, "completed "},
+		{"failed", false, "failed    "},
+		{"stale", false, "stale     "},
+		{"pending", false, "pending   "},
 
-		// TTY: wrapped in ANSI codes.
-		{"running", true, statusColorGreen + "running" + statusColorReset},
-		{"completed", true, statusColorGreen + "completed" + statusColorReset},
-		{"failed", true, statusColorRed + "failed" + statusColorReset},
-		{"stale", true, statusColorYellow + "stale" + statusColorReset},
-		{"retrying", true, statusColorYellow + "retrying" + statusColorReset},
-		{"pending", true, statusColorDim + "pending" + statusColorReset},
+		// TTY: padded and wrapped in ANSI codes.
+		{"running", true, statusColorGreen + "running   " + statusColorReset},
+		{"completed", true, statusColorGreen + "completed " + statusColorReset},
+		{"failed", true, statusColorRed + "failed    " + statusColorReset},
+		{"stale", true, statusColorYellow + "stale     " + statusColorReset},
+		{"retrying", true, statusColorYellow + "retrying  " + statusColorReset},
+		{"pending", true, statusColorDim + "pending   " + statusColorReset},
 	}
 	for _, tc := range tests {
 		got := colorizeStatus(tc.status, tc.isTTY)


### PR DESCRIPTION
## Summary

- **Stale lock masking**: `pipelineStatus()` now checks phase states before lock state — completed/failed pipelines no longer show as "stale" when a leftover lock file exists
- **Column alignment**: Status column padded to fixed width before ANSI color codes are added, so `tabwriter` computes correct alignment. Timestamps use consistent left-aligned padding.

## Test plan

- [x] 2 new test cases: `lock dead, all completed → completed` and `lock dead, any failed → failed`
- [x] Updated `TestColorizeStatus` and `TestFormatSubmitted` for new padding
- [x] All existing status tests pass
- [x] Full test suite passes, `go vet` clean
- [x] Visual verification: `soda status` output is properly aligned with no "stale" on completed runs