### PR TITLE
feat(ci): release and nightly workflows + switch to upstream go-arapuca

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,30 +21,42 @@ permissions:
   contents: read
 
 env:
-  GOPRIVATE: github.com/decko/go-arapuca
   GIT_LFS_SKIP_SMUDGE: "1"
 
 jobs:
   build:
-    name: Build
+    name: Build (${{ matrix.suffix }})
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    strategy:
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+            suffix: linux-amd64
+          - goos: linux
+            goarch: arm64
+            suffix: linux-arm64
+          - goos: darwin
+            goarch: amd64
+            suffix: darwin-amd64
+          - goos: darwin
+            goarch: arm64
+            suffix: darwin-arm64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Configure private Go modules
-        run: git config --global url."https://${{ secrets.GO_PRIVATE_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.25"
           cache: true
 
-      - name: Install gcc (for cgo/sandbox)
-        run: sudo apt-get update && sudo apt-get install -y gcc
-
       - name: Build
-        run: CGO_ENABLED=0 go build ./...
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: "0"
+        run: go build ./...
 
   test:
     name: Test
@@ -53,16 +65,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Configure private Go modules
-        run: git config --global url."https://${{ secrets.GO_PRIVATE_TOKEN }}@github.com/".insteadOf "https://github.com/"
-
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.25"
           cache: true
-
-      - name: Install gcc (for cgo/sandbox)
-        run: sudo apt-get update && sudo apt-get install -y gcc
 
       - name: Test
         run: CGO_ENABLED=0 go test -coverprofile=coverage.out ./...
@@ -81,16 +87,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Configure private Go modules
-        run: git config --global url."https://${{ secrets.GO_PRIVATE_TOKEN }}@github.com/".insteadOf "https://github.com/"
-
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.25"
           cache: true
-
-      - name: Install gcc (for cgo/sandbox)
-        run: sudo apt-get update && sudo apt-get install -y gcc
 
       - name: Vet
         run: CGO_ENABLED=0 go vet ./...
@@ -117,9 +117,6 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Configure private Go modules
-        run: git config --global url."https://${{ secrets.GO_PRIVATE_TOKEN }}@github.com/".insteadOf "https://github.com/"
-
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.25"
@@ -144,9 +141,6 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Configure private Go modules
-        run: git config --global url."https://${{ secrets.GO_PRIVATE_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,151 @@
+name: Nightly
+
+on:
+  schedule:
+    - cron: "0 4 * * *" # 04:00 UTC daily
+  workflow_dispatch: # manual trigger
+
+permissions:
+  contents: write
+
+env:
+  GIT_LFS_SKIP_SMUDGE: "1"
+
+jobs:
+  check-changes:
+    name: Check for changes
+    runs-on: ubuntu-latest
+    outputs:
+      has_changes: ${{ steps.check.outputs.has_changes }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Check for commits in last 24h
+        id: check
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          elif git log --since="24 hours ago" --oneline | grep -q .; then
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  nightly:
+    name: Nightly Build
+    needs: check-changes
+    if: needs.check-changes.outputs.has_changes == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+            cgo: "1"
+            suffix: linux-amd64-sandbox
+          - goos: linux
+            goarch: arm64
+            cgo: "0"
+            suffix: linux-arm64
+          - goos: darwin
+            goarch: amd64
+            cgo: "0"
+            suffix: darwin-amd64
+          - goos: darwin
+            goarch: arm64
+            cgo: "0"
+            suffix: darwin-arm64
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: "1.25"
+          cache: true
+
+      - name: Install gcc (cgo builds)
+        if: matrix.cgo == '1'
+        run: sudo apt-get update && sudo apt-get install -y gcc
+
+      - name: Fetch go-arapuca LFS binary (cgo builds)
+        if: matrix.cgo == '1'
+        run: |
+          mod_dir="$(go env GOMODCACHE)/github.com/sergio-correia/go-arapuca@$(go list -m -f '{{.Version}}' github.com/sergio-correia/go-arapuca)"
+          lib_path="${mod_dir}/lib/linux_amd64/libarapuca.a"
+          if [ -f "$lib_path" ] && file "$lib_path" | grep -q "ASCII"; then
+            oid=$(awk '/^oid sha256:/{print substr($2,8)}' "$lib_path")
+            url="https://github.com/sergio-correia/go-arapuca.git/info/lfs/objects/batch"
+            download_url=$(curl -s -X POST "$url" \
+              -H "Content-Type: application/vnd.git-lfs+json" \
+              -d "{\"operation\":\"download\",\"objects\":[{\"oid\":\"${oid}\",\"size\":1}]}" \
+              | python3 -c "import sys,json; print(json.load(sys.stdin)['objects'][0]['actions']['download']['href'])")
+            chmod u+w "$(dirname "$lib_path")"
+            chmod u+w "$lib_path"
+            curl -sL "$download_url" -o "$lib_path"
+            echo "Fetched libarapuca.a ($(wc -c < "$lib_path") bytes)"
+          fi
+
+      - name: Build
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: ${{ matrix.cgo }}
+        run: |
+          date_tag="$(date -u +%Y%m%d)"
+          short_sha="${GITHUB_SHA:0:8}"
+          version="nightly-${date_tag}-${short_sha}"
+          go build -ldflags "-s -w -X main.version=${version}" \
+            -o soda-${{ matrix.suffix }} ./cmd/soda
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: soda-${{ matrix.suffix }}
+          path: soda-${{ matrix.suffix }}
+
+  publish:
+    name: Publish Nightly
+    needs: nightly
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+        with:
+          path: dist/
+          merge-multiple: true
+
+      - name: Generate checksums
+        working-directory: dist
+        run: sha256sum soda-* > checksums.txt
+
+      - name: Delete previous nightly release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release delete nightly --yes --cleanup-tag 2>/dev/null || true
+
+      - name: Create nightly release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          date_tag="$(date -u +%Y%m%d)"
+          short_sha="${GITHUB_SHA:0:8}"
+
+          gh release create nightly \
+            --prerelease \
+            --title "soda nightly (${date_tag})" \
+            --notes "## Nightly build — $(date -u +%Y-%m-%d)
+
+          **⚠️ Unstable** — built from main at \`${short_sha}\`. Use tagged releases for production.
+
+          Binaries with \`-sandbox\` in the name include kernel-enforced process isolation. Other builds run without sandbox.
+
+          Automatically replaced on each nightly build." \
+            --target "$GITHUB_SHA" \
+            dist/*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,121 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+env:
+  GIT_LFS_SKIP_SMUDGE: "1"
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+            cgo: "1"
+            suffix: linux-amd64-sandbox
+          - goos: linux
+            goarch: arm64
+            cgo: "0"
+            suffix: linux-arm64
+          - goos: darwin
+            goarch: amd64
+            cgo: "0"
+            suffix: darwin-amd64
+          - goos: darwin
+            goarch: arm64
+            cgo: "0"
+            suffix: darwin-arm64
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: "1.25"
+          cache: true
+
+      - name: Install gcc (cgo builds)
+        if: matrix.cgo == '1'
+        run: sudo apt-get update && sudo apt-get install -y gcc
+
+      - name: Fetch go-arapuca LFS binary (cgo builds)
+        if: matrix.cgo == '1'
+        run: |
+          mod_dir="$(go env GOMODCACHE)/github.com/sergio-correia/go-arapuca@$(go list -m -f '{{.Version}}' github.com/sergio-correia/go-arapuca)"
+          lib_path="${mod_dir}/lib/linux_amd64/libarapuca.a"
+          if [ -f "$lib_path" ] && file "$lib_path" | grep -q "ASCII"; then
+            oid=$(awk '/^oid sha256:/{print substr($2,8)}' "$lib_path")
+            url="https://github.com/sergio-correia/go-arapuca.git/info/lfs/objects/batch"
+            download_url=$(curl -s -X POST "$url" \
+              -H "Content-Type: application/vnd.git-lfs+json" \
+              -d "{\"operation\":\"download\",\"objects\":[{\"oid\":\"${oid}\",\"size\":1}]}" \
+              | python3 -c "import sys,json; print(json.load(sys.stdin)['objects'][0]['actions']['download']['href'])")
+            chmod u+w "$(dirname "$lib_path")"
+            chmod u+w "$lib_path"
+            curl -sL "$download_url" -o "$lib_path"
+            echo "Fetched libarapuca.a ($(wc -c < "$lib_path") bytes)"
+          fi
+
+      - name: Build
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: ${{ matrix.cgo }}
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          go build -ldflags "-s -w -X main.version=${version}" \
+            -o soda-${{ matrix.suffix }} ./cmd/soda
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: soda-${{ matrix.suffix }}
+          path: soda-${{ matrix.suffix }}
+
+  publish:
+    name: Publish Release
+    needs: release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+        with:
+          path: dist/
+          merge-multiple: true
+
+      - name: Generate checksums
+        working-directory: dist
+        run: sha256sum soda-* > checksums.txt
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          gh release create "$GITHUB_REF_NAME" \
+            --title "soda ${version}" \
+            --notes "## soda ${version}
+
+          Binaries with \`-sandbox\` in the name include kernel-enforced process isolation (Landlock + seccomp + cgroups). Builds without it run normally but skip sandbox enforcement.
+
+          | Binary | Platform | Sandbox |
+          |--------|----------|---------|
+          | \`soda-linux-amd64-sandbox\` | Linux x86_64 | ✅ |
+          | \`soda-linux-arm64\` | Linux ARM64 | ❌ |
+          | \`soda-darwin-amd64\` | macOS Intel | ❌ |
+          | \`soda-darwin-arm64\` | macOS Apple Silicon | ❌ |
+
+          See checksums.txt for SHA-256 verification." \
+            dist/*

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/mattn/go-isatty v0.0.20
-	github.com/sergio-correia/go-arapuca v0.1.0
+	github.com/sergio-correia/go-arapuca v0.1.1
 	github.com/spf13/cobra v1.10.2
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -35,5 +35,3 @@ require (
 	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/text v0.3.8 // indirect
 )
-
-replace github.com/sergio-correia/go-arapuca => github.com/decko/go-arapuca v0.1.1-0.20260421121428-18be6a8cdc3f

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,6 @@ github.com/clipperhouse/stringish v0.1.1/go.mod h1:v/WhFtE1q0ovMta2+m+UbpZ+2/HEX
 github.com/clipperhouse/uax29/v2 v2.5.0 h1:x7T0T4eTHDONxFJsL94uKNKPHrclyFI0lm7+w94cO8U=
 github.com/clipperhouse/uax29/v2 v2.5.0/go.mod h1:Wn1g7MK6OoeDT0vL+Q0SQLDz/KpfsVRgg6W7ihQeh4g=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
-github.com/decko/go-arapuca v0.1.1-0.20260421121428-18be6a8cdc3f h1:+NkeKYHOTo5cRs44i2qjP4vz7/dwZQLV1bjzmtQxQKU=
-github.com/decko/go-arapuca v0.1.1-0.20260421121428-18be6a8cdc3f/go.mod h1:n3QwYrcRa8hGT5Xc6T1OAogHNzn/lTm5XaQmQhOJhuM=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
@@ -44,6 +42,8 @@ github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/sergio-correia/go-arapuca v0.1.1 h1:9JiazgSiWj2Kcej3Z+yQkJbJNI1GRnxpExw3LWmddnE=
+github.com/sergio-correia/go-arapuca v0.1.1/go.mod h1:n3QwYrcRa8hGT5Xc6T1OAogHNzn/lTm5XaQmQhOJhuM=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=


### PR DESCRIPTION
## Summary

- **Release workflow** (`release.yaml`): triggered on `v*` tags, builds 4 platform binaries (linux/amd64 with sandbox, linux/arm64, darwin/amd64, darwin/arm64), publishes to GitHub Releases with SHA-256 checksums
- **Nightly workflow** (`nightly.yaml`): daily at 04:00 UTC (skips if no commits in 24h), builds same matrix, publishes as rolling `nightly` pre-release that replaces itself each build
- **Upstream go-arapuca**: switch from `decko/go-arapuca` fork to `sergio-correia/go-arapuca@v0.1.1` (now public with Env + Stdin support). Remove `GOPRIVATE` and `GO_PRIVATE_TOKEN` from all CI workflows.
- **LFS workaround**: cgo builds fetch `libarapuca.a` via LFS batch API since the Go module proxy serves LFS pointers

## Usage

```bash
# Tagged release
git tag v0.1.0 && git push --tags
# → creates GitHub Release "soda 0.1.0" with 4 binaries

# Manual nightly
gh workflow run nightly.yaml
# → creates pre-release "soda nightly (YYYYMMDD)"
```

## Test plan

- [x] YAML syntax validated
- [x] `go build -ldflags "-X main.version=test"` works
- [x] `go.mod` clean — no replace directives, `go mod tidy` passes
- [x] Full test suite passes with `CGO_ENABLED=0`
- [x] `go vet` clean
- [ ] Release workflow validated on first tag push (post-merge)
- [ ] Nightly workflow validated via manual dispatch (post-merge)