### PR TITLE
fix(cli): replace tabwriter with manual column formatting for ANSI alignment

### DIFF
--- a/cmd/soda/status.go
+++ b/cmd/soda/status.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"text/tabwriter"
+	"strings"
 	"time"
 
 	"github.com/decko/soda/internal/pipeline"
@@ -157,15 +157,58 @@ func runStatus(stateDir string) error {
 
 	// Render collected entries.
 	isTTY := isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd())
-	tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', tabwriter.StripEscape)
-	fmt.Fprintln(tw, "TICKET\tPHASE\tSTATUS\tSUBMITTED\tELAPSED\tCOST\tREWORK\tTREND")
+
+	// Compute column widths from data (ANSI-free).
+	headers := []string{"TICKET", "PHASE", "STATUS", "SUBMITTED", "ELAPSED", "COST", "REWORK", "TREND"}
+	widths := make([]int, len(headers))
+	for idx, header := range headers {
+		widths[idx] = len(header)
+	}
 	for _, r := range rows {
-		status := colorizeStatus(r.status, isTTY)
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%d\t%s\n", r.ticket, r.phase, status, r.submitted, r.elapsed, r.cost, r.rework, r.costTrend)
+		reworkStr := fmt.Sprintf("%d", r.rework)
+		vals := []string{r.ticket, r.phase, r.status, r.submitted, r.elapsed, r.cost, reworkStr, r.costTrend}
+		for idx, val := range vals {
+			if len(val) > widths[idx] {
+				widths[idx] = len(val)
+			}
+		}
 	}
 
-	if err := tw.Flush(); err != nil {
-		return fmt.Errorf("status: flush output: %w", err)
+	// Build format string with computed widths: "%-Ws  %-Ws  ..." + newline.
+	fmtParts := make([]string, len(widths))
+	for idx, w := range widths {
+		fmtParts[idx] = fmt.Sprintf("%%-%ds", w)
+	}
+	rowFmt := strings.Join(fmtParts, "  ") + "\n"
+
+	// Print header.
+	headerArgs := make([]any, len(headers))
+	for idx, header := range headers {
+		headerArgs[idx] = header
+	}
+	fmt.Fprintf(os.Stdout, rowFmt, headerArgs...)
+
+	// Print data rows (colorize status AFTER padding).
+	for _, r := range rows {
+		reworkStr := fmt.Sprintf("%d", r.rework)
+		// Pad status to column width before colorizing so ANSI codes don't affect alignment.
+		paddedStatus := fmt.Sprintf("%-*s", widths[2], r.status)
+		if isTTY {
+			paddedStatus = colorizeStatus(paddedStatus, true)
+		}
+
+		// Format all other columns normally.
+		line := fmt.Sprintf("%-*s  %-*s  %s  %-*s  %-*s  %-*s  %-*s  %s\n",
+			widths[0], r.ticket,
+			widths[1], r.phase,
+			paddedStatus,
+			widths[3], r.submitted,
+			widths[4], r.elapsed,
+			widths[5], r.cost,
+			widths[6], reworkStr,
+			r.costTrend,
+		)
+		fmt.Fprint(os.Stdout, line)
 	}
 
 	// Cumulative cost footer.
@@ -276,14 +319,15 @@ func statusGroup(status string) int {
 }
 
 // colorizeStatus wraps the status string in ANSI color codes when isTTY is true.
-// ANSI escape sequences are wrapped in \xff delimiters so that tabwriter
-// (with StripEscape) ignores them for column width calculation.
+// The string should already be padded to the desired width before calling.
 func colorizeStatus(status string, isTTY bool) string {
 	if !isTTY {
 		return status
 	}
+	// Extract the base status word for color selection.
+	base := strings.TrimSpace(status)
 	var color string
-	switch status {
+	switch base {
 	case "running", "completed":
 		color = statusColorGreen
 	case "failed":
@@ -293,7 +337,7 @@ func colorizeStatus(status string, isTTY bool) string {
 	default:
 		color = statusColorDim
 	}
-	return "\xff" + color + "\xff" + status + "\xff" + statusColorReset + "\xff"
+	return color + status + statusColorReset
 }
 
 func phaseRank(status pipeline.PhaseStatus) int {

--- a/cmd/soda/status_test.go
+++ b/cmd/soda/status_test.go
@@ -389,20 +389,20 @@ func TestColorizeStatus(t *testing.T) {
 		isTTY  bool
 		want   string
 	}{
-		// Non-TTY: no colors, no padding.
+		// Non-TTY: returned as-is.
 		{"running", false, "running"},
 		{"completed", false, "completed"},
 		{"failed", false, "failed"},
 		{"stale", false, "stale"},
 		{"pending", false, "pending"},
 
-		// TTY: wrapped in ANSI codes with \xff escape delimiters.
-		{"running", true, "\xff" + statusColorGreen + "\xff" + "running" + "\xff" + statusColorReset + "\xff"},
-		{"completed", true, "\xff" + statusColorGreen + "\xff" + "completed" + "\xff" + statusColorReset + "\xff"},
-		{"failed", true, "\xff" + statusColorRed + "\xff" + "failed" + "\xff" + statusColorReset + "\xff"},
-		{"stale", true, "\xff" + statusColorYellow + "\xff" + "stale" + "\xff" + statusColorReset + "\xff"},
-		{"retrying", true, "\xff" + statusColorYellow + "\xff" + "retrying" + "\xff" + statusColorReset + "\xff"},
-		{"pending", true, "\xff" + statusColorDim + "\xff" + "pending" + "\xff" + statusColorReset + "\xff"},
+		// TTY: wrapped in ANSI codes.
+		{"running", true, statusColorGreen + "running" + statusColorReset},
+		{"completed", true, statusColorGreen + "completed" + statusColorReset},
+		{"failed", true, statusColorRed + "failed" + statusColorReset},
+		{"stale", true, statusColorYellow + "stale" + statusColorReset},
+		{"retrying", true, statusColorYellow + "retrying" + statusColorReset},
+		{"pending", true, statusColorDim + "pending" + statusColorReset},
 	}
 	for _, tc := range tests {
 		got := colorizeStatus(tc.status, tc.isTTY)
@@ -476,10 +476,9 @@ func TestRunStatus_ColumnAlignment(t *testing.T) {
 	output := buf.String()
 	lines := strings.Split(strings.TrimSpace(output), "\n")
 
-	// Strip ANSI escape codes and tabwriter \xff delimiters for alignment check.
+	// Strip ANSI escape codes for alignment check.
 	ansiRe := regexp.MustCompile(`\x1b\[[0-9;]*m`)
 	stripANSI := func(s string) string {
-		s = strings.ReplaceAll(s, "\xff", "")
 		return ansiRe.ReplaceAllString(s, "")
 	}
 


### PR DESCRIPTION
## Summary

- `tabwriter.StripEscape` doesn't work for ANSI codes — it prevents tab interpretation but still counts escaped content for column width. This caused columns after STATUS to shift right on TTY.
- Replace tabwriter with manual `fmt.Sprintf` formatting: compute column widths from data, pad status to column width *before* adding ANSI codes, render each row with fixed-width fields.

## Test plan

- [x] `TestRunStatus_ColumnAlignment` passes — strips ANSI, verifies column positions match header
- [x] All status tests pass
- [x] Full test suite passes, `go vet` clean
- [x] Visual verification: columns properly aligned on TTY