### PR TITLE
test: e2e smoke tests for sandbox, monitor, and config [#341]

### DIFF
--- a/cmd/soda/main.go
+++ b/cmd/soda/main.go
@@ -88,9 +88,7 @@ func loadConfig(cmd *cobra.Command) (*config.Config, error) {
 
 	if !cmd.Flags().Changed("config") {
 		if localPath, localErr := filepath.Abs("soda.yaml"); localErr == nil {
-			if _, statErr := os.Stat(localPath); statErr == nil {
-				cfgPath = localPath
-			}
+			cfgPath = config.ResolveConfigPath(localPath, cfgPath)
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -221,3 +221,17 @@ func DefaultPath() (string, error) {
 	}
 	return filepath.Join(configDir, "soda", "config.yaml"), nil
 }
+
+// ResolveConfigPath implements the config file discovery chain:
+//
+//  1. localPath (e.g., soda.yaml in CWD) — if it exists on disk, wins.
+//  2. globalPath (e.g., ~/.config/soda/config.yaml) — fallback.
+//
+// This is the resolution logic used by the CLI when --config is not
+// explicitly set. An explicit --config flag bypasses this entirely.
+func ResolveConfigPath(localPath, globalPath string) string {
+	if _, err := os.Stat(localPath); err == nil {
+		return localPath
+	}
+	return globalPath
+}

--- a/internal/config/config_smoke_test.go
+++ b/internal/config/config_smoke_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -624,43 +625,53 @@ state_dir: .soda
 
 // TestSmoke_RepoConfig_FieldParity verifies that config.RepoConfig and
 // pipeline.RepoConfig remain in sync. If a field is added to one but not
-// the other, this test catches it.
+// the other, this test catches it via reflect-based field comparison.
 func TestSmoke_RepoConfig_FieldParity(t *testing.T) {
-	// Build a config.RepoConfig with all fields populated.
-	configRepo := RepoConfig{
-		Name:        "test-repo",
-		Forge:       "github",
-		PushTo:      "user/repo",
-		Target:      "org/repo",
-		Description: "Test repository",
-		Formatter:   "gofmt -w .",
-		TestCommand: "go test ./...",
-		Labels:      []string{"ai-assisted"},
-		Trailers:    []string{"Assisted-by: SODA"},
+	configType := reflect.TypeOf(RepoConfig{})
+	pipelineType := reflect.TypeOf(pipeline.RepoConfig{})
+
+	// Check field count.
+	if configType.NumField() != pipelineType.NumField() {
+		t.Errorf("field count mismatch: config.RepoConfig has %d fields, pipeline.RepoConfig has %d fields",
+			configType.NumField(), pipelineType.NumField())
 	}
 
-	// Build a pipeline.RepoConfig with the same values.
-	pipelineRepo := pipeline.RepoConfig{
-		Name:        configRepo.Name,
-		Forge:       configRepo.Forge,
-		PushTo:      configRepo.PushTo,
-		Target:      configRepo.Target,
-		Description: configRepo.Description,
-		Formatter:   configRepo.Formatter,
-		TestCommand: configRepo.TestCommand,
-		Labels:      configRepo.Labels,
-		Trailers:    configRepo.Trailers,
+	// Build maps of field name → field type for each struct.
+	configFields := make(map[string]reflect.StructField)
+	for i := 0; i < configType.NumField(); i++ {
+		f := configType.Field(i)
+		configFields[f.Name] = f
 	}
 
-	// Verify they match.
-	if pipelineRepo.Name != configRepo.Name {
-		t.Errorf("Name mismatch: %q != %q", pipelineRepo.Name, configRepo.Name)
+	pipelineFields := make(map[string]reflect.StructField)
+	for i := 0; i < pipelineType.NumField(); i++ {
+		f := pipelineType.Field(i)
+		pipelineFields[f.Name] = f
 	}
-	if pipelineRepo.Forge != configRepo.Forge {
-		t.Errorf("Forge mismatch: %q != %q", pipelineRepo.Forge, configRepo.Forge)
+
+	// Check for fields in config but not in pipeline.
+	for name, cf := range configFields {
+		pf, ok := pipelineFields[name]
+		if !ok {
+			t.Errorf("config.RepoConfig has field %q (%v) missing from pipeline.RepoConfig", name, cf.Type)
+			continue
+		}
+		if cf.Type != pf.Type {
+			t.Errorf("field %q type mismatch: config has %v, pipeline has %v", name, cf.Type, pf.Type)
+		}
+		// Verify YAML tags match so serialization stays consistent.
+		configTag := cf.Tag.Get("yaml")
+		pipelineTag := pf.Tag.Get("yaml")
+		if configTag != pipelineTag {
+			t.Errorf("field %q yaml tag mismatch: config has %q, pipeline has %q", name, configTag, pipelineTag)
+		}
 	}
-	if pipelineRepo.TestCommand != configRepo.TestCommand {
-		t.Errorf("TestCommand mismatch: %q != %q", pipelineRepo.TestCommand, configRepo.TestCommand)
+
+	// Check for fields in pipeline but not in config.
+	for name, pf := range pipelineFields {
+		if _, ok := configFields[name]; !ok {
+			t.Errorf("pipeline.RepoConfig has field %q (%v) missing from config.RepoConfig", name, pf.Type)
+		}
 	}
 }
 

--- a/internal/config/config_smoke_test.go
+++ b/internal/config/config_smoke_test.go
@@ -1,0 +1,694 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/decko/soda/internal/pipeline"
+	"gopkg.in/yaml.v3"
+)
+
+// TestSmoke_ConfigDiscovery_ResolutionOrder verifies the full config file
+// discovery chain: local soda.yaml takes precedence over the global
+// ~/.config/soda/config.yaml. This mirrors the resolution logic in cmd/soda/main.go.
+func TestSmoke_ConfigDiscovery_ResolutionOrder(t *testing.T) {
+	t.Run("local_soda_yaml_takes_precedence", func(t *testing.T) {
+		localDir := t.TempDir()
+		globalDir := t.TempDir()
+
+		// Write a local soda.yaml with a distinctive marker.
+		localConfig := `ticket_source: github
+model: local-model-marker
+mode: autonomous
+state_dir: .soda
+`
+		localPath := filepath.Join(localDir, "soda.yaml")
+		if err := os.WriteFile(localPath, []byte(localConfig), 0644); err != nil {
+			t.Fatalf("write local config: %v", err)
+		}
+
+		// Write a global config with a different marker.
+		globalConfig := `ticket_source: jira
+model: global-model-marker
+mode: autonomous
+state_dir: .soda
+`
+		globalPath := filepath.Join(globalDir, "config.yaml")
+		if err := os.WriteFile(globalPath, []byte(globalConfig), 0644); err != nil {
+			t.Fatalf("write global config: %v", err)
+		}
+
+		// Simulate discovery: check for local first, fall back to global.
+		var resolvedPath string
+		if _, err := os.Stat(localPath); err == nil {
+			resolvedPath = localPath
+		} else {
+			resolvedPath = globalPath
+		}
+
+		cfg, err := Load(resolvedPath)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+
+		if cfg.Model != "local-model-marker" {
+			t.Errorf("resolved Model = %q, want local-model-marker (local should win)", cfg.Model)
+		}
+	})
+
+	t.Run("falls_back_to_global_when_no_local", func(t *testing.T) {
+		localDir := t.TempDir()
+		globalDir := t.TempDir()
+
+		// No local soda.yaml exists.
+		globalConfig := `ticket_source: jira
+model: global-model-marker
+mode: autonomous
+state_dir: .soda
+`
+		globalPath := filepath.Join(globalDir, "config.yaml")
+		if err := os.WriteFile(globalPath, []byte(globalConfig), 0644); err != nil {
+			t.Fatalf("write global config: %v", err)
+		}
+
+		// Simulate discovery: local doesn't exist, use global.
+		localPath := filepath.Join(localDir, "soda.yaml")
+		var resolvedPath string
+		if _, err := os.Stat(localPath); err == nil {
+			resolvedPath = localPath
+		} else {
+			resolvedPath = globalPath
+		}
+
+		cfg, err := Load(resolvedPath)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+
+		if cfg.Model != "global-model-marker" {
+			t.Errorf("resolved Model = %q, want global-model-marker (should fall back to global)", cfg.Model)
+		}
+	})
+}
+
+// TestSmoke_ConfigDiscovery_PipelineDiscovery verifies the pipeline file
+// discovery mechanism across local, user, and embedded directories.
+func TestSmoke_ConfigDiscovery_PipelineDiscovery(t *testing.T) {
+	t.Run("three_tier_discovery", func(t *testing.T) {
+		localDir := t.TempDir()
+		userDir := t.TempDir()
+		embeddedDir := t.TempDir()
+
+		// Local: has default and a "fast" pipeline.
+		writeTestFile(t, filepath.Join(localDir, "phases.yaml"), minimalPhasesContent)
+		writeTestFile(t, filepath.Join(localDir, "phases-fast.yaml"), minimalPhasesContent)
+
+		// User: has default (lower priority) and "full" pipeline.
+		writeTestFile(t, filepath.Join(userDir, "phases.yaml"), minimalPhasesContent)
+		writeTestFile(t, filepath.Join(userDir, "phases-full.yaml"), minimalPhasesContent)
+
+		// Embedded: has default (lowest priority) and "docs-only" pipeline.
+		writeTestFile(t, filepath.Join(embeddedDir, "phases.yaml"), minimalPhasesContent)
+		writeTestFile(t, filepath.Join(embeddedDir, "phases-docs-only.yaml"), minimalPhasesContent)
+
+		pipelines := pipeline.DiscoverPipelines(
+			[]string{localDir, userDir, embeddedDir},
+			[]string{"local", "user", "embedded"},
+		)
+
+		// Should discover 4 unique pipelines: default, docs-only, fast, full.
+		if len(pipelines) != 4 {
+			t.Fatalf("got %d pipelines, want 4: %v", len(pipelines), pipelineNames(pipelines))
+		}
+
+		// Default should be first and from local (highest priority).
+		if pipelines[0].Name != "default" {
+			t.Errorf("first pipeline = %q, want default", pipelines[0].Name)
+		}
+		if pipelines[0].Source != "local" {
+			t.Errorf("default source = %q, want local", pipelines[0].Source)
+		}
+
+		// Verify sources for non-default pipelines.
+		sourceMap := make(map[string]string)
+		for _, p := range pipelines {
+			sourceMap[p.Name] = p.Source
+		}
+
+		if sourceMap["fast"] != "local" {
+			t.Errorf("fast source = %q, want local", sourceMap["fast"])
+		}
+		if sourceMap["full"] != "user" {
+			t.Errorf("full source = %q, want user", sourceMap["full"])
+		}
+		if sourceMap["docs-only"] != "embedded" {
+			t.Errorf("docs-only source = %q, want embedded", sourceMap["docs-only"])
+		}
+	})
+
+	t.Run("pipeline_filename_conventions", func(t *testing.T) {
+		// Verify the naming convention works for all pipeline names.
+		tests := []struct {
+			name     string
+			wantFile string
+		}{
+			{"default", "phases.yaml"},
+			{"", "phases.yaml"},
+			{"fast", "phases-fast.yaml"},
+			{"ci-lite", "phases-ci-lite.yaml"},
+		}
+
+		for _, tt := range tests {
+			got := pipeline.PipelineFilename(tt.name)
+			if got != tt.wantFile {
+				t.Errorf("PipelineFilename(%q) = %q, want %q", tt.name, got, tt.wantFile)
+			}
+
+			// Round-trip: filename → name → filename.
+			roundTrippedName := pipeline.PipelineNameFromFile(got)
+			expectedName := tt.name
+			if expectedName == "" {
+				expectedName = "default"
+			}
+			if roundTrippedName != expectedName {
+				t.Errorf("PipelineNameFromFile(%q) = %q, want %q", got, roundTrippedName, expectedName)
+			}
+		}
+	})
+
+	t.Run("pipeline_name_validation", func(t *testing.T) {
+		// Safe names should pass.
+		for _, safe := range []string{"", "default", "fast", "ci-lite", "my_pipeline"} {
+			if err := pipeline.ValidatePipelineName(safe); err != nil {
+				t.Errorf("ValidatePipelineName(%q) unexpected error: %v", safe, err)
+			}
+		}
+
+		// Dangerous names should fail.
+		for _, dangerous := range []string{"foo/bar", `foo\bar`, "..", "foo/../bar"} {
+			if err := pipeline.ValidatePipelineName(dangerous); err == nil {
+				t.Errorf("ValidatePipelineName(%q) should have failed", dangerous)
+			}
+		}
+	})
+}
+
+// TestSmoke_ConfigToSandbox_Wiring verifies that config file sandbox settings
+// are correctly representable for the sandbox.Config struct.
+func TestSmoke_ConfigToSandbox_Wiring(t *testing.T) {
+	configYAML := `ticket_source: github
+mode: autonomous
+model: claude-sonnet-4-20250514
+sandbox:
+  enabled: true
+  binary: custom-claude
+  limits:
+    memory_mb: 4096
+    cpu_percent: 400
+    max_pids: 512
+  proxy:
+    enabled: true
+    upstream_url: https://api.anthropic.com
+    max_input_tokens: 100000
+    max_output_tokens: 50000
+    log_dir: /var/log/soda-proxy
+state_dir: .soda
+`
+	tmpFile := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(tmpFile, []byte(configYAML), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load(tmpFile)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	// Verify sandbox config was parsed correctly.
+	if !cfg.Sandbox.Enabled {
+		t.Error("Sandbox.Enabled should be true")
+	}
+	if cfg.Sandbox.Binary != "custom-claude" {
+		t.Errorf("Sandbox.Binary = %q, want custom-claude", cfg.Sandbox.Binary)
+	}
+	if cfg.Sandbox.Limits.MemoryMB != 4096 {
+		t.Errorf("Sandbox.Limits.MemoryMB = %d, want 4096", cfg.Sandbox.Limits.MemoryMB)
+	}
+	if cfg.Sandbox.Limits.CPUPercent != 400 {
+		t.Errorf("Sandbox.Limits.CPUPercent = %d, want 400", cfg.Sandbox.Limits.CPUPercent)
+	}
+	if cfg.Sandbox.Limits.MaxPIDs != 512 {
+		t.Errorf("Sandbox.Limits.MaxPIDs = %d, want 512", cfg.Sandbox.Limits.MaxPIDs)
+	}
+
+	// Verify proxy config.
+	if !cfg.Sandbox.Proxy.Enabled {
+		t.Error("Sandbox.Proxy.Enabled should be true")
+	}
+	if cfg.Sandbox.Proxy.UpstreamURL != "https://api.anthropic.com" {
+		t.Errorf("Sandbox.Proxy.UpstreamURL = %q", cfg.Sandbox.Proxy.UpstreamURL)
+	}
+	if cfg.Sandbox.Proxy.MaxInputTokens != 100000 {
+		t.Errorf("Sandbox.Proxy.MaxInputTokens = %d, want 100000", cfg.Sandbox.Proxy.MaxInputTokens)
+	}
+	if cfg.Sandbox.Proxy.MaxOutputTokens != 50000 {
+		t.Errorf("Sandbox.Proxy.MaxOutputTokens = %d, want 50000", cfg.Sandbox.Proxy.MaxOutputTokens)
+	}
+	if cfg.Sandbox.Proxy.LogDir != "/var/log/soda-proxy" {
+		t.Errorf("Sandbox.Proxy.LogDir = %q", cfg.Sandbox.Proxy.LogDir)
+	}
+}
+
+// TestSmoke_ConfigToMonitor_Wiring verifies that monitor config from the config
+// file correctly maps to the monitor subsystem's expected format.
+func TestSmoke_ConfigToMonitor_Wiring(t *testing.T) {
+	configYAML := `ticket_source: github
+mode: autonomous
+model: claude-sonnet-4-20250514
+monitor:
+  profile: aggressive
+  self_user: ci-bot
+  bot_users:
+    - dependabot
+    - renovate
+    - codecov[bot]
+  codeowners: .github/CODEOWNERS
+state_dir: .soda
+`
+	tmpFile := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(tmpFile, []byte(configYAML), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load(tmpFile)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	// Verify monitor config.
+	if cfg.Monitor.Profile != "aggressive" {
+		t.Errorf("Monitor.Profile = %q, want aggressive", cfg.Monitor.Profile)
+	}
+	if cfg.Monitor.SelfUser != "ci-bot" {
+		t.Errorf("Monitor.SelfUser = %q, want ci-bot", cfg.Monitor.SelfUser)
+	}
+	if len(cfg.Monitor.BotUsers) != 3 {
+		t.Fatalf("len(Monitor.BotUsers) = %d, want 3", len(cfg.Monitor.BotUsers))
+	}
+	if cfg.Monitor.BotUsers[0] != "dependabot" {
+		t.Errorf("BotUsers[0] = %q, want dependabot", cfg.Monitor.BotUsers[0])
+	}
+	if cfg.Monitor.BotUsers[2] != "codecov[bot]" {
+		t.Errorf("BotUsers[2] = %q, want codecov[bot]", cfg.Monitor.BotUsers[2])
+	}
+	if cfg.Monitor.CODEOWNERS != ".github/CODEOWNERS" {
+		t.Errorf("Monitor.CODEOWNERS = %q", cfg.Monitor.CODEOWNERS)
+	}
+
+	// Verify the profile name maps to a valid pipeline MonitorProfile.
+	profile, err := pipeline.GetMonitorProfile(pipeline.MonitorProfileName(cfg.Monitor.Profile))
+	if err != nil {
+		t.Fatalf("GetMonitorProfile: %v", err)
+	}
+	if profile.Name != pipeline.ProfileAggressive {
+		t.Errorf("profile.Name = %q, want aggressive", profile.Name)
+	}
+	if !profile.ShouldApplyNit() {
+		t.Error("aggressive profile should auto-fix nits")
+	}
+	if !profile.ShouldAutoRebase() {
+		t.Error("aggressive profile should auto-rebase")
+	}
+	if !profile.ShouldRespondToNonAuth() {
+		t.Error("aggressive profile should respond to non-auth")
+	}
+}
+
+// TestSmoke_ConfigRoundtrip_AllFields verifies that a fully-populated config
+// survives a marshal → unmarshal roundtrip with all fields intact.
+func TestSmoke_ConfigRoundtrip_AllFields(t *testing.T) {
+	original := &Config{
+		TicketSource: "github",
+		GitHub: GitHubTicketConfig{
+			Owner:         "decko",
+			Repo:          "soda",
+			FetchComments: true,
+			Spec: ExtractionStrategy{
+				StartMarker: "<!-- spec:start -->",
+				EndMarker:   "<!-- spec:end -->",
+			},
+			Plan: ExtractionStrategy{
+				StartMarker: "<!-- plan:start -->",
+				EndMarker:   "<!-- plan:end -->",
+			},
+		},
+		Jira: JiraConfig{
+			Command: "jira-mcp",
+			Project: "SODA",
+			Query:   "status = Open",
+			Extraction: JiraExtractionConfig{
+				SpecField:    "cf_spec",
+				PlanField:    "cf_plan",
+				SubtaskField: "subtasks",
+			},
+		},
+		Mode:        "autonomous",
+		Model:       "claude-sonnet-4-20250514",
+		PhasesPath:  "/custom/phases.yaml",
+		PromptsPath: "/custom/prompts",
+		WorktreeDir: ".worktrees",
+		StateDir:    ".soda",
+		Context:     []string{"AGENTS.md", "CLAUDE.md"},
+		PhaseContext: map[string][]string{
+			"plan":      {"docs/design.md"},
+			"implement": {"docs/gotchas.md"},
+		},
+		Sandbox: SandboxConfig{
+			Enabled: true,
+			Binary:  "claude",
+			Limits: SandboxLimits{
+				MemoryMB:   2048,
+				CPUPercent: 200,
+				MaxPIDs:    256,
+			},
+			Proxy: SandboxProxyConfig{
+				Enabled:         true,
+				MaxInputTokens:  100000,
+				MaxOutputTokens: 50000,
+			},
+		},
+		Limits: LimitsConfig{
+			MaxCostPerTicket:       30.0,
+			MaxCostPerPhase:        15.0,
+			MaxCostPerGeneration:   5.0,
+			MaxPipelineDuration:    "2h",
+			MaxDiffBytes:           50000,
+			MaxAPIConcurrency:      4,
+			MaxSiblingContextBytes: 20000,
+		},
+		Repos: []RepoConfig{
+			{
+				Name:        "soda",
+				Forge:       "github",
+				PushTo:      "decko/soda",
+				Target:      "decko/soda",
+				Description: "Main repo",
+				Formatter:   "gofmt -w .",
+				TestCommand: "go test ./...",
+				Labels:      []string{"ai-assisted"},
+				Trailers:    []string{"Assisted-by: SODA <noreply@soda.dev>"},
+			},
+		},
+		Monitor: MonitorConfig{
+			Profile:    "smart",
+			SelfUser:   "soda-bot",
+			BotUsers:   []string{"dependabot", "renovate"},
+			CODEOWNERS: ".github/CODEOWNERS",
+		},
+	}
+
+	// Marshal to YAML.
+	data, err := Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("Marshal returned empty data")
+	}
+
+	// Unmarshal back.
+	var roundTripped Config
+	if err := yaml.Unmarshal(data, &roundTripped); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	// Verify all critical fields survived.
+	checks := []struct {
+		name string
+		got  interface{}
+		want interface{}
+	}{
+		{"TicketSource", roundTripped.TicketSource, "github"},
+		{"GitHub.Owner", roundTripped.GitHub.Owner, "decko"},
+		{"GitHub.Repo", roundTripped.GitHub.Repo, "soda"},
+		{"GitHub.FetchComments", roundTripped.GitHub.FetchComments, true},
+		{"Jira.Command", roundTripped.Jira.Command, "jira-mcp"},
+		{"Mode", roundTripped.Mode, "autonomous"},
+		{"Model", roundTripped.Model, "claude-sonnet-4-20250514"},
+		{"PhasesPath", roundTripped.PhasesPath, "/custom/phases.yaml"},
+		{"PromptsPath", roundTripped.PromptsPath, "/custom/prompts"},
+		{"StateDir", roundTripped.StateDir, ".soda"},
+		{"WorktreeDir", roundTripped.WorktreeDir, ".worktrees"},
+		{"Sandbox.Enabled", roundTripped.Sandbox.Enabled, true},
+		{"Sandbox.Limits.MemoryMB", roundTripped.Sandbox.Limits.MemoryMB, 2048},
+		{"Sandbox.Proxy.Enabled", roundTripped.Sandbox.Proxy.Enabled, true},
+		{"Sandbox.Proxy.MaxInputTokens", roundTripped.Sandbox.Proxy.MaxInputTokens, int64(100000)},
+		{"Limits.MaxCostPerTicket", roundTripped.Limits.MaxCostPerTicket, 30.0},
+		{"Limits.MaxCostPerPhase", roundTripped.Limits.MaxCostPerPhase, 15.0},
+		{"Limits.MaxPipelineDuration", roundTripped.Limits.MaxPipelineDuration, "2h"},
+		{"Monitor.Profile", roundTripped.Monitor.Profile, "smart"},
+		{"Monitor.SelfUser", roundTripped.Monitor.SelfUser, "soda-bot"},
+		{"Monitor.CODEOWNERS", roundTripped.Monitor.CODEOWNERS, ".github/CODEOWNERS"},
+	}
+
+	for _, check := range checks {
+		if check.got != check.want {
+			t.Errorf("%s = %v, want %v", check.name, check.got, check.want)
+		}
+	}
+
+	// Verify arrays survived.
+	if len(roundTripped.Context) != 2 {
+		t.Errorf("len(Context) = %d, want 2", len(roundTripped.Context))
+	}
+	if len(roundTripped.Repos) != 1 {
+		t.Errorf("len(Repos) = %d, want 1", len(roundTripped.Repos))
+	}
+	if len(roundTripped.Monitor.BotUsers) != 2 {
+		t.Errorf("len(Monitor.BotUsers) = %d, want 2", len(roundTripped.Monitor.BotUsers))
+	}
+	if len(roundTripped.PhaseContext) != 2 {
+		t.Errorf("len(PhaseContext) = %d, want 2", len(roundTripped.PhaseContext))
+	}
+}
+
+// TestSmoke_DefaultConfig_SelfUserGuard verifies that DefaultConfig leaves
+// SelfUser empty so that the monitor phase falls back to the stub, and
+// Marshal includes a REQUIRED comment to guide users.
+func TestSmoke_DefaultConfig_SelfUserGuard(t *testing.T) {
+	cfg := DefaultConfig()
+
+	if cfg.Monitor.SelfUser != "" {
+		t.Errorf("DefaultConfig().Monitor.SelfUser = %q, want empty", cfg.Monitor.SelfUser)
+	}
+
+	data, err := Marshal(cfg)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	yamlStr := string(data)
+	if !strings.Contains(yamlStr, "REQUIRED") {
+		t.Error("marshalled config should contain REQUIRED comment when SelfUser is empty")
+	}
+
+	// Setting SelfUser should remove the REQUIRED comment.
+	cfg.Monitor.SelfUser = "ci-bot"
+	data2, err := Marshal(cfg)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if strings.Contains(string(data2), "REQUIRED") {
+		t.Error("marshalled config should NOT contain REQUIRED comment when SelfUser is set")
+	}
+}
+
+// TestSmoke_ConfigLoad_ErrorHandling verifies that config loading produces
+// clear, actionable error messages for common failure modes.
+func TestSmoke_ConfigLoad_ErrorHandling(t *testing.T) {
+	t.Run("missing_file_wraps_os_error", func(t *testing.T) {
+		_, err := Load("/nonexistent/path/config.yaml")
+		if err == nil {
+			t.Fatal("expected error for missing file")
+		}
+		if !strings.Contains(err.Error(), "config:") {
+			t.Errorf("error should have config: prefix, got: %v", err)
+		}
+	})
+
+	t.Run("malformed_yaml_wraps_parse_error", func(t *testing.T) {
+		tmpFile := filepath.Join(t.TempDir(), "bad.yaml")
+		if err := os.WriteFile(tmpFile, []byte("not: valid: yaml: [[["), 0644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		_, err := Load(tmpFile)
+		if err == nil {
+			t.Fatal("expected error for malformed yaml")
+		}
+		if !strings.Contains(err.Error(), "config:") {
+			t.Errorf("error should have config: prefix, got: %v", err)
+		}
+	})
+
+	t.Run("empty_file_returns_zero_config", func(t *testing.T) {
+		tmpFile := filepath.Join(t.TempDir(), "empty.yaml")
+		if err := os.WriteFile(tmpFile, []byte(""), 0644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		cfg, err := Load(tmpFile)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		// Empty YAML should produce a zero-valued Config.
+		if cfg.TicketSource != "" {
+			t.Errorf("TicketSource = %q, want empty", cfg.TicketSource)
+		}
+		if cfg.Model != "" {
+			t.Errorf("Model = %q, want empty", cfg.Model)
+		}
+	})
+}
+
+// TestSmoke_ConfigDiscovery_PhasesPath verifies that the phases_path config
+// field can override the default pipeline discovery.
+func TestSmoke_ConfigDiscovery_PhasesPath(t *testing.T) {
+	customPhasesDir := t.TempDir()
+	customPhasesPath := filepath.Join(customPhasesDir, "custom-phases.yaml")
+	writeTestFile(t, customPhasesPath, minimalPhasesContent)
+
+	configYAML := `ticket_source: github
+model: claude-sonnet-4-20250514
+phases_path: ` + customPhasesPath + `
+state_dir: .soda
+`
+	tmpFile := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(tmpFile, []byte(configYAML), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load(tmpFile)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if cfg.PhasesPath != customPhasesPath {
+		t.Errorf("PhasesPath = %q, want %q", cfg.PhasesPath, customPhasesPath)
+	}
+
+	// Verify the custom phases file can be loaded.
+	pipelineCfg, err := pipeline.LoadPipeline(cfg.PhasesPath)
+	if err != nil {
+		t.Fatalf("LoadPipeline: %v", err)
+	}
+	if len(pipelineCfg.Phases) == 0 {
+		t.Error("expected at least one phase from custom phases file")
+	}
+}
+
+// TestSmoke_ConfigDiscovery_PromptsPath verifies that the prompts_path config
+// field is correctly loaded and can be used to locate prompt templates.
+func TestSmoke_ConfigDiscovery_PromptsPath(t *testing.T) {
+	promptsDir := t.TempDir()
+	promptFile := filepath.Join(promptsDir, "triage.md")
+	writeTestFile(t, promptFile, "# Triage\nTicket: {{.Ticket.Key}}")
+
+	configYAML := `ticket_source: github
+model: claude-sonnet-4-20250514
+prompts_path: ` + promptsDir + `
+state_dir: .soda
+`
+	tmpFile := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(tmpFile, []byte(configYAML), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load(tmpFile)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if cfg.PromptsPath != promptsDir {
+		t.Errorf("PromptsPath = %q, want %q", cfg.PromptsPath, promptsDir)
+	}
+
+	// Verify a PromptLoader can find templates at this path.
+	loader := pipeline.NewPromptLoader(cfg.PromptsPath)
+	content, err := loader.Load("triage.md")
+	if err != nil {
+		t.Fatalf("Load prompt: %v", err)
+	}
+	if !strings.Contains(content, "Triage") {
+		t.Errorf("prompt content = %q, want to contain 'Triage'", content)
+	}
+}
+
+// TestSmoke_RepoConfig_FieldParity verifies that config.RepoConfig and
+// pipeline.RepoConfig remain in sync. If a field is added to one but not
+// the other, this test catches it.
+func TestSmoke_RepoConfig_FieldParity(t *testing.T) {
+	// Build a config.RepoConfig with all fields populated.
+	configRepo := RepoConfig{
+		Name:        "test-repo",
+		Forge:       "github",
+		PushTo:      "user/repo",
+		Target:      "org/repo",
+		Description: "Test repository",
+		Formatter:   "gofmt -w .",
+		TestCommand: "go test ./...",
+		Labels:      []string{"ai-assisted"},
+		Trailers:    []string{"Assisted-by: SODA"},
+	}
+
+	// Build a pipeline.RepoConfig with the same values.
+	pipelineRepo := pipeline.RepoConfig{
+		Name:        configRepo.Name,
+		Forge:       configRepo.Forge,
+		PushTo:      configRepo.PushTo,
+		Target:      configRepo.Target,
+		Description: configRepo.Description,
+		Formatter:   configRepo.Formatter,
+		TestCommand: configRepo.TestCommand,
+		Labels:      configRepo.Labels,
+		Trailers:    configRepo.Trailers,
+	}
+
+	// Verify they match.
+	if pipelineRepo.Name != configRepo.Name {
+		t.Errorf("Name mismatch: %q != %q", pipelineRepo.Name, configRepo.Name)
+	}
+	if pipelineRepo.Forge != configRepo.Forge {
+		t.Errorf("Forge mismatch: %q != %q", pipelineRepo.Forge, configRepo.Forge)
+	}
+	if pipelineRepo.TestCommand != configRepo.TestCommand {
+		t.Errorf("TestCommand mismatch: %q != %q", pipelineRepo.TestCommand, configRepo.TestCommand)
+	}
+}
+
+// Helper functions.
+
+const minimalPhasesContent = `phases:
+  - name: triage
+    prompt: prompts/triage.md
+    timeout: 1m
+`
+
+func writeTestFile(t *testing.T, path, content string) {
+	t.Helper()
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func pipelineNames(pipelines []pipeline.PipelineInfo) []string {
+	names := make([]string, len(pipelines))
+	for idx, p := range pipelines {
+		names[idx] = p.Name + "(" + p.Source + ")"
+	}
+	return names
+}

--- a/internal/config/config_smoke_test.go
+++ b/internal/config/config_smoke_test.go
@@ -11,8 +11,8 @@ import (
 )
 
 // TestSmoke_ConfigDiscovery_ResolutionOrder verifies the full config file
-// discovery chain: local soda.yaml takes precedence over the global
-// ~/.config/soda/config.yaml. This mirrors the resolution logic in cmd/soda/main.go.
+// discovery chain using the production ResolveConfigPath function: local
+// soda.yaml takes precedence over the global ~/.config/soda/config.yaml.
 func TestSmoke_ConfigDiscovery_ResolutionOrder(t *testing.T) {
 	t.Run("local_soda_yaml_takes_precedence", func(t *testing.T) {
 		localDir := t.TempDir()
@@ -40,12 +40,11 @@ state_dir: .soda
 			t.Fatalf("write global config: %v", err)
 		}
 
-		// Simulate discovery: check for local first, fall back to global.
-		var resolvedPath string
-		if _, err := os.Stat(localPath); err == nil {
-			resolvedPath = localPath
-		} else {
-			resolvedPath = globalPath
+		// Use the production discovery function — local should win.
+		resolvedPath := ResolveConfigPath(localPath, globalPath)
+
+		if resolvedPath != localPath {
+			t.Errorf("ResolveConfigPath() = %q, want local path %q", resolvedPath, localPath)
 		}
 
 		cfg, err := Load(resolvedPath)
@@ -73,13 +72,12 @@ state_dir: .soda
 			t.Fatalf("write global config: %v", err)
 		}
 
-		// Simulate discovery: local doesn't exist, use global.
+		// Local path does not exist — ResolveConfigPath should fall back to global.
 		localPath := filepath.Join(localDir, "soda.yaml")
-		var resolvedPath string
-		if _, err := os.Stat(localPath); err == nil {
-			resolvedPath = localPath
-		} else {
-			resolvedPath = globalPath
+		resolvedPath := ResolveConfigPath(localPath, globalPath)
+
+		if resolvedPath != globalPath {
+			t.Errorf("ResolveConfigPath() = %q, want global path %q", resolvedPath, globalPath)
 		}
 
 		cfg, err := Load(resolvedPath)

--- a/internal/pipeline/monitor_smoke_test.go
+++ b/internal/pipeline/monitor_smoke_test.go
@@ -1,0 +1,666 @@
+package pipeline
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/decko/soda/internal/runner"
+	"github.com/decko/soda/schemas"
+)
+
+// TestSmoke_Monitor_FullLifecycle exercises a complete monitor lifecycle:
+// poll → detect comments → classify → respond → CI change → approve.
+// This is the happy path through all monitor subsystems working together.
+func TestSmoke_Monitor_FullLifecycle(t *testing.T) {
+	monitorOutput := schemas.MonitorOutput{
+		CommentsHandled: []schemas.CommentAction{
+			{CommentID: "IC_1", Author: "reviewer", Action: "fixed", Response: "Fixed the issue"},
+		},
+		FilesChanged: []schemas.FileChange{{Path: "internal/pipeline/engine.go", Action: "modified"}},
+		Commits:      []schemas.CommitRecord{{Hash: "abc123", Message: "fix error handling"}},
+		TestsPassed:  true,
+	}
+	outputJSON, _ := json.Marshal(monitorOutput)
+
+	mockRunner := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"monitor/response_0": {
+				{result: &runner.RunResult{
+					Output:    json.RawMessage(outputJSON),
+					CostUSD:   0.15,
+					TokensIn:  5000,
+					TokensOut: 2000,
+				}},
+			},
+		},
+	}
+
+	poller := &mockPRPoller{
+		statusResponses: []mockPRStatusResponse{
+			{status: &PRStatus{State: "open", Approved: false}}, // poll 1: open
+			{status: &PRStatus{State: "open", Approved: false}}, // poll 2: open
+			{status: &PRStatus{State: "open", Approved: true}},  // poll 3: approved
+		},
+		commentResponses: []mockCommentResponse{
+			// Poll 1: reviewer posts a code change request
+			{comments: []PRComment{
+				{ID: "IC_1", Author: "reviewer", Body: "Please fix the error handling here", Path: "internal/pipeline/engine.go", Line: 42},
+			}},
+			// Poll 2: no new comments
+			{comments: nil},
+		},
+		ciResponses: []mockCIResponse{
+			{status: &CIStatus{Overall: "pending"}},
+			{status: &CIStatus{Overall: "success", Jobs: []CIJobInfo{
+				{Name: "test", Status: "completed", Conclusion: "success"},
+				{Name: "lint", Status: "completed", Conclusion: "success"},
+			}}},
+			{status: &CIStatus{Overall: "success"}},
+		},
+	}
+
+	engine, state, events := setupMonitorEngineWithRunner(t, mockRunner, poller, nil)
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// Verify final state.
+	if !state.IsCompleted("monitor") {
+		t.Error("monitor should be completed after PR approval")
+	}
+
+	monState, err := state.ReadMonitorState()
+	if err != nil {
+		t.Fatalf("ReadMonitorState: %v", err)
+	}
+	if monState.Status != MonitorCompleted {
+		t.Errorf("status = %q, want %q", monState.Status, MonitorCompleted)
+	}
+	if monState.PollCount != 3 {
+		t.Errorf("PollCount = %d, want 3", monState.PollCount)
+	}
+	if monState.ResponseRounds != 1 {
+		t.Errorf("ResponseRounds = %d, want 1", monState.ResponseRounds)
+	}
+	if monState.LastCommentID != "IC_1" {
+		t.Errorf("LastCommentID = %q, want IC_1", monState.LastCommentID)
+	}
+
+	// Verify event sequence contains the expected lifecycle events.
+	var eventKinds []string
+	for _, evt := range *events {
+		eventKinds = append(eventKinds, evt.Kind)
+	}
+
+	wantEvents := []string{
+		EventPhaseStarted,
+		EventMonitorPolling,           // poll 1
+		EventMonitorCommentClassified, // reviewer comment classified
+		EventMonitorNewComments,       // new comments detected
+		EventMonitorResponseStarted,   // response session started
+		EventMonitorResponseCompleted, // response session completed
+		EventMonitorCIChange,          // pending → success
+		EventMonitorPolling,           // poll 2
+		EventMonitorPolling,           // poll 3
+		EventMonitorPRApproved,        // PR approved
+		EventPhaseCompleted,
+	}
+
+	for _, want := range wantEvents {
+		found := false
+		for _, got := range eventKinds {
+			if got == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("missing event %q in lifecycle; got: %v", want, eventKinds)
+		}
+	}
+
+	// Verify cost was recorded.
+	phaseCost := state.Meta().Phases["monitor"].CumulativeCost
+	if phaseCost < 0.15 {
+		t.Errorf("cumulative cost = %f, want >= 0.15", phaseCost)
+	}
+
+	// Verify summary was posted.
+	poller.mu.Lock()
+	posted := poller.postedComments
+	poller.mu.Unlock()
+	if len(posted) == 0 {
+		t.Error("expected response summary to be posted to PR")
+	}
+}
+
+// TestSmoke_Monitor_MultiRoundComments exercises multiple comment-response
+// cycles before hitting max rounds, verifying the round counting is accurate.
+func TestSmoke_Monitor_MultiRoundComments(t *testing.T) {
+	makeOutput := func(commentID string) json.RawMessage {
+		output := schemas.MonitorOutput{
+			CommentsHandled: []schemas.CommentAction{
+				{CommentID: commentID, Author: "reviewer", Action: "fixed"},
+			},
+			FilesChanged: []schemas.FileChange{{Path: "file.go", Action: "modified"}},
+			TestsPassed:  true,
+		}
+		data, _ := json.Marshal(output)
+		return data
+	}
+
+	mockRunner := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"monitor/response_0": {{result: &runner.RunResult{Output: makeOutput("IC_1"), CostUSD: 0.10}}},
+			"monitor/response_1": {{result: &runner.RunResult{Output: makeOutput("IC_2"), CostUSD: 0.12}}},
+		},
+	}
+
+	poller := &mockPRPoller{
+		statusResponses: []mockPRStatusResponse{
+			{status: &PRStatus{State: "open"}},
+			{status: &PRStatus{State: "open"}},
+			{status: &PRStatus{State: "open"}},
+		},
+		commentResponses: []mockCommentResponse{
+			{comments: []PRComment{{ID: "IC_1", Author: "reviewer", Body: "Fix error handling"}}},
+			{comments: []PRComment{{ID: "IC_2", Author: "reviewer", Body: "Also fix logging"}}},
+		},
+	}
+
+	pollingCfg := &PollingConfig{
+		InitialInterval:   Duration{Duration: 1 * time.Millisecond},
+		MaxInterval:       Duration{Duration: 2 * time.Millisecond},
+		EscalateAfter:     Duration{Duration: 10 * time.Millisecond},
+		MaxDuration:       Duration{Duration: 1 * time.Second},
+		MaxResponseRounds: 2,
+		RespondToComments: true,
+	}
+
+	engine, state, events := setupMonitorEngineWithRunner(t, mockRunner, poller, pollingCfg)
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	monState, err := state.ReadMonitorState()
+	if err != nil {
+		t.Fatalf("ReadMonitorState: %v", err)
+	}
+
+	if monState.Status != MonitorMaxRounds {
+		t.Errorf("status = %q, want %q", monState.Status, MonitorMaxRounds)
+	}
+	if monState.ResponseRounds != 2 {
+		t.Errorf("ResponseRounds = %d, want 2", monState.ResponseRounds)
+	}
+
+	// Verify both response rounds were executed.
+	responseStarted := 0
+	responseCompleted := 0
+	for _, evt := range *events {
+		if evt.Kind == EventMonitorResponseStarted {
+			responseStarted++
+		}
+		if evt.Kind == EventMonitorResponseCompleted {
+			responseCompleted++
+		}
+	}
+	if responseStarted != 2 {
+		t.Errorf("response_started events = %d, want 2", responseStarted)
+	}
+	if responseCompleted != 2 {
+		t.Errorf("response_completed events = %d, want 2", responseCompleted)
+	}
+
+	// Verify cumulative cost.
+	totalCost := state.Meta().TotalCost
+	if totalCost < 0.20 {
+		t.Errorf("total cost = %f, want >= 0.20 (0.10 + 0.12)", totalCost)
+	}
+}
+
+// TestSmoke_Monitor_ClassifierPipeline exercises the full comment classification
+// pipeline: self-authored, bot, approval, nit, question, code_change, and
+// non-authoritative comments are all correctly classified and routed.
+func TestSmoke_Monitor_ClassifierPipeline(t *testing.T) {
+	classifier, err := NewCommentClassifier("soda-bot", []string{"dependabot", "codecov[bot]"}, nil)
+	if err != nil {
+		t.Fatalf("NewCommentClassifier: %v", err)
+	}
+
+	comments := []PRComment{
+		{ID: "1", Author: "soda-bot", Body: "I pushed a fix"},             // self
+		{ID: "2", Author: "dependabot", Body: "Bump version"},             // bot (username)
+		{ID: "3", Author: "random", Body: "<!-- bot: auto --> triggered"}, // bot (content)
+		{ID: "4", Author: "reviewer", Body: "LGTM"},                       // approval
+		{ID: "5", Author: "reviewer", Body: "nit: use camelCase"},         // nit
+		{ID: "6", Author: "reviewer", Body: "Why did you choose this?"},   // question
+		{ID: "7", Author: "reviewer", Body: "Please add error handling"},  // code_change
+		{ID: "8", Author: "reviewer", Body: "never mind"},                 // dismissal
+	}
+
+	classified := classifier.ClassifyAll(comments)
+
+	if len(classified) != len(comments) {
+		t.Fatalf("classified %d comments, want %d", len(classified), len(comments))
+	}
+
+	// Verify classifications.
+	expectations := []struct {
+		commentID  string
+		wantType   CommentType
+		wantAction CommentAction
+		actionable bool
+	}{
+		{"1", CommentSelfAuthored, ActionSkip, false},
+		{"2", CommentBotGenerated, ActionSkip, false},
+		{"3", CommentBotGenerated, ActionSkip, false},
+		{"4", CommentApproval, ActionAcknowledge, false},
+		{"5", CommentNit, ActionApplyFix, true},
+		{"6", CommentQuestion, ActionRespond, true},
+		{"7", CommentCodeChange, ActionApplyFix, true},
+		{"8", CommentDismissal, ActionSkip, false},
+	}
+
+	for idx, want := range expectations {
+		got := classified[idx]
+		if got.Comment.ID != want.commentID {
+			t.Errorf("classified[%d].ID = %q, want %q", idx, got.Comment.ID, want.commentID)
+		}
+		if got.Type != want.wantType {
+			t.Errorf("comment %s: type = %q, want %q", want.commentID, got.Type, want.wantType)
+		}
+		if got.Action != want.wantAction {
+			t.Errorf("comment %s: action = %q, want %q", want.commentID, got.Action, want.wantAction)
+		}
+		if got.Actionable != want.actionable {
+			t.Errorf("comment %s: actionable = %v, want %v", want.commentID, got.Actionable, want.actionable)
+		}
+	}
+
+	// Verify HasActionable with mixed results.
+	if !HasActionable(classified) {
+		t.Error("HasActionable should be true with nit/question/code_change comments")
+	}
+
+	// Verify with only non-actionable comments.
+	nonActionable := classified[:4] // self, bot, bot, approval
+	if HasActionable(nonActionable) {
+		t.Error("HasActionable should be false with only self/bot/approval comments")
+	}
+}
+
+// TestSmoke_Monitor_ProfileFilterChain verifies that profile behavior filters
+// correctly modify classified comments: nit downgrade, non-auth suppression.
+func TestSmoke_Monitor_ProfileFilterChain(t *testing.T) {
+	t.Run("conservative_profile_downgrades_nits", func(t *testing.T) {
+		profile, err := GetMonitorProfile(ProfileConservative)
+		if err != nil {
+			t.Fatalf("GetMonitorProfile: %v", err)
+		}
+
+		// Conservative: AutoFixNits=false, RespondToNonAuth=false
+		if profile.ShouldApplyNit() {
+			t.Error("conservative profile should not auto-fix nits")
+		}
+		if profile.ShouldAutoRebase() {
+			t.Error("conservative profile should not auto-rebase")
+		}
+
+		classified := []ClassifiedComment{
+			{
+				Comment:    PRComment{ID: "1", Author: "r1", Body: "nit: fix style"},
+				Type:       CommentNit,
+				Action:     ActionApplyFix,
+				Actionable: true,
+			},
+			{
+				Comment:    PRComment{ID: "2", Author: "r1", Body: "Fix bug"},
+				Type:       CommentCodeChange,
+				Action:     ActionApplyFix,
+				Actionable: true,
+			},
+		}
+
+		filtered := applyProfileFilters(classified, profile)
+
+		// Nit should be downgraded to acknowledge.
+		if filtered[0].Action != ActionAcknowledge {
+			t.Errorf("nit action = %q, want %q", filtered[0].Action, ActionAcknowledge)
+		}
+		if filtered[0].Actionable {
+			t.Error("nit should not be actionable after conservative downgrade")
+		}
+
+		// Code change should remain.
+		if filtered[1].Action != ActionApplyFix {
+			t.Errorf("code change action = %q, want %q", filtered[1].Action, ActionApplyFix)
+		}
+		if !filtered[1].Actionable {
+			t.Error("code change should remain actionable")
+		}
+	})
+
+	t.Run("aggressive_profile_keeps_all", func(t *testing.T) {
+		profile, err := GetMonitorProfile(ProfileAggressive)
+		if err != nil {
+			t.Fatalf("GetMonitorProfile: %v", err)
+		}
+
+		// Aggressive: AutoFixNits=true, RespondToNonAuth=true
+		if !profile.ShouldApplyNit() {
+			t.Error("aggressive profile should auto-fix nits")
+		}
+		if !profile.ShouldAutoRebase() {
+			t.Error("aggressive profile should auto-rebase")
+		}
+		if !profile.ShouldRespondToNonAuth() {
+			t.Error("aggressive profile should respond to non-auth")
+		}
+
+		classified := []ClassifiedComment{
+			{
+				Comment:    PRComment{ID: "1", Author: "r1", Body: "nit: fix style"},
+				Type:       CommentNit,
+				Action:     ActionApplyFix,
+				Actionable: true,
+			},
+		}
+
+		filtered := applyProfileFilters(classified, profile)
+
+		// Nit should remain actionable with aggressive profile.
+		if filtered[0].Action != ActionApplyFix {
+			t.Errorf("nit action = %q, want %q (aggressive keeps nits)", filtered[0].Action, ActionApplyFix)
+		}
+		if !filtered[0].Actionable {
+			t.Error("nit should remain actionable with aggressive profile")
+		}
+	})
+
+	t.Run("profile_to_polling_config_roundtrip", func(t *testing.T) {
+		profile, _ := GetMonitorProfile(ProfileSmart)
+		polling := profile.ToPollingConfig()
+
+		if polling.InitialInterval.Duration != 2*time.Minute {
+			t.Errorf("InitialInterval = %v, want 2m", polling.InitialInterval.Duration)
+		}
+		if polling.MaxInterval.Duration != 5*time.Minute {
+			t.Errorf("MaxInterval = %v, want 5m", polling.MaxInterval.Duration)
+		}
+		if polling.MaxResponseRounds != 3 {
+			t.Errorf("MaxResponseRounds = %d, want 3", polling.MaxResponseRounds)
+		}
+	})
+}
+
+// TestSmoke_Monitor_AuthorityResolution verifies the CODEOWNERS-based authority
+// resolution chain: parse → match → classify with authority checks.
+func TestSmoke_Monitor_AuthorityResolution(t *testing.T) {
+	// Rules follow CODEOWNERS last-match-wins semantics.
+	// The catch-all "*" must come first so more specific patterns override it.
+	rules := []CODEOWNERSRule{
+		{Pattern: "*", Owners: []string{"default-owner"}},
+		{Pattern: "*.go", Owners: []string{"go-team", "alice"}},
+		{Pattern: "internal/pipeline/", Owners: []string{"pipeline-team", "bob"}},
+	}
+	authority := NewCODEOWNERSAuthority(rules)
+
+	t.Run("authoritative_owner_gets_full_classification", func(t *testing.T) {
+		classifier, _ := NewCommentClassifier("soda-bot", nil, authority)
+		// bob owns internal/pipeline/ (last matching rule for this path)
+		comment := PRComment{ID: "1", Author: "bob", Body: "Fix this bug", Path: "internal/pipeline/engine.go"}
+		result := classifier.Classify(comment)
+
+		if result.NonAuthoritative {
+			t.Error("bob should be authoritative for internal/pipeline/")
+		}
+		if result.Action != ActionApplyFix {
+			t.Errorf("action = %q, want %q", result.Action, ActionApplyFix)
+		}
+		if !result.Actionable {
+			t.Error("authoritative code_change should be actionable")
+		}
+	})
+
+	t.Run("non_authoritative_user_gets_acknowledged", func(t *testing.T) {
+		classifier, _ := NewCommentClassifier("soda-bot", nil, authority)
+		// random-user is not in the internal/pipeline/ owner list
+		comment := PRComment{ID: "2", Author: "random-user", Body: "Fix this bug", Path: "internal/pipeline/engine.go"}
+		result := classifier.Classify(comment)
+
+		if !result.NonAuthoritative {
+			t.Error("random-user should be non-authoritative")
+		}
+		if result.Action != ActionAcknowledge {
+			t.Errorf("action = %q, want %q", result.Action, ActionAcknowledge)
+		}
+		if result.Actionable {
+			t.Error("non-authoritative comment should not be actionable")
+		}
+	})
+
+	t.Run("general_comment_checks_any_rule", func(t *testing.T) {
+		classifier, _ := NewCommentClassifier("soda-bot", nil, authority)
+
+		// default-owner appears in catch-all rule, should be authoritative for general comments
+		comment := PRComment{ID: "3", Author: "default-owner", Body: "Looks good overall"}
+		result := classifier.Classify(comment)
+
+		if result.NonAuthoritative {
+			t.Error("default-owner should be authoritative for general comments")
+		}
+	})
+
+	t.Run("no_authority_resolver_means_all_authoritative", func(t *testing.T) {
+		classifier, _ := NewCommentClassifier("soda-bot", nil, nil)
+		comment := PRComment{ID: "4", Author: "anyone", Body: "Fix this", Path: "any/file.go"}
+		result := classifier.Classify(comment)
+
+		if result.NonAuthoritative {
+			t.Error("without authority resolver, all users should be authoritative")
+		}
+		if !result.Actionable {
+			t.Error("code_change from authoritative user should be actionable")
+		}
+	})
+}
+
+// TestSmoke_Monitor_ReplyOnlySession verifies that question-only comments
+// result in a reply-only session with restricted tools.
+func TestSmoke_Monitor_ReplyOnlySession(t *testing.T) {
+	t.Run("question_only_is_reply_only", func(t *testing.T) {
+		classified := []ClassifiedComment{
+			{
+				Comment:    PRComment{ID: "1", Author: "r", Body: "Why this approach?"},
+				Type:       CommentQuestion,
+				Action:     ActionRespond,
+				Actionable: true,
+			},
+		}
+
+		if !isReplyOnly(classified) {
+			t.Error("question-only should be reply-only")
+		}
+	})
+
+	t.Run("mixed_is_not_reply_only", func(t *testing.T) {
+		classified := []ClassifiedComment{
+			{
+				Comment:    PRComment{ID: "1", Author: "r", Body: "Why this?"},
+				Type:       CommentQuestion,
+				Action:     ActionRespond,
+				Actionable: true,
+			},
+			{
+				Comment:    PRComment{ID: "2", Author: "r", Body: "Fix this"},
+				Type:       CommentCodeChange,
+				Action:     ActionApplyFix,
+				Actionable: true,
+			},
+		}
+
+		if isReplyOnly(classified) {
+			t.Error("mixed comments should not be reply-only")
+		}
+	})
+
+	t.Run("reply_only_restricts_tools", func(t *testing.T) {
+		fullTools := []string{"Read", "Write", "Edit", "Bash", "Bash(git:*)", "Bash(go test:*)"}
+		restricted := replyOnlyTools(fullTools)
+
+		// Write, Edit, and unrestricted Bash should be excluded.
+		for _, tool := range restricted {
+			if tool == "Write" || tool == "Edit" || tool == "Bash" {
+				t.Errorf("reply-only tools should not include %q", tool)
+			}
+		}
+
+		// Read and restricted Bash patterns should remain.
+		hasRead := false
+		for _, tool := range restricted {
+			if tool == "Read" {
+				hasRead = true
+			}
+		}
+		if !hasRead {
+			t.Error("reply-only tools should include Read")
+		}
+	})
+}
+
+// TestSmoke_Monitor_FormatCommentsForPrompt verifies that classified comments
+// are rendered into a format suitable for prompt injection.
+func TestSmoke_Monitor_FormatCommentsForPrompt(t *testing.T) {
+	classified := []ClassifiedComment{
+		{
+			Comment: PRComment{ID: "IC_1", Author: "alice", Body: "Fix error handling", Path: "main.go", Line: 42},
+			Type:    CommentCodeChange,
+			Action:  ActionApplyFix,
+		},
+		{
+			Comment: PRComment{ID: "IC_2", Author: "bob", Body: "Why this approach?"},
+			Type:    CommentQuestion,
+			Action:  ActionRespond,
+		},
+	}
+
+	formatted := formatCommentsForPrompt(classified)
+
+	// Should contain both comment IDs.
+	if !strings.Contains(formatted, "IC_1") {
+		t.Error("formatted output should contain IC_1")
+	}
+	if !strings.Contains(formatted, "IC_2") {
+		t.Error("formatted output should contain IC_2")
+	}
+
+	// Should contain file path and line number.
+	if !strings.Contains(formatted, "main.go:42") {
+		t.Error("formatted output should contain file:line reference")
+	}
+
+	// Should contain author names.
+	if !strings.Contains(formatted, "alice") || !strings.Contains(formatted, "bob") {
+		t.Error("formatted output should contain author names")
+	}
+
+	// Should contain classification.
+	if !strings.Contains(formatted, "code_change") || !strings.Contains(formatted, "question") {
+		t.Error("formatted output should contain classification types")
+	}
+}
+
+// TestSmoke_Monitor_StateResumption verifies that monitor state is correctly
+// loaded on resume and that poll count continues from the persisted value.
+func TestSmoke_Monitor_StateResumption(t *testing.T) {
+	stateDir := t.TempDir()
+	state, err := LoadOrCreate(stateDir, "RESUME-1")
+	if err != nil {
+		t.Fatalf("LoadOrCreate: %v", err)
+	}
+
+	// Write initial monitor state as if 5 polls already happened.
+	startTime := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
+	initial := &MonitorState{
+		PRURL:             "https://github.com/decko/soda/pull/100",
+		PollCount:         5,
+		ResponseRounds:    1,
+		MaxResponseRounds: 3,
+		LastCommentID:     "IC_prev",
+		LastCIStatus:      "success",
+		LastPolledAt:      startTime.Add(10 * time.Minute),
+		StartedAt:         startTime,
+		Status:            MonitorPolling,
+	}
+	if err := state.WriteMonitorState(initial); err != nil {
+		t.Fatalf("WriteMonitorState: %v", err)
+	}
+
+	// Read it back and verify all fields survived the roundtrip.
+	loaded, err := state.ReadMonitorState()
+	if err != nil {
+		t.Fatalf("ReadMonitorState: %v", err)
+	}
+
+	if loaded.PollCount != 5 {
+		t.Errorf("PollCount = %d, want 5", loaded.PollCount)
+	}
+	if loaded.ResponseRounds != 1 {
+		t.Errorf("ResponseRounds = %d, want 1", loaded.ResponseRounds)
+	}
+	if loaded.LastCommentID != "IC_prev" {
+		t.Errorf("LastCommentID = %q, want IC_prev", loaded.LastCommentID)
+	}
+	if loaded.Status != MonitorPolling {
+		t.Errorf("Status = %q, want polling", loaded.Status)
+	}
+	if loaded.StartedAt.IsZero() {
+		t.Error("StartedAt should be preserved on resume")
+	}
+	if loaded.PRURL != "https://github.com/decko/soda/pull/100" {
+		t.Errorf("PRURL = %q, want full URL", loaded.PRURL)
+	}
+}
+
+// TestSmoke_Monitor_ContextSleep verifies that contextSleep respects both
+// normal completion and context cancellation.
+func TestSmoke_Monitor_ContextSleep(t *testing.T) {
+	t.Run("normal_sleep_completes", func(t *testing.T) {
+		sleepCalled := false
+		err := contextSleep(context.Background(), 1*time.Millisecond, func(d time.Duration) {
+			sleepCalled = true
+		})
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if !sleepCalled {
+			t.Error("sleep function should have been called")
+		}
+	})
+
+	t.Run("cancelled_context_returns_early", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // cancel immediately
+
+		err := contextSleep(ctx, 1*time.Hour, func(d time.Duration) {
+			// This should not complete because context is already cancelled.
+			time.Sleep(d)
+		})
+		if err == nil {
+			t.Error("expected error from cancelled context")
+		}
+	})
+
+	t.Run("nil_sleep_func_uses_timer", func(t *testing.T) {
+		err := contextSleep(context.Background(), 1*time.Millisecond, nil)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+}

--- a/internal/sandbox/smoke_test.go
+++ b/internal/sandbox/smoke_test.go
@@ -1,0 +1,433 @@
+package sandbox
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/decko/soda/internal/runner"
+)
+
+// TestSmoke_NoCGO_NewReturnsError verifies that sandbox.New fails gracefully
+// when CGO is disabled, providing a clear error message.
+func TestSmoke_NoCGO_NewReturnsError(t *testing.T) {
+	if isCGO() {
+		t.Skip("this test only runs when CGO_ENABLED=0")
+	}
+
+	cfg := Config{
+		MemoryMB:   2048,
+		CPUPercent: 200,
+		MaxPIDs:    256,
+	}
+
+	r, err := New(cfg)
+	if err == nil {
+		r.Close()
+		t.Fatal("expected error from New() without CGO, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "cgo") {
+		t.Errorf("error should mention cgo, got: %v", err)
+	}
+}
+
+// TestSmoke_NoCGO_RunReturnsError verifies that Runner.Run fails gracefully
+// when CGO is disabled.
+func TestSmoke_NoCGO_RunReturnsError(t *testing.T) {
+	if isCGO() {
+		t.Skip("this test only runs when CGO_ENABLED=0")
+	}
+
+	r := &Runner{}
+	_, err := r.Run(context.Background(), runner.RunOpts{
+		Phase:   "triage",
+		WorkDir: "/tmp",
+		Model:   "test-model",
+	})
+	if err == nil {
+		t.Fatal("expected error from Run() without CGO, got nil")
+	}
+	if !strings.Contains(err.Error(), "cgo") {
+		t.Errorf("error should mention cgo, got: %v", err)
+	}
+}
+
+// TestSmoke_ConfigToEnv_EndToEnd verifies the complete path from a sandbox Config
+// through env construction, ensuring that API keys are correctly handled in both
+// direct and proxy modes. This is an end-to-end test of the config → env wiring.
+func TestSmoke_ConfigToEnv_EndToEnd(t *testing.T) {
+	t.Run("direct_mode_with_api_key", func(t *testing.T) {
+		t.Setenv("ANTHROPIC_API_KEY", "sk-test-real-key")
+		t.Setenv("CLAUDE_CODE_USE_VERTEX", "")
+
+		opts := runner.RunOpts{
+			Phase:   "implement",
+			WorkDir: "/workspace/project",
+		}
+		env := claudeEnv("/tmp/sandbox-home", opts, "/usr/bin/claude", "")
+
+		envMap := envSliceToMap(env)
+
+		// Verify HOME and TMPDIR are isolated to sandbox temp.
+		if envMap["HOME"] != "/tmp/sandbox-home" {
+			t.Errorf("HOME = %q, want /tmp/sandbox-home", envMap["HOME"])
+		}
+		if envMap["TMPDIR"] != "/tmp/sandbox-home" {
+			t.Errorf("TMPDIR = %q, want /tmp/sandbox-home", envMap["TMPDIR"])
+		}
+
+		// Verify real API key is passed through in direct mode.
+		if envMap["ANTHROPIC_API_KEY"] != "sk-test-real-key" {
+			t.Errorf("ANTHROPIC_API_KEY = %q, want sk-test-real-key", envMap["ANTHROPIC_API_KEY"])
+		}
+
+		// Verify no proxy-related vars are set.
+		if _, ok := envMap["ANTHROPIC_BASE_URL"]; ok {
+			t.Error("ANTHROPIC_BASE_URL should not be set in direct mode without proxy")
+		}
+	})
+
+	t.Run("proxy_mode_isolates_credentials", func(t *testing.T) {
+		t.Setenv("ANTHROPIC_API_KEY", "sk-test-real-key")
+		t.Setenv("CLAUDE_CODE_USE_VERTEX", "")
+
+		opts := runner.RunOpts{
+			Phase:   "implement",
+			WorkDir: "/workspace/project",
+		}
+		proxyURL := "http://127.0.0.1:9090"
+		env := claudeEnv("/tmp/sandbox-home", opts, "/usr/bin/claude", proxyURL)
+
+		envMap := envSliceToMap(env)
+
+		// In proxy mode, real API key must NOT be passed to sandbox.
+		if envMap["ANTHROPIC_API_KEY"] == "sk-test-real-key" {
+			t.Error("real API key should NOT be passed to sandbox in proxy mode")
+		}
+
+		// Instead, a proxy nonce should be set.
+		if envMap["ANTHROPIC_API_KEY"] != "sk-proxy-nonce" {
+			t.Errorf("ANTHROPIC_API_KEY = %q, want sk-proxy-nonce", envMap["ANTHROPIC_API_KEY"])
+		}
+
+		// Proxy base URL should be set.
+		if envMap["ANTHROPIC_BASE_URL"] != proxyURL {
+			t.Errorf("ANTHROPIC_BASE_URL = %q, want %q", envMap["ANTHROPIC_BASE_URL"], proxyURL)
+		}
+	})
+
+	t.Run("vertex_proxy_mode_skips_auth", func(t *testing.T) {
+		t.Setenv("CLAUDE_CODE_USE_VERTEX", "1")
+		t.Setenv("VERTEXAI_PROJECT", "my-gcp-project")
+		t.Setenv("VERTEXAI_LOCATION", "us-central1")
+		t.Setenv("ANTHROPIC_API_KEY", "")
+
+		opts := runner.RunOpts{
+			Phase:   "plan",
+			WorkDir: "/workspace/project",
+		}
+		proxyURL := "http://127.0.0.1:9091"
+		env := claudeEnv("/tmp/sandbox-home", opts, "/usr/bin/claude", proxyURL)
+
+		envMap := envSliceToMap(env)
+
+		// Vertex proxy mode should set skip auth flag.
+		if envMap["CLAUDE_CODE_SKIP_VERTEX_AUTH"] != "1" {
+			t.Errorf("CLAUDE_CODE_SKIP_VERTEX_AUTH = %q, want 1", envMap["CLAUDE_CODE_SKIP_VERTEX_AUTH"])
+		}
+
+		// Vertex base URL should point to proxy.
+		if envMap["ANTHROPIC_VERTEX_BASE_URL"] != proxyURL {
+			t.Errorf("ANTHROPIC_VERTEX_BASE_URL = %q, want %q", envMap["ANTHROPIC_VERTEX_BASE_URL"], proxyURL)
+		}
+
+		// Vertex project should be forwarded.
+		if envMap["VERTEXAI_PROJECT"] != "my-gcp-project" {
+			t.Errorf("VERTEXAI_PROJECT = %q, want my-gcp-project", envMap["VERTEXAI_PROJECT"])
+		}
+
+		// Anthropic API key should NOT be present in Vertex mode.
+		if _, ok := envMap["ANTHROPIC_API_KEY"]; ok {
+			t.Error("ANTHROPIC_API_KEY should not be set in Vertex proxy mode")
+		}
+	})
+
+	t.Run("no_credentials_means_no_credential_env", func(t *testing.T) {
+		t.Setenv("ANTHROPIC_API_KEY", "")
+		t.Setenv("CLAUDE_CODE_USE_VERTEX", "")
+		t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "")
+
+		opts := runner.RunOpts{Phase: "verify", WorkDir: "/work"}
+		env := claudeEnv("/tmp/sb", opts, "/usr/bin/claude", "")
+
+		for _, entry := range env {
+			if strings.HasPrefix(entry, "ANTHROPIC_API_KEY=") {
+				t.Error("ANTHROPIC_API_KEY should not be emitted when empty")
+			}
+			if strings.HasPrefix(entry, "GOOGLE_APPLICATION_CREDENTIALS=") {
+				t.Error("GOOGLE_APPLICATION_CREDENTIALS should not be emitted when empty")
+			}
+		}
+	})
+}
+
+// TestSmoke_ErrorMapping_EndToEnd exercises the full error mapping chain:
+// ExitError → mapSandboxError → runner.TransientError, ensuring the error
+// classification pipeline preserves diagnostic information end-to-end.
+func TestSmoke_ErrorMapping_EndToEnd(t *testing.T) {
+	exitErr := &ExitError{
+		Code:    137,
+		Signal:  9,
+		OOMKill: true,
+		Stderr:  []byte("cgroup: memory limit exceeded"),
+	}
+
+	// Verify error message includes diagnostic info.
+	errMsg := exitErr.Error()
+	if !strings.Contains(errMsg, "OOM") {
+		t.Errorf("ExitError message should mention OOM, got: %s", errMsg)
+	}
+
+	// Verify stderr is preserved for debugging.
+	if string(exitErr.Stderr) != "cgroup: memory limit exceeded" {
+		t.Errorf("Stderr not preserved: %s", exitErr.Stderr)
+	}
+}
+
+// TestSmoke_SystemReadPaths_Security verifies that system read paths include
+// essential directories but exclude sensitive locations like /tmp.
+func TestSmoke_SystemReadPaths_Security(t *testing.T) {
+	paths := systemReadPaths()
+
+	// Must include basic OS paths.
+	required := map[string]bool{
+		"/usr":  false,
+		"/lib":  false,
+		"/bin":  false,
+		"/proc": false,
+		"/dev":  false,
+		"/etc":  false,
+	}
+	for _, path := range paths {
+		if _, ok := required[path]; ok {
+			required[path] = true
+		}
+	}
+	for path, found := range required {
+		if !found {
+			t.Errorf("systemReadPaths missing required path: %s", path)
+		}
+	}
+
+	// /tmp must NOT be in read paths (sandbox has its own tmpDir).
+	for _, path := range paths {
+		if path == "/tmp" {
+			t.Error("/tmp should not be in systemReadPaths — sandbox uses dedicated tmpDir")
+		}
+	}
+
+	// Home directory must NOT be in read paths.
+	home, _ := os.UserHomeDir()
+	if home != "" {
+		for _, path := range paths {
+			if path == home {
+				t.Errorf("user home %s should not be in systemReadPaths", home)
+			}
+		}
+	}
+}
+
+// TestSmoke_LimitWriter_OOMProtection verifies that the limit writer correctly
+// prevents unbounded memory growth from a runaway process, as used in the
+// sandbox to cap stdout at maxStdoutBytes.
+func TestSmoke_LimitWriter_OOMProtection(t *testing.T) {
+	var buf testBuffer
+	// Simulate the production maxStdoutBytes cap at a smaller scale.
+	limit := int64(100)
+	lw := &limitWriter{writer: &buf, remaining: limit}
+
+	// Write data that exceeds the limit.
+	largeData := strings.Repeat("x", 200)
+	written, err := lw.Write([]byte(largeData))
+	if err != nil {
+		t.Fatalf("Write should not error: %v", err)
+	}
+
+	// Write must report full length to avoid blocking pipe draining.
+	if written != 200 {
+		t.Errorf("Write returned %d, want 200 (must report full length)", written)
+	}
+
+	// Buffer should only contain up to the limit.
+	if len(buf.data) != int(limit) {
+		t.Errorf("buffer has %d bytes, want %d", len(buf.data), limit)
+	}
+
+	// Subsequent writes should be silently discarded.
+	written2, err2 := lw.Write([]byte("more data"))
+	if err2 != nil {
+		t.Fatalf("subsequent Write should not error: %v", err2)
+	}
+	if written2 != len("more data") {
+		t.Errorf("subsequent Write returned %d, want %d", written2, len("more data"))
+	}
+	if len(buf.data) != int(limit) {
+		t.Errorf("buffer grew after limit: %d bytes", len(buf.data))
+	}
+}
+
+// TestSmoke_ParseSignal_EndToEnd tests signal parsing from arapuca error
+// messages with various formats that may appear in production.
+func TestSmoke_ParseSignal_EndToEnd(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  string
+		want int
+	}{
+		{"oom_kill_signal", "killed by signal 9", 9},
+		{"sigterm", "killed by signal 15", 15},
+		{"sigsegv", "killed by signal 11", 11},
+		{"wrapped_by_arapuca", "arapuca: wait: killed by signal 9: context canceled", 9},
+		{"double_wrapped", "engine: sandbox: arapuca: killed by signal 6: abort", 6},
+		{"no_signal", "process exited normally", 0},
+		{"empty_after_prefix", "killed by signal", 0},
+		{"trailing_text", "killed by signal 11 (core dumped)", 11},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := &testError{msg: tt.msg}
+			got := parseSignalFromError(err)
+			if got != tt.want {
+				t.Errorf("parseSignalFromError(%q) = %d, want %d", tt.msg, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSmoke_SetEnvForLaunch_Isolation verifies that the env mutation/restore
+// cycle correctly isolates sandbox env from the host process.
+func TestSmoke_SetEnvForLaunch_Isolation(t *testing.T) {
+	// Set up known state.
+	t.Setenv("SODA_SMOKE_A", "original-a")
+	t.Setenv("SODA_SMOKE_B", "original-b")
+
+	// Simulate a sandbox launch that overrides both vars.
+	sandboxEnv := []string{
+		"SODA_SMOKE_A=sandbox-a",
+		"SODA_SMOKE_B=sandbox-b",
+		"SODA_SMOKE_C=sandbox-c", // new var not in host
+	}
+
+	restore := setEnvForLaunch(sandboxEnv)
+
+	// During "launch", sandbox values should be active.
+	if got := os.Getenv("SODA_SMOKE_A"); got != "sandbox-a" {
+		t.Errorf("during launch: SODA_SMOKE_A = %q, want sandbox-a", got)
+	}
+	if got := os.Getenv("SODA_SMOKE_B"); got != "sandbox-b" {
+		t.Errorf("during launch: SODA_SMOKE_B = %q, want sandbox-b", got)
+	}
+	if got := os.Getenv("SODA_SMOKE_C"); got != "sandbox-c" {
+		t.Errorf("during launch: SODA_SMOKE_C = %q, want sandbox-c", got)
+	}
+
+	// Restore host state.
+	restore()
+
+	// After restore, original values should be back.
+	if got := os.Getenv("SODA_SMOKE_A"); got != "original-a" {
+		t.Errorf("after restore: SODA_SMOKE_A = %q, want original-a", got)
+	}
+	if got := os.Getenv("SODA_SMOKE_B"); got != "original-b" {
+		t.Errorf("after restore: SODA_SMOKE_B = %q, want original-b", got)
+	}
+	// SODA_SMOKE_C should be unset (wasn't in host env before).
+	if _, found := os.LookupEnv("SODA_SMOKE_C"); found {
+		t.Error("after restore: SODA_SMOKE_C should be unset")
+	}
+}
+
+// TestSmoke_Config_Defaults verifies that the Config struct zero value
+// produces safe defaults (no network namespace, no proxy, no extra paths).
+func TestSmoke_Config_Defaults(t *testing.T) {
+	cfg := Config{}
+
+	if cfg.UseNetNS {
+		t.Error("default UseNetNS should be false (v1 — Claude needs network)")
+	}
+	if cfg.Proxy.Enabled {
+		t.Error("default Proxy.Enabled should be false")
+	}
+	if len(cfg.ExtraReadPaths) != 0 {
+		t.Errorf("default ExtraReadPaths should be empty, got %v", cfg.ExtraReadPaths)
+	}
+	if len(cfg.ExtraWritePaths) != 0 {
+		t.Errorf("default ExtraWritePaths should be empty, got %v", cfg.ExtraWritePaths)
+	}
+	if cfg.MemoryMB != 0 {
+		t.Errorf("default MemoryMB should be 0 (unset), got %d", cfg.MemoryMB)
+	}
+}
+
+// TestSmoke_ParseWrapperPaths_Realistic tests path extraction from a realistic
+// Claude wrapper script that would be found in production installations.
+func TestSmoke_ParseWrapperPaths_Realistic(t *testing.T) {
+	tmpDir := t.TempDir()
+	scriptPath := tmpDir + "/claude"
+
+	// Write a realistic wrapper script.
+	script := `#!/usr/bin/env bash
+# Claude Code CLI wrapper
+set -euo pipefail
+export NODE_PATH="/opt/claude-code/lib/node_modules:/usr/local/lib/node_modules"
+export NODE_OPTIONS="--max-old-space-size=4096"
+exec /opt/claude-code/bin/node /opt/claude-code/lib/cli.js "$@"
+`
+	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	paths := parseWrapperPaths(scriptPath)
+
+	// Should find the node_modules paths.
+	foundOpt := false
+	foundUsr := false
+	for _, path := range paths {
+		if path == "/opt/claude-code/lib/node_modules" {
+			foundOpt = true
+		}
+		if path == "/usr/local/lib/node_modules" {
+			foundUsr = true
+		}
+	}
+	if !foundOpt {
+		t.Errorf("missing /opt/claude-code/lib/node_modules in parsed paths: %v", paths)
+	}
+	if !foundUsr {
+		t.Errorf("missing /usr/local/lib/node_modules in parsed paths: %v", paths)
+	}
+}
+
+// envSliceToMap converts an env slice (KEY=VALUE) to a map for easy lookup.
+func envSliceToMap(env []string) map[string]string {
+	result := make(map[string]string, len(env))
+	for _, entry := range env {
+		key, val, _ := parseEnvEntry(entry)
+		result[key] = val
+	}
+	return result
+}
+
+// isCGO returns true if this binary was built with CGO enabled.
+// Since the cgo build tag gates the real sandbox implementation,
+// we check whether New returns the cgo-specific error message.
+func isCGO() bool {
+	_, err := New(Config{})
+	if err == nil {
+		return true
+	}
+	return !strings.Contains(err.Error(), "cgo is required")
+}


### PR DESCRIPTION
## Summary

- Extract `ResolveConfigPath` from inline `main.go` logic into a testable function in `internal/config`
- Add 31 end-to-end smoke tests across three packages covering config discovery, monitor lifecycle, and sandbox subsystem
- Use reflect-based `RepoConfig` field parity check to catch schema drift between `config.RepoConfig` and `pipeline.RepoConfig`

### Acceptance Criteria

- [x] **AC1 – Config discovery**: `ResolveConfigPath` tests verify local-precedence and global-fallback paths using the production function
- [x] **AC2 – Monitor self_user guard**: `DefaultConfig` leaves `SelfUser` empty; `NewCommentClassifier` returns error for empty selfUser; monitor degrades to passive mode with warning
- [x] **AC3 – Sandbox smoke tests**: Env propagation tests across 4 modes (direct, proxy, vertex, no-creds); proxy connectivity tested via env wiring
- [x] **AC4 – Pipeline lifecycle**: Full monitor lifecycle exercised: poll → detect → classify → respond → CI change → approve, with event sequence, state, and cost verification
- [x] **AC5 – Regression protection**: Tests use production functions (not mocks) for critical paths; reflect-based field parity check catches schema drift
- [x] **AC6 – CI coverage**: CI runs `CGO_ENABLED=0 go test ./...` which includes all smoke tests; CGO-specific tests use `t.Skip`

### Files Changed

| File | Change |
|------|--------|
| `cmd/soda/main.go` | Use extracted `config.ResolveConfigPath` |
| `internal/config/config.go` | Add `ResolveConfigPath` function |
| `internal/config/config_smoke_test.go` | 10 config discovery smoke tests |
| `internal/pipeline/monitor_smoke_test.go` | 10 monitor lifecycle smoke tests |
| `internal/sandbox/smoke_test.go` | 11 sandbox subsystem smoke tests |

## Test plan

- [x] `CGO_ENABLED=0 go test ./internal/config/... ./internal/pipeline/... ./internal/sandbox/...` — all 31 tests pass
- [x] Full suite `go test ./...` passes with no regressions
- [x] Verify reflect-based parity test catches intentional field additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)