### PR TITLE
chore: add Go version to .editorconfig [#359]

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,6 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.go]
+go_version = 1.25.0


### PR DESCRIPTION
## Summary

- Adds a `[*.go]` section to `.editorconfig` with `go_version = 1.25.0`, matching the version specified in `go.mod`
- Ensures editor tooling (e.g., gopls) can pick up the target Go version from `.editorconfig`

## Test plan

- [x] Verified `go_version` in `.editorconfig` matches `go.mod` (`1.25.0`)
- [x] Confirmed proper `.editorconfig` syntax (blank line separator, correct section header, trailing newline)
- [x] Ran `go vet` — no regressions
- [x] No Go source files were modified

## Acceptance criteria

- [x] `.editorconfig` contains a `[*.go]` section with `go_version = 1.25.0`
- [x] Go version matches `go.mod`

🤖 Generated with [Claude Code](https://claude.com/claude-code)