### PR TITLE
fix(sandbox): pass GitHub token and SSH agent through to sandboxed processes

### DIFF
--- a/internal/sandbox/resolve.go
+++ b/internal/sandbox/resolve.go
@@ -164,6 +164,34 @@ func claudeEnv(tmpDir string, opts runner.RunOpts, claudeBin, proxyURL string) [
 		}
 	}
 
+	// Git/GitHub credentials for submit, follow-up, and monitor phases.
+	// gh CLI uses GH_TOKEN or GITHUB_TOKEN; git push uses SSH_AUTH_SOCK.
+	gitVars := []string{
+		"GH_TOKEN",
+		"GITHUB_TOKEN",
+		"GH_HOST",
+		"SSH_AUTH_SOCK",
+		"GIT_AUTHOR_NAME",
+		"GIT_AUTHOR_EMAIL",
+		"GIT_COMMITTER_NAME",
+		"GIT_COMMITTER_EMAIL",
+	}
+	for _, key := range gitVars {
+		if val := os.Getenv(key); val != "" {
+			env = append(env, key+"="+val)
+		}
+	}
+
+	// If no GH_TOKEN is set, try to extract from gh CLI keyring so that
+	// gh commands work inside the sandbox (no keyring access there).
+	if os.Getenv("GH_TOKEN") == "" && os.Getenv("GITHUB_TOKEN") == "" {
+		if token, err := exec.Command("gh", "auth", "token").Output(); err == nil {
+			if t := strings.TrimSpace(string(token)); t != "" {
+				env = append(env, "GH_TOKEN="+t)
+			}
+		}
+	}
+
 	return env
 }
 

--- a/internal/sandbox/resolve_test.go
+++ b/internal/sandbox/resolve_test.go
@@ -109,6 +109,51 @@ func TestClaudeEnvNoKeyMeansNoEntry(t *testing.T) {
 	}
 }
 
+func TestClaudeEnvGitHubTokenPassthrough(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+	t.Setenv("GH_TOKEN", "ghp_test123")
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("SSH_AUTH_SOCK", "/tmp/ssh-agent/agent.1234")
+
+	opts := runner.RunOpts{Phase: "submit", WorkDir: "/work"}
+	env := claudeEnv("/tmp/sb", opts, "/usr/bin/claude", "")
+
+	envMap := make(map[string]string)
+	for _, entry := range env {
+		parts := strings.SplitN(entry, "=", 2)
+		if len(parts) == 2 {
+			envMap[parts[0]] = parts[1]
+		}
+	}
+
+	if envMap["GH_TOKEN"] != "ghp_test123" {
+		t.Errorf("GH_TOKEN = %q, want ghp_test123", envMap["GH_TOKEN"])
+	}
+	if envMap["SSH_AUTH_SOCK"] != "/tmp/ssh-agent/agent.1234" {
+		t.Errorf("SSH_AUTH_SOCK = %q, want /tmp/ssh-agent/agent.1234", envMap["SSH_AUTH_SOCK"])
+	}
+}
+
+func TestClaudeEnvGitHubTokenNotDuplicated(t *testing.T) {
+	// When GH_TOKEN is set, the keyring fallback should not run.
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+	t.Setenv("GH_TOKEN", "ghp_explicit")
+	t.Setenv("GITHUB_TOKEN", "")
+
+	opts := runner.RunOpts{Phase: "submit", WorkDir: "/work"}
+	env := claudeEnv("/tmp/sb", opts, "/usr/bin/claude", "")
+
+	count := 0
+	for _, entry := range env {
+		if strings.HasPrefix(entry, "GH_TOKEN=") {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("GH_TOKEN appears %d times, want exactly 1", count)
+	}
+}
+
 func TestClaudeEnvProxyMode(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "sk-real-key")
 	t.Setenv("CLAUDE_CODE_USE_VERTEX", "") // ensure non-Vertex for this test

--- a/internal/sandbox/runner.go
+++ b/internal/sandbox/runner.go
@@ -123,6 +123,11 @@ func (r *Runner) Run(ctx context.Context, opts runner.RunOpts) (*runner.RunResul
 	readPaths = append(readPaths, opts.WorkDir)
 	readPaths = append(readPaths, r.config.ExtraReadPaths...)
 
+	// Allow SSH agent socket access for git push.
+	if sshSock := os.Getenv("SSH_AUTH_SOCK"); sshSock != "" {
+		readPaths = append(readPaths, filepath.Dir(sshSock))
+	}
+
 	writePaths := []string{opts.WorkDir}
 	writePaths = append(writePaths, r.config.ExtraWritePaths...)
 


### PR DESCRIPTION
## Summary

- Submit and follow-up phases use `gh` CLI and `git push` inside the sandbox, but the sandbox had no GitHub credentials — `gh` hung on interactive `gh auth login` with no keyring access
- Pass `GH_TOKEN`, `GITHUB_TOKEN`, `SSH_AUTH_SOCK`, and git identity vars through the sandbox env
- When no explicit token env var is set, extract from `gh auth token` on the host side (keyring → env var bridge)
- Add SSH agent socket directory to sandbox read paths for `git push`

## Root cause

`gh` CLI authenticates via OS keyring by default. Inside the arapuca sandbox, there's no keyring access, so `gh` falls back to interactive `gh auth login` which hangs indefinitely waiting for user input.

## Test plan

- [x] `TestClaudeEnvGitHubTokenPassthrough` — verifies GH_TOKEN and SSH_AUTH_SOCK in env
- [x] `TestClaudeEnvGitHubTokenNotDuplicated` — no duplicate when explicit token set
- [x] All existing sandbox tests pass
- [x] Full test suite passes, `go vet` clean
- [x] **End-to-end validated**: `soda run 359` completed submit phase inside sandbox → PR #360 created