### PR TITLE
fix(monitor): remove --slurp flag incompatible with --jq (#362)

### DIFF
--- a/internal/pipeline/github_poller.go
+++ b/internal/pipeline/github_poller.go
@@ -112,13 +112,13 @@ func (p *GitHubPRPoller) GetNewComments(ctx context.Context, prURL string, after
 	}
 
 	// Get review comments (inline code review comments).
-	// --paginate --slurp produces [[page1...],[page2...]], so we use --jq 'flatten'
+	// --paginate may produce concatenated JSON arrays, so we use --jq 'flatten'
 	// to merge pages into a single flat array.
 	// Sort by created ascending so newest comments are last (consistent with afterID filtering).
 	endpoint := fmt.Sprintf("repos/%s/%s/pulls/%s/comments?sort=created&direction=asc", owner, repo, number)
 	out, err := exec.CommandContext(ctx, p.command,
 		"api", endpoint,
-		"--paginate", "--slurp", "--jq", "flatten",
+		"--paginate", "--jq", "flatten",
 	).Output()
 	if err != nil {
 		return nil, fmt.Errorf("monitor: get comments: %w: %s", err, ghStderr(err))
@@ -134,7 +134,7 @@ func (p *GitHubPRPoller) GetNewComments(ctx context.Context, prURL string, after
 	issueEndpoint := fmt.Sprintf("repos/%s/%s/issues/%s/comments?sort=created&direction=asc", owner, repo, number)
 	issueOut, err := exec.CommandContext(ctx, p.command,
 		"api", issueEndpoint,
-		"--paginate", "--slurp", "--jq", "flatten",
+		"--paginate", "--jq", "flatten",
 	).Output()
 	if err != nil {
 		return nil, fmt.Errorf("monitor: get issue comments: %w: %s", err, ghStderr(err))


### PR DESCRIPTION
## Summary
- Remove `--slurp` flag from two `gh api` calls in `GetNewComments` (review comments and issue comments endpoints)
- Update comment to accurately describe `--paginate` behavior without `--slurp`
- The `flatten` jq expression is retained as a safe no-op for flat arrays and correct merge for nested arrays

## Why
The `--slurp` flag is incompatible with `--jq` in newer versions of the `gh` CLI, causing GitHub poller failures. Since `--paginate` already concatenates pages and `flatten` handles both flat and nested arrays, `--slurp` was unnecessary.

## Changes
- `internal/pipeline/github_poller.go`: Removed `--slurp` from both `gh api` calls (lines 121 and 137) and updated the explanatory comment (line 115)

## Test plan
- [x] `go build ./...` succeeds
- [x] `go vet ./...` clean
- [x] All existing tests pass
- [x] No remaining `--slurp` references in `internal/`
- [x] Verified `flatten` is a safe no-op on already-flat arrays

## Acceptance criteria
- [x] `--slurp` flag removed from review comments API call
- [x] `--slurp` flag removed from issue comments API call
- [x] Comment updated to no longer reference `--slurp`
- [x] `flatten` jq expression retained for pagination safety

Refs: #362

🤖 Generated with [Claude Code](https://claude.com/claude-code)