### PR TITLE
fix(config): default example config to GitHub Issues [#390]

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -2,26 +2,26 @@
 # Auto-generate a starter version of this file with: soda init
 
 # Ticket source
-ticket_source: jira
-jira:
-  command: wtmcp
-  project: MYPROJECT
-  query: "labels = ai-workable AND status = Refinement"
+ticket_source: github
+github:
+  owner: myorg
+  repo: my-service
+  fetch_comments: true
+  # Extraction strategies: pull spec/plan from ticket comments using markers.
+  # When configured, comments are scanned for content between start/end markers.
+  # If multiple comments contain the same markers, the last one wins.
+  spec:
+    start_marker: "<!-- spec:start -->"
+    end_marker: "<!-- spec:end -->"
+  plan:
+    start_marker: "<!-- plan:start -->"
+    end_marker: "<!-- plan:end -->"
 
-# GitHub Issues source (alternative to Jira)
-# github:
-#   owner: myorg
-#   repo: my-service
-#   fetch_comments: true
-#   # Extraction strategies: pull spec/plan from ticket comments using markers.
-#   # When configured, comments are scanned for content between start/end markers.
-#   # If multiple comments contain the same markers, the last one wins.
-#   spec:
-#     start_marker: "<!-- spec:start -->"
-#     end_marker: "<!-- spec:end -->"
-#   plan:
-#     start_marker: "<!-- plan:start -->"
-#     end_marker: "<!-- plan:end -->"
+# Jira configuration (uncomment to use Jira instead)
+# jira:
+#   command: wtmcp
+#   project: MYPROJECT
+#   query: "labels = ai-workable AND status = Refinement"
 
 # Default execution mode
 mode: autonomous   # or "checkpoint"


### PR DESCRIPTION
## Summary
- Swap the active/commented sections in `config.example.yaml` so **GitHub Issues** is the uncommented default and **Jira** is shown as a commented-out alternative
- Aligns the example file with the Go runtime defaults (`DefaultConfig()` and `configFromDetected()` already default to `ticket_source: github`)
- Only 1 file changed; no Go code modifications needed

## Acceptance Criteria
- [x] Default `ticket_source` is `github`
- [x] Jira config block is commented out with clear instructions
- [x] `soda init` produces a GitHub-first config (already worked — Go defaults were correct)

## Test Plan
- [x] All existing tests pass (`go test ./...`)
- [x] Verified `config.example.yaml` renders correctly with GitHub as default
- [x] Confirmed no regressions in Go default config paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)