### PR TITLE
docs(claude): document minimum CLI version 2.1.81 (#372)

### DIFF
--- a/internal/claude/args.go
+++ b/internal/claude/args.go
@@ -2,6 +2,21 @@ package claude
 
 import "strconv"
 
+// MinCLIVersion is the minimum Claude Code CLI version that supports all
+// flags used by SODA. The bottleneck is --bare, introduced in v2.1.81.
+//
+// Flag introduction timeline:
+//
+//	--print                            pre-0.2.x
+//	--output-format json               ≤ v0.2.66
+//	--allowed-tools                    pre-1.0.x
+//	--system-prompt-file               v1.0.55
+//	--permission-mode bypassPermissions ≤ v2.0.x
+//	--max-budget-usd                   v2.0.28
+//	--json-schema                      ≤ v2.1.21 (fix in v2.1.22)
+//	--bare                             v2.1.81 ← bottleneck
+const MinCLIVersion = "2.1.81"
+
 // BuildArgs constructs the CLI argument list from RunOpts and model.
 // When opts.Model is non-empty it takes precedence over the runner-level
 // model, enabling per-phase and per-reviewer model overrides.


### PR DESCRIPTION
## Summary

Add `MinCLIVersion` constant to `internal/claude/args.go` documenting the minimum Claude Code CLI version (2.1.81) required by SODA.

The bottleneck is `--bare`, introduced in v2.1.81. All other required flags (`--print`, `--json-schema`, `--output-format json`, `--permission-mode bypassPermissions`, `--allowed-tools`, `--system-prompt-file`, `--max-budget-usd`) were introduced in earlier versions.

Includes a flag introduction timeline comment for future reference.

This constant will be consumed by:
- `soda doctor` (#370) for prerequisite validation
- `soda run` prereq check (#371) for fail-fast errors
- README (#366) and quickstart (#367) for documentation

Closes #372