### PR TITLE
fix(doctor): assert skipped in NoConfigFound test (#400)

### DIFF
--- a/cmd/soda/doctor_test.go
+++ b/cmd/soda/doctor_test.go
@@ -531,8 +531,8 @@ func TestCheckConfigValid_NoConfigFound(t *testing.T) {
 		return nil, os.ErrNotExist
 	}
 	r := checkConfigValid(env)
-	if r.passed {
-		t.Error("expected config-valid check to fail with no config files")
+	if !r.skipped {
+		t.Error("expected config-valid check to be skipped when no config files exist")
 	}
 }
 


### PR DESCRIPTION
## Summary

Fix `TestCheckConfigValid_NoConfigFound` to assert `r.skipped` instead of `!r.passed`.

When no config files exist, `checkConfigValid()` returns `skipped: true`. The old test asserted `!r.passed`, which passed coincidentally because `passed` defaults to `false` (zero value), but it was checking the wrong semantic — failure vs skip.

## Changes

- **`cmd/soda/doctor_test.go`**: Changed assertion from `if r.passed` to `if !r.skipped` and updated the error message to reflect skip semantics.

## Test Plan

- [x] `go test ./cmd/soda/ -run TestCheckConfigValid_NoConfigFound` passes
- [x] Full test suite passes (`go test ./...`)
- [x] Assertion pattern is consistent with other skip-scenario tests in the file

## Acceptance Criteria

- [x] Test asserts `skipped` status, not `passed` status
- [x] Error message accurately describes the expected behavior
- [x] No regressions introduced

Closes #400