### PR TITLE
#371 feat(cli): preflight checks in soda run — fail fast

### DIFF
--- a/cmd/soda/preflight.go
+++ b/cmd/soda/preflight.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+// PreflightError is returned when one or more prerequisite checks fail
+// before the pipeline starts. It aggregates all failures into a single
+// error with actionable fix suggestions.
+type PreflightError struct {
+	Failures []checkResult
+}
+
+func (e *PreflightError) Error() string {
+	var b strings.Builder
+	b.WriteString("preflight check failed:\n")
+	for _, f := range e.Failures {
+		b.WriteString(fmt.Sprintf("  ✗ %s: %s\n", f.name, f.detail))
+		if f.fix != "" {
+			b.WriteString(fmt.Sprintf("    fix: %s\n", f.fix))
+		}
+	}
+	b.WriteString("\nRun 'soda doctor' for full diagnostics")
+	return b.String()
+}
+
+// runPreflight executes a targeted subset of the doctor checks that are
+// prerequisites for running a pipeline. It fails fast with actionable
+// errors before any expensive work (ticket fetching, worktree setup, etc.)
+// begins.
+//
+// When useMock is true, Claude CLI checks are skipped because the mock
+// runner doesn't invoke Claude.
+func runPreflight(env *doctorEnv, useMock bool) error {
+	checks := []func(*doctorEnv) checkResult{
+		checkGit,
+		checkGitRepo,
+	}
+
+	if !useMock {
+		checks = append(checks, checkClaude, checkClaudeVersion)
+	}
+
+	checks = append(checks, checkConfig, checkConfigValid)
+
+	var failures []checkResult
+	for _, check := range checks {
+		result := check(env)
+		if result.skipped {
+			continue
+		}
+		if !result.passed && result.required {
+			failures = append(failures, result)
+		}
+	}
+
+	if len(failures) > 0 {
+		return &PreflightError{Failures: failures}
+	}
+	return nil
+}

--- a/cmd/soda/preflight.go
+++ b/cmd/soda/preflight.go
@@ -42,7 +42,11 @@ func runPreflight(env *doctorEnv, useMock bool) error {
 		checks = append(checks, checkClaude, checkClaudeVersion)
 	}
 
-	checks = append(checks, checkConfig, checkConfigValid)
+	// Config checks (checkConfig, checkConfigValid) are intentionally
+	// omitted here. loadConfig already validated the configuration
+	// (respecting --config) before runPipeline was called, so
+	// re-checking from default paths would incorrectly reject valid
+	// --config overrides.
 
 	var failures []checkResult
 	for _, check := range checks {

--- a/cmd/soda/preflight_test.go
+++ b/cmd/soda/preflight_test.go
@@ -1,0 +1,309 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/decko/soda/internal/claude"
+	"github.com/decko/soda/internal/config"
+)
+
+func TestRunPreflight_AllPass(t *testing.T) {
+	env := allPassEnv()
+	err := runPreflight(env, false)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestRunPreflight_AllPass_MockMode(t *testing.T) {
+	// When mock mode is enabled, claude checks are skipped.
+	env := allPassEnv()
+	env.LookPath = func(file string) (string, error) {
+		if file == "claude" {
+			return "", errors.New("not found")
+		}
+		return "/usr/bin/" + file, nil
+	}
+	err := runPreflight(env, true)
+	if err != nil {
+		t.Fatalf("expected no error in mock mode even without claude, got: %v", err)
+	}
+}
+
+func TestRunPreflight_GitMissing(t *testing.T) {
+	env := allPassEnv()
+	env.LookPath = func(file string) (string, error) {
+		if file == "git" {
+			return "", errors.New("not found")
+		}
+		return "/usr/bin/" + file, nil
+	}
+	err := runPreflight(env, false)
+	if err == nil {
+		t.Fatal("expected error when git is missing")
+	}
+	var pe *PreflightError
+	if !errors.As(err, &pe) {
+		t.Fatalf("expected PreflightError, got: %T", err)
+	}
+	// git check should fail; git-repo should be skipped (so only 1 failure for git)
+	found := false
+	for _, f := range pe.Failures {
+		if f.name == "git" {
+			found = true
+		}
+		if f.name == "git-repo" {
+			t.Error("git-repo should be skipped when git is missing, not listed as failure")
+		}
+	}
+	if !found {
+		t.Error("expected git failure in PreflightError")
+	}
+}
+
+func TestRunPreflight_NotGitRepo(t *testing.T) {
+	env := allPassEnv()
+	env.RunCmd = func(name string, args ...string) (string, error) {
+		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
+			return "", errors.New("not a git repository")
+		}
+		if name == "claude" && len(args) > 0 && args[0] == "--version" {
+			return fmt.Sprintf("claude %s", claude.MinCLIVersion), nil
+		}
+		return "", nil
+	}
+	err := runPreflight(env, false)
+	if err == nil {
+		t.Fatal("expected error when not in a git repo")
+	}
+	var pe *PreflightError
+	if !errors.As(err, &pe) {
+		t.Fatalf("expected PreflightError, got: %T", err)
+	}
+	found := false
+	for _, f := range pe.Failures {
+		if f.name == "git-repo" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected git-repo failure in PreflightError")
+	}
+}
+
+func TestRunPreflight_ClaudeMissing(t *testing.T) {
+	env := allPassEnv()
+	env.LookPath = func(file string) (string, error) {
+		if file == "claude" {
+			return "", errors.New("not found")
+		}
+		return "/usr/bin/" + file, nil
+	}
+	err := runPreflight(env, false)
+	if err == nil {
+		t.Fatal("expected error when claude is missing")
+	}
+	var pe *PreflightError
+	if !errors.As(err, &pe) {
+		t.Fatalf("expected PreflightError, got: %T", err)
+	}
+	found := false
+	for _, f := range pe.Failures {
+		if f.name == "claude" {
+			found = true
+		}
+		// claude-version should be skipped, not a failure
+		if f.name == "claude-version" {
+			t.Error("claude-version should be skipped when claude is missing")
+		}
+	}
+	if !found {
+		t.Error("expected claude failure in PreflightError")
+	}
+}
+
+func TestRunPreflight_ClaudeMissing_MockMode(t *testing.T) {
+	env := allPassEnv()
+	env.LookPath = func(file string) (string, error) {
+		if file == "claude" {
+			return "", errors.New("not found")
+		}
+		return "/usr/bin/" + file, nil
+	}
+	// In mock mode, claude checks are entirely skipped.
+	err := runPreflight(env, true)
+	if err != nil {
+		t.Fatalf("expected no error in mock mode, got: %v", err)
+	}
+}
+
+func TestRunPreflight_ClaudeVersionTooOld(t *testing.T) {
+	env := allPassEnv()
+	env.RunCmd = func(name string, args ...string) (string, error) {
+		if name == "claude" && len(args) > 0 && args[0] == "--version" {
+			return "claude 1.0.0", nil
+		}
+		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
+			return ".git", nil
+		}
+		return "", nil
+	}
+	err := runPreflight(env, false)
+	if err == nil {
+		t.Fatal("expected error when claude version is too old")
+	}
+	var pe *PreflightError
+	if !errors.As(err, &pe) {
+		t.Fatalf("expected PreflightError, got: %T", err)
+	}
+	found := false
+	for _, f := range pe.Failures {
+		if f.name == "claude-version" {
+			found = true
+			if !strings.Contains(f.detail, "minimum required") {
+				t.Errorf("expected 'minimum required' in detail, got: %q", f.detail)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected claude-version failure in PreflightError")
+	}
+}
+
+func TestRunPreflight_NoConfig(t *testing.T) {
+	env := allPassEnv()
+	env.Stat = func(name string) (os.FileInfo, error) {
+		return nil, os.ErrNotExist
+	}
+	env.UserConfigDir = func() (string, error) {
+		return "/home/testuser/.config", nil
+	}
+	err := runPreflight(env, false)
+	if err == nil {
+		t.Fatal("expected error when config is missing")
+	}
+	var pe *PreflightError
+	if !errors.As(err, &pe) {
+		t.Fatalf("expected PreflightError, got: %T", err)
+	}
+	found := false
+	for _, f := range pe.Failures {
+		if f.name == "config" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected config failure in PreflightError")
+	}
+}
+
+func TestRunPreflight_InvalidConfig(t *testing.T) {
+	env := allPassEnv()
+	env.LoadConfig = func(path string) (*config.Config, error) {
+		return nil, errors.New("invalid YAML syntax")
+	}
+	err := runPreflight(env, false)
+	if err == nil {
+		t.Fatal("expected error when config is invalid")
+	}
+	var pe *PreflightError
+	if !errors.As(err, &pe) {
+		t.Fatalf("expected PreflightError, got: %T", err)
+	}
+	found := false
+	for _, f := range pe.Failures {
+		if f.name == "config-valid" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected config-valid failure in PreflightError")
+	}
+}
+
+func TestRunPreflight_MultipleFailures(t *testing.T) {
+	env := allPassEnv()
+	env.LookPath = func(file string) (string, error) {
+		return "", errors.New("not found")
+	}
+	env.Stat = func(name string) (os.FileInfo, error) {
+		return nil, os.ErrNotExist
+	}
+	err := runPreflight(env, false)
+	if err == nil {
+		t.Fatal("expected error with multiple failures")
+	}
+	var pe *PreflightError
+	if !errors.As(err, &pe) {
+		t.Fatalf("expected PreflightError, got: %T", err)
+	}
+	if len(pe.Failures) < 3 {
+		t.Errorf("expected at least 3 failures (git, claude, config), got %d", len(pe.Failures))
+	}
+}
+
+func TestPreflightError_ErrorMessage(t *testing.T) {
+	pe := &PreflightError{
+		Failures: []checkResult{
+			{name: "git", detail: "not found in PATH", fix: "install git"},
+			{name: "claude", detail: "not found in PATH", fix: "install Claude Code"},
+		},
+	}
+	msg := pe.Error()
+
+	if !strings.Contains(msg, "preflight check failed") {
+		t.Error("expected 'preflight check failed' header")
+	}
+	if !strings.Contains(msg, "✗ git: not found in PATH") {
+		t.Error("expected git failure in message")
+	}
+	if !strings.Contains(msg, "fix: install git") {
+		t.Error("expected git fix suggestion")
+	}
+	if !strings.Contains(msg, "✗ claude: not found in PATH") {
+		t.Error("expected claude failure in message")
+	}
+	if !strings.Contains(msg, "fix: install Claude Code") {
+		t.Error("expected claude fix suggestion")
+	}
+	if !strings.Contains(msg, "soda doctor") {
+		t.Error("expected 'soda doctor' suggestion")
+	}
+}
+
+func TestPreflightError_ErrorMessageNoFix(t *testing.T) {
+	pe := &PreflightError{
+		Failures: []checkResult{
+			{name: "test-check", detail: "something wrong", fix: ""},
+		},
+	}
+	msg := pe.Error()
+
+	if !strings.Contains(msg, "✗ test-check: something wrong") {
+		t.Error("expected failure line")
+	}
+	if strings.Contains(msg, "fix: \n") {
+		t.Error("should not show empty fix line")
+	}
+}
+
+func TestRunPreflight_OptionalFailuresIgnored(t *testing.T) {
+	// gh and node are optional — they should not cause preflight to fail.
+	// The current preflight does not include optional checks, so this
+	// verifies that optional checks from doctor are not accidentally included.
+	env := allPassEnv()
+	env.LookPath = func(file string) (string, error) {
+		if file == "gh" || file == "node" {
+			return "", errors.New("not found")
+		}
+		return "/usr/bin/" + file, nil
+	}
+	err := runPreflight(env, false)
+	if err != nil {
+		t.Fatalf("expected no error for optional-only failures, got: %v", err)
+	}
+}

--- a/cmd/soda/preflight_test.go
+++ b/cmd/soda/preflight_test.go
@@ -174,7 +174,11 @@ func TestRunPreflight_ClaudeVersionTooOld(t *testing.T) {
 	}
 }
 
-func TestRunPreflight_NoConfig(t *testing.T) {
+func TestRunPreflight_NoConfigDoesNotFail(t *testing.T) {
+	// Config checks are intentionally excluded from preflight because
+	// loadConfig already validates the config (respecting --config)
+	// before runPipeline is called. Missing config at default paths
+	// should not cause preflight to fail.
 	env := allPassEnv()
 	env.Stat = func(name string) (os.FileInfo, error) {
 		return nil, os.ErrNotExist
@@ -183,45 +187,21 @@ func TestRunPreflight_NoConfig(t *testing.T) {
 		return "/home/testuser/.config", nil
 	}
 	err := runPreflight(env, false)
-	if err == nil {
-		t.Fatal("expected error when config is missing")
-	}
-	var pe *PreflightError
-	if !errors.As(err, &pe) {
-		t.Fatalf("expected PreflightError, got: %T", err)
-	}
-	found := false
-	for _, f := range pe.Failures {
-		if f.name == "config" {
-			found = true
-		}
-	}
-	if !found {
-		t.Error("expected config failure in PreflightError")
+	if err != nil {
+		t.Fatalf("expected no error (config checks excluded from preflight), got: %v", err)
 	}
 }
 
-func TestRunPreflight_InvalidConfig(t *testing.T) {
+func TestRunPreflight_InvalidConfigDoesNotFail(t *testing.T) {
+	// Config validation is handled by loadConfig before runPipeline,
+	// so preflight should not re-check config validity.
 	env := allPassEnv()
 	env.LoadConfig = func(path string) (*config.Config, error) {
 		return nil, errors.New("invalid YAML syntax")
 	}
 	err := runPreflight(env, false)
-	if err == nil {
-		t.Fatal("expected error when config is invalid")
-	}
-	var pe *PreflightError
-	if !errors.As(err, &pe) {
-		t.Fatalf("expected PreflightError, got: %T", err)
-	}
-	found := false
-	for _, f := range pe.Failures {
-		if f.name == "config-valid" {
-			found = true
-		}
-	}
-	if !found {
-		t.Error("expected config-valid failure in PreflightError")
+	if err != nil {
+		t.Fatalf("expected no error (config checks excluded from preflight), got: %v", err)
 	}
 }
 
@@ -241,8 +221,9 @@ func TestRunPreflight_MultipleFailures(t *testing.T) {
 	if !errors.As(err, &pe) {
 		t.Fatalf("expected PreflightError, got: %T", err)
 	}
-	if len(pe.Failures) < 3 {
-		t.Errorf("expected at least 3 failures (git, claude, config), got %d", len(pe.Failures))
+	// Config checks are excluded from preflight; expect git + claude failures.
+	if len(pe.Failures) < 2 {
+		t.Errorf("expected at least 2 failures (git, claude), got %d", len(pe.Failures))
 	}
 }
 

--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -96,6 +96,12 @@ func newRunCmd() *cobra.Command {
 }
 
 func runPipeline(cfg *config.Config, opts pipelineOpts) error {
+	// Fail fast: run lightweight prerequisite checks before any expensive
+	// work (ticket fetching, worktree setup, runner creation, etc.).
+	if err := runPreflight(defaultDoctorEnv(), opts.useMock); err != nil {
+		return err
+	}
+
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 


### PR DESCRIPTION
## Summary

Add prerequisite checks to `soda run` that fail fast with actionable errors before any expensive pipeline work begins.

### Changes

**`cmd/soda/preflight.go`** — `runPreflight()` runs a targeted subset of `soda doctor` checks (git, git-repo, claude, claude-version) at the top of `runPipeline`, before signal setup, ticket fetching, worktree creation, or runner invocation. Failures are collected into a single `PreflightError` with per-check fix suggestions and a pointer to `soda doctor`.

Config checks (`checkConfig`, `checkConfigValid`) were **removed** from preflight because they only inspected default paths, ignoring `--config`. Since `loadConfig` already validates configuration (respecting `--config`) before `runPipeline` is called, the duplicate checks were both redundant and incorrect.

**`cmd/soda/preflight_test.go`** — 13 tests covering all scenarios: all-pass (normal and mock mode), missing git, not in a repo, missing Claude, old Claude version, multiple failures, optional-check filtering, mock mode skipping Claude checks, and error formatting.

### Files changed
- `cmd/soda/preflight.go` — Remove config checks, add explanatory comment
- `cmd/soda/preflight_test.go` — 3 tests updated for new behavior
- `cmd/soda/run.go` — `runPreflight()` call at top of `runPipeline`

### Test plan
- All 13 preflight tests pass
- Full test suite (15 packages) passes
- Manual: `soda run` without git → immediate actionable error
- Manual: `soda run --config /custom/path.yaml` → no false positive from preflight

### Acceptance criteria

- [x] Fails fast with clear, actionable message before expensive work
- [x] Error format matches `soda doctor` (same `checkResult` struct and check functions)
- [x] Checks run in <1 second with no LLM calls (only `exec.LookPath` + two local commands)
- [x] Non-applicable checks are skipped (Claude checks omitted in mock mode; dependent checks like git-repo skipped when git is missing)