### PR TITLE
[364] docs: update RUNBOOK, SKILL.md, and config.example.yaml

### DIFF
--- a/cmd/soda/embeds/claude-code/skills/soda-pipeline/RUNBOOK.md
+++ b/cmd/soda/embeds/claude-code/skills/soda-pipeline/RUNBOOK.md
@@ -61,6 +61,25 @@ All pipeline state lives under `.soda/<ticket>/`:
 
 > **Note:** `flock` is per-machine. The lock file does not protect against concurrent runs on different hosts.
 
+### Process crash — no failure event in events.jsonl
+
+**Symptom:** `soda run <ticket>` reports the pipeline as still running, but no process is alive. `events.jsonl` shows a `phase_started` with no matching `phase_completed` or `phase_failed`.
+
+**Cause:** SODA crashed or was killed between phase completion and event emission (e.g., OOM kill, SIGKILL, machine restart).
+
+**Diagnosis:**
+1. Check the lock file: `cat .soda/<ticket>/lock` — note the PID and timestamp
+2. Verify the PID is dead: `kill -0 <pid>` (non-zero exit = process not running)
+3. Find the incomplete phase:
+   ```bash
+   grep '"phase_started"\|"phase_completed"' .soda/<ticket>/events.jsonl
+   ```
+   The last `phase_started` without a matching `phase_completed` is the crashed phase.
+
+**Fix:**
+1. Remove the stale lock: `rm .soda/<ticket>/lock`
+2. Resume from the crashed phase: `soda run <ticket> --from <phase>`
+
 ### Phase failed — transient error (429, 500, timeout)
 
 **Symptom:** Phase fails with `claude: transient (rate_limit)`, `claude: transient (timeout)`, or `claude: transient (overloaded)`.
@@ -94,6 +113,25 @@ All pipeline state lives under `.soda/<ticket>/`:
 3. Fix the root cause (API key, account credits, model access)
 4. Resume: `soda run <ticket> --from <phase>`
 
+### Sandbox submit — gh auth hangs
+
+**Symptom:** Submit or follow-up phase hangs indefinitely inside the sandbox. No output after the `gh` call. The phase eventually times out.
+
+**Cause:** The `gh` CLI attempts OS keyring or browser authentication, which is inaccessible inside the arapuca sandbox. Fixed in #361: `claudeEnv()` now extracts `GH_TOKEN` from `gh auth token` on the host side and injects it before spawning the sandbox. Users with older binaries still need the workaround.
+
+**Fix (older binaries or if the automatic extraction fails):**
+1. Export the token manually before running soda:
+   ```bash
+   export GH_TOKEN=$(gh auth token)
+   soda run <ticket> --from submit
+   ```
+2. Or add it to your shell profile so it persists across sessions:
+   ```bash
+   echo 'export GH_TOKEN=$(gh auth token 2>/dev/null)' >> ~/.bashrc
+   ```
+
+> **Note:** Upgrade to the latest `soda` binary to get the automatic `GH_TOKEN` extraction.
+
 ### Budget exceeded
 
 **Symptom:** Pipeline stops with `pipeline: budget exceeded in phase <name>`.
@@ -112,6 +150,31 @@ All pipeline state lives under `.soda/<ticket>/`:
 
 > **Note:** `max_cost_per_phase` is cumulative across rework/patch generations, not just the current run.
 
+### Review phase — budget exceeded after rework cycles
+
+**Symptom:** Review phase fails with `pipeline: budget exceeded in phase review` after one or more rework cycles.
+
+**Cause:** `max_cost_per_phase` is cumulative across rework generations. Two review cycles ($3–5 each) plus the rework implement sessions they trigger can exhaust a conservative limit. See gotcha #11 in AGENTS.md.
+
+**Fix — choose one approach:**
+
+Option A — raise the cumulative cap for review-heavy workflows:
+```yaml
+limits:
+  max_cost_per_phase: 15.00
+```
+
+Option B — switch to a per-attempt cap so each generation is capped independently (allows more rework cycles):
+```yaml
+limits:
+  max_cost_per_phase: 0        # disable cumulative cap (or remove the line)
+  max_cost_per_generation: 8.00
+```
+
+> **Tradeoff:** `max_cost_per_phase` limits total spend per phase (safer for absolute budget control). `max_cost_per_generation` caps each attempt independently but allows unlimited rework cycles — total spend is unbounded if rework loops repeat.
+
+Resume: `soda run <ticket> --from review`
+
 ### Pipeline timeout
 
 **Symptom:** Pipeline stops with `pipeline: timeout after <elapsed> (limit <limit>) during phase <name>`.
@@ -122,6 +185,23 @@ All pipeline state lives under `.soda/<ticket>/`:
 1. Review phase durations: `soda history <ticket>`
 2. Increase `limits.max_pipeline_duration` in `soda.yaml` if the work legitimately needs more time
 3. Resume: `soda run <ticket> --from <phase>`
+
+### Implement phase — context deadline exceeded on large tickets
+
+**Symptom:** Implement phase fails with `context deadline exceeded` or times out part-way through. Ticket has 7 or more tasks.
+
+**Cause:** The embedded default implement timeout is 15m — too short for large tickets. The root `phases.yaml` (if present) overrides the embedded defaults without requiring a rebuild. See gotcha #25 in AGENTS.md.
+
+**Fix:**
+1. Create or edit `phases.yaml` in your project root:
+   ```yaml
+   phases:
+     implement:
+       timeout: 25m
+   ```
+2. Resume: `soda run <ticket> --from implement`
+
+> **Note:** The root `phases.yaml` takes precedence over the compiled-in defaults. Changes take effect immediately — no rebuild required.
 
 ### Triage gates ticket as not automatable
 
@@ -224,6 +304,25 @@ grep '"reviewer_failed"' .soda/<ticket>/events.jsonl
        respond_to_comments: true
    ```
 3. Re-run: `soda run <ticket> --from monitor`
+
+### GitHub Actions — all CI jobs fail in under 3 seconds
+
+**Symptom:** All CI jobs fail within 3 seconds of triggering. No test output, no compilation errors. The failure happens before any code runs.
+
+**Cause:** GitHub Actions runner allocation failure — the runner never started. This is a GitHub infrastructure issue, not a code problem.
+
+**How to distinguish from a real failure:**
+- Real test failures: jobs run for >10 seconds before failing
+- Runner allocation failures: jobs fail in <3 seconds with no meaningful output
+
+**Fix:**
+1. Re-run the workflow: `gh run rerun <run-id>`
+2. If the PR is already reviewed and approved and you need to unblock immediately:
+   ```bash
+   gh pr merge <pr-number> --admin --squash
+   ```
+
+> **Note:** Do not push new commits or restart the pipeline in response to a <3s CI failure — the code is fine. It will pass on the next attempt.
 
 ### Worktree issues — nested worktrees or stale branches
 

--- a/cmd/soda/embeds/claude-code/skills/soda-pipeline/SKILL.md
+++ b/cmd/soda/embeds/claude-code/skills/soda-pipeline/SKILL.md
@@ -85,9 +85,14 @@ Pipeline state lives in `.soda/<ticket>/`:
 
 After PR submission, the monitor polls for activity:
 
-- **Passive mode** (default): polls CI status, PR state (merged/closed/approved), detects new comments and notifies user. No self_user required.
-- **Active mode** (`respond_to_comments: true` + `self_user`): classifies comments, responds with Claude sessions (fix or reply), posts acknowledgments, auto-rebases.
+- **Passive mode** (default): polls CI status, PR state (merged/closed/approved), detects new comments and emits `monitor_notify_user` events — even without `self_user` or `respond_to_comments`. No special config required; this is always on.
+- **Active mode** (`respond_to_comments: true` + `self_user` in config): classifies comments by authority (CODEOWNERS), responds with Claude sessions (fix or reply), posts acknowledgments, auto-rebases.
 - **Profiles**: `conservative`, `smart`, `aggressive` control auto-rebase, nit handling, and response to non-authoritative comments.
+
+To check passive-mode comment detection:
+```bash
+grep '"monitor_new_comments"\|"monitor_notify_user"' .soda/<ticket>/events.jsonl
+```
 
 ## Named pipelines
 
@@ -97,11 +102,45 @@ Custom pipeline definitions in `./pipelines/` or `~/.config/soda/pipelines/`:
 - `soda pipelines` — list available pipelines
 - `soda pipelines new <name>` — scaffold a new pipeline definition
 
+## Plugin management
+
+The SODA plugin installs slash commands, skills, and agents into Claude Code's `.claude/` directory for auto-discovery.
+
+```bash
+soda plugin install [--global] [--force]    # Install to .claude/ (or ~/.claude/ with --global)
+soda plugin uninstall [--global]            # Remove SODA files
+soda plugin update [--global] [--dry-run]   # Selectively refresh changed files
+```
+
+`soda plugin update` performs a **diff-based refresh**: it compares each installed file against the version embedded in the current binary. Only changed files are overwritten; unchanged files are left untouched. New files are automatically added. Use `--dry-run` to preview what would change without writing.
+
+Run `soda plugin update` after upgrading the `soda` binary to pick up updated commands, skills, and agents without touching other `.claude/` files.
+
+## Sandbox environment requirements
+
+The arapuca sandbox isolates filesystem and network access but passes through specific environment variables from the host shell. These are required for submit, follow-up, and monitor phases:
+
+| Variable | Required for | Auto-extracted |
+|----------|--------------|----------------|
+| `GH_TOKEN` or `GITHUB_TOKEN` | `gh` CLI operations (submit, follow-up, monitor) | Yes — extracted from `gh auth token` if unset |
+| `SSH_AUTH_SOCK` | `git push` via SSH key | Yes — passed from parent shell |
+| `GIT_AUTHOR_NAME` / `GIT_AUTHOR_EMAIL` | Git commits | Yes — passed from parent shell |
+| `ANTHROPIC_API_KEY` | Claude Code API calls | Yes — passed from parent shell |
+
+**Automatic extraction:** If `GH_TOKEN` is not set in the environment, SODA calls `gh auth token` on the host side and injects the result before spawning the sandbox (fixed in #361). In most cases, no manual setup is needed.
+
+**If `gh` commands still fail inside the sandbox:**
+```bash
+export GH_TOKEN=$(gh auth token)
+```
+Add this to your shell profile (`~/.bashrc`, `~/.zshrc`) to make it permanent.
+
 ## Embedded content
 
 Embedded content lives in `cmd/soda/embeds/`:
 - `phases.yaml` — pipeline phase definitions (go:embed as `[]byte`)
 - `prompts/*.md` — phase prompt templates (go:embed as `embed.FS`)
+- `claude-code/` — commands, skills, agents (go:embed as `embed.FS`)
 
 Resolution order: user config dir > working dir > embedded defaults.
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -29,7 +29,7 @@ mode: autonomous   # or "checkpoint"
 # Model (used for all phases in v1)
 model: claude-opus-4-6
 
-# Sandbox (via agentic-orchestrator)
+# Sandbox (via go-arapuca)
 sandbox:
   enabled: true
   binary: agent-node
@@ -37,6 +37,15 @@ sandbox:
     memory_mb: 2048
     cpu_percent: 200
     max_pids: 256
+
+  # Environment passthrough: the sandbox automatically passes through these
+  # variables from the calling shell — no config needed:
+  #   GH_TOKEN / GITHUB_TOKEN  — for gh CLI (auto-extracted via `gh auth token` if unset)
+  #   SSH_AUTH_SOCK             — for git push via SSH key
+  #   GIT_AUTHOR_NAME / EMAIL, GIT_COMMITTER_NAME / EMAIL — for git commits
+  #   ANTHROPIC_API_KEY         — for Claude Code API calls
+  #
+  # If submit/follow-up phases hang on gh auth, run: export GH_TOKEN=$(gh auth token)
 
   # LLM proxy — route API calls through a host-side proxy for
   # credential isolation, token metering, and budget enforcement.
@@ -52,8 +61,16 @@ sandbox:
 # Budget and duration limits
 limits:
   max_cost_per_ticket: 30.00
+  # max_cost_per_phase: cumulative cap across ALL rework/patch generations of a phase.
+  # Two review cycles ($3-5 each) can exceed a $8 limit. Raise to $15 for review-heavy
+  # workflows, or disable (set to 0) and use max_cost_per_generation instead.
   max_cost_per_phase: 15.00
-  max_cost_per_generation: 8.00  # per-attempt cost cap (resets each generation); 0 or omitted means disabled
+  # max_cost_per_generation: per-attempt cap that resets on each rework cycle.
+  # Use this instead of (or alongside) max_cost_per_phase when you want to cap
+  # individual attempts without limiting total rework cycles.
+  # Tradeoff: max_cost_per_phase = hard ceiling on total phase spend;
+  #           max_cost_per_generation = ceiling per attempt (total spend is unbounded).
+  max_cost_per_generation: 8.00  # 0 or omitted means disabled
   max_pipeline_duration: "2h"    # max wall-clock time for the entire pipeline; empty or "0" means no limit
   max_api_concurrency: 2         # max concurrent API calls (e.g., parallel reviewers); 0 or omitted means unlimited
 
@@ -108,7 +125,10 @@ monitor:
   # - aggressive: 1min polls, 5 rounds, auto-fix nits, auto-rebase, respond to non-auth
   profile: smart
 
-  # PR author username (for self-comment filtering)
+  # PR author username — required for active comment response.
+  # Without self_user, monitor runs in passive mode: it polls CI status and
+  # PR state, detects new comments and notifies you, but does NOT respond
+  # automatically. Set self_user to enable active response mode.
   self_user: soda-bot
 
   # Known bot usernames to filter out
@@ -125,3 +145,12 @@ monitor:
 # Prompt overrides (optional)
 # Place custom prompts in ~/.config/soda/prompts/<phase>.md
 # They take precedence over built-in prompts.
+
+# Phase-level overrides (optional) — these merge with your root phases.yaml.
+# Example: enable active comment response in the monitor phase.
+# phases:
+#   monitor:
+#     polling:
+#       respond_to_comments: true   # enable active response (requires self_user above)
+#       max_response_rounds: 3      # max Claude sessions for comment responses
+#       max_duration: "4h"          # total monitor phase wall-clock limit


### PR DESCRIPTION
## Summary

Applies documentation improvements captured from the 2026-04-23 session learnings across three files.

### RUNBOOK.md — 5 new failure scenarios

| Scenario | Key details |
|----------|-------------|
| **Process crash — no failure event** | PID check + `phase_started`/`phase_completed` gap in events.jsonl |
| **Sandbox submit — gh auth hangs** | Keyring inaccessible in arapuca; `GH_TOKEN` env var workaround; refs #361 fix |
| **Review budget exhaustion** | Cumulative `max_cost_per_phase` vs per-attempt `max_cost_per_generation` tradeoffs |
| **Implement timeout on large tickets** | 25m override via root `phases.yaml`; refs gotcha #25 in AGENTS.md |
| **GitHub Actions infra failures** | <3s job duration = runner allocation failure; fix via `gh run rerun` or `--admin merge` |

### SKILL.md — 3 additions

- **Monitor phase** passive mode clarified: works without `self_user`/`respond_to_comments`; events grep pattern included
- **Plugin management**: `soda plugin update` diff-based refresh documented with `--dry-run` flag
- **Sandbox environment**: env var passthrough table with auto-extraction behaviour and shell profile workaround

### config.example.yaml — 4 additions

- Sandbox header corrected to `go-arapuca` + env passthrough comment block
- `self_user` comment expanded to explain passive vs active monitor mode
- `max_cost_per_phase` / `max_cost_per_generation` inline comments with tradeoff explanation
- Commented-out `phases:` override example for `respond_to_comments`, `max_response_rounds`, `max_duration`

## Test Plan

Documentation-only change — no code paths affected.

- [ ] Review RUNBOOK.md additions for accuracy and placement
- [ ] Review SKILL.md additions for clarity
- [ ] Review config.example.yaml additions for correctness

## Acceptance Criteria

- [ ] All 5 new RUNBOOK failure scenarios are present and well-placed
- [ ] SKILL.md monitor passive-mode section is accurate
- [ ] SKILL.md plugin update section matches CLI behaviour
- [ ] SKILL.md sandbox env section matches implementation
- [ ] config.example.yaml comments are consistent with code defaults