### PR TITLE
docs(366): full README rewrite for v0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ go install github.com/decko/soda/cmd/soda@latest
 
 | Platform | File |
 |----------|------|
-| Linux amd64 | `soda_linux_amd64.tar.gz` |
-| Linux arm64 | `soda_linux_arm64.tar.gz` |
-| macOS amd64 | `soda_darwin_amd64.tar.gz` |
-| macOS arm64 | `soda_darwin_arm64.tar.gz` |
+| Linux amd64 (with sandbox) | `soda-linux-amd64-sandbox` |
+| Linux arm64 | `soda-linux-arm64` |
+| macOS Intel | `soda-darwin-amd64` |
+| macOS Apple Silicon | `soda-darwin-arm64` |
 
 **Build from source**:
 
@@ -127,7 +127,7 @@ and [docs/configuration.md](docs/configuration.md) for the full guide.
 |----------|--------|----------|
 | `default` | Full 9-phase pipeline | New features, bug fixes |
 | `quick-fix` | implement → verify → submit | Small, well-understood fixes |
-| `docs-only` | implement → submit | Documentation changes |
+| `docs-only` | plan → implement → submit | Documentation changes (Sonnet) |
 
 ```bash
 soda run 42 --pipeline quick-fix

--- a/README.md
+++ b/README.md
@@ -1,59 +1,171 @@
 # SODA — Session-Orchestrated Development Agent
 
-A CLI/TUI that orchestrates AI coding sessions through a pipeline to implement tickets end-to-end.
+[![CI](https://github.com/decko/soda/actions/workflows/ci.yaml/badge.svg)](https://github.com/decko/soda/actions/workflows/ci.yaml) [![Go 1.25](https://img.shields.io/badge/go-1.25-blue.svg)](https://go.dev) [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
+
+Give it a ticket, get a PR. SODA is a Go CLI/TUI that orchestrates AI coding
+sessions through a structured pipeline to implement GitHub Issues end-to-end.
+Each pipeline phase runs in a fresh, sandboxed Claude Code session with
+structured output — no shared context, no prompt bleed. A typical run costs
+**$5–11 USD** in Claude API usage and produces a reviewed, tested pull request.
+
+## Pipeline
 
 ```
-Ticket → Triage → Plan → Implement → Verify → Submit → Monitor → Done
+Ticket → Triage → Plan → Implement → Verify → Review → Submit → Monitor → PR
 ```
 
-Each phase runs in a fresh, sandboxed Claude Code session with structured output.
-State lives on disk. Context resets between phases. The agent runs inside
-OS-level isolation (Landlock, network namespaces, cgroups).
+| Phase | What it does |
+|-------|-------------|
+| **Triage** | Classifies the ticket, identifies relevant files, routes the pipeline |
+| **Plan** | Designs the approach, breaks work into atomic tasks |
+| **Implement** | Writes code, runs tests, commits |
+| **Verify** | Runs tests, checks acceptance criteria, reviews code quality |
+| **Review** | Parallel specialist review (Go, AI harness, SRE) |
+| **Submit** | Pushes branch, opens pull request |
+| **Monitor** | Polls PR for comments and CI, responds and fixes |
 
-## Status
+Conditional phases: **Patch** runs when verify fails (targeted fixes);
+**Follow-up** runs when review passes with minor findings (creates follow-up tickets).
 
-Design phase. Not yet implemented.
+## Cost
 
-## Getting Started
+| Ticket type | Typical cost |
+|-------------|-------------|
+| Simple fix (1–3 tasks) | $2–6 |
+| Medium feature (4–8 tasks) | $8–15 |
+| Full 9-phase pipeline | $5–11 average |
 
-Generate a starter configuration file:
+Set `max_cost_per_ticket` in `soda.yaml` as a hard safety net. Per-phase
+and per-generation limits are also available.
+
+## Prerequisites
+
+| Prerequisite | Why | Install |
+|---|---|---|
+| Claude Code CLI | AI agent backend (paid subscription required) | [claude.ai/code](https://claude.ai/code) |
+| `gh` CLI | GitHub integration | [cli.github.com](https://cli.github.com) |
+| Git 2.9+ | Worktree support | [git-scm.com](https://git-scm.com) |
+| Go 1.25+ | For `go install` (or use a binary release) | [go.dev](https://go.dev) |
+
+## Installation
+
+**Via `go install`** (recommended):
 
 ```bash
-soda init                        # auto-detect project stack, write soda.yaml
-soda init --dry-run              # preview generated config without writing
-soda init --phases               # also write phases.yaml alongside the config
-soda init --no-gitignore         # skip adding .soda/.worktrees to .gitignore
-soda init --force                # overwrite existing config
-soda init -o ./my-config.yaml    # write to a custom path
+go install github.com/decko/soda/cmd/soda@latest
 ```
 
-The generated file auto-detects your project's language, forge, and
-tooling from the repository. Edit it to match your project before
-running the pipeline. See [config.example.yaml](config.example.yaml)
-for a fully annotated reference.
+**Binary release** — download a pre-built binary for your platform from
+[GitHub Releases](https://github.com/decko/soda/releases):
 
-## Architecture
+| Platform | File |
+|----------|------|
+| Linux amd64 | `soda_linux_amd64.tar.gz` |
+| Linux arm64 | `soda_linux_arm64.tar.gz` |
+| macOS amd64 | `soda_darwin_amd64.tar.gz` |
+| macOS arm64 | `soda_darwin_arm64.tar.gz` |
 
+**Build from source**:
+
+```bash
+CGO_ENABLED=0 go build -o soda ./cmd/soda
 ```
-soda (Go TUI + Pipeline Engine)
-  └── agentic-orchestrator sandbox
-       ├── Landlock filesystem isolation
-       ├── Network namespace isolation
-       ├── cgroup resource limits
-       └── claude --print --bare --output-format json --json-schema ...
+
+> **Note:** Sandbox features (Landlock, seccomp, cgroups) require
+> `CGO_ENABLED=1`. The binary works without them — sandbox is optional.
+
+## Quick Start
+
+```bash
+soda init                    # generate soda.yaml for this project
+soda doctor                  # verify prerequisites are installed
+soda run <issue-number>      # run the full pipeline for a GitHub issue
+soda status                  # check active and recent pipelines
+soda history <issue-number>  # inspect phase-by-phase results
 ```
 
-## Design Documents
+See [docs/quickstart.md](docs/quickstart.md) for a step-by-step walkthrough.
 
-- `phases.yaml` — Pipeline phase configuration (tools, timeouts, retries, dependencies)
-- `prompts/` — Phase prompt templates (Go templates)
-- `schemas/` — Structured output schemas per phase (Go structs → JSON Schema)
-- `config.example.yaml` — User configuration example
+## Configuration
 
-## Claude Code Integration
+SODA uses three config layers:
 
-SODA ships an embedded Claude Code plugin that gives Claude knowledge of SODA
-pipelines and quick access to soda commands.
+| Layer | File | Purpose |
+|-------|------|---------|
+| Project config | `soda.yaml` | Ticket source, model, budget limits, repo settings |
+| Pipeline config | `phases.yaml` | Add, remove, or reorder phases; set tools and timeouts |
+| Prompt overrides | `~/.config/soda/prompts/<phase>.md` | Customize phase prompts without forking |
+
+Run `soda init` to generate a `soda.yaml` auto-detected from your project.
+See [config.example.yaml](config.example.yaml) for a fully annotated reference
+and [docs/configuration.md](docs/configuration.md) for the full guide.
+
+## CLI Reference
+
+| Command | Purpose |
+|---------|---------|
+| `soda run <ticket>` | Run pipeline for a ticket |
+| `soda run <ticket> --pipeline docs-only` | Use a named pipeline |
+| `soda run <ticket> --from last` | Resume from last failed phase |
+| `soda run <ticket> --mode checkpoint` | Pause after each phase for confirmation |
+| `soda status` | Show active and recent pipelines |
+| `soda history <ticket>` | Show phase details for a ticket |
+| `soda log <ticket> -f` | Tail live pipeline events |
+| `soda attach <ticket>` | Stream live output of a running pipeline |
+| `soda clean <ticket>` | Remove worktree and branches |
+| `soda cost` | Show cost breakdown across all sessions |
+| `soda doctor` | Check prerequisites |
+| `soda validate` | Check config, phases, and prompts for errors |
+| `soda spec "description"` | Generate a ticket specification |
+| `soda pick` | Interactive ticket picker |
+| `soda pipelines` | List available named pipelines |
+| `soda init` | Generate `soda.yaml` config |
+
+## Named Pipelines
+
+| Pipeline | Phases | Use case |
+|----------|--------|----------|
+| `default` | Full 9-phase pipeline | New features, bug fixes |
+| `quick-fix` | implement → verify → submit | Small, well-understood fixes |
+| `docs-only` | implement → submit | Documentation changes |
+
+```bash
+soda run 42 --pipeline quick-fix
+soda run 42 --pipeline docs-only
+soda pipelines new my-pipeline   # create a custom pipeline
+```
+
+## How It Works
+
+SODA creates a Git worktree before any phase runs — all phases execute inside
+the worktree, never in the main checkout. For each phase, SODA renders a prompt
+template with handoff artifacts from upstream phases, spawns a Claude Code
+session with `--bare --json-schema` (structured output, no auto-discovery),
+streams output to the TUI, parses the JSON response, and writes the artifact
+to `.soda/<ticket>/`. Context resets between phases: each session starts fresh.
+A rework loop triggers when review flags critical or major findings (max 2
+cycles). A corrective loop triggers when verify fails (patch phase, then
+re-verify).
+
+## Sandbox
+
+When built with `CGO_ENABLED=1`, SODA uses
+[go-arapuca](https://github.com/sergio-correia/go-arapuca) for OS-level
+isolation around each Claude Code session:
+
+- **Landlock** — filesystem access restricted to the worktree
+- **seccomp** — syscall allowlist enforced at the kernel level
+- **cgroups** — memory, CPU, and PID limits
+
+Sandbox is **optional**. Builds with `CGO_ENABLED=0` run without isolation —
+useful for environments where CGO is unavailable. Configure via the `sandbox:`
+block in `soda.yaml`.
+
+## Claude Code Plugin
+
+SODA ships an embedded plugin that gives Claude Code knowledge of SODA
+pipelines and quick access to soda commands. The plugin is auto-discovered
+from the `.claude/` directory.
 
 ### Install
 
@@ -73,42 +185,20 @@ soda plugin uninstall --global   # remove global plugin
 
 | Component | Description |
 |-----------|-------------|
-| **Skill: `soda-pipeline`** | Teaches Claude about pipeline architecture, phase lifecycle, state management, and troubleshooting |
+| **Skill: `soda-pipeline`** | Pipeline architecture, phase lifecycle, state management, troubleshooting |
 | **`/soda:run <ticket>`** | Run the pipeline for a ticket |
 | **`/soda:status`** | Show current pipeline status |
 | **`/soda:sessions`** | List previous pipeline sessions |
-| **Agent: `pipeline-architect`** | Design-only agent that proposes a `phases.yaml` for the current project |
+| **Agent: `pipeline-architect`** | Design-only agent that proposes a `phases.yaml` |
 
-The plugin is auto-discovered by Claude Code from `.claude/plugins/`. Plugin
-files are embedded in the soda binary and version-matched — updates come with
-`go install`.
-
-## Key Design Decisions
-
-- **Go + bubbletea** for the CLI/TUI
-- **Claude Code CLI** as the inner agent (`--bare` mode for full context control)
-- **agentic-orchestrator** sandbox for OS-level isolation
-- **Structured output** via `--json-schema` (no regex parsing)
-- **Disk-based state** in `.soda/<ticket>/` (crash recovery, resume)
-- **Pluggable ticket sources** (Jira first, GitHub later)
-- **Config-driven phases** (add, remove, reorder via YAML)
-
-## Documentation
-
-Full documentation lives in [`docs/`](docs/README.md):
-
-- **[Quickstart](docs/quickstart.md)** — install, configure, run your first ticket
-- **[CLI reference](docs/cli-reference.md)** — all commands and flags
-- **[Configuration](docs/configuration.md)** — `soda.yaml` and `phases.yaml` reference
-- **[Pipelines](docs/pipelines.md)** — named pipelines and phase customization
-- **[Troubleshooting](docs/troubleshooting.md)** — common failure modes and fixes
-
-See [`docs/README.md`](docs/README.md) for the full documentation index.
+Plugin files are embedded in the soda binary and version-matched — updates
+arrive with `go install`.
 
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions, pre-commit
-hooks, and code style guidelines.
+hooks, and code style guidelines. All contributions must follow TDD: write
+failing tests before writing implementation code.
 
 ## License
 


### PR DESCRIPTION
## Summary

Closes #366

Replaces the 95-line placeholder README (which said "Design phase. Not yet implemented.") with a complete, user-facing landing page.

## Changes

- **Header + Badges** — CI, Go version, License badges
- **Elevator pitch** — "Give it a ticket, get a PR" with cost and output framing
- **Pipeline diagram** — ASCII flow + per-phase table with conditional phases explained
- **Cost** — `$2-6` simple, `$8-15` medium, `$5-11` average; `max_cost_per_ticket` mentioned
- **Prerequisites** — table with Claude Code CLI, `gh`, Git 2.9+, Go 1.25+, all with links
- **Installation** — `go install`, binary releases (platform table), build from source
- **Quick Start** — 5 commands (`init` → `doctor` → `run` → `status` → `history`)
- **Configuration** — three-layer table + links to `config.example.yaml`, `docs/configuration.md`
- **CLI Reference** — 16-row table covering all commands (`doctor`, `pick`, `attach` verified in source)
- **Named Pipelines** — `default`, `quick-fix`, `docs-only` with usage examples
- **How it works** — worktree-first, structured output, rework/corrective loops
- **Sandbox** — go-arapuca, Landlock/seccomp/cgroups, explicitly optional (CGO)
- **Claude Code Plugin** — auto-discovery via `.claude/`, install/uninstall, component table
- **Contributing** — link to CONTRIBUTING.md + TDD requirement
- **License** — Apache-2.0

## Deviations from Spec

- `soda doctor`, `soda pick`, `soda attach` weren't in AGENTS.md's CLI table but all three exist in `cmd/soda/` — included them as the spec listed them
- The `docs-only` pipeline is actually 2 phases (implement → submit), not 3 as the spec stated — README reflects reality

## Test Plan

- [ ] Render README.md on GitHub and verify all sections display correctly
- [ ] Verify all badge URLs are valid
- [ ] Verify all links in prerequisites and installation sections are correct
- [ ] Verify pipeline diagram renders correctly in GitHub Markdown

## Acceptance Criteria

- [ ] README no longer says "Design phase. Not yet implemented."
- [ ] All 15 sections from the spec are present
- [ ] No references to `agentic-orchestrator` (old name)
- [ ] No references to Jira as primary ticket source
- [ ] Cost estimates match spec ($2-6 simple, $8-15 medium, $5-11 average)
- [ ] CI, Go, and License badges present in header

---
Assisted-by: SODA
