### PR TITLE
fix(ci): release workflow resilience — fail-fast false, LFS auth, partial publish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
+      fail-fast: false
       matrix:
         include:
           - goos: linux
@@ -49,16 +50,24 @@ jobs:
 
       - name: Fetch go-arapuca LFS binary (cgo builds)
         if: matrix.cgo == '1'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           mod_dir="$(go env GOMODCACHE)/github.com/sergio-correia/go-arapuca@$(go list -m -f '{{.Version}}' github.com/sergio-correia/go-arapuca)"
           lib_path="${mod_dir}/lib/linux_amd64/libarapuca.a"
           if [ -f "$lib_path" ] && file "$lib_path" | grep -q "ASCII"; then
             oid=$(awk '/^oid sha256:/{print substr($2,8)}' "$lib_path")
             url="https://github.com/sergio-correia/go-arapuca.git/info/lfs/objects/batch"
-            download_url=$(curl -s -X POST "$url" \
+            response=$(curl -s -X POST "$url" \
               -H "Content-Type: application/vnd.git-lfs+json" \
-              -d "{\"operation\":\"download\",\"objects\":[{\"oid\":\"${oid}\",\"size\":1}]}" \
-              | python3 -c "import sys,json; print(json.load(sys.stdin)['objects'][0]['actions']['download']['href'])")
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -d "{\"operation\":\"download\",\"objects\":[{\"oid\":\"${oid}\",\"size\":1}]}")
+            download_url=$(echo "$response" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['objects'][0]['actions']['download']['href'])" 2>/dev/null) || {
+              echo "::warning::Failed to fetch LFS binary — sandbox build will be skipped"
+              echo "LFS API response: $response"
+              exit 1
+            }
             chmod u+w "$(dirname "$lib_path")"
             chmod u+w "$lib_path"
             curl -sL "$download_url" -o "$lib_path"
@@ -84,6 +93,7 @@ jobs:
   publish:
     name: Publish Release
     needs: release
+    if: always() && !cancelled()
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
Fixes the v0.1.0 release build failure. The sandbox build fails on LFS fetch (go-arapuca upstream issue) but that was cancelling all other builds too.

Changes:
- `fail-fast: false` — non-sandbox builds succeed independently
- Add `GH_TOKEN` auth to LFS batch API request
- `continue-on-error` on LFS fetch with warning annotation
- Publish job runs even if some matrix entries fail (`if: always()`)