### PR TITLE
fix(monitor): paginated GH comments silently dropped [#415]

### DIFF
--- a/internal/pipeline/github_poller.go
+++ b/internal/pipeline/github_poller.go
@@ -1,10 +1,12 @@
 package pipeline
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os/exec"
 	"sort"
 	"strings"
@@ -71,6 +73,24 @@ type ghComment struct {
 	Line int    `json:"line"`
 }
 
+// decodeGHComments decodes a newline-delimited JSON stream of ghComment
+// objects (as produced by gh --paginate --jq ".[]") into a slice.
+func decodeGHComments(data []byte) ([]ghComment, error) {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	var comments []ghComment
+	for {
+		var c ghComment
+		if err := dec.Decode(&c); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, err
+		}
+		comments = append(comments, c)
+	}
+	return comments, nil
+}
+
 // GetPRStatus returns the current status of a pull request.
 func (p *GitHubPRPoller) GetPRStatus(ctx context.Context, prURL string) (*PRStatus, error) {
 	owner, repo, number, err := parsePRRef(prURL)
@@ -112,20 +132,20 @@ func (p *GitHubPRPoller) GetNewComments(ctx context.Context, prURL string, after
 	}
 
 	// Get review comments (inline code review comments).
-	// --paginate may produce concatenated JSON arrays, so we use --jq 'flatten'
-	// to merge pages into a single flat array.
+	// --paginate with --jq ".[]" unwraps each page's array into individual
+	// JSON objects, producing a clean newline-delimited stream across pages.
 	// Sort by created ascending so newest comments are last (consistent with afterID filtering).
 	endpoint := fmt.Sprintf("repos/%s/%s/pulls/%s/comments?sort=created&direction=asc", owner, repo, number)
 	out, err := exec.CommandContext(ctx, p.command,
 		"api", endpoint,
-		"--paginate", "--jq", "flatten",
+		"--paginate", "--jq", ".[]",
 	).Output()
 	if err != nil {
 		return nil, fmt.Errorf("monitor: get comments: %w: %s", err, ghStderr(err))
 	}
 
-	var comments []ghComment
-	if err := json.Unmarshal(out, &comments); err != nil {
+	comments, err := decodeGHComments(out)
+	if err != nil {
 		return nil, fmt.Errorf("monitor: parse comments: %w", err)
 	}
 
@@ -134,14 +154,14 @@ func (p *GitHubPRPoller) GetNewComments(ctx context.Context, prURL string, after
 	issueEndpoint := fmt.Sprintf("repos/%s/%s/issues/%s/comments?sort=created&direction=asc", owner, repo, number)
 	issueOut, err := exec.CommandContext(ctx, p.command,
 		"api", issueEndpoint,
-		"--paginate", "--jq", "flatten",
+		"--paginate", "--jq", ".[]",
 	).Output()
 	if err != nil {
 		return nil, fmt.Errorf("monitor: get issue comments: %w: %s", err, ghStderr(err))
 	}
 
-	var issueComments []ghComment
-	if err := json.Unmarshal(issueOut, &issueComments); err != nil {
+	issueComments, err := decodeGHComments(issueOut)
+	if err != nil {
 		return nil, fmt.Errorf("monitor: parse issue comments: %w", err)
 	}
 

--- a/internal/pipeline/github_poller_test.go
+++ b/internal/pipeline/github_poller_test.go
@@ -2,7 +2,9 @@ package pipeline
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 )
@@ -146,6 +148,101 @@ func TestFilterCommentsAfterID_Empty(t *testing.T) {
 	result := filterCommentsAfterID(nil, "IC_1")
 	if result != nil {
 		t.Errorf("nil comments should return nil, got %v", result)
+	}
+}
+
+func TestDecodeGHComments(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    int // expected number of decoded comments
+		wantErr bool
+	}{
+		{
+			name: "single_page",
+			input: `{"id":1,"body":"first","user":{"login":"alice"}}
+{"id":2,"body":"second","user":{"login":"bob"}}
+{"id":3,"body":"third","user":{"login":"charlie"}}
+`,
+			want: 3,
+		},
+		{
+			name: "multi_page",
+			// Simulates gh --paginate --jq ".[]" output across two pages.
+			// Each page's array is unwrapped into individual objects, then
+			// concatenated. The old json.Unmarshal approach would fail here
+			// because the result is not a single JSON array.
+			input: `{"id":1,"body":"page1-a","user":{"login":"alice"}}
+{"id":2,"body":"page1-b","user":{"login":"bob"}}
+{"id":3,"body":"page2-a","user":{"login":"charlie"}}
+{"id":4,"body":"page2-b","user":{"login":"dave"}}
+`,
+			want: 4,
+		},
+		{
+			name:  "empty",
+			input: "",
+			want:  0,
+		},
+		{
+			name:  "single_comment",
+			input: `{"id":42,"body":"only one","user":{"login":"eve"}}`,
+			want:  1,
+		},
+		{
+			name:    "invalid_json",
+			input:   `{"id":1,"body":"ok"}\n{not json`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := decodeGHComments([]byte(tt.input))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != tt.want {
+				t.Fatalf("got %d comments, want %d", len(got), tt.want)
+			}
+		})
+	}
+}
+
+func TestDecodeGHComments_LargePageSimulation(t *testing.T) {
+	// Simulate 3+ pages of 25 comments each (typical GitHub page size is 30).
+	// This produces 75 newline-delimited JSON objects, which the old
+	// json.Unmarshal approach could not decode.
+	var buf strings.Builder
+	const total = 75
+	for i := 1; i <= total; i++ {
+		fmt.Fprintf(&buf, `{"id":%d,"body":"comment %d","user":{"login":"user%d"}}`, i, i, i%5)
+		buf.WriteByte('\n')
+	}
+
+	got, err := decodeGHComments([]byte(buf.String()))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != total {
+		t.Fatalf("got %d comments, want %d", len(got), total)
+	}
+
+	// Spot-check first and last.
+	if got[0].ID != 1 {
+		t.Errorf("first comment ID = %d, want 1", got[0].ID)
+	}
+	if got[total-1].ID != total {
+		t.Errorf("last comment ID = %d, want %d", got[total-1].ID, total)
+	}
+	if got[0].Body != "comment 1" {
+		t.Errorf("first comment Body = %q, want %q", got[0].Body, "comment 1")
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes a bug where `gh api --paginate --jq "flatten"` silently dropped comments beyond the first page of GitHub API results. This caused the monitor pipeline to miss review and issue comments when a PR had more than one page of results.

### Root Cause

`gh --paginate` emits newline-delimited JSON arrays (one per page), but `--jq "flatten"` only flattens within a single top-level array. After page 1, subsequent pages were concatenated as raw JSON, and `json.Unmarshal` silently failed on the multi-object stream.

### Changes

- **`internal/pipeline/github_poller.go`**: 
  - Replaced `--jq "flatten"` with `--jq ".[]"` for both review-comments and issue-comments API calls, so each comment is emitted as a separate JSON object
  - Added `decodeGHComments(data []byte) ([]ghComment, error)` helper that uses `json.NewDecoder` to correctly parse newline-delimited JSON objects (multi-page output)
  - Replaced both `json.Unmarshal` calls (for comments) with `decodeGHComments()`

- **`internal/pipeline/github_poller_test.go`**:
  - Added `TestDecodeGHComments` with 5 subtests: `single_page`, `multi_page` (regression), `empty`, `single_comment`, `invalid_json`
  - Added `TestDecodeGHComments_LargePageSimulation` with 75 objects simulating 3+ pages

### Test Plan

- [x] `go test ./internal/pipeline/...` — all tests pass
- [x] Multi-page regression subtest explicitly verifies the exact bug scenario
- [x] Large-page simulation confirms correct parsing at scale
- [x] Existing non-paginated `json.Unmarshal` calls (for `pr view`) left unchanged — verified correct

### Acceptance Criteria

- [x] Comments beyond the first API page are no longer silently dropped
- [x] `decodeGHComments` correctly handles single-page, multi-page, empty, and error cases
- [x] No regressions in existing tests