### PR TITLE
fix(engine): warn on LogEvent disk failure [#417]

### DIFF
--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"math"
+	"os"
 	"sync"
 	"time"
 
@@ -61,6 +63,7 @@ type EngineConfig struct {
 	MonitorProfile         *MonitorProfile   // behavioral profile; nil → use polling config as-is
 	SelfUser               string            // PR author username for self-comment filtering
 	BotUsers               []string          // known bot usernames to filter
+	Stderr                 io.Writer         // destination for warning messages; defaults to os.Stderr
 }
 
 // maxReworkCycles returns the configured max rework cycles, defaulting to DefaultMaxReworkCycles.
@@ -90,6 +93,7 @@ type Engine struct {
 	apiSem           *Semaphore // limits concurrent runner.Run calls; nil means unlimited
 	confirmCh        chan struct{}
 	reranPhases      map[string]bool // phases that ran (not skipped) in this execution
+	eventLogWarnOnce sync.Once       // ensures at most one LogEvent warning is printed
 	pauseMu          sync.Mutex
 	paused           bool
 	pauseCond        *sync.Cond
@@ -107,6 +111,9 @@ func NewEngine(r runner.Runner, state *State, cfg EngineConfig) *Engine {
 	}
 	if cfg.JitterFunc == nil {
 		cfg.JitterFunc = func(time.Duration) time.Duration { return 0 }
+	}
+	if cfg.Stderr == nil {
+		cfg.Stderr = os.Stderr
 	}
 
 	e := &Engine{
@@ -1066,8 +1073,14 @@ func (e *Engine) makeOnChunk(ctx context.Context, phase string) func(string) {
 
 // emit logs an event to state and calls the OnEvent callback if set.
 // Also broadcasts to any attached clients via the Unix socket.
+// If LogEvent fails (e.g., disk full), a warning is printed to stderr
+// once to avoid flooding logs; subsequent failures are silently ignored.
 func (e *Engine) emit(event Event) {
-	_ = e.state.LogEvent(event)
+	if err := e.state.LogEvent(event); err != nil {
+		e.eventLogWarnOnce.Do(func() {
+			fmt.Fprintf(e.config.Stderr, "engine: warning: failed to write event log: %v\n", err)
+		})
+	}
 	if e.config.OnEvent != nil {
 		e.config.OnEvent(event)
 	}

--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/json"
@@ -5659,5 +5660,65 @@ func TestEngine_RecoverCrashedPhase_PhaseStatusMarkedFailed(t *testing.T) {
 	}
 	if failedIdx >= startedIdx {
 		t.Errorf("crash-recovery phase_failed (idx=%d) should appear before phase_started (idx=%d)", failedIdx, startedIdx)
+	}
+}
+
+func TestEngine_EmitLogsWarningOnEventLogFailure(t *testing.T) {
+	phases := []PhaseConfig{
+		{
+			Name:   "triage",
+			Prompt: "triage.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"triage": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"automatable":true}`),
+					RawText: "Triage: automatable",
+					CostUSD: 0.05,
+				},
+			}},
+		},
+	}
+
+	var stderr bytes.Buffer
+	engine, state := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.Stderr = &stderr
+	})
+
+	// Replace events.jsonl with a directory so every LogEvent call fails
+	// with "is a directory" (or equivalent OS error).
+	eventsPath := filepath.Join(state.Dir(), "events.jsonl")
+	os.Remove(eventsPath) // remove if pre-existing
+	if err := os.Mkdir(eventsPath, 0755); err != nil {
+		t.Fatalf("mkdir events.jsonl: %v", err)
+	}
+
+	// Run should still succeed — LogEvent errors are non-fatal.
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run should succeed despite event log failure: %v", err)
+	}
+
+	// Verify exactly one warning line was printed to stderr.
+	output := stderr.String()
+	if output == "" {
+		t.Fatal("expected a warning on stderr, got nothing")
+	}
+
+	lines := strings.Split(strings.TrimRight(output, "\n"), "\n")
+	if len(lines) != 1 {
+		t.Errorf("expected exactly 1 warning line, got %d:\n%s", len(lines), output)
+	}
+
+	if !strings.Contains(output, "engine: warning: failed to write event log") {
+		t.Errorf("warning message doesn't match expected prefix, got: %s", output)
+	}
+
+	// The pipeline should still complete successfully.
+	if !state.IsCompleted("triage") {
+		t.Error("triage should be completed")
 	}
 }


### PR DESCRIPTION
## Summary

Fixes **#417** — `LogEvent` errors were silently discarded (`_ = e.state.LogEvent(event)`), causing event logs to go empty on disk failure with no indication to the operator.

### Changes

- **`engine.go`**: Replace silent error discard with `sync.Once`-guarded warning printed to `Stderr` on the first `LogEvent` failure. Subsequent failures are suppressed to avoid log spam.
- **`engine.go`**: Add `Stderr io.Writer` field to `EngineConfig` (defaults to `os.Stderr`), following the existing injectable-dependency pattern (`SleepFunc`, `JitterFunc`, `NowFunc`).
- **`engine.go`**: Add `eventLogWarnOnce sync.Once` field to `Engine` struct.
- **`engine_test.go`**: Add `TestEngine_EmitLogsWarningOnEventLogFailure` — forces `LogEvent` failures by replacing `events.jsonl` with a directory, and asserts behaviour.

### Test Plan

- `go test -race ./internal/pipeline/...` — all tests pass, including the new one.
- New test verifies:
  1. Pipeline still succeeds (error is non-fatal)
  2. Exactly **one** warning line is printed to stderr
  3. Warning message contains the expected text
  4. Phase completes successfully despite `LogEvent` failures

### Acceptance Criteria

- [x] First `LogEvent` error prints a warning to stderr
- [x] Subsequent `LogEvent` errors are silently suppressed (no spam)
- [x] Pipeline execution is not interrupted by `LogEvent` failures
- [x] `Stderr` is injectable for testing
- [x] Test covers all criteria above
- [x] Full test suite passes with `-race`