### PR TITLE
fix: commit 3-phase docs-only pipeline to main (#426)

### DIFF
--- a/cmd/soda/embeds/pipelines/docs-only.yaml
+++ b/cmd/soda/embeds/pipelines/docs-only.yaml
@@ -1,9 +1,26 @@
 # SODA Docs-Only Pipeline
 #
-# A minimal pipeline for documentation-only changes that skip triage,
-# planning, and verification. Two phases: implement → submit.
+# A lightweight pipeline for documentation-only changes that skip triage
+# and verification. Three phases: plan → implement → submit.
 
 phases:
+  - name: plan
+    prompt: prompts/docs-plan.md
+    schema: |
+      {"type":"object","properties":{"ticket_key":{"type":"string"},"approach":{"type":"string"},"tasks":{"type":"array","items":{"type":"object","properties":{"id":{"type":"string"},"description":{"type":"string"},"files":{"type":"array","items":{"type":"string"}},"done_when":{"type":"string"},"depends_on":{"type":"array","items":{"type":"string"}}},"required":["id","description","files","done_when"]}},"verification":{"type":"object","properties":{"commands":{"type":"array","items":{"type":"string"}},"manual_steps":{"type":"array","items":{"type":"string"}}},"required":["commands"]},"deviations":{"type":"array","items":{"type":"string"}}},"required":["ticket_key","approach","tasks","verification"]}
+    tools:
+      - Read
+      - Glob
+      - Grep
+      - Bash(git:*)
+      - Bash(ls:*)
+    timeout: 5m
+    retry:
+      transient: 2
+      parse: 1
+      semantic: 1
+    depends_on: []
+
   - name: implement
     prompt: prompts/docs-implement.md
     schema: |
@@ -20,7 +37,8 @@ phases:
       transient: 2
       parse: 1
       semantic: 0
-    depends_on: []
+    depends_on:
+      - plan
 
   - name: submit
     prompt: prompts/submit.md

--- a/cmd/soda/embeds/prompts/docs-plan.md
+++ b/cmd/soda/embeds/prompts/docs-plan.md
@@ -1,0 +1,51 @@
+You are a technical writer planning documentation changes for a project.
+
+## Ticket
+
+Key: {{.Ticket.Key}}
+Summary: {{.Ticket.Summary}}
+
+### Description
+{{.Ticket.Description}}
+
+{{- if .Ticket.AcceptanceCriteria}}
+
+### Acceptance Criteria
+{{range .Ticket.AcceptanceCriteria}}- {{.}}
+{{end}}
+{{- end}}
+
+{{- if .Ticket.ExistingSpec}}
+
+## Existing Spec
+{{.Ticket.ExistingSpec}}
+{{- end}}
+
+{{- if .Context.ProjectContext}}
+
+## Project Context
+{{.Context.ProjectContext}}
+{{- end}}
+
+{{- if .Context.RepoConventions}}
+
+## Repo Conventions
+{{.Context.RepoConventions}}
+{{- end}}
+
+## Your Task
+
+Read the existing documentation and plan the changes needed. This is a docs-only pipeline — only documentation files should be changed.
+
+1. **Understand the current state** — read the existing docs, understand formatting, tone, and structure.
+2. **Identify all files to change** — which docs need creating, updating, or removing?
+3. **Break into atomic tasks** — each task should be independently verifiable.
+4. **For each task, specify**:
+   - What to do (clear, unambiguous description)
+   - Which files to create or modify
+   - What the done state looks like (verifiable condition)
+   - Dependencies on other tasks (if any)
+5. **Define verification strategy** — how to confirm the docs are correct (e.g., link checks, rendering).
+6. **Flag deviations** — if the plan differs from the ticket description, explain why.
+
+Do NOT plan changes to source code, tests, or configuration files.


### PR DESCRIPTION
## Summary

Add the missing `plan` phase to the docs-only pipeline and its corresponding `docs-plan.md` prompt template. PR #411 updated test expectations to require 3 phases (plan → implement → submit), but the embedded pipeline and prompt files were never committed to `main`, causing CI failures on every subsequent PR branch.

## Changes

- **`cmd/soda/embeds/pipelines/docs-only.yaml`** — upgraded from 2-phase (implement → submit) to 3-phase (plan → implement → submit) with read-only tools, appropriate timeout, and valid JSON schema for the plan phase.
- **`cmd/soda/embeds/prompts/docs-plan.md`** — new Go template prompt for the plan phase, scoped to docs-only changes, following existing prompt conventions.

## Test Plan

- All 13 test packages pass (uncached run), including the two that were failing:
  - `TestResolvePhasesPath_EmbeddedDocsOnly`
  - `TestRunValidate_DocsOnlyPipeline`
- `go build` and `go vet` clean
- YAML valid, embedded JSON schemas parse correctly

## Acceptance Criteria

- [x] `docs-only.yaml` has 3 phases: `plan[]` → `implement[plan]` → `submit[implement]`
- [x] `docs-plan.md` exists and uses correct Go template syntax
- [x] Phase dependency chain is correct
- [x] All tests pass
- [x] Minimal, focused change — exactly 2 files, no unrelated modifications

Unblocks: #422, #423, #424, #425