### PR TITLE
fix(doctor): deduplicate config resolution, add fallback [#398]

### DIFF
--- a/cmd/soda/doctor.go
+++ b/cmd/soda/doctor.go
@@ -398,9 +398,13 @@ func resolveConfigPath(env *doctorEnv) *configLocation {
 		if _, statErr := env.Stat(path); statErr == nil {
 			return &configLocation{path: path, label: "global"}
 		}
+		// UserConfigDir succeeded but file not found — do NOT fall through
+		// to UserHomeDir. This matches config.DefaultPath() which only uses
+		// UserHomeDir when UserConfigDir() itself returns an error.
+		return nil
 	}
 
-	// 3. Fallback: UserHomeDir + ".config".
+	// 3. Fallback: UserHomeDir + ".config" — only reached when UserConfigDir fails.
 	if env.UserHomeDir != nil {
 		home, homeErr := env.UserHomeDir()
 		if homeErr == nil {

--- a/cmd/soda/doctor.go
+++ b/cmd/soda/doctor.go
@@ -32,6 +32,7 @@ type doctorEnv struct {
 	Stat          func(name string) (os.FileInfo, error)
 	LoadConfig    func(path string) (*config.Config, error)
 	UserConfigDir func() (string, error)
+	UserHomeDir   func() (string, error)
 
 	// ParsedConfig is populated by checkConfigValid on success.
 	// Downstream checks use it to adjust their required status.
@@ -56,6 +57,7 @@ func defaultDoctorEnv() *doctorEnv {
 		Stat:          os.Stat,
 		LoadConfig:    config.Load,
 		UserConfigDir: os.UserConfigDir,
+		UserHomeDir:   os.UserHomeDir,
 	}
 }
 

--- a/cmd/soda/doctor.go
+++ b/cmd/soda/doctor.go
@@ -371,31 +371,59 @@ func checkNode(env *doctorEnv) checkResult {
 	}
 }
 
-// checkConfig verifies that at least one config file exists.
-// SODA's loadConfig uses a fallback chain: soda.yaml in CWD → ~/.config/soda/config.yaml.
-// Either one is sufficient.
-func checkConfig(env *doctorEnv) checkResult {
-	// Check local config first.
+// configLocation holds the resolved path and label for a config file.
+type configLocation struct {
+	path  string // absolute or relative path to the config file
+	label string // human-readable label: "local" or "global"
+}
+
+// resolveConfigPath finds the best available config file using the same
+// fallback chain as loadConfig and config.DefaultPath:
+//
+//  1. soda.yaml in CWD (project-local)
+//  2. UserConfigDir()/soda/config.yaml
+//  3. UserHomeDir()/.config/soda/config.yaml (fallback when UserConfigDir fails)
+//
+// Returns nil when no config file is found.
+func resolveConfigPath(env *doctorEnv) *configLocation {
+	// 1. Local config.
 	if _, err := env.Stat("soda.yaml"); err == nil {
-		return checkResult{
-			name:     "config",
-			passed:   true,
-			required: true,
-			detail:   "soda.yaml (local)",
-		}
+		return &configLocation{path: "soda.yaml", label: "local"}
 	}
 
-	// Check global config.
+	// 2. Global config via UserConfigDir.
 	configDir, err := env.UserConfigDir()
 	if err == nil {
 		path := filepath.Join(configDir, "soda", "config.yaml")
 		if _, statErr := env.Stat(path); statErr == nil {
-			return checkResult{
-				name:     "config",
-				passed:   true,
-				required: true,
-				detail:   path + " (global)",
+			return &configLocation{path: path, label: "global"}
+		}
+	}
+
+	// 3. Fallback: UserHomeDir + ".config".
+	if env.UserHomeDir != nil {
+		home, homeErr := env.UserHomeDir()
+		if homeErr == nil {
+			path := filepath.Join(home, ".config", "soda", "config.yaml")
+			if _, statErr := env.Stat(path); statErr == nil {
+				return &configLocation{path: path, label: "global"}
 			}
+		}
+	}
+
+	return nil
+}
+
+// checkConfig verifies that at least one config file exists.
+// Uses the shared resolveConfigPath fallback chain.
+func checkConfig(env *doctorEnv) checkResult {
+	loc := resolveConfigPath(env)
+	if loc != nil {
+		return checkResult{
+			name:     "config",
+			passed:   true,
+			required: true,
+			detail:   fmt.Sprintf("%s (%s)", loc.path, loc.label),
 		}
 	}
 
@@ -409,55 +437,26 @@ func checkConfig(env *doctorEnv) checkResult {
 }
 
 // checkConfigValid attempts to parse the best available config file
-// (local soda.yaml first, then global config.yaml) and reports whether
-// it is valid. Skipped if no config file was found by checkConfig.
+// and reports whether it is valid. Skipped if no config file was
+// found by resolveConfigPath.
 func checkConfigValid(env *doctorEnv) checkResult {
-	// Try local config first.
-	if _, statErr := env.Stat("soda.yaml"); statErr == nil {
-		cfg, err := env.LoadConfig("soda.yaml")
-		if err != nil {
-			return checkResult{
-				name:     "config-valid",
-				passed:   false,
-				required: true,
-				detail:   fmt.Sprintf("soda.yaml: %v", err),
-				fix:      "fix syntax errors in soda.yaml",
-			}
-		}
-		env.ParsedConfig = cfg
+	loc := resolveConfigPath(env)
+	if loc == nil {
 		return checkResult{
-			name:     "config-valid",
-			passed:   true,
-			required: true,
-			detail:   "soda.yaml parses successfully",
+			name:    "config-valid",
+			skipped: true,
+			detail:  "skipped (no config file found)",
 		}
 	}
 
-	// Fall back to global config.
-	configDir, err := env.UserConfigDir()
-	if err != nil {
-		return checkResult{
-			name:    "config-valid",
-			skipped: true,
-			detail:  "skipped (no config file found)",
-		}
-	}
-	path := filepath.Join(configDir, "soda", "config.yaml")
-	if _, statErr := env.Stat(path); statErr != nil {
-		return checkResult{
-			name:    "config-valid",
-			skipped: true,
-			detail:  "skipped (no config file found)",
-		}
-	}
-	cfg, err := env.LoadConfig(path)
+	cfg, err := env.LoadConfig(loc.path)
 	if err != nil {
 		return checkResult{
 			name:     "config-valid",
 			passed:   false,
 			required: true,
-			detail:   fmt.Sprintf("%s: %v", path, err),
-			fix:      "fix syntax errors in config file",
+			detail:   fmt.Sprintf("%s: %v", loc.path, err),
+			fix:      "fix syntax errors in " + loc.path,
 		}
 	}
 	env.ParsedConfig = cfg
@@ -465,6 +464,6 @@ func checkConfigValid(env *doctorEnv) checkResult {
 		name:     "config-valid",
 		passed:   true,
 		required: true,
-		detail:   fmt.Sprintf("%s parses successfully", path),
+		detail:   fmt.Sprintf("%s parses successfully", loc.path),
 	}
 }

--- a/cmd/soda/doctor_test.go
+++ b/cmd/soda/doctor_test.go
@@ -434,9 +434,36 @@ func TestCheckConfig_NoConfigDir(t *testing.T) {
 	env.UserConfigDir = func() (string, error) {
 		return "", errors.New("no config dir")
 	}
+	env.UserHomeDir = func() (string, error) {
+		return "", errors.New("no home dir")
+	}
 	r := checkConfig(env)
 	if r.passed {
-		t.Error("expected config check to fail when no local config and no config dir")
+		t.Error("expected config check to fail when no local config and no config/home dir")
+	}
+}
+
+func TestCheckConfig_UserHomeDirFallback(t *testing.T) {
+	env := allPassEnv()
+	env.Stat = func(name string) (os.FileInfo, error) {
+		// Only the UserHomeDir-based path exists.
+		if name == "/home/testuser/.config/soda/config.yaml" {
+			return mockFileInfo{name: name}, nil
+		}
+		return nil, os.ErrNotExist
+	}
+	env.UserConfigDir = func() (string, error) {
+		return "", errors.New("no config dir")
+	}
+	r := checkConfig(env)
+	if !r.passed {
+		t.Error("expected config check to pass via UserHomeDir fallback")
+	}
+	if !strings.Contains(r.detail, "global") {
+		t.Errorf("expected detail to mention global, got: %q", r.detail)
+	}
+	if !strings.Contains(r.detail, "/home/testuser/.config/soda/config.yaml") {
+		t.Errorf("expected detail to include fallback path, got: %q", r.detail)
 	}
 }
 
@@ -748,6 +775,126 @@ func TestRunDoctor_GhOptionalWhenJiraSource(t *testing.T) {
 	out := buf.String()
 	if !strings.Contains(out, "⚠ gh:") {
 		t.Errorf("expected ⚠ marker for gh, got:\n%s", out)
+	}
+}
+
+func TestCheckConfigValid_UserHomeDirFallback(t *testing.T) {
+	env := allPassEnv()
+	homePath := "/home/testuser/.config/soda/config.yaml"
+	env.Stat = func(name string) (os.FileInfo, error) {
+		if name == homePath {
+			return mockFileInfo{name: name}, nil
+		}
+		return nil, os.ErrNotExist
+	}
+	env.UserConfigDir = func() (string, error) {
+		return "", errors.New("no config dir")
+	}
+	r := checkConfigValid(env)
+	if !r.passed {
+		t.Error("expected config-valid check to pass via UserHomeDir fallback")
+	}
+	if !strings.Contains(r.detail, homePath) {
+		t.Errorf("expected detail to mention fallback path, got: %q", r.detail)
+	}
+}
+
+// --- resolveConfigPath tests ---
+
+func TestResolveConfigPath_Local(t *testing.T) {
+	env := allPassEnv()
+	loc := resolveConfigPath(env)
+	if loc == nil {
+		t.Fatal("expected non-nil location")
+	}
+	if loc.path != "soda.yaml" {
+		t.Errorf("expected path 'soda.yaml', got %q", loc.path)
+	}
+	if loc.label != "local" {
+		t.Errorf("expected label 'local', got %q", loc.label)
+	}
+}
+
+func TestResolveConfigPath_GlobalViaUserConfigDir(t *testing.T) {
+	env := allPassEnv()
+	env.Stat = func(name string) (os.FileInfo, error) {
+		if name == "soda.yaml" {
+			return nil, os.ErrNotExist
+		}
+		return mockFileInfo{name: name}, nil
+	}
+	loc := resolveConfigPath(env)
+	if loc == nil {
+		t.Fatal("expected non-nil location")
+	}
+	if loc.label != "global" {
+		t.Errorf("expected label 'global', got %q", loc.label)
+	}
+	if !strings.Contains(loc.path, ".config/soda/config.yaml") {
+		t.Errorf("expected global config path, got %q", loc.path)
+	}
+}
+
+func TestResolveConfigPath_GlobalViaUserHomeDir(t *testing.T) {
+	env := allPassEnv()
+	homePath := "/home/testuser/.config/soda/config.yaml"
+	env.Stat = func(name string) (os.FileInfo, error) {
+		if name == homePath {
+			return mockFileInfo{name: name}, nil
+		}
+		return nil, os.ErrNotExist
+	}
+	env.UserConfigDir = func() (string, error) {
+		return "", errors.New("no config dir")
+	}
+	loc := resolveConfigPath(env)
+	if loc == nil {
+		t.Fatal("expected non-nil location via UserHomeDir fallback")
+	}
+	if loc.path != homePath {
+		t.Errorf("expected path %q, got %q", homePath, loc.path)
+	}
+	if loc.label != "global" {
+		t.Errorf("expected label 'global', got %q", loc.label)
+	}
+}
+
+func TestResolveConfigPath_NoneFound(t *testing.T) {
+	env := allPassEnv()
+	env.Stat = func(name string) (os.FileInfo, error) {
+		return nil, os.ErrNotExist
+	}
+	env.UserConfigDir = func() (string, error) {
+		return "", errors.New("no config dir")
+	}
+	env.UserHomeDir = func() (string, error) {
+		return "", errors.New("no home dir")
+	}
+	loc := resolveConfigPath(env)
+	if loc != nil {
+		t.Errorf("expected nil location, got %+v", loc)
+	}
+}
+
+func TestResolveConfigPath_UserHomeDirNotCalled_WhenUserConfigDirSucceeds(t *testing.T) {
+	env := allPassEnv()
+	env.Stat = func(name string) (os.FileInfo, error) {
+		if name == "soda.yaml" {
+			return nil, os.ErrNotExist
+		}
+		return mockFileInfo{name: name}, nil
+	}
+	homeDirCalled := false
+	env.UserHomeDir = func() (string, error) {
+		homeDirCalled = true
+		return "/home/testuser", nil
+	}
+	loc := resolveConfigPath(env)
+	if loc == nil {
+		t.Fatal("expected non-nil location")
+	}
+	if homeDirCalled {
+		t.Error("UserHomeDir should not be called when UserConfigDir succeeds")
 	}
 }
 

--- a/cmd/soda/doctor_test.go
+++ b/cmd/soda/doctor_test.go
@@ -50,6 +50,9 @@ func allPassEnv() *doctorEnv {
 		UserConfigDir: func() (string, error) {
 			return "/home/testuser/.config", nil
 		},
+		UserHomeDir: func() (string, error) {
+			return "/home/testuser", nil
+		},
 	}
 }
 

--- a/cmd/soda/doctor_test.go
+++ b/cmd/soda/doctor_test.go
@@ -898,6 +898,36 @@ func TestResolveConfigPath_UserHomeDirNotCalled_WhenUserConfigDirSucceeds(t *tes
 	}
 }
 
+// TestResolveConfigPath_NoFalsePositive_WhenUserConfigDirSucceeds verifies
+// that on platforms where UserConfigDir differs from ~/.config (e.g. macOS
+// returns ~/Library/Application Support), doctor does NOT fall through to
+// the UserHomeDir ~/.config path. This would be a false positive: doctor
+// says "config OK" but runtime config.DefaultPath() would look only at
+// the UserConfigDir path and fail to find it.
+func TestResolveConfigPath_NoFalsePositive_WhenUserConfigDirSucceeds(t *testing.T) {
+	env := allPassEnv()
+	// Simulate macOS: UserConfigDir returns ~/Library/Application Support
+	env.UserConfigDir = func() (string, error) {
+		return "/Users/testuser/Library/Application Support", nil
+	}
+	env.UserHomeDir = func() (string, error) {
+		return "/Users/testuser", nil
+	}
+	env.Stat = func(name string) (os.FileInfo, error) {
+		// Config exists at ~/.config/soda/config.yaml but NOT at
+		// ~/Library/Application Support/soda/config.yaml
+		if name == "/Users/testuser/.config/soda/config.yaml" {
+			return mockFileInfo{name: name}, nil
+		}
+		return nil, os.ErrNotExist
+	}
+	loc := resolveConfigPath(env)
+	// Must return nil — the file at ~/.config is not where runtime would look.
+	if loc != nil {
+		t.Errorf("expected nil (no false positive), got %+v", loc)
+	}
+}
+
 // --- extractSemver tests ---
 
 func TestExtractSemver(t *testing.T) {


### PR DESCRIPTION
## Summary

Fix false-positive config detection in `soda doctor` when `UserConfigDir()` succeeds but the config file does not exist at that path.

### Problem

`resolveConfigPath` had a fallback chain that diverged from `config.DefaultPath()` on macOS. When `UserConfigDir()` succeeded (returning e.g. `~/Library/Application Support`) but no config file existed there, `resolveConfigPath` would fall through to step 3 and check `~/.config/soda/config.yaml` via `UserHomeDir`. However, `config.DefaultPath()` only uses the `UserHomeDir` path when `UserConfigDir()` **fails** — so `doctor` could report "config OK" for a file that the runtime would never actually load.

### Changes

- **`cmd/soda/doctor.go`** — Added early `return nil` after step 2 when `UserConfigDir` succeeds but the file is not found. This ensures the `UserHomeDir` fallback (step 3) only runs when `UserConfigDir()` itself returns an error, matching `config.DefaultPath()` exactly.
- **`cmd/soda/doctor_test.go`** — Added `TestResolveConfigPath_NoFalsePositive_WhenUserConfigDirSucceeds` to cover the macOS-like scenario and prevent regression.

### Test Plan

- [x] `go test ./cmd/soda/... -run TestResolveConfigPath` — all resolve path tests pass
- [x] New test validates that when `UserConfigDir` succeeds, a config file under `~/.config` is **not** detected (no false positive)
- [x] Existing tests continue to pass

### Acceptance Criteria

- [x] `resolveConfigPath` fallback chain matches `config.DefaultPath()` behaviour
- [x] No false-positive config detection on macOS when `UserConfigDir` succeeds
- [x] Test coverage for the fixed scenario
