### PR TITLE
fix(git): use CommandContext to prevent hangs [#416]

### DIFF
--- a/cmd/soda/clean.go
+++ b/cmd/soda/clean.go
@@ -141,7 +141,7 @@ func cleanTicket(ctx context.Context, stateDir, ticketKey string, dryRun, force,
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Warning: cannot resolve repo dir to delete branch %s: %v\n", meta.Branch, err)
 			} else {
-				if brErr := sodagit.DeleteBranch(repoDir, meta.Branch); brErr != nil {
+				if brErr := sodagit.DeleteBranch(ctx, repoDir, meta.Branch); brErr != nil {
 					fmt.Fprintf(os.Stderr, "Warning: git branch delete %s: %v\n", meta.Branch, brErr)
 				} else {
 					branchCleared = true

--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -180,7 +180,7 @@ func runPipeline(cfg *config.Config, opts pipelineOpts) error {
 	// Resolve working directory to the main repo root so worktrees,
 	// state, and all paths are always relative to the root, even when
 	// soda is invoked from inside an existing worktree.
-	workDir, err := git.RepoRoot(".")
+	workDir, err := git.RepoRoot(ctx, ".")
 	if err != nil {
 		return fmt.Errorf("run: resolve repo root: %w", err)
 	}

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -13,8 +13,8 @@ import (
 // RepoRoot returns the absolute path of the main repository root,
 // even when called from inside a worktree. Uses --git-common-dir
 // which always points to the shared .git directory.
-func RepoRoot(dir string) (string, error) {
-	cmd := exec.Command("git", "rev-parse", "--git-common-dir")
+func RepoRoot(ctx context.Context, dir string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--git-common-dir")
 	cmd.Dir = dir
 	out, err := cmd.Output()
 	if err != nil {

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -164,8 +164,8 @@ func FetchBranch(ctx context.Context, repoDir, remote, branch string) error {
 
 // DeleteBranch deletes a local git branch. It runs "git branch -D <branch>"
 // from the given repoDir. Returns nil if the branch was deleted or did not exist.
-func DeleteBranch(repoDir, branch string) error {
-	cmd := exec.Command("git", "branch", "-D", branch)
+func DeleteBranch(ctx context.Context, repoDir, branch string) error {
+	cmd := exec.CommandContext(ctx, "git", "branch", "-D", branch)
 	cmd.Dir = repoDir
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -218,7 +218,7 @@ func TestDeleteBranch(t *testing.T) {
 		}
 
 		// Delete it
-		if err := DeleteBranch(repoDir, "feat/to-delete"); err != nil {
+		if err := DeleteBranch(context.Background(), repoDir, "feat/to-delete"); err != nil {
 			t.Fatalf("DeleteBranch: %v", err)
 		}
 
@@ -237,9 +237,28 @@ func TestDeleteBranch(t *testing.T) {
 	t.Run("no_error_for_nonexistent_branch", func(t *testing.T) {
 		repoDir := initGitRepo(t)
 
-		err := DeleteBranch(repoDir, "feat/does-not-exist")
+		err := DeleteBranch(context.Background(), repoDir, "feat/does-not-exist")
 		if err != nil {
 			t.Fatalf("DeleteBranch should not error for nonexistent branch: %v", err)
+		}
+	})
+
+	t.Run("respects_context_cancellation", func(t *testing.T) {
+		repoDir := initGitRepo(t)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		// Create a branch to attempt deleting with a cancelled context.
+		cmd := exec.Command("git", "branch", "feat/cancel-delete")
+		cmd.Dir = repoDir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git branch: %s: %v", out, err)
+		}
+
+		err := DeleteBranch(ctx, repoDir, "feat/cancel-delete")
+		if err == nil {
+			t.Fatal("expected error from cancelled context")
 		}
 	})
 }

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -33,7 +33,7 @@ func TestRepoRoot(t *testing.T) {
 	t.Run("returns_repo_root", func(t *testing.T) {
 		repoDir := initGitRepo(t)
 
-		got, err := RepoRoot(repoDir)
+		got, err := RepoRoot(context.Background(), repoDir)
 		if err != nil {
 			t.Fatalf("RepoRoot: %v", err)
 		}
@@ -50,7 +50,7 @@ func TestRepoRoot(t *testing.T) {
 			t.Fatalf("MkdirAll: %v", err)
 		}
 
-		got, err := RepoRoot(subDir)
+		got, err := RepoRoot(context.Background(), subDir)
 		if err != nil {
 			t.Fatalf("RepoRoot: %v", err)
 		}
@@ -68,7 +68,7 @@ func TestRepoRoot(t *testing.T) {
 			t.Fatalf("CreateWorktree: %v", err)
 		}
 
-		got, err := RepoRoot(wtPath)
+		got, err := RepoRoot(context.Background(), wtPath)
 		if err != nil {
 			t.Fatalf("RepoRoot: %v", err)
 		}
@@ -92,7 +92,7 @@ func TestRepoRoot(t *testing.T) {
 			t.Fatalf("Chdir: %v", err)
 		}
 
-		got, err := RepoRoot(".")
+		got, err := RepoRoot(context.Background(), ".")
 		if err != nil {
 			t.Fatalf("RepoRoot: %v", err)
 		}
@@ -106,9 +106,21 @@ func TestRepoRoot(t *testing.T) {
 
 	t.Run("errors_outside_git_repo", func(t *testing.T) {
 		dir := t.TempDir()
-		_, err := RepoRoot(dir)
+		_, err := RepoRoot(context.Background(), dir)
 		if err == nil {
 			t.Fatal("expected error outside git repo")
+		}
+	})
+
+	t.Run("respects_context_cancellation", func(t *testing.T) {
+		repoDir := initGitRepo(t)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, err := RepoRoot(ctx, repoDir)
+		if err == nil {
+			t.Fatal("expected error from cancelled context")
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Fix `exec.Command` calls without context in `internal/git/worktree.go` that could hang indefinitely if git blocks (e.g., waiting for credentials or a stuck network call).

### Changes

1. **`RepoRoot`** — Changed signature from `RepoRoot(dir string)` to `RepoRoot(ctx context.Context, dir string)` and switched to `exec.CommandContext`. Updated caller in `cmd/soda/run.go`.

2. **`DeleteBranch`** — Changed signature from `DeleteBranch(repoDir, branch string)` to `DeleteBranch(ctx context.Context, repoDir, branch string)` and switched to `exec.CommandContext`. Updated caller in `cmd/soda/clean.go`.

After these changes, **zero** `exec.Command` calls remain in `worktree.go` — all 13 git subprocess invocations use `exec.CommandContext`.

## Test Plan

- All existing tests updated to pass `context.Background()`
- New `respects_context_cancellation` test added for both `RepoRoot` and `DeleteBranch`
- All 18 git package tests pass with no regressions

## Acceptance Criteria

- [x] `RepoRoot` accepts `context.Context` as first parameter
- [x] `RepoRoot` uses `exec.CommandContext` instead of `exec.Command`
- [x] `DeleteBranch` accepts `context.Context` as first parameter
- [x] `DeleteBranch` uses `exec.CommandContext` instead of `exec.Command`
- [x] All callers updated to pass context
- [x] All existing tests updated and passing
- [x] Context cancellation tests added for both functions
- [x] Zero `exec.Command` calls remain in `worktree.go`

Refs: #416