### PR TITLE
feat(engine): configurable bytes-per-token ratio [384]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ config.yaml
 
 # Prompt overrides (use ~/.config/soda/prompts/ instead)
 prompts/
+soda-system-prompt-*.md

--- a/cmd/soda/history.go
+++ b/cmd/soda/history.go
@@ -74,16 +74,17 @@ func runHistory(stateDir, ticketKey string, detail bool, phaseFilter string) err
 func renderEventsHistory(meta *pipeline.PipelineMeta, events []pipeline.Event, stateDir string, detail bool, phaseFilter string) error {
 	h := pipeline.BuildHistory(events, stateDir)
 
-	// Populate PromptHash on non-superseded entries only. The PhaseState in
-	// meta stores the hash for the latest generation; applying it to
-	// superseded entries would show a misleading hash that doesn't match the
-	// prompt actually sent for that generation.
+	// Populate PromptHash and EstimatedPromptTokens on non-superseded entries
+	// only. The PhaseState in meta stores the values for the latest generation;
+	// applying them to superseded entries would show misleading data that
+	// doesn't match the prompt actually sent for that generation.
 	for i := range h.Entries {
 		if h.Entries[i].Superseded {
 			continue
 		}
 		if ps, ok := meta.Phases[h.Entries[i].Phase]; ok {
 			h.Entries[i].PromptHash = ps.PromptHash
+			h.Entries[i].EstimatedPromptTokens = ps.EstimatedPromptTokens
 		}
 	}
 
@@ -116,10 +117,11 @@ func renderEventsHistory(meta *pipeline.PipelineMeta, events []pipeline.Event, s
 	// Collect full outputs and prompt hashes to print after the table (to avoid
 	// breaking tabwriter alignment).
 	type outputBlock struct {
-		phase      string
-		generation int
-		promptHash string
-		data       json.RawMessage
+		phase                 string
+		generation            int
+		promptHash            string
+		estimatedPromptTokens int64
+		data                  json.RawMessage
 	}
 	var outputs []outputBlock
 
@@ -146,12 +148,13 @@ func renderEventsHistory(meta *pipeline.PipelineMeta, events []pipeline.Event, s
 		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
 			entry.Phase, gen, sym, dur, cost, details)
 
-		if (detail || phaseFilter != "") && (len(entry.FullOutput) > 0 || entry.PromptHash != "") {
+		if (detail || phaseFilter != "") && (len(entry.FullOutput) > 0 || entry.PromptHash != "" || entry.EstimatedPromptTokens > 0) {
 			outputs = append(outputs, outputBlock{
-				phase:      entry.Phase,
-				generation: entry.Generation,
-				promptHash: entry.PromptHash,
-				data:       entry.FullOutput,
+				phase:                 entry.Phase,
+				generation:            entry.Generation,
+				promptHash:            entry.PromptHash,
+				estimatedPromptTokens: entry.EstimatedPromptTokens,
+				data:                  entry.FullOutput,
 			})
 		}
 
@@ -182,6 +185,9 @@ func renderEventsHistory(meta *pipeline.PipelineMeta, events []pipeline.Event, s
 		fmt.Printf("\n--- %s (gen %d) ---\n", ob.phase, ob.generation)
 		if ob.promptHash != "" {
 			fmt.Printf("Prompt Hash: %s\n", ob.promptHash)
+		}
+		if ob.estimatedPromptTokens > 0 {
+			fmt.Printf("Estimated Prompt Tokens: %d\n", ob.estimatedPromptTokens)
 		}
 		if len(ob.data) > 0 {
 			fmt.Println(prettyJSON(ob.data))

--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -386,7 +386,8 @@ func runPipeline(cfg *config.Config, opts pipelineOpts) error {
 		MaxAPIConcurrency:      cfg.Limits.MaxAPIConcurrency,
 		MaxSiblingContextBytes: cfg.Limits.MaxSiblingContextBytes,
 		TokenBudget: pipeline.TokenBudgetConfig{
-			WarnTokens: cfg.Limits.TokenBudget.WarnTokens,
+			WarnTokens:    cfg.Limits.TokenBudget.WarnTokens,
+			BytesPerToken: cfg.Limits.TokenBudget.BytesPerToken,
 		},
 		Mode:              mode,
 		PRPoller:          prPoller,

--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -385,12 +385,15 @@ func runPipeline(cfg *config.Config, opts pipelineOpts) error {
 		MaxDiffBytes:           cfg.Limits.MaxDiffBytes,
 		MaxAPIConcurrency:      cfg.Limits.MaxAPIConcurrency,
 		MaxSiblingContextBytes: cfg.Limits.MaxSiblingContextBytes,
-		Mode:                   mode,
-		PRPoller:               prPoller,
-		SelfUser:               selfUser,
-		BotUsers:               botUsers,
-		MonitorProfile:         monitorProfile,
-		AuthorityResolver:      authorityResolver,
+		TokenBudget: pipeline.TokenBudgetConfig{
+			WarnTokens: cfg.Limits.TokenBudget.WarnTokens,
+		},
+		Mode:              mode,
+		PRPoller:          prPoller,
+		SelfUser:          selfUser,
+		BotUsers:          botUsers,
+		MonitorProfile:    monitorProfile,
+		AuthorityResolver: authorityResolver,
 		OnEvent: func(event pipeline.Event) {
 			if event.Kind == pipeline.EventPhaseSkipped || event.Kind == pipeline.EventMonitorSkipped {
 				skippedPhases[event.Phase] = true
@@ -819,6 +822,21 @@ func handleEvent(ctx context.Context, cancel context.CancelFunc, engine *pipelin
 			phase = p
 		}
 		prog.Message(fmt.Sprintf("  ⏹  Pipeline timeout after %s (during %s)", limit, phase))
+
+	case pipeline.EventTokenBudgetWarning:
+		var estimated int64
+		if e, ok := event.Data["estimated_tokens"].(int64); ok {
+			estimated = e
+		} else if ef, ok := event.Data["estimated_tokens"].(float64); ok {
+			estimated = int64(ef)
+		}
+		var warnLimit int
+		if w, ok := event.Data["warn_limit"].(int); ok {
+			warnLimit = w
+		} else if wf, ok := event.Data["warn_limit"].(float64); ok {
+			warnLimit = int(wf)
+		}
+		prog.Message(fmt.Sprintf("  ⚠️  Prompt size warning: ~%d tokens estimated (limit: %d)", estimated, warnLimit))
 
 	case pipeline.EventBinaryVersionMismatch:
 		var stored string

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -114,11 +114,12 @@ type LimitsConfig struct {
 
 // TokenBudgetConfig configures the prompt-size estimation check that runs
 // before each CLI invocation. When WarnTokens > 0, the engine estimates
-// the rendered prompt's token count (bytes / 3.3) and emits a warning
-// event if the estimate exceeds the threshold. This is a warn-only check;
-// it never blocks execution.
+// the rendered prompt's token count (bytes / BytesPerToken) and emits a
+// warning event if the estimate exceeds the threshold. This is a warn-only
+// check; it never blocks execution.
 type TokenBudgetConfig struct {
-	WarnTokens int `yaml:"warn_tokens,omitempty"` // emit warning when estimated prompt tokens exceed this; 0 disables
+	WarnTokens    int     `yaml:"warn_tokens,omitempty"`     // emit warning when estimated prompt tokens exceed this; 0 disables
+	BytesPerToken float64 `yaml:"bytes_per_token,omitempty"` // bytes-per-token ratio for estimation; 0 defaults to 3.3
 }
 
 // RepoConfig holds per-repo configuration.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -102,13 +102,23 @@ type SandboxLimits struct {
 
 // LimitsConfig holds budget and duration limits.
 type LimitsConfig struct {
-	MaxCostPerTicket       float64 `yaml:"max_cost_per_ticket"`
-	MaxCostPerPhase        float64 `yaml:"max_cost_per_phase"`
-	MaxCostPerGeneration   float64 `yaml:"max_cost_per_generation,omitempty"`   // per-attempt cost cap; 0 means disabled
-	MaxPipelineDuration    string  `yaml:"max_pipeline_duration,omitempty"`     // Go duration string (e.g., "2h", "90m"); 0 or empty means no limit
-	MaxDiffBytes           int     `yaml:"max_diff_bytes,omitempty"`            // max bytes of git diff injected into rework prompts; 0 means use default (50000)
-	MaxAPIConcurrency      int     `yaml:"max_api_concurrency,omitempty"`       // max concurrent API calls (runner.Run); 0 means unlimited
-	MaxSiblingContextBytes int     `yaml:"max_sibling_context_bytes,omitempty"` // max bytes of sibling-function context injected into implement prompts; 0 means use default (20000)
+	MaxCostPerTicket       float64           `yaml:"max_cost_per_ticket"`
+	MaxCostPerPhase        float64           `yaml:"max_cost_per_phase"`
+	MaxCostPerGeneration   float64           `yaml:"max_cost_per_generation,omitempty"`   // per-attempt cost cap; 0 means disabled
+	MaxPipelineDuration    string            `yaml:"max_pipeline_duration,omitempty"`     // Go duration string (e.g., "2h", "90m"); 0 or empty means no limit
+	MaxDiffBytes           int               `yaml:"max_diff_bytes,omitempty"`            // max bytes of git diff injected into rework prompts; 0 means use default (50000)
+	MaxAPIConcurrency      int               `yaml:"max_api_concurrency,omitempty"`       // max concurrent API calls (runner.Run); 0 means unlimited
+	MaxSiblingContextBytes int               `yaml:"max_sibling_context_bytes,omitempty"` // max bytes of sibling-function context injected into implement prompts; 0 means use default (20000)
+	TokenBudget            TokenBudgetConfig `yaml:"token_budget,omitempty"`              // prompt token budget estimation; zero value disables checks
+}
+
+// TokenBudgetConfig configures the prompt-size estimation check that runs
+// before each CLI invocation. When WarnTokens > 0, the engine estimates
+// the rendered prompt's token count (bytes / 3.3) and emits a warning
+// event if the estimate exceeds the threshold. This is a warn-only check;
+// it never blocks execution.
+type TokenBudgetConfig struct {
+	WarnTokens int `yaml:"warn_tokens,omitempty"` // emit warning when estimated prompt tokens exceed this; 0 disables
 }
 
 // RepoConfig holds per-repo configuration.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -50,6 +50,9 @@ func TestLoad(t *testing.T) {
 				if cfg.Limits.TokenBudget.WarnTokens != 100000 {
 					t.Errorf("TokenBudget.WarnTokens = %d, want 100000", cfg.Limits.TokenBudget.WarnTokens)
 				}
+				if cfg.Limits.TokenBudget.BytesPerToken != 3.5 {
+					t.Errorf("TokenBudget.BytesPerToken = %f, want 3.5", cfg.Limits.TokenBudget.BytesPerToken)
+				}
 				if cfg.StateDir != ".soda" {
 					t.Errorf("StateDir = %q, want %q", cfg.StateDir, ".soda")
 				}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -47,6 +47,9 @@ func TestLoad(t *testing.T) {
 				if cfg.Limits.MaxPipelineDuration != "2h" {
 					t.Errorf("MaxPipelineDuration = %q, want %q", cfg.Limits.MaxPipelineDuration, "2h")
 				}
+				if cfg.Limits.TokenBudget.WarnTokens != 100000 {
+					t.Errorf("TokenBudget.WarnTokens = %d, want 100000", cfg.Limits.TokenBudget.WarnTokens)
+				}
 				if cfg.StateDir != ".soda" {
 					t.Errorf("StateDir = %q, want %q", cfg.StateDir, ".soda")
 				}

--- a/internal/config/testdata/valid.yaml
+++ b/internal/config/testdata/valid.yaml
@@ -39,6 +39,7 @@ limits:
   max_pipeline_duration: "2h"
   token_budget:
     warn_tokens: 100000
+    bytes_per_token: 3.5
 worktree_dir: .worktrees
 state_dir: .soda
 context:

--- a/internal/config/testdata/valid.yaml
+++ b/internal/config/testdata/valid.yaml
@@ -37,6 +37,8 @@ limits:
   max_cost_per_phase: 8.00
   max_cost_per_generation: 5.00
   max_pipeline_duration: "2h"
+  token_budget:
+    warn_tokens: 100000
 worktree_dir: .worktrees
 state_dir: .soda
 context:

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -70,7 +70,8 @@ type EngineConfig struct {
 // TokenBudgetConfig configures the prompt-size estimation check.
 // Mirrors config.TokenBudgetConfig — kept separate to avoid cross-package imports.
 type TokenBudgetConfig struct {
-	WarnTokens int // emit warning when estimated prompt tokens exceed this; 0 disables
+	WarnTokens    int     // emit warning when estimated prompt tokens exceed this; 0 disables
+	BytesPerToken float64 // bytes-per-token ratio for estimation; 0 defaults to 3.3
 }
 
 // maxReworkCycles returns the configured max rework cycles, defaulting to DefaultMaxReworkCycles.
@@ -674,9 +675,13 @@ func (e *Engine) runPhase(ctx context.Context, phase PhaseConfig) error {
 	e.state.Meta().Phases[phase.Name].PromptHash = fmt.Sprintf("%x", promptDigest)
 
 	// Token budget estimation: estimate prompt tokens from rendered byte
-	// length (bytes / 3.3) and warn if above the configured threshold.
+	// length (bytes / ratio) and warn if above the configured threshold.
 	// This is a warn-only check — it never blocks execution.
-	estimatedTokens := int64(float64(len(rendered)) / 3.3)
+	bytesPerToken := e.config.TokenBudget.BytesPerToken
+	if bytesPerToken <= 0 {
+		bytesPerToken = 3.3
+	}
+	estimatedTokens := int64(float64(len(rendered)) / bytesPerToken)
 	e.state.Meta().Phases[phase.Name].EstimatedPromptTokens = estimatedTokens
 	if warnLimit := e.config.TokenBudget.WarnTokens; warnLimit > 0 && estimatedTokens > int64(warnLimit) {
 		e.emit(Event{

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -64,6 +64,13 @@ type EngineConfig struct {
 	SelfUser               string            // PR author username for self-comment filtering
 	BotUsers               []string          // known bot usernames to filter
 	Stderr                 io.Writer         // destination for warning messages; defaults to os.Stderr
+	TokenBudget            TokenBudgetConfig // prompt token budget estimation; zero value disables checks
+}
+
+// TokenBudgetConfig configures the prompt-size estimation check.
+// Mirrors config.TokenBudgetConfig — kept separate to avoid cross-package imports.
+type TokenBudgetConfig struct {
+	WarnTokens int // emit warning when estimated prompt tokens exceed this; 0 disables
 }
 
 // maxReworkCycles returns the configured max rework cycles, defaulting to DefaultMaxReworkCycles.

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -673,6 +673,23 @@ func (e *Engine) runPhase(ctx context.Context, phase PhaseConfig) error {
 	promptDigest := sha256.Sum256([]byte(rendered))
 	e.state.Meta().Phases[phase.Name].PromptHash = fmt.Sprintf("%x", promptDigest)
 
+	// Token budget estimation: estimate prompt tokens from rendered byte
+	// length (bytes / 3.3) and warn if above the configured threshold.
+	// This is a warn-only check — it never blocks execution.
+	estimatedTokens := int64(float64(len(rendered)) / 3.3)
+	e.state.Meta().Phases[phase.Name].EstimatedPromptTokens = estimatedTokens
+	if warnLimit := e.config.TokenBudget.WarnTokens; warnLimit > 0 && estimatedTokens > int64(warnLimit) {
+		e.emit(Event{
+			Phase: phase.Name,
+			Kind:  EventTokenBudgetWarning,
+			Data: map[string]any{
+				"estimated_tokens": estimatedTokens,
+				"warn_limit":       warnLimit,
+				"prompt_bytes":     len(rendered),
+			},
+		})
+	}
+
 	_ = e.state.WriteLog(phase.Name, "prompt", []byte(rendered))
 
 	// Build runner opts. Tighten budget to the smallest remaining limit.
@@ -738,6 +755,23 @@ func (e *Engine) runPhase(ctx context.Context, phase PhaseConfig) error {
 	}
 	if err := e.state.AccumulateTokens(phase.Name, result.TokensIn, result.TokensOut, result.CacheTokensIn); err != nil {
 		return fmt.Errorf("engine: accumulate tokens for %s: %w", phase.Name, err)
+	}
+
+	// Token budget calibration: after the LLM returns actual token counts,
+	// emit a calibration event pairing the prompt byte length with the real
+	// tokens_in so operators can tune the bytes-per-token ratio (default 3.3).
+	if ps := e.state.Meta().Phases[phase.Name]; ps != nil && ps.TokensIn > 0 {
+		actualRatio := float64(len(rendered)) / float64(ps.TokensIn)
+		e.emit(Event{
+			Phase: phase.Name,
+			Kind:  EventTokenBudgetCalibration,
+			Data: map[string]any{
+				"prompt_bytes":     len(rendered),
+				"estimated_tokens": estimatedTokens,
+				"actual_tokens_in": ps.TokensIn,
+				"bytes_per_token":  math.Round(actualRatio*100) / 100,
+			},
+		})
 	}
 
 	// Per-phase cost enforcement: abort if this phase exceeded its budget.

--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -5890,7 +5890,8 @@ func TestEngine_TokenBudgetEstimationPersisted(t *testing.T) {
 		t.Errorf("EstimatedPromptTokens = %d, want > 0", ps.EstimatedPromptTokens)
 	}
 
-	// Verify the estimate matches the formula: int64(float64(len(rendered)) / 3.3).
+	// Verify the estimate matches the formula: int64(float64(len(rendered)) / ratio).
+	// When BytesPerToken is 0 (default), the ratio defaults to 3.3.
 	// The rendered prompt is "Phase: triage\nTicket: TEST-1\n"; read from log.
 	promptLog, err := os.ReadFile(filepath.Join(state.Dir(), "logs", "triage_prompt.md"))
 	if err != nil {
@@ -5899,6 +5900,54 @@ func TestEngine_TokenBudgetEstimationPersisted(t *testing.T) {
 	expectedTokens := int64(float64(len(promptLog)) / 3.3)
 	if ps.EstimatedPromptTokens != expectedTokens {
 		t.Errorf("EstimatedPromptTokens = %d, want %d (from %d bytes)", ps.EstimatedPromptTokens, expectedTokens, len(promptLog))
+	}
+}
+
+// TestEngine_TokenBudgetCustomBytesPerToken verifies that a custom BytesPerToken
+// ratio is used for estimation instead of the default 3.3.
+func TestEngine_TokenBudgetCustomBytesPerToken(t *testing.T) {
+	phases := []PhaseConfig{
+		{
+			Name:   "triage",
+			Prompt: "triage.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"triage": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"automatable":true}`),
+					RawText: "Triage: automatable",
+					CostUSD: 0.10,
+				},
+			}},
+		},
+	}
+
+	customRatio := 4.0
+	engine, state := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.TokenBudget = TokenBudgetConfig{BytesPerToken: customRatio}
+	})
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	ps := state.Meta().Phases["triage"]
+	if ps == nil {
+		t.Fatal("triage phase not found in meta")
+	}
+
+	promptLog, err := os.ReadFile(filepath.Join(state.Dir(), "logs", "triage_prompt.md"))
+	if err != nil {
+		t.Fatalf("read prompt log: %v", err)
+	}
+	expectedTokens := int64(float64(len(promptLog)) / customRatio)
+	if ps.EstimatedPromptTokens != expectedTokens {
+		t.Errorf("EstimatedPromptTokens = %d, want %d (custom ratio %.1f, %d bytes)",
+			ps.EstimatedPromptTokens, expectedTokens, customRatio, len(promptLog))
 	}
 }
 

--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -5853,3 +5853,256 @@ func TestEngine_EmitLogsWarningOnEventLogFailure(t *testing.T) {
 		t.Error("triage should be completed")
 	}
 }
+
+func TestEngine_TokenBudgetEstimationPersisted(t *testing.T) {
+	phases := []PhaseConfig{
+		{
+			Name:   "triage",
+			Prompt: "triage.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"triage": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"automatable":true}`),
+					RawText: "Triage: automatable",
+					CostUSD: 0.10,
+				},
+			}},
+		},
+	}
+
+	engine, state := setupEngine(t, phases, mock)
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	ps := state.Meta().Phases["triage"]
+	if ps == nil {
+		t.Fatal("triage phase not found in meta")
+	}
+
+	if ps.EstimatedPromptTokens <= 0 {
+		t.Errorf("EstimatedPromptTokens = %d, want > 0", ps.EstimatedPromptTokens)
+	}
+
+	// Verify the estimate matches the formula: int64(float64(len(rendered)) / 3.3).
+	// The rendered prompt is "Phase: triage\nTicket: TEST-1\n"; read from log.
+	promptLog, err := os.ReadFile(filepath.Join(state.Dir(), "logs", "triage_prompt.md"))
+	if err != nil {
+		t.Fatalf("read prompt log: %v", err)
+	}
+	expectedTokens := int64(float64(len(promptLog)) / 3.3)
+	if ps.EstimatedPromptTokens != expectedTokens {
+		t.Errorf("EstimatedPromptTokens = %d, want %d (from %d bytes)", ps.EstimatedPromptTokens, expectedTokens, len(promptLog))
+	}
+}
+
+func TestEngine_TokenBudgetWarningEmitted(t *testing.T) {
+	phases := []PhaseConfig{
+		{
+			Name:   "triage",
+			Prompt: "triage.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"triage": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"automatable":true}`),
+					RawText: "Triage: automatable",
+					CostUSD: 0.10,
+				},
+			}},
+		},
+	}
+
+	var events []Event
+	engine, _ := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+		// Set WarnTokens very low (1) so the 26-byte prompt triggers a warning.
+		cfg.TokenBudget = TokenBudgetConfig{WarnTokens: 1}
+		cfg.OnEvent = func(e Event) {
+			events = append(events, e)
+		}
+	})
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// Should have a token_budget_warning event.
+	var found bool
+	for _, ev := range events {
+		if ev.Kind == EventTokenBudgetWarning && ev.Phase == "triage" {
+			found = true
+			if est, ok := ev.Data["estimated_tokens"]; !ok {
+				t.Error("token_budget_warning missing estimated_tokens")
+			} else if toInt64(est) <= 0 {
+				t.Errorf("estimated_tokens = %v, want > 0", est)
+			}
+			if wl, ok := ev.Data["warn_limit"]; !ok {
+				t.Error("token_budget_warning missing warn_limit")
+			} else if toInt(wl) != 1 {
+				t.Errorf("warn_limit = %v, want 1", wl)
+			}
+			if pb, ok := ev.Data["prompt_bytes"]; !ok {
+				t.Error("token_budget_warning missing prompt_bytes")
+			} else if toInt(pb) <= 0 {
+				t.Errorf("prompt_bytes = %v, want > 0", pb)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected token_budget_warning event, but none was emitted")
+	}
+}
+
+func TestEngine_TokenBudgetNoWarningBelowThreshold(t *testing.T) {
+	phases := []PhaseConfig{
+		{
+			Name:   "triage",
+			Prompt: "triage.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"triage": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"automatable":true}`),
+					RawText: "Triage: automatable",
+					CostUSD: 0.10,
+				},
+			}},
+		},
+	}
+
+	var events []Event
+	engine, _ := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+		// Set WarnTokens high (100000) so the small prompt does NOT trigger.
+		cfg.TokenBudget = TokenBudgetConfig{WarnTokens: 100000}
+		cfg.OnEvent = func(e Event) {
+			events = append(events, e)
+		}
+	})
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	for _, ev := range events {
+		if ev.Kind == EventTokenBudgetWarning {
+			t.Errorf("unexpected token_budget_warning event for small prompt")
+		}
+	}
+}
+
+func TestEngine_TokenBudgetCalibrationEmitted(t *testing.T) {
+	phases := []PhaseConfig{
+		{
+			Name:   "triage",
+			Prompt: "triage.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"triage": {{
+				result: &runner.RunResult{
+					Output:        json.RawMessage(`{"automatable":true}`),
+					RawText:       "Triage: automatable",
+					CostUSD:       0.10,
+					TokensIn:      500,
+					TokensOut:     100,
+					CacheTokensIn: 0,
+				},
+			}},
+		},
+	}
+
+	var events []Event
+	engine, _ := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.OnEvent = func(e Event) {
+			events = append(events, e)
+		}
+	})
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	var found bool
+	for _, ev := range events {
+		if ev.Kind == EventTokenBudgetCalibration && ev.Phase == "triage" {
+			found = true
+			if pb, ok := ev.Data["prompt_bytes"]; !ok || toInt(pb) <= 0 {
+				t.Errorf("calibration event prompt_bytes = %v, want > 0", pb)
+			}
+			if est, ok := ev.Data["estimated_tokens"]; !ok || toInt64(est) <= 0 {
+				t.Errorf("calibration event estimated_tokens = %v, want > 0", est)
+			}
+			if actual, ok := ev.Data["actual_tokens_in"]; !ok || toInt64(actual) != 500 {
+				t.Errorf("calibration event actual_tokens_in = %v, want 500", actual)
+			}
+			if bpt, ok := ev.Data["bytes_per_token"]; !ok {
+				t.Error("calibration event missing bytes_per_token")
+			} else {
+				ratio := toFloat64(bpt)
+				if ratio <= 0 {
+					t.Errorf("bytes_per_token = %v, want > 0", ratio)
+				}
+			}
+		}
+	}
+	if !found {
+		t.Error("expected token_budget_calibration event, but none was emitted")
+	}
+}
+
+func TestEngine_TokenBudgetCalibrationNotEmittedWhenZeroTokens(t *testing.T) {
+	phases := []PhaseConfig{
+		{
+			Name:   "triage",
+			Prompt: "triage.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"triage": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"automatable":true}`),
+					RawText: "Triage: automatable",
+					CostUSD: 0.10,
+					// TokensIn is 0 — no calibration event should be emitted
+				},
+			}},
+		},
+	}
+
+	var events []Event
+	engine, _ := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.OnEvent = func(e Event) {
+			events = append(events, e)
+		}
+	})
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	for _, ev := range events {
+		if ev.Kind == EventTokenBudgetCalibration {
+			t.Error("unexpected token_budget_calibration event when TokensIn is zero")
+		}
+	}
+}

--- a/internal/pipeline/events.go
+++ b/internal/pipeline/events.go
@@ -89,6 +89,8 @@ const (
 	EventBinaryVersionMismatch    = "binary_version_mismatch"
 	EventAPISemaphoreWait         = "api_semaphore_wait"
 	EventImplementNoChanges       = "implement_no_changes"
+	EventTokenBudgetWarning       = "token_budget_warning"
+	EventTokenBudgetCalibration   = "token_budget_calibration"
 )
 
 // FormatEvent formats an event as a compact, human-readable line:

--- a/internal/pipeline/history.go
+++ b/internal/pipeline/history.go
@@ -12,19 +12,20 @@ import (
 
 // PhaseGeneration represents a single generation (attempt) of a phase.
 type PhaseGeneration struct {
-	Phase         string
-	Generation    int
-	Status        PhaseStatus
-	Cost          float64
-	DurationMs    int64
-	TokensIn      int64
-	TokensOut     int64
-	CacheTokensIn int64
-	Error         string
-	Details       string          // one-line summary from result JSON
-	FullOutput    json.RawMessage // full structured output JSON (populated by LoadFullOutputs)
-	Superseded    bool            // true if a later generation exists
-	PromptHash    string          // SHA-256 hex digest of the rendered prompt (from PhaseState)
+	Phase                 string
+	Generation            int
+	Status                PhaseStatus
+	Cost                  float64
+	DurationMs            int64
+	TokensIn              int64
+	TokensOut             int64
+	CacheTokensIn         int64
+	Error                 string
+	Details               string          // one-line summary from result JSON
+	FullOutput            json.RawMessage // full structured output JSON (populated by LoadFullOutputs)
+	Superseded            bool            // true if a later generation exists
+	PromptHash            string          // SHA-256 hex digest of the rendered prompt (from PhaseState)
+	EstimatedPromptTokens int64           // pre-invocation token estimate (from PhaseState)
 }
 
 // History holds the reconstructed multi-generation history for a ticket.

--- a/internal/pipeline/meta.go
+++ b/internal/pipeline/meta.go
@@ -23,18 +23,19 @@ const (
 
 // PhaseState holds the status and metrics for a single phase.
 type PhaseState struct {
-	Status         PhaseStatus `json:"status"`
-	Cost           float64     `json:"cost,omitempty"`
-	CumulativeCost float64     `json:"cumulative_cost,omitempty"`
-	DurationMs     int64       `json:"duration_ms,omitempty"`
-	TokensIn       int64       `json:"tokens_in,omitempty"`
-	TokensOut      int64       `json:"tokens_out,omitempty"`
-	CacheTokensIn  int64       `json:"cache_tokens_in,omitempty"`
-	Error          string      `json:"error,omitempty"`
-	Generation     int         `json:"generation,omitempty"`
-	PlanHash       string      `json:"plan_hash,omitempty"`
-	PromptHash     string      `json:"prompt_hash,omitempty"` // SHA-256 hex digest of the rendered prompt sent to the LLM
-	startedAt      time.Time
+	Status                PhaseStatus `json:"status"`
+	Cost                  float64     `json:"cost,omitempty"`
+	CumulativeCost        float64     `json:"cumulative_cost,omitempty"`
+	DurationMs            int64       `json:"duration_ms,omitempty"`
+	TokensIn              int64       `json:"tokens_in,omitempty"`
+	TokensOut             int64       `json:"tokens_out,omitempty"`
+	CacheTokensIn         int64       `json:"cache_tokens_in,omitempty"`
+	Error                 string      `json:"error,omitempty"`
+	Generation            int         `json:"generation,omitempty"`
+	PlanHash              string      `json:"plan_hash,omitempty"`
+	PromptHash            string      `json:"prompt_hash,omitempty"`             // SHA-256 hex digest of the rendered prompt sent to the LLM
+	EstimatedPromptTokens int64       `json:"estimated_prompt_tokens,omitempty"` // pre-invocation estimate: len(rendered) / 3.3
+	startedAt             time.Time
 }
 
 // PipelineMeta is the top-level state stored in meta.json.

--- a/internal/pipeline/state.go
+++ b/internal/pipeline/state.go
@@ -136,6 +136,7 @@ func (s *State) MarkRunning(phase string) error {
 	ps.TokensIn = 0
 	ps.TokensOut = 0
 	ps.CacheTokensIn = 0
+	ps.EstimatedPromptTokens = 0
 	ps.Error = ""
 	ps.PlanHash = ""
 	ps.PromptHash = ""


### PR DESCRIPTION
## Summary

Make the hardcoded `3.3` bytes-per-token ratio used for prompt token estimation configurable via `TokenBudgetConfig.BytesPerToken`, and wire it end-to-end from config through CLI to engine.

## Changes

| File | What changed |
|------|-------------|
| `internal/config/config.go` | Added `BytesPerToken float64` field (`yaml:"bytes_per_token,omitempty"`) |
| `internal/config/config_test.go` | Assert new field parses correctly from YAML |
| `internal/config/testdata/valid.yaml` | Added `bytes_per_token: 3.5` fixture value |
| `internal/pipeline/engine.go` | Added `BytesPerToken` to pipeline config; estimation uses it with `<= 0` guard defaulting to `3.3` |
| `internal/pipeline/engine_test.go` | Added `TestEngine_TokenBudgetCustomBytesPerToken` verifying custom ratio produces different estimates |
| `cmd/soda/run.go` | Forward `BytesPerToken` from config to engine config alongside `WarnTokens` |

## Test Plan

- [x] Existing `TestEngine_TokenBudgetEstimation` continues to pass (default `3.3` ratio)
- [x] New `TestEngine_TokenBudgetCustomBytesPerToken` validates that a custom ratio (`4.0`) produces different estimates than the default
- [x] Config parsing test validates `bytes_per_token` round-trip from YAML
- [x] Guard clause ensures `BytesPerToken <= 0` falls back to default `3.3`

## Acceptance Criteria

- [x] `BytesPerToken` is configurable in YAML config (`bytes_per_token`)
- [x] Engine defaults to `3.3` when field is unset or non-positive
- [x] `cmd/soda/run.go` wires the new field through to the engine
- [x] Unit tests cover the new behaviour
