### PR TITLE
feat(engine): notification hook on pipeline completion [#376]

### DIFF
--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -367,10 +367,13 @@ func runPipeline(cfg *config.Config, opts pipelineOpts) error {
 
 	// Build notification config from user settings.
 	var notifyCfg pipeline.NotifyConfig
-	if cfg.Notifications.WebhookURL != "" || cfg.Notifications.Script != "" {
+	if cfg.Notifications.WebhookURL != "" || cfg.Notifications.Script != "" ||
+		cfg.Notifications.OnFailureWebhookURL != "" || cfg.Notifications.OnFailureScript != "" {
 		notifyCfg = pipeline.NotifyConfig{
-			WebhookURL: cfg.Notifications.WebhookURL,
-			Script:     cfg.Notifications.Script,
+			WebhookURL:        cfg.Notifications.WebhookURL,
+			Script:            cfg.Notifications.Script,
+			FailureWebhookURL: cfg.Notifications.OnFailureWebhookURL,
+			FailureScript:     cfg.Notifications.OnFailureScript,
 		}
 		if cfg.Notifications.TimeoutSec > 0 {
 			notifyCfg.Timeout = time.Duration(cfg.Notifications.TimeoutSec) * time.Second

--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -846,6 +846,14 @@ func handleEvent(ctx context.Context, cancel context.CancelFunc, engine *pipelin
 			current = c
 		}
 		prog.Message(fmt.Sprintf("Warning: binary version changed since pipeline started (was %s, now %s)", stored, current))
+
+	case pipeline.EventNotifyFailed:
+		handlerType, _ := event.Data["type"].(string)
+		errMsg, _ := event.Data["error"].(string)
+		prog.Message(fmt.Sprintf("  ⚠️  Notification %s failed: %s", handlerType, errMsg))
+
+	case pipeline.EventNotifySuccess:
+		// Notification succeeded — no user-facing output needed.
 	}
 }
 

--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -365,6 +365,18 @@ func runPipeline(cfg *config.Config, opts pipelineOpts) error {
 		maxPipelineDuration = parsed
 	}
 
+	// Build notification config from user settings.
+	var notifyCfg pipeline.NotifyConfig
+	if cfg.Notifications.WebhookURL != "" || cfg.Notifications.Script != "" {
+		notifyCfg = pipeline.NotifyConfig{
+			WebhookURL: cfg.Notifications.WebhookURL,
+			Script:     cfg.Notifications.Script,
+		}
+		if cfg.Notifications.TimeoutSec > 0 {
+			notifyCfg.Timeout = time.Duration(cfg.Notifications.TimeoutSec) * time.Second
+		}
+	}
+
 	engineCfg := pipeline.EngineConfig{
 		Pipeline:               pl,
 		Loader:                 loader,
@@ -391,6 +403,7 @@ func runPipeline(cfg *config.Config, opts pipelineOpts) error {
 		BotUsers:               botUsers,
 		MonitorProfile:         monitorProfile,
 		AuthorityResolver:      authorityResolver,
+		Notify:                 notifyCfg,
 		OnEvent: func(event pipeline.Event) {
 			if event.Kind == pipeline.EventPhaseSkipped || event.Kind == pipeline.EventMonitorSkipped {
 				skippedPhases[event.Phase] = true

--- a/cmd/soda/validate.go
+++ b/cmd/soda/validate.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -77,6 +78,9 @@ func runValidate(w io.Writer, errW io.Writer, cfg *config.Config, pipelineName s
 
 	// Stage 5: Context files
 	validateContextFiles(w, result, cfg)
+
+	// Stage 6: Notifications
+	validateNotifications(w, result, cfg)
 
 	// Print summary
 	fmt.Fprintln(w)
@@ -200,6 +204,57 @@ func validateSchemas(w io.Writer, result *validationResult, pl *pipeline.PhasePi
 		fmt.Fprintln(w, "✓ schemas: all phases have schemas")
 	} else {
 		fmt.Fprintf(w, "⚠ schemas: %d phase(s) missing schemas\n", missingSchemas)
+	}
+}
+
+// validateNotifications checks the notifications config for common errors:
+// script path must exist and be executable, webhook URL must be a valid
+// HTTP(S) URL.
+func validateNotifications(w io.Writer, result *validationResult, cfg *config.Config) {
+	nc := cfg.Notifications
+	if nc.WebhookURL == "" && nc.Script == "" {
+		fmt.Fprintln(w, "✓ notifications: not configured")
+		return
+	}
+
+	notifyErrors := 0
+
+	if nc.WebhookURL != "" {
+		u, err := url.Parse(nc.WebhookURL)
+		if err != nil {
+			result.addError("notifications: invalid webhook URL: %v", err)
+			notifyErrors++
+		} else if u.Scheme != "http" && u.Scheme != "https" {
+			result.addError("notifications: webhook URL must use http or https scheme, got %q", u.Scheme)
+			notifyErrors++
+		} else if u.Host == "" {
+			result.addError("notifications: webhook URL has no host")
+			notifyErrors++
+		}
+	}
+
+	if nc.Script != "" {
+		info, err := os.Stat(nc.Script)
+		if err != nil {
+			result.addError("notifications: script %q not found", nc.Script)
+			notifyErrors++
+		} else if info.IsDir() {
+			result.addError("notifications: script %q is a directory", nc.Script)
+			notifyErrors++
+		} else if info.Mode()&0111 == 0 {
+			result.addWarning("notifications: script %q is not executable", nc.Script)
+		}
+	}
+
+	if notifyErrors == 0 {
+		parts := []string{}
+		if nc.WebhookURL != "" {
+			parts = append(parts, "webhook")
+		}
+		if nc.Script != "" {
+			parts = append(parts, "script")
+		}
+		fmt.Fprintf(w, "✓ notifications: %s configured\n", strings.Join(parts, " + "))
 	}
 }
 

--- a/cmd/soda/validate.go
+++ b/cmd/soda/validate.go
@@ -207,9 +207,46 @@ func validateSchemas(w io.Writer, result *validationResult, pl *pipeline.PhasePi
 	}
 }
 
+// validateWebhookURL validates a single webhook URL and records errors.
+// Returns true if an error was found.
+func validateWebhookURL(result *validationResult, label, rawURL string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		result.addError("notifications: invalid %s URL: %v", label, err)
+		return true
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		result.addError("notifications: %s URL must use http or https scheme, got %q", label, u.Scheme)
+		return true
+	}
+	if u.Host == "" {
+		result.addError("notifications: %s URL has no host", label)
+		return true
+	}
+	return false
+}
+
+// validateScriptPath validates a single script path and records errors/warnings.
+// Returns true if an error was found.
+func validateScriptPath(result *validationResult, label, scriptPath string) bool {
+	info, err := os.Stat(scriptPath)
+	if err != nil {
+		result.addError("notifications: %s %q not found", label, scriptPath)
+		return true
+	}
+	if info.IsDir() {
+		result.addError("notifications: %s %q is a directory", label, scriptPath)
+		return true
+	}
+	if info.Mode()&0111 == 0 {
+		result.addWarning("notifications: %s %q is not executable", label, scriptPath)
+	}
+	return false
+}
+
 // validateNotifications checks the notifications config for common errors:
-// script path must exist and be executable, webhook URL must be a valid
-// HTTP(S) URL.
+// script paths must exist and be executable, webhook URLs must be valid
+// HTTP(S) URLs. Validates both on_finish and on_failure handlers.
 func validateNotifications(w io.Writer, result *validationResult, cfg *config.Config) {
 	nc := cfg.Notifications
 	if nc.WebhookURL == "" && nc.Script == "" && nc.OnFailureWebhookURL == "" && nc.OnFailureScript == "" {
@@ -220,29 +257,26 @@ func validateNotifications(w io.Writer, result *validationResult, cfg *config.Co
 	notifyErrors := 0
 
 	if nc.WebhookURL != "" {
-		u, err := url.Parse(nc.WebhookURL)
-		if err != nil {
-			result.addError("notifications: invalid webhook URL: %v", err)
-			notifyErrors++
-		} else if u.Scheme != "http" && u.Scheme != "https" {
-			result.addError("notifications: webhook URL must use http or https scheme, got %q", u.Scheme)
-			notifyErrors++
-		} else if u.Host == "" {
-			result.addError("notifications: webhook URL has no host")
+		if validateWebhookURL(result, "webhook", nc.WebhookURL) {
 			notifyErrors++
 		}
 	}
 
 	if nc.Script != "" {
-		info, err := os.Stat(nc.Script)
-		if err != nil {
-			result.addError("notifications: script %q not found", nc.Script)
+		if validateScriptPath(result, "script", nc.Script) {
 			notifyErrors++
-		} else if info.IsDir() {
-			result.addError("notifications: script %q is a directory", nc.Script)
+		}
+	}
+
+	if nc.OnFailureWebhookURL != "" {
+		if validateWebhookURL(result, "on_failure webhook", nc.OnFailureWebhookURL) {
 			notifyErrors++
-		} else if info.Mode()&0111 == 0 {
-			result.addWarning("notifications: script %q is not executable", nc.Script)
+		}
+	}
+
+	if nc.OnFailureScript != "" {
+		if validateScriptPath(result, "on_failure script", nc.OnFailureScript) {
+			notifyErrors++
 		}
 	}
 
@@ -253,6 +287,12 @@ func validateNotifications(w io.Writer, result *validationResult, cfg *config.Co
 		}
 		if nc.Script != "" {
 			parts = append(parts, "script")
+		}
+		if nc.OnFailureWebhookURL != "" {
+			parts = append(parts, "on_failure webhook")
+		}
+		if nc.OnFailureScript != "" {
+			parts = append(parts, "on_failure script")
 		}
 		fmt.Fprintf(w, "✓ notifications: %s configured\n", strings.Join(parts, " + "))
 	}

--- a/cmd/soda/validate.go
+++ b/cmd/soda/validate.go
@@ -212,7 +212,7 @@ func validateSchemas(w io.Writer, result *validationResult, pl *pipeline.PhasePi
 // HTTP(S) URL.
 func validateNotifications(w io.Writer, result *validationResult, cfg *config.Config) {
 	nc := cfg.Notifications
-	if nc.WebhookURL == "" && nc.Script == "" {
+	if nc.WebhookURL == "" && nc.Script == "" && nc.OnFailureWebhookURL == "" && nc.OnFailureScript == "" {
 		fmt.Fprintln(w, "✓ notifications: not configured")
 		return
 	}

--- a/cmd/soda/validate_test.go
+++ b/cmd/soda/validate_test.go
@@ -498,6 +498,150 @@ func TestValidateNotifications_ScriptNotExecutable(t *testing.T) {
 	}
 }
 
+func TestValidateNotifications_OnFailureWebhookValid(t *testing.T) {
+	cfg := &config.Config{
+		Notifications: config.NotificationsConfig{
+			OnFailureWebhookURL: "https://alerts.example.com/fail",
+		},
+	}
+
+	result := &validationResult{}
+	var buf bytes.Buffer
+	validateNotifications(&buf, result, cfg)
+
+	if result.hasErrors() {
+		t.Errorf("expected no errors, got: %v", result.errors)
+	}
+	if !strings.Contains(buf.String(), "on_failure webhook configured") {
+		t.Errorf("expected 'on_failure webhook configured' message, got: %s", buf.String())
+	}
+}
+
+func TestValidateNotifications_OnFailureWebhookInvalidScheme(t *testing.T) {
+	cfg := &config.Config{
+		Notifications: config.NotificationsConfig{
+			OnFailureWebhookURL: "ftp://alerts.example.com/fail",
+		},
+	}
+
+	result := &validationResult{}
+	var buf bytes.Buffer
+	validateNotifications(&buf, result, cfg)
+
+	if !result.hasErrors() {
+		t.Error("expected error for non-HTTP scheme in on_failure webhook")
+	}
+	if !strings.Contains(result.errors[0], "http or https") {
+		t.Errorf("error should mention http/https, got: %s", result.errors[0])
+	}
+}
+
+func TestValidateNotifications_OnFailureScriptNotFound(t *testing.T) {
+	cfg := &config.Config{
+		Notifications: config.NotificationsConfig{
+			OnFailureScript: "/nonexistent/fail-notify.sh",
+		},
+	}
+
+	result := &validationResult{}
+	var buf bytes.Buffer
+	validateNotifications(&buf, result, cfg)
+
+	if !result.hasErrors() {
+		t.Error("expected error for missing on_failure script")
+	}
+	if !strings.Contains(result.errors[0], "not found") {
+		t.Errorf("error should mention 'not found', got: %s", result.errors[0])
+	}
+}
+
+func TestValidateNotifications_OnFailureScriptExists(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "fail-notify.sh")
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\necho fail\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{
+		Notifications: config.NotificationsConfig{
+			OnFailureScript: scriptPath,
+		},
+	}
+
+	result := &validationResult{}
+	var buf bytes.Buffer
+	validateNotifications(&buf, result, cfg)
+
+	if result.hasErrors() {
+		t.Errorf("expected no errors, got: %v", result.errors)
+	}
+	if !strings.Contains(buf.String(), "on_failure script configured") {
+		t.Errorf("expected 'on_failure script configured' message, got: %s", buf.String())
+	}
+}
+
+func TestValidateNotifications_OnFailureScriptNotExecutable(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "fail-notify.sh")
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\necho fail\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{
+		Notifications: config.NotificationsConfig{
+			OnFailureScript: scriptPath,
+		},
+	}
+
+	result := &validationResult{}
+	var buf bytes.Buffer
+	validateNotifications(&buf, result, cfg)
+
+	if result.hasErrors() {
+		t.Errorf("not-executable should be a warning, not error: %v", result.errors)
+	}
+	if len(result.warnings) == 0 {
+		t.Error("expected warning for non-executable on_failure script")
+	}
+	if len(result.warnings) > 0 && !strings.Contains(result.warnings[0], "not executable") {
+		t.Errorf("warning should mention 'not executable', got: %s", result.warnings[0])
+	}
+}
+
+func TestValidateNotifications_AllHandlersConfigured(t *testing.T) {
+	dir := t.TempDir()
+	finishScript := filepath.Join(dir, "notify.sh")
+	failScript := filepath.Join(dir, "fail-notify.sh")
+	for _, p := range []string{finishScript, failScript} {
+		if err := os.WriteFile(p, []byte("#!/bin/sh\necho ok\n"), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cfg := &config.Config{
+		Notifications: config.NotificationsConfig{
+			WebhookURL:          "https://hooks.example.com/finish",
+			Script:              finishScript,
+			OnFailureWebhookURL: "https://hooks.example.com/fail",
+			OnFailureScript:     failScript,
+		},
+	}
+
+	result := &validationResult{}
+	var buf bytes.Buffer
+	validateNotifications(&buf, result, cfg)
+
+	if result.hasErrors() {
+		t.Errorf("expected no errors, got: %v", result.errors)
+	}
+	output := buf.String()
+	for _, want := range []string{"webhook", "script", "on_failure webhook", "on_failure script"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("expected output to contain %q, got: %s", want, output)
+		}
+	}
+}
+
 func TestRunValidate_ErrorOutput(t *testing.T) {
 	// Test that errors go to stderr and success markers go to stdout.
 	cfg := &config.Config{

--- a/cmd/soda/validate_test.go
+++ b/cmd/soda/validate_test.go
@@ -352,6 +352,152 @@ func TestRunValidate_DocsOnlyPipeline(t *testing.T) {
 	}
 }
 
+// --- Notification validation tests ---
+
+func TestValidateNotifications_NotConfigured(t *testing.T) {
+	cfg := &config.Config{}
+
+	result := &validationResult{}
+	var buf bytes.Buffer
+	validateNotifications(&buf, result, cfg)
+
+	if result.hasErrors() {
+		t.Error("expected no errors for unconfigured notifications")
+	}
+	if !strings.Contains(buf.String(), "not configured") {
+		t.Errorf("expected 'not configured' message, got: %s", buf.String())
+	}
+}
+
+func TestValidateNotifications_ValidWebhookURL(t *testing.T) {
+	cfg := &config.Config{
+		Notifications: config.NotificationsConfig{
+			WebhookURL: "https://hooks.example.com/pipeline",
+		},
+	}
+
+	result := &validationResult{}
+	var buf bytes.Buffer
+	validateNotifications(&buf, result, cfg)
+
+	if result.hasErrors() {
+		t.Errorf("expected no errors, got: %v", result.errors)
+	}
+	if !strings.Contains(buf.String(), "webhook configured") {
+		t.Errorf("expected 'webhook configured' message, got: %s", buf.String())
+	}
+}
+
+func TestValidateNotifications_InvalidWebhookScheme(t *testing.T) {
+	cfg := &config.Config{
+		Notifications: config.NotificationsConfig{
+			WebhookURL: "ftp://hooks.example.com/pipeline",
+		},
+	}
+
+	result := &validationResult{}
+	var buf bytes.Buffer
+	validateNotifications(&buf, result, cfg)
+
+	if !result.hasErrors() {
+		t.Error("expected error for non-HTTP scheme")
+	}
+	if !strings.Contains(result.errors[0], "http or https") {
+		t.Errorf("error should mention http/https, got: %s", result.errors[0])
+	}
+}
+
+func TestValidateNotifications_WebhookNoHost(t *testing.T) {
+	cfg := &config.Config{
+		Notifications: config.NotificationsConfig{
+			WebhookURL: "https://",
+		},
+	}
+
+	result := &validationResult{}
+	var buf bytes.Buffer
+	validateNotifications(&buf, result, cfg)
+
+	if !result.hasErrors() {
+		t.Error("expected error for URL with no host")
+	}
+	if !strings.Contains(result.errors[0], "no host") {
+		t.Errorf("error should mention 'no host', got: %s", result.errors[0])
+	}
+}
+
+func TestValidateNotifications_ScriptExists(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "notify.sh")
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\necho ok\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{
+		Notifications: config.NotificationsConfig{
+			Script: scriptPath,
+		},
+	}
+
+	result := &validationResult{}
+	var buf bytes.Buffer
+	validateNotifications(&buf, result, cfg)
+
+	if result.hasErrors() {
+		t.Errorf("expected no errors, got: %v", result.errors)
+	}
+	if !strings.Contains(buf.String(), "script configured") {
+		t.Errorf("expected 'script configured' message, got: %s", buf.String())
+	}
+}
+
+func TestValidateNotifications_ScriptNotFound(t *testing.T) {
+	cfg := &config.Config{
+		Notifications: config.NotificationsConfig{
+			Script: "/nonexistent/notify.sh",
+		},
+	}
+
+	result := &validationResult{}
+	var buf bytes.Buffer
+	validateNotifications(&buf, result, cfg)
+
+	if !result.hasErrors() {
+		t.Error("expected error for missing script")
+	}
+	if !strings.Contains(result.errors[0], "not found") {
+		t.Errorf("error should mention 'not found', got: %s", result.errors[0])
+	}
+}
+
+func TestValidateNotifications_ScriptNotExecutable(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "notify.sh")
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\necho ok\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{
+		Notifications: config.NotificationsConfig{
+			Script: scriptPath,
+		},
+	}
+
+	result := &validationResult{}
+	var buf bytes.Buffer
+	validateNotifications(&buf, result, cfg)
+
+	if result.hasErrors() {
+		t.Errorf("not-executable should be a warning, not error: %v", result.errors)
+	}
+	if len(result.warnings) == 0 {
+		t.Error("expected warning for non-executable script")
+	}
+	if len(result.warnings) > 0 && !strings.Contains(result.warnings[0], "not executable") {
+		t.Errorf("warning should mention 'not executable', got: %s", result.warnings[0])
+	}
+}
+
 func TestRunValidate_ErrorOutput(t *testing.T) {
 	// Test that errors go to stderr and success markers go to stdout.
 	cfg := &config.Config{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,21 +11,31 @@ import (
 
 // Config holds all SODA configuration loaded from a YAML file.
 type Config struct {
-	TicketSource string              `yaml:"ticket_source"`
-	Jira         JiraConfig          `yaml:"jira"`
-	GitHub       GitHubTicketConfig  `yaml:"github"`
-	Mode         string              `yaml:"mode"`
-	Model        string              `yaml:"model"`
-	Sandbox      SandboxConfig       `yaml:"sandbox"`
-	Limits       LimitsConfig        `yaml:"limits"`
-	PhasesPath   string              `yaml:"phases_path"`  // explicit path to pipeline YAML; overrides CWD discovery
-	PromptsPath  string              `yaml:"prompts_path"` // base directory for prompt templates; overrides CWD discovery
-	WorktreeDir  string              `yaml:"worktree_dir"`
-	StateDir     string              `yaml:"state_dir"`
-	Context      []string            `yaml:"context"`
-	PhaseContext map[string][]string `yaml:"phase_context"`
-	Repos        []RepoConfig        `yaml:"repos"`
-	Monitor      MonitorConfig       `yaml:"monitor"`
+	TicketSource  string              `yaml:"ticket_source"`
+	Jira          JiraConfig          `yaml:"jira"`
+	GitHub        GitHubTicketConfig  `yaml:"github"`
+	Mode          string              `yaml:"mode"`
+	Model         string              `yaml:"model"`
+	Sandbox       SandboxConfig       `yaml:"sandbox"`
+	Limits        LimitsConfig        `yaml:"limits"`
+	PhasesPath    string              `yaml:"phases_path"`  // explicit path to pipeline YAML; overrides CWD discovery
+	PromptsPath   string              `yaml:"prompts_path"` // base directory for prompt templates; overrides CWD discovery
+	WorktreeDir   string              `yaml:"worktree_dir"`
+	StateDir      string              `yaml:"state_dir"`
+	Context       []string            `yaml:"context"`
+	PhaseContext  map[string][]string `yaml:"phase_context"`
+	Repos         []RepoConfig        `yaml:"repos"`
+	Monitor       MonitorConfig       `yaml:"monitor"`
+	Notifications NotificationsConfig `yaml:"notifications"`
+}
+
+// NotificationsConfig holds pipeline completion notification settings.
+// Both webhook and script callbacks are optional; if both are configured,
+// both are invoked (best-effort, errors are logged but never propagated).
+type NotificationsConfig struct {
+	WebhookURL string `yaml:"webhook_url"` // HTTP(S) URL to POST a JSON payload on completion
+	Script     string `yaml:"script"`      // path to executable script invoked on completion
+	TimeoutSec int    `yaml:"timeout_sec"` // max seconds for webhook/script; 0 means default (30)
 }
 
 // MonitorConfig holds monitor phase settings loaded from the config file.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,9 +33,11 @@ type Config struct {
 // Both webhook and script callbacks are optional; if both are configured,
 // both are invoked (best-effort, errors are logged but never propagated).
 type NotificationsConfig struct {
-	WebhookURL string `yaml:"webhook_url"` // HTTP(S) URL to POST a JSON payload on completion
-	Script     string `yaml:"script"`      // path to executable script invoked on completion
-	TimeoutSec int    `yaml:"timeout_sec"` // max seconds for webhook/script; 0 means default (30)
+	WebhookURL          string `yaml:"webhook_url"`            // HTTP(S) URL to POST a JSON payload on completion (on_finish)
+	Script              string `yaml:"script"`                 // path to executable script invoked on completion (on_finish)
+	OnFailureWebhookURL string `yaml:"on_failure_webhook_url"` // HTTP(S) URL to POST only when the pipeline fails (on_failure)
+	OnFailureScript     string `yaml:"on_failure_script"`      // path to executable script invoked only when the pipeline fails (on_failure)
+	TimeoutSec          int    `yaml:"timeout_sec"`            // max seconds for webhook/script; 0 means default (10)
 }
 
 // MonitorConfig holds monitor phase settings loaded from the config file.

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -64,6 +64,7 @@ type EngineConfig struct {
 	SelfUser               string            // PR author username for self-comment filtering
 	BotUsers               []string          // known bot usernames to filter
 	Stderr                 io.Writer         // destination for warning messages; defaults to os.Stderr
+	Notify                 NotifyConfig      // notification settings for pipeline completion; zero value disables
 }
 
 // maxReworkCycles returns the configured max rework cycles, defaulting to DefaultMaxReworkCycles.

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -257,7 +257,7 @@ func (e *Engine) ensureWorktree(ctx context.Context) error {
 }
 
 // Run executes the full pipeline from the beginning, skipping completed phases.
-func (e *Engine) Run(ctx context.Context) error {
+func (e *Engine) Run(ctx context.Context) (runErr error) {
 	if err := e.state.AcquireLock(); err != nil {
 		return fmt.Errorf("engine: %w", err)
 	}
@@ -266,6 +266,9 @@ func (e *Engine) Run(ctx context.Context) error {
 	// Start broadcast socket for live streaming to attach clients.
 	e.startBroadcaster()
 	defer e.stopBroadcaster()
+
+	// Fire notification hooks on exit (best-effort).
+	defer func() { e.notifyOnFinish(runErr) }()
 
 	// Apply pipeline-level timeout if configured.
 	ctx, cancel := e.applyPipelineTimeout(ctx)
@@ -329,7 +332,7 @@ func (e *Engine) Run(ctx context.Context) error {
 }
 
 // Resume restarts the pipeline from the named phase, skipping prior completed phases.
-func (e *Engine) Resume(ctx context.Context, fromPhase string) error {
+func (e *Engine) Resume(ctx context.Context, fromPhase string) (runErr error) {
 	startIdx := -1
 	for i, phase := range e.config.Pipeline.Phases {
 		if phase.Name == fromPhase {
@@ -349,6 +352,9 @@ func (e *Engine) Resume(ctx context.Context, fromPhase string) error {
 	// Start broadcast socket for live streaming to attach clients.
 	e.startBroadcaster()
 	defer e.stopBroadcaster()
+
+	// Fire notification hooks on exit (best-effort).
+	defer func() { e.notifyOnFinish(runErr) }()
 
 	// Apply pipeline-level timeout if configured.
 	ctx, cancel := e.applyPipelineTimeout(ctx)

--- a/internal/pipeline/notify.go
+++ b/internal/pipeline/notify.go
@@ -1,6 +1,13 @@
 package pipeline
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os/exec"
 	"time"
 )
 
@@ -37,4 +44,158 @@ func (c *NotifyConfig) notifyTimeout() time.Duration {
 		return c.Timeout
 	}
 	return defaultNotifyTimeout
+}
+
+// EventNotifyFailed is emitted when a notification callback fails.
+// Notification errors are best-effort and never propagated to the caller.
+const EventNotifyFailed = "notify_failed"
+
+// EventNotifySuccess is emitted when a notification callback succeeds.
+const EventNotifySuccess = "notify_success"
+
+// webhookPayload is the JSON body sent to the configured webhook URL.
+type webhookPayload struct {
+	Ticket    string       `json:"ticket"`
+	Status    NotifyStatus `json:"status"`
+	Branch    string       `json:"branch,omitempty"`
+	PRURL     string       `json:"pr_url,omitempty"`
+	TotalCost float64      `json:"total_cost"`
+	Error     string       `json:"error,omitempty"`
+}
+
+// deriveStatus determines the notification status from the pipeline run error
+// and meta state. It uses errors.As to classify the error, matching existing
+// patterns in wrapTimeoutError and formatNextSteps.
+func (e *Engine) deriveStatus(runErr error) NotifyStatus {
+	if runErr == nil {
+		return NotifyStatusSuccess
+	}
+
+	// Check for pipeline timeout.
+	var pte *PipelineTimeoutError
+	if errors.As(runErr, &pte) {
+		return NotifyStatusTimeout
+	}
+
+	// Check for partial: submit completed but a later phase (e.g., monitor) failed.
+	meta := e.state.Meta()
+	if ps := meta.Phases["submit"]; ps != nil && ps.Status == PhaseCompleted {
+		// If submit completed and we still got an error, it's partial.
+		return NotifyStatusPartial
+	}
+
+	return NotifyStatusFailure
+}
+
+// buildWebhookPayload constructs the JSON payload for the webhook notification.
+func (e *Engine) buildWebhookPayload(status NotifyStatus, runErr error) webhookPayload {
+	meta := e.state.Meta()
+	p := webhookPayload{
+		Ticket:    meta.Ticket,
+		Status:    status,
+		Branch:    meta.Branch,
+		TotalCost: meta.TotalCost,
+	}
+	if runErr != nil {
+		p.Error = runErr.Error()
+	}
+	// Extract PR URL from submit result.
+	p.PRURL = e.extractPRURL()
+	return p
+}
+
+// runScript executes the notification script with status information passed
+// as arguments. The script is invoked directly (no shell) via
+// exec.CommandContext.
+func (e *Engine) runScript(ctx context.Context, status NotifyStatus, runErr error) error {
+	script := e.config.Notify.Script
+	meta := e.state.Meta()
+
+	args := []string{
+		string(status),
+		meta.Ticket,
+	}
+	if meta.Branch != "" {
+		args = append(args, meta.Branch)
+	}
+
+	cmd := exec.CommandContext(ctx, script, args...)
+	cmd.Dir = e.config.WorkDir
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("notify script %s: %w (output: %s)", script, err, string(output))
+	}
+	return nil
+}
+
+// postWebhook sends a POST request with the JSON payload to the configured
+// webhook URL.
+func (e *Engine) postWebhook(ctx context.Context, payload webhookPayload) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("notify webhook marshal: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, e.config.Notify.WebhookURL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("notify webhook request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("notify webhook POST: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("notify webhook POST: status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// notifyOnFinish is the best-effort notification orchestrator. It derives the
+// pipeline status, runs the configured script and/or webhook, and emits events
+// on success or failure. Errors are captured via EventNotifyFailed and never
+// propagated to the caller.
+func (e *Engine) notifyOnFinish(runErr error) {
+	cfg := e.config.Notify
+	if cfg.WebhookURL == "" && cfg.Script == "" {
+		return
+	}
+
+	status := e.deriveStatus(runErr)
+	timeout := cfg.notifyTimeout()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	if cfg.Script != "" {
+		if err := e.runScript(ctx, status, runErr); err != nil {
+			e.emit(Event{
+				Kind: EventNotifyFailed,
+				Data: map[string]any{"type": "script", "error": err.Error()},
+			})
+		} else {
+			e.emit(Event{
+				Kind: EventNotifySuccess,
+				Data: map[string]any{"type": "script"},
+			})
+		}
+	}
+
+	if cfg.WebhookURL != "" {
+		payload := e.buildWebhookPayload(status, runErr)
+		if err := e.postWebhook(ctx, payload); err != nil {
+			e.emit(Event{
+				Kind: EventNotifyFailed,
+				Data: map[string]any{"type": "webhook", "error": err.Error()},
+			})
+		} else {
+			e.emit(Event{
+				Kind: EventNotifySuccess,
+				Data: map[string]any{"type": "webhook"},
+			})
+		}
+	}
 }

--- a/internal/pipeline/notify.go
+++ b/internal/pipeline/notify.go
@@ -29,9 +29,11 @@ const (
 // Both WebhookURL and Script are optional; when both are set, both
 // are invoked best-effort.
 type NotifyConfig struct {
-	WebhookURL string        // HTTP(S) URL to POST a JSON payload on completion
-	Script     string        // path to executable script invoked on completion
-	Timeout    time.Duration // max duration for webhook/script; 0 means default (30s)
+	WebhookURL        string        // HTTP(S) URL to POST a JSON payload on completion (on_finish)
+	Script            string        // path to executable script invoked on completion (on_finish)
+	FailureWebhookURL string        // HTTP(S) URL to POST only when the pipeline fails (on_failure)
+	FailureScript     string        // path to executable script invoked only when the pipeline fails (on_failure)
+	Timeout           time.Duration // max duration for webhook/script; 0 means default (10s)
 }
 
 // defaultNotifyTimeout is the default timeout for notification webhook and
@@ -125,11 +127,9 @@ func (e *Engine) buildWebhookPayload(status NotifyStatus, runErr error) webhookP
 	return p
 }
 
-// runScript executes the notification script with status information passed
-// as arguments. The script is invoked directly (no shell) via
-// exec.CommandContext.
-func (e *Engine) runScript(ctx context.Context, status NotifyStatus, runErr error) error {
-	script := e.config.Notify.Script
+// runScriptAt executes the script at scriptPath with status information passed
+// as arguments. The script is invoked directly (no shell) via exec.CommandContext.
+func (e *Engine) runScriptAt(ctx context.Context, scriptPath string, status NotifyStatus, runErr error) error {
 	meta := e.state.Meta()
 
 	args := []string{
@@ -140,25 +140,31 @@ func (e *Engine) runScript(ctx context.Context, status NotifyStatus, runErr erro
 		args = append(args, meta.Branch)
 	}
 
-	cmd := exec.CommandContext(ctx, script, args...)
+	cmd := exec.CommandContext(ctx, scriptPath, args...)
 	cmd.Dir = e.config.WorkDir
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("notify script %s: %w (output: %s)", script, err, string(output))
+		return fmt.Errorf("notify script %s: %w (output: %s)", scriptPath, err, string(output))
 	}
 	return nil
 }
 
-// postWebhook sends a POST request with the JSON payload to the configured
-// webhook URL.
-func (e *Engine) postWebhook(ctx context.Context, payload webhookPayload) error {
+// runScript executes the notification script with status information passed
+// as arguments. The script is invoked directly (no shell) via
+// exec.CommandContext.
+func (e *Engine) runScript(ctx context.Context, status NotifyStatus, runErr error) error {
+	return e.runScriptAt(ctx, e.config.Notify.Script, status, runErr)
+}
+
+// postWebhookTo sends a POST request with the JSON payload to the given URL.
+func (e *Engine) postWebhookTo(ctx context.Context, webhookURL string, payload webhookPayload) error {
 	body, err := json.Marshal(payload)
 	if err != nil {
 		return fmt.Errorf("notify webhook marshal: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, e.config.Notify.WebhookURL, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, webhookURL, bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("notify webhook request: %w", err)
 	}
@@ -176,13 +182,19 @@ func (e *Engine) postWebhook(ctx context.Context, payload webhookPayload) error 
 	return nil
 }
 
+// postWebhook sends a POST request with the JSON payload to the configured
+// webhook URL.
+func (e *Engine) postWebhook(ctx context.Context, payload webhookPayload) error {
+	return e.postWebhookTo(ctx, e.config.Notify.WebhookURL, payload)
+}
+
 // notifyOnFinish is the best-effort notification orchestrator. It derives the
 // pipeline status, runs the configured script and/or webhook, and emits events
 // on success or failure. Errors are captured via EventNotifyFailed and never
 // propagated to the caller.
 func (e *Engine) notifyOnFinish(runErr error) {
 	cfg := e.config.Notify
-	if cfg.WebhookURL == "" && cfg.Script == "" {
+	if cfg.WebhookURL == "" && cfg.Script == "" && cfg.FailureWebhookURL == "" && cfg.FailureScript == "" {
 		return
 	}
 
@@ -191,6 +203,7 @@ func (e *Engine) notifyOnFinish(runErr error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
+	// on_finish handlers: fire on every completion (success or failure).
 	if cfg.Script != "" {
 		if err := e.runScript(ctx, status, runErr); err != nil {
 			e.emit(Event{
@@ -217,6 +230,38 @@ func (e *Engine) notifyOnFinish(runErr error) {
 				Kind: EventNotifySuccess,
 				Data: map[string]any{"type": "webhook"},
 			})
+		}
+	}
+
+	// on_failure handlers: fire only when the pipeline encountered an error.
+	if runErr != nil {
+		if cfg.FailureScript != "" {
+			if err := e.runScriptAt(ctx, cfg.FailureScript, status, runErr); err != nil {
+				e.emit(Event{
+					Kind: EventNotifyFailed,
+					Data: map[string]any{"type": "script", "error": err.Error()},
+				})
+			} else {
+				e.emit(Event{
+					Kind: EventNotifySuccess,
+					Data: map[string]any{"type": "script"},
+				})
+			}
+		}
+
+		if cfg.FailureWebhookURL != "" {
+			payload := e.buildWebhookPayload(status, runErr)
+			if err := e.postWebhookTo(ctx, cfg.FailureWebhookURL, payload); err != nil {
+				e.emit(Event{
+					Kind: EventNotifyFailed,
+					Data: map[string]any{"type": "webhook", "error": err.Error()},
+				})
+			} else {
+				e.emit(Event{
+					Kind: EventNotifySuccess,
+					Data: map[string]any{"type": "webhook"},
+				})
+			}
 		}
 	}
 }

--- a/internal/pipeline/notify.go
+++ b/internal/pipeline/notify.go
@@ -1,0 +1,40 @@
+package pipeline
+
+import (
+	"time"
+)
+
+// NotifyStatus represents the outcome of a pipeline run for notifications.
+type NotifyStatus string
+
+const (
+	// NotifyStatusSuccess indicates the pipeline completed all phases.
+	NotifyStatusSuccess NotifyStatus = "success"
+	// NotifyStatusFailure indicates the pipeline failed.
+	NotifyStatusFailure NotifyStatus = "failure"
+	// NotifyStatusTimeout indicates the pipeline exceeded its time limit.
+	NotifyStatusTimeout NotifyStatus = "timeout"
+	// NotifyStatusPartial indicates submit succeeded but monitor failed.
+	NotifyStatusPartial NotifyStatus = "partial"
+)
+
+// NotifyConfig holds notification settings for the engine.
+// Both WebhookURL and Script are optional; when both are set, both
+// are invoked best-effort.
+type NotifyConfig struct {
+	WebhookURL string        // HTTP(S) URL to POST a JSON payload on completion
+	Script     string        // path to executable script invoked on completion
+	Timeout    time.Duration // max duration for webhook/script; 0 means default (30s)
+}
+
+// defaultNotifyTimeout is the default timeout for notification webhook and
+// script callbacks when no explicit timeout is configured.
+const defaultNotifyTimeout = 30 * time.Second
+
+// notifyTimeout returns the configured timeout, falling back to the default.
+func (c *NotifyConfig) notifyTimeout() time.Duration {
+	if c.Timeout > 0 {
+		return c.Timeout
+	}
+	return defaultNotifyTimeout
+}

--- a/internal/pipeline/notify.go
+++ b/internal/pipeline/notify.go
@@ -129,6 +129,7 @@ func (e *Engine) buildWebhookPayload(status NotifyStatus, runErr error) webhookP
 
 // runScriptAt executes the script at scriptPath with status information passed
 // as arguments. The script is invoked directly (no shell) via exec.CommandContext.
+// stderr is captured separately and logged even on success.
 func (e *Engine) runScriptAt(ctx context.Context, scriptPath string, status NotifyStatus, runErr error) error {
 	meta := e.state.Meta()
 
@@ -143,9 +144,15 @@ func (e *Engine) runScriptAt(ctx context.Context, scriptPath string, status Noti
 	cmd := exec.CommandContext(ctx, scriptPath, args...)
 	cmd.Dir = e.config.WorkDir
 
-	output, err := cmd.CombinedOutput()
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = &stderrBuf
+
+	err := cmd.Run()
+	if stderrOut := stderrBuf.String(); stderrOut != "" {
+		fmt.Fprintf(e.config.Stderr, "notify script %s stderr: %s", scriptPath, stderrOut)
+	}
 	if err != nil {
-		return fmt.Errorf("notify script %s: %w (output: %s)", scriptPath, err, string(output))
+		return fmt.Errorf("notify script %s: %w", scriptPath, err)
 	}
 	return nil
 }

--- a/internal/pipeline/notify.go
+++ b/internal/pipeline/notify.go
@@ -53,14 +53,22 @@ const EventNotifyFailed = "notify_failed"
 // EventNotifySuccess is emitted when a notification callback succeeds.
 const EventNotifySuccess = "notify_success"
 
+// phaseTokens holds the per-phase token counts included in webhook payloads.
+type phaseTokens struct {
+	TokensIn      int64 `json:"tokens_in"`
+	TokensOut     int64 `json:"tokens_out"`
+	CacheTokensIn int64 `json:"cache_tokens_in"`
+}
+
 // webhookPayload is the JSON body sent to the configured webhook URL.
 type webhookPayload struct {
-	Ticket    string       `json:"ticket"`
-	Status    NotifyStatus `json:"status"`
-	Branch    string       `json:"branch,omitempty"`
-	PRURL     string       `json:"pr_url,omitempty"`
-	TotalCost float64      `json:"total_cost"`
-	Error     string       `json:"error,omitempty"`
+	Ticket    string                 `json:"ticket"`
+	Status    NotifyStatus           `json:"status"`
+	Branch    string                 `json:"branch,omitempty"`
+	PRURL     string                 `json:"pr_url,omitempty"`
+	TotalCost float64                `json:"total_cost"`
+	Error     string                 `json:"error,omitempty"`
+	Tokens    map[string]phaseTokens `json:"tokens,omitempty"`
 }
 
 // deriveStatus determines the notification status from the pipeline run error
@@ -101,6 +109,19 @@ func (e *Engine) buildWebhookPayload(status NotifyStatus, runErr error) webhookP
 	}
 	// Extract PR URL from submit result.
 	p.PRURL = e.extractPRURL()
+	// Populate per-phase token counts with cache breakdown.
+	if len(meta.Phases) > 0 {
+		p.Tokens = make(map[string]phaseTokens, len(meta.Phases))
+		for name, ps := range meta.Phases {
+			if ps != nil {
+				p.Tokens[name] = phaseTokens{
+					TokensIn:      ps.TokensIn,
+					TokensOut:     ps.TokensOut,
+					CacheTokensIn: ps.CacheTokensIn,
+				}
+			}
+		}
+	}
 	return p
 }
 

--- a/internal/pipeline/notify.go
+++ b/internal/pipeline/notify.go
@@ -195,10 +195,31 @@ func (e *Engine) postWebhook(ctx context.Context, payload webhookPayload) error 
 	return e.postWebhookTo(ctx, e.config.Notify.WebhookURL, payload)
 }
 
+// notifyWithTimeout runs fn with a fresh per-handler timeout. It is a helper
+// for notifyOnFinish to ensure each handler gets its own independent timeout
+// rather than sharing a single deadline across sequential handlers.
+func (e *Engine) notifyWithTimeout(timeout time.Duration, handlerType string, fn func(ctx context.Context) error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	if err := fn(ctx); err != nil {
+		e.emit(Event{
+			Kind: EventNotifyFailed,
+			Data: map[string]any{"type": handlerType, "error": err.Error()},
+		})
+	} else {
+		e.emit(Event{
+			Kind: EventNotifySuccess,
+			Data: map[string]any{"type": handlerType},
+		})
+	}
+}
+
 // notifyOnFinish is the best-effort notification orchestrator. It derives the
 // pipeline status, runs the configured script and/or webhook, and emits events
-// on success or failure. Errors are captured via EventNotifyFailed and never
-// propagated to the caller.
+// on success or failure. Each handler gets its own independent timeout so that
+// a slow handler cannot starve subsequent ones. Errors are captured via
+// EventNotifyFailed and never propagated to the caller.
 func (e *Engine) notifyOnFinish(runErr error) {
 	cfg := e.config.Notify
 	if cfg.WebhookURL == "" && cfg.Script == "" && cfg.FailureWebhookURL == "" && cfg.FailureScript == "" {
@@ -207,68 +228,34 @@ func (e *Engine) notifyOnFinish(runErr error) {
 
 	status := e.deriveStatus(runErr)
 	timeout := cfg.notifyTimeout()
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
 
 	// on_finish handlers: fire on every completion (success or failure).
 	if cfg.Script != "" {
-		if err := e.runScript(ctx, status, runErr); err != nil {
-			e.emit(Event{
-				Kind: EventNotifyFailed,
-				Data: map[string]any{"type": "script", "error": err.Error()},
-			})
-		} else {
-			e.emit(Event{
-				Kind: EventNotifySuccess,
-				Data: map[string]any{"type": "script"},
-			})
-		}
+		e.notifyWithTimeout(timeout, "script", func(ctx context.Context) error {
+			return e.runScript(ctx, status, runErr)
+		})
 	}
 
 	if cfg.WebhookURL != "" {
 		payload := e.buildWebhookPayload(status, runErr)
-		if err := e.postWebhook(ctx, payload); err != nil {
-			e.emit(Event{
-				Kind: EventNotifyFailed,
-				Data: map[string]any{"type": "webhook", "error": err.Error()},
-			})
-		} else {
-			e.emit(Event{
-				Kind: EventNotifySuccess,
-				Data: map[string]any{"type": "webhook"},
-			})
-		}
+		e.notifyWithTimeout(timeout, "webhook", func(ctx context.Context) error {
+			return e.postWebhook(ctx, payload)
+		})
 	}
 
 	// on_failure handlers: fire only when the pipeline encountered an error.
 	if runErr != nil {
 		if cfg.FailureScript != "" {
-			if err := e.runScriptAt(ctx, cfg.FailureScript, status, runErr); err != nil {
-				e.emit(Event{
-					Kind: EventNotifyFailed,
-					Data: map[string]any{"type": "script", "error": err.Error()},
-				})
-			} else {
-				e.emit(Event{
-					Kind: EventNotifySuccess,
-					Data: map[string]any{"type": "script"},
-				})
-			}
+			e.notifyWithTimeout(timeout, "script", func(ctx context.Context) error {
+				return e.runScriptAt(ctx, cfg.FailureScript, status, runErr)
+			})
 		}
 
 		if cfg.FailureWebhookURL != "" {
 			payload := e.buildWebhookPayload(status, runErr)
-			if err := e.postWebhookTo(ctx, cfg.FailureWebhookURL, payload); err != nil {
-				e.emit(Event{
-					Kind: EventNotifyFailed,
-					Data: map[string]any{"type": "webhook", "error": err.Error()},
-				})
-			} else {
-				e.emit(Event{
-					Kind: EventNotifySuccess,
-					Data: map[string]any{"type": "webhook"},
-				})
-			}
+			e.notifyWithTimeout(timeout, "webhook", func(ctx context.Context) error {
+				return e.postWebhookTo(ctx, cfg.FailureWebhookURL, payload)
+			})
 		}
 	}
 }

--- a/internal/pipeline/notify.go
+++ b/internal/pipeline/notify.go
@@ -36,7 +36,7 @@ type NotifyConfig struct {
 
 // defaultNotifyTimeout is the default timeout for notification webhook and
 // script callbacks when no explicit timeout is configured.
-const defaultNotifyTimeout = 30 * time.Second
+const defaultNotifyTimeout = 10 * time.Second
 
 // notifyTimeout returns the configured timeout, falling back to the default.
 func (c *NotifyConfig) notifyTimeout() time.Duration {

--- a/internal/pipeline/notify.go
+++ b/internal/pipeline/notify.go
@@ -18,7 +18,7 @@ const (
 	// NotifyStatusSuccess indicates the pipeline completed all phases.
 	NotifyStatusSuccess NotifyStatus = "success"
 	// NotifyStatusFailure indicates the pipeline failed.
-	NotifyStatusFailure NotifyStatus = "failure"
+	NotifyStatusFailure NotifyStatus = "failed"
 	// NotifyStatusTimeout indicates the pipeline exceeded its time limit.
 	NotifyStatusTimeout NotifyStatus = "timeout"
 	// NotifyStatusPartial indicates submit succeeded but monitor failed.

--- a/internal/pipeline/notify_test.go
+++ b/internal/pipeline/notify_test.go
@@ -1,0 +1,593 @@
+package pipeline
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/decko/soda/internal/runner"
+)
+
+// --- Status derivation ---
+
+func TestDeriveStatus_Success(t *testing.T) {
+	engine, _ := setupEngine(t, []PhaseConfig{
+		{Name: "triage", Prompt: "triage.md"},
+	}, &flexMockRunner{})
+
+	status := engine.deriveStatus(nil)
+	if status != NotifyStatusSuccess {
+		t.Errorf("deriveStatus(nil) = %q, want %q", status, NotifyStatusSuccess)
+	}
+}
+
+func TestDeriveStatus_Failure(t *testing.T) {
+	engine, _ := setupEngine(t, []PhaseConfig{
+		{Name: "triage", Prompt: "triage.md"},
+	}, &flexMockRunner{})
+
+	status := engine.deriveStatus(fmt.Errorf("some error"))
+	if status != NotifyStatusFailure {
+		t.Errorf("deriveStatus(error) = %q, want %q", status, NotifyStatusFailure)
+	}
+}
+
+func TestDeriveStatus_Timeout(t *testing.T) {
+	engine, _ := setupEngine(t, []PhaseConfig{
+		{Name: "triage", Prompt: "triage.md"},
+	}, &flexMockRunner{})
+
+	pte := &PipelineTimeoutError{
+		Limit:   2 * time.Hour,
+		Elapsed: 2*time.Hour + 5*time.Minute,
+		Phase:   "implement",
+	}
+	status := engine.deriveStatus(pte)
+	if status != NotifyStatusTimeout {
+		t.Errorf("deriveStatus(PipelineTimeoutError) = %q, want %q", status, NotifyStatusTimeout)
+	}
+}
+
+func TestDeriveStatus_TimeoutWrapped(t *testing.T) {
+	engine, _ := setupEngine(t, []PhaseConfig{
+		{Name: "triage", Prompt: "triage.md"},
+	}, &flexMockRunner{})
+
+	pte := &PipelineTimeoutError{
+		Limit:   2 * time.Hour,
+		Elapsed: 2*time.Hour + 5*time.Minute,
+		Phase:   "implement",
+	}
+	wrapped := fmt.Errorf("engine: %w", pte)
+	status := engine.deriveStatus(wrapped)
+	if status != NotifyStatusTimeout {
+		t.Errorf("deriveStatus(wrapped PipelineTimeoutError) = %q, want %q", status, NotifyStatusTimeout)
+	}
+}
+
+func TestDeriveStatus_Partial(t *testing.T) {
+	engine, state := setupEngine(t, []PhaseConfig{
+		{Name: "submit", Prompt: "submit.md"},
+		{Name: "monitor", Prompt: "monitor.md"},
+	}, &flexMockRunner{})
+
+	// Mark submit as completed.
+	state.Meta().Phases["submit"] = &PhaseState{Status: PhaseCompleted}
+
+	status := engine.deriveStatus(fmt.Errorf("monitor failed"))
+	if status != NotifyStatusPartial {
+		t.Errorf("deriveStatus(submit completed + error) = %q, want %q", status, NotifyStatusPartial)
+	}
+}
+
+func TestDeriveStatus_SubmitNotCompleted(t *testing.T) {
+	engine, state := setupEngine(t, []PhaseConfig{
+		{Name: "submit", Prompt: "submit.md"},
+	}, &flexMockRunner{})
+
+	// Submit failed — should be failure, not partial.
+	state.Meta().Phases["submit"] = &PhaseState{Status: PhaseFailed}
+
+	status := engine.deriveStatus(fmt.Errorf("submit failed"))
+	if status != NotifyStatusFailure {
+		t.Errorf("deriveStatus(submit failed) = %q, want %q", status, NotifyStatusFailure)
+	}
+}
+
+// --- Webhook payload ---
+
+func TestBuildWebhookPayload_Success(t *testing.T) {
+	engine, state := setupEngine(t, []PhaseConfig{
+		{Name: "triage", Prompt: "triage.md"},
+	}, &flexMockRunner{})
+
+	state.Meta().Ticket = "TEST-42"
+	state.Meta().Branch = "soda/TEST-42"
+	state.Meta().TotalCost = 1.50
+
+	payload := engine.buildWebhookPayload(NotifyStatusSuccess, nil)
+
+	if payload.Ticket != "TEST-42" {
+		t.Errorf("Ticket = %q, want %q", payload.Ticket, "TEST-42")
+	}
+	if payload.Status != NotifyStatusSuccess {
+		t.Errorf("Status = %q, want %q", payload.Status, NotifyStatusSuccess)
+	}
+	if payload.Branch != "soda/TEST-42" {
+		t.Errorf("Branch = %q, want %q", payload.Branch, "soda/TEST-42")
+	}
+	if payload.TotalCost != 1.50 {
+		t.Errorf("TotalCost = %f, want 1.50", payload.TotalCost)
+	}
+	if payload.Error != "" {
+		t.Errorf("Error = %q, want empty", payload.Error)
+	}
+}
+
+func TestBuildWebhookPayload_WithError(t *testing.T) {
+	engine, _ := setupEngine(t, []PhaseConfig{
+		{Name: "triage", Prompt: "triage.md"},
+	}, &flexMockRunner{})
+
+	payload := engine.buildWebhookPayload(NotifyStatusFailure, fmt.Errorf("phase triage failed"))
+
+	if payload.Error != "phase triage failed" {
+		t.Errorf("Error = %q, want %q", payload.Error, "phase triage failed")
+	}
+}
+
+// --- Webhook POST ---
+
+func TestPostWebhook_Success(t *testing.T) {
+	var received webhookPayload
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("Method = %q, want POST", r.Method)
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "application/json" {
+			t.Errorf("Content-Type = %q, want application/json", ct)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&received); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	engine, _ := setupEngine(t, []PhaseConfig{
+		{Name: "triage", Prompt: "triage.md"},
+	}, &flexMockRunner{}, func(cfg *EngineConfig) {
+		cfg.Notify.WebhookURL = server.URL
+	})
+
+	payload := webhookPayload{
+		Ticket: "TEST-1",
+		Status: NotifyStatusSuccess,
+	}
+	err := engine.postWebhook(context.Background(), payload)
+	if err != nil {
+		t.Fatalf("postWebhook: %v", err)
+	}
+	if received.Ticket != "TEST-1" {
+		t.Errorf("received.Ticket = %q, want %q", received.Ticket, "TEST-1")
+	}
+}
+
+func TestPostWebhook_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	engine, _ := setupEngine(t, []PhaseConfig{
+		{Name: "triage", Prompt: "triage.md"},
+	}, &flexMockRunner{}, func(cfg *EngineConfig) {
+		cfg.Notify.WebhookURL = server.URL
+	})
+
+	err := engine.postWebhook(context.Background(), webhookPayload{})
+	if err == nil {
+		t.Fatal("expected error for 500 response")
+	}
+}
+
+func TestPostWebhook_Timeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Block longer than context timeout.
+		time.Sleep(2 * time.Second)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	engine, _ := setupEngine(t, []PhaseConfig{
+		{Name: "triage", Prompt: "triage.md"},
+	}, &flexMockRunner{}, func(cfg *EngineConfig) {
+		cfg.Notify.WebhookURL = server.URL
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	err := engine.postWebhook(ctx, webhookPayload{})
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+}
+
+// --- Script execution ---
+
+func TestRunScript_Success(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("script tests require Unix")
+	}
+
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "notify.sh")
+	outputFile := filepath.Join(dir, "output.txt")
+	script := fmt.Sprintf("#!/bin/sh\necho \"$1 $2\" > %s\n", outputFile)
+	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	engine, state := setupEngine(t, []PhaseConfig{
+		{Name: "triage", Prompt: "triage.md"},
+	}, &flexMockRunner{}, func(cfg *EngineConfig) {
+		cfg.Notify.Script = scriptPath
+		cfg.WorkDir = dir
+	})
+
+	state.Meta().Ticket = "TEST-99"
+
+	err := engine.runScript(context.Background(), NotifyStatusSuccess, nil)
+	if err != nil {
+		t.Fatalf("runScript: %v", err)
+	}
+
+	data, err := os.ReadFile(outputFile)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	got := string(data)
+	if got != "success TEST-99\n" {
+		t.Errorf("script output = %q, want %q", got, "success TEST-99\n")
+	}
+}
+
+func TestRunScript_NotFound(t *testing.T) {
+	engine, _ := setupEngine(t, []PhaseConfig{
+		{Name: "triage", Prompt: "triage.md"},
+	}, &flexMockRunner{}, func(cfg *EngineConfig) {
+		cfg.Notify.Script = "/nonexistent/script.sh"
+	})
+
+	err := engine.runScript(context.Background(), NotifyStatusFailure, nil)
+	if err == nil {
+		t.Fatal("expected error for missing script")
+	}
+}
+
+func TestRunScript_Timeout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("script tests require Unix")
+	}
+
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "slow.sh")
+	// Use a trap and wait loop so the process exits promptly when killed.
+	script := "#!/bin/sh\ntrap 'exit 1' TERM\nwhile true; do sleep 0.1; done\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	engine, _ := setupEngine(t, []PhaseConfig{
+		{Name: "triage", Prompt: "triage.md"},
+	}, &flexMockRunner{}, func(cfg *EngineConfig) {
+		cfg.Notify.Script = scriptPath
+		cfg.WorkDir = dir
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	err := engine.runScript(ctx, NotifyStatusSuccess, nil)
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+}
+
+// --- notifyOnFinish orchestrator ---
+
+func TestNotifyOnFinish_NoConfig(t *testing.T) {
+	var events []Event
+	engine, _ := setupEngine(t, []PhaseConfig{
+		{Name: "triage", Prompt: "triage.md"},
+	}, &flexMockRunner{}, func(cfg *EngineConfig) {
+		cfg.OnEvent = func(e Event) {
+			events = append(events, e)
+		}
+	})
+
+	// No notify config — should be a no-op.
+	engine.notifyOnFinish(nil)
+
+	for _, e := range events {
+		if e.Kind == EventNotifySuccess || e.Kind == EventNotifyFailed {
+			t.Errorf("unexpected notify event: %s", e.Kind)
+		}
+	}
+}
+
+func TestNotifyOnFinish_WebhookSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	var events []Event
+	engine, _ := setupEngine(t, []PhaseConfig{
+		{Name: "triage", Prompt: "triage.md"},
+	}, &flexMockRunner{}, func(cfg *EngineConfig) {
+		cfg.Notify.WebhookURL = server.URL
+		cfg.OnEvent = func(e Event) {
+			events = append(events, e)
+		}
+	})
+
+	engine.notifyOnFinish(nil)
+
+	hasSuccess := false
+	for _, e := range events {
+		if e.Kind == EventNotifySuccess {
+			if typ, _ := e.Data["type"].(string); typ == "webhook" {
+				hasSuccess = true
+			}
+		}
+	}
+	if !hasSuccess {
+		t.Error("expected notify_success event for webhook")
+	}
+}
+
+func TestNotifyOnFinish_WebhookFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	var events []Event
+	engine, _ := setupEngine(t, []PhaseConfig{
+		{Name: "triage", Prompt: "triage.md"},
+	}, &flexMockRunner{}, func(cfg *EngineConfig) {
+		cfg.Notify.WebhookURL = server.URL
+		cfg.OnEvent = func(e Event) {
+			events = append(events, e)
+		}
+	})
+
+	engine.notifyOnFinish(nil)
+
+	hasFailed := false
+	for _, e := range events {
+		if e.Kind == EventNotifyFailed {
+			if typ, _ := e.Data["type"].(string); typ == "webhook" {
+				hasFailed = true
+			}
+		}
+	}
+	if !hasFailed {
+		t.Error("expected notify_failed event for webhook")
+	}
+}
+
+// --- Integration with Run/Resume ---
+
+func TestRun_NotifiesOnSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	var mu sync.Mutex
+	var events []Event
+	engine, _ := setupEngine(t, []PhaseConfig{
+		{
+			Name:   "triage",
+			Prompt: "triage.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+	}, &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"triage": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"automatable":true}`),
+					RawText: "Triage complete",
+				},
+			}},
+		},
+	}, func(cfg *EngineConfig) {
+		cfg.Notify.WebhookURL = server.URL
+		cfg.OnEvent = func(e Event) {
+			mu.Lock()
+			events = append(events, e)
+			mu.Unlock()
+		}
+	})
+
+	err := engine.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	hasNotifySuccess := false
+	for _, e := range events {
+		if e.Kind == EventNotifySuccess {
+			hasNotifySuccess = true
+		}
+	}
+	if !hasNotifySuccess {
+		t.Error("expected notify_success event after successful Run")
+	}
+}
+
+func TestRun_NotifiesOnFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload webhookPayload
+		json.NewDecoder(r.Body).Decode(&payload)
+		if payload.Status != NotifyStatusFailure {
+			t.Errorf("webhook status = %q, want %q", payload.Status, NotifyStatusFailure)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	var mu sync.Mutex
+	var events []Event
+	engine, _ := setupEngine(t, []PhaseConfig{
+		{
+			Name:   "triage",
+			Prompt: "triage.md",
+			Retry:  RetryConfig{},
+		},
+	}, &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"triage": {{
+				err: fmt.Errorf("runner failed"),
+			}},
+		},
+	}, func(cfg *EngineConfig) {
+		cfg.Notify.WebhookURL = server.URL
+		cfg.OnEvent = func(e Event) {
+			mu.Lock()
+			events = append(events, e)
+			mu.Unlock()
+		}
+	})
+
+	err := engine.Run(context.Background())
+	if err == nil {
+		t.Fatal("expected error from Run")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	hasNotifySuccess := false
+	for _, e := range events {
+		if e.Kind == EventNotifySuccess {
+			hasNotifySuccess = true
+		}
+	}
+	if !hasNotifySuccess {
+		t.Error("expected notify_success event (webhook accepted the failure payload)")
+	}
+}
+
+func TestResume_NotifiesOnSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	var mu sync.Mutex
+	var events []Event
+	engine, state := setupEngine(t, []PhaseConfig{
+		{
+			Name:   "triage",
+			Prompt: "triage.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+		{
+			Name:      "plan",
+			Prompt:    "plan.md",
+			DependsOn: []string{"triage"},
+			Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+	}, &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"plan": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"tasks":["t1"]}`),
+					RawText: "Plan done",
+				},
+			}},
+		},
+	}, func(cfg *EngineConfig) {
+		cfg.Notify.WebhookURL = server.URL
+		cfg.OnEvent = func(e Event) {
+			mu.Lock()
+			events = append(events, e)
+			mu.Unlock()
+		}
+	})
+
+	// Mark triage as completed so resume from plan works.
+	state.Meta().Phases["triage"] = &PhaseState{Status: PhaseCompleted}
+
+	err := engine.Resume(context.Background(), "plan")
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	hasNotifySuccess := false
+	for _, e := range events {
+		if e.Kind == EventNotifySuccess {
+			hasNotifySuccess = true
+		}
+	}
+	if !hasNotifySuccess {
+		t.Error("expected notify_success event after successful Resume")
+	}
+}
+
+// --- NotifyConfig timeout default ---
+
+func TestNotifyConfig_DefaultTimeout(t *testing.T) {
+	cfg := NotifyConfig{}
+	if got := cfg.notifyTimeout(); got != defaultNotifyTimeout {
+		t.Errorf("notifyTimeout() = %v, want %v", got, defaultNotifyTimeout)
+	}
+}
+
+func TestNotifyConfig_CustomTimeout(t *testing.T) {
+	cfg := NotifyConfig{Timeout: 10 * time.Second}
+	if got := cfg.notifyTimeout(); got != 10*time.Second {
+		t.Errorf("notifyTimeout() = %v, want 10s", got)
+	}
+}
+
+// Verify errors.As works for PipelineTimeoutError through wrapping.
+func TestDeriveStatus_ErrorsAsIntegration(t *testing.T) {
+	engine, _ := setupEngine(t, []PhaseConfig{
+		{Name: "triage", Prompt: "triage.md"},
+	}, &flexMockRunner{})
+
+	// Deeply wrapped PipelineTimeoutError.
+	inner := &PipelineTimeoutError{Limit: time.Hour, Elapsed: time.Hour, Phase: "plan"}
+	wrapped := fmt.Errorf("outer: %w", fmt.Errorf("middle: %w", inner))
+
+	status := engine.deriveStatus(wrapped)
+	if status != NotifyStatusTimeout {
+		t.Errorf("deriveStatus(deeply wrapped PipelineTimeoutError) = %q, want %q", status, NotifyStatusTimeout)
+	}
+
+	// Verify errors.As actually works.
+	var pte *PipelineTimeoutError
+	if !errors.As(wrapped, &pte) {
+		t.Fatal("errors.As should find PipelineTimeoutError")
+	}
+}

--- a/soda-system-prompt-1149155144.md
+++ b/soda-system-prompt-1149155144.md
@@ -1,0 +1,83 @@
+You are a surgical code fixer applying targeted corrections to an existing implementation.
+
+## Ticket
+
+Key: 376
+Summary: feat(engine): notification hook on pipeline completion — webhook or script callback
+
+### Acceptance Criteria (reference only)
+- Script callback works via `exec.Command` (no shell)
+- Webhook POST works with 10s default timeout
+- Status enum: `success`, `failed`, `timeout`, `partial`
+- Token fields included in webhook (per-phase with cache breakdown)
+- Both `on_finish` and `on_failure` handlers supported
+- Fires from both `Run()` and `Resume()` paths
+- Notification failure logged, never blocks pipeline
+- Script stderr captured and logged
+- `soda validate` checks script path and webhook URL
+- Tests cover: success notification, failure notification, webhook timeout, missing script, partial status
+
+
+## FIXES REQUIRED
+
+You will address the issues listed below **one at a time, in order**. Report one fix_result per item in the Fixes section (use fix_index matching the 0-based index).
+
+Do NOT address multiple findings in a single edit. Fix one, verify it, then move to the next.
+
+### Verdict: FAIL
+### Fixes
+#### Finding 1 of 5
+0. **Status enum uses "failure" but AC requires "failed" — change NotifyStatusFailure to "failed"**
+→ Fix this finding, then verify before proceeding.
+#### Finding 2 of 5
+1. **Default timeout is 30s but AC specifies 10s — change defaultNotifyTimeout to 10 * time.Second**
+→ Fix this finding, then verify before proceeding.
+#### Finding 3 of 5
+2. **Webhook payload missing token fields — AC requires per-phase token counts with cache breakdown (TokensIn, TokensOut, CacheTokensIn per phase). PhaseState already has these fields; add a Tokens map to webhookPayload**
+→ Fix this finding, then verify before proceeding.
+#### Finding 4 of 5
+3. **No separate on_finish and on_failure handlers — AC requires both; current implementation fires a single notifyOnFinish for all outcomes. Add on_failure config option (separate webhook URL or script) that only fires when runErr != nil**
+→ Fix this finding, then verify before proceeding.
+#### Finding 5 of 5
+4. **Script stderr not captured separately — AC says "Script stderr captured and logged". Currently uses CombinedOutput() which merges stdout+stderr, and on success discards all output. Use separate cmd.Stderr buffer, and log stderr content even on success**
+→ Fix this finding, then verify before proceeding.
+
+### Failed Acceptance Criteria
+#### Finding 1 of 5
+0. **FAIL**: Webhook POST works with 10s default timeout
+   Evidence: notify.go:39 sets defaultNotifyTimeout = 30 * time.Second. AC specifies 10s default.
+→ Fix this finding, then verify before proceeding.
+#### Finding 2 of 5
+1. **FAIL**: Status enum: success, failed, timeout, partial
+   Evidence: notify.go:21 defines NotifyStatusFailure = "failure" but AC specifies the value must be "failed"
+→ Fix this finding, then verify before proceeding.
+#### Finding 3 of 5
+2. **FAIL**: Token fields included in webhook (per-phase with cache breakdown)
+   Evidence: webhookPayload struct (notify.go:57-65) only contains Ticket, Status, Branch, PRURL, TotalCost, Error. No per-phase token counts (TokensIn, TokensOut, CacheTokensIn) despite PhaseState having these fields in meta.go:30-32.
+→ Fix this finding, then verify before proceeding.
+#### Finding 4 of 5
+3. **FAIL**: Both on_finish and on_failure handlers supported
+   Evidence: Only a single notifyOnFinish handler exists that always fires. No separate on_failure config option (e.g., a failure-only webhook URL or script). NotificationsConfig in config.go has only WebhookURL and Script — no on_finish/on_failure distinction.
+→ Fix this finding, then verify before proceeding.
+#### Finding 5 of 5
+4. **FAIL**: Script stderr captured and logged
+   Evidence: notify.go:125 uses CombinedOutput() which mixes stdout+stderr. On success, all output is discarded. AC requires stderr to be captured separately and logged. Should use separate stderr buffer and log its contents even when the script exits 0.
+→ Fix this finding, then verify before proceeding.
+
+
+## Working Directory
+
+Worktree: /home/ddebrito/dev/soda/.worktrees/soda/376
+Branch: soda/376
+Base: main
+
+## Rules
+
+1. **BEFORE editing any file**, state which fix number you are addressing and why.
+2. **Do NOT modify files** not mentioned in the feedback above.
+3. **Do NOT add new features** or refactor beyond what the fixes require.
+4. **If a fix requires more than 50 lines of changes**, STOP and set `too_complex: true` with a reason. Do not attempt the fix.
+5. **Run the formatter** after changes: `gofmt -w .`
+6. **Run the tests** after changes: `go test ./...`
+7. **Each fix_result must map 1:1** to the numbered items in the **Fixes** section only. Use the same 0-based index (the number before each fix). Display headers show 1-based "Finding X of N" but fix_index uses the 0-based number. Code Issues provide additional context but do not need separate fix_results.
+8. **Commit** the fix with a message referencing the ticket key and fix number.


### PR DESCRIPTION
## Summary

Add script callback and webhook notification when pipeline completes or fails. Best-effort — notification failures never block the pipeline.

## Changes

- `internal/pipeline/notify.go` — `NotifyConfig`, `notifyOnFinish()`, status constants (success/failed/timeout/partial)
- `internal/config/config.go` — `NotificationsConfig` struct
- `cmd/soda/run.go` — wire config into EngineConfig
- `cmd/soda/validate.go` — Stage 6 validates notification config
- Script invocation via `exec.Command` (no shell — injection-safe)
- Webhook POST with 10s default timeout
- Per-phase token fields with cache breakdown in webhook payload
- `on_finish` + `on_failure` separate handlers
- Tests: `notify_test.go` + validation tests

## Note

Verify passed (all tests pass). Review budget exceeded ($8.04/$8.00) after 2 rework cycles — submitting manually.

Closes #376