### PR TITLE
feat(engine): notification hook on pipeline completion [#376]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,25 @@ Monitor requires `self_user` in config to distinguish self-authored comments fro
 
 Monitor profiles (`conservative`, `smart`, `aggressive`) control auto-rebase, nit auto-fix, and response to non-authoritative comments.
 
+### Notification hooks
+
+On pipeline completion (success or failure), the engine can fire webhook and/or script notifications. Both hooks are best-effort: failures are logged as events (`notify_success` / `notify_failed`) but do not affect the pipeline's exit status.
+
+**Configuration** (in `soda.yaml`):
+```yaml
+notify:
+  webhook:
+    url: https://hooks.example.com/soda
+    headers:
+      Authorization: "Bearer token"
+  script:
+    command: "./scripts/on-complete.sh"
+```
+
+The webhook receives an HTTP POST with a JSON `PipelineResult` payload containing ticket, status, error, total cost, duration, and per-phase details. The script receives the same JSON on stdin.
+
+`soda validate` checks notify config for obvious errors (empty URL, non-HTTP scheme, empty command).
+
 ### Spec/plan extraction
 
 Triage can detect existing specs and plans from ticket comments (GitHub) or structured fields (Jira). When a reviewed plan is found, triage sets `skip_plan: true` and the plan phase is skipped — the existing plan is injected as the plan artifact directly.
@@ -199,6 +218,7 @@ soda/
 │   │   ├── monitor_classifier.go  # Comment classification
 │   │   ├── monitor_authority.go   # CODEOWNERS authority resolution
 │   │   ├── monitor_profile.go     # Monitor behavior profiles
+│   │   ├── notify.go              # Webhook + script notification hooks
 │   │   ├── github_poller.go       # GitHub PR poller via gh CLI
 │   │   ├── history.go             # Session history queries
 │   │   ├── atomic.go              # Atomic file writes

--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -1361,7 +1361,33 @@ func convertNotifyConfig(cfg config.NotifyConfig) pipeline.NotifyConfig {
 			Command: cfg.Script.Command,
 		}
 	}
+	if cfg.OnFinish != nil {
+		nc.OnFinish = convertNotifyHookConfig(cfg.OnFinish)
+	}
+	if cfg.OnFailure != nil {
+		nc.OnFailure = convertNotifyHookConfig(cfg.OnFailure)
+	}
 	return nc
+}
+
+// convertNotifyHookConfig converts a config.NotifyHookConfig to a pipeline.NotifyHookConfig.
+func convertNotifyHookConfig(cfg *config.NotifyHookConfig) *pipeline.NotifyHookConfig {
+	if cfg == nil {
+		return nil
+	}
+	var hc pipeline.NotifyHookConfig
+	if cfg.Webhook != nil {
+		hc.Webhook = &pipeline.WebhookNotifyConfig{
+			URL:     cfg.Webhook.URL,
+			Headers: cfg.Webhook.Headers,
+		}
+	}
+	if cfg.Script != nil {
+		hc.Script = &pipeline.ScriptNotifyConfig{
+			Command: cfg.Script.Command,
+		}
+	}
+	return &hc
 }
 
 // resolveLastPhase finds the last running or failed phase in pipeline order.

--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -389,6 +389,7 @@ func runPipeline(cfg *config.Config, opts pipelineOpts) error {
 			WarnTokens:    cfg.Limits.TokenBudget.WarnTokens,
 			BytesPerToken: cfg.Limits.TokenBudget.BytesPerToken,
 		},
+		Notify:            convertNotifyConfig(cfg.Notify),
 		Mode:              mode,
 		PRPoller:          prPoller,
 		SelfUser:          selfUser,
@@ -849,6 +850,16 @@ func handleEvent(ctx context.Context, cancel context.CancelFunc, engine *pipelin
 			current = c
 		}
 		prog.Message(fmt.Sprintf("Warning: binary version changed since pipeline started (was %s, now %s)", stored, current))
+
+	case pipeline.EventNotifySuccess:
+		prog.Message("  📬 Notification sent")
+
+	case pipeline.EventNotifyFailed:
+		var errMsg string
+		if e, ok := event.Data["error"].(string); ok {
+			errMsg = e
+		}
+		prog.Message(fmt.Sprintf("  ⚠️  Notification failed: %s", errMsg))
 	}
 }
 
@@ -1334,6 +1345,23 @@ func buildPromptContext(cfg *config.Config) pipeline.ContextData {
 	}
 
 	return ctx
+}
+
+// convertNotifyConfig converts a config.NotifyConfig to a pipeline.NotifyConfig.
+func convertNotifyConfig(cfg config.NotifyConfig) pipeline.NotifyConfig {
+	var nc pipeline.NotifyConfig
+	if cfg.Webhook != nil {
+		nc.Webhook = &pipeline.WebhookNotifyConfig{
+			URL:     cfg.Webhook.URL,
+			Headers: cfg.Webhook.Headers,
+		}
+	}
+	if cfg.Script != nil {
+		nc.Script = &pipeline.ScriptNotifyConfig{
+			Command: cfg.Script.Command,
+		}
+	}
+	return nc
 }
 
 // resolveLastPhase finds the last running or failed phase in pipeline order.

--- a/cmd/soda/run_test.go
+++ b/cmd/soda/run_test.go
@@ -980,3 +980,104 @@ func TestHandleEventPatchExhaustedCycles(t *testing.T) {
 		})
 	}
 }
+
+func TestConvertNotifyConfig_Empty(t *testing.T) {
+	nc := convertNotifyConfig(config.NotifyConfig{})
+	if nc.Webhook != nil {
+		t.Error("expected nil Webhook for empty config")
+	}
+	if nc.Script != nil {
+		t.Error("expected nil Script for empty config")
+	}
+}
+
+func TestConvertNotifyConfig_WebhookOnly(t *testing.T) {
+	nc := convertNotifyConfig(config.NotifyConfig{
+		Webhook: &config.WebhookNotifyConfig{
+			URL:     "https://hooks.example.com/soda",
+			Headers: map[string]string{"Authorization": "Bearer tok"},
+		},
+	})
+	if nc.Webhook == nil {
+		t.Fatal("expected non-nil Webhook")
+	}
+	if nc.Webhook.URL != "https://hooks.example.com/soda" {
+		t.Errorf("URL = %q, want %q", nc.Webhook.URL, "https://hooks.example.com/soda")
+	}
+	if nc.Webhook.Headers["Authorization"] != "Bearer tok" {
+		t.Errorf("Authorization header = %q, want %q", nc.Webhook.Headers["Authorization"], "Bearer tok")
+	}
+	if nc.Script != nil {
+		t.Error("expected nil Script")
+	}
+}
+
+func TestConvertNotifyConfig_ScriptOnly(t *testing.T) {
+	nc := convertNotifyConfig(config.NotifyConfig{
+		Script: &config.ScriptNotifyConfig{
+			Command: "notify-send 'done'",
+		},
+	})
+	if nc.Script == nil {
+		t.Fatal("expected non-nil Script")
+	}
+	if nc.Script.Command != "notify-send 'done'" {
+		t.Errorf("Command = %q, want %q", nc.Script.Command, "notify-send 'done'")
+	}
+	if nc.Webhook != nil {
+		t.Error("expected nil Webhook")
+	}
+}
+
+func TestConvertNotifyConfig_Both(t *testing.T) {
+	nc := convertNotifyConfig(config.NotifyConfig{
+		Webhook: &config.WebhookNotifyConfig{URL: "https://example.com"},
+		Script:  &config.ScriptNotifyConfig{Command: "echo done"},
+	})
+	if nc.Webhook == nil {
+		t.Fatal("expected non-nil Webhook")
+	}
+	if nc.Script == nil {
+		t.Fatal("expected non-nil Script")
+	}
+}
+
+func TestHandleEvent_NotifySuccess(t *testing.T) {
+	var buf bytes.Buffer
+	prog := progress.New(&buf, false)
+	state, err := pipeline.LoadOrCreate(t.TempDir(), "NOTIFY-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	event := pipeline.Event{Kind: pipeline.EventNotifySuccess}
+	handleEvent(context.Background(), nil, nil, state, prog, event)
+
+	output := buf.String()
+	if !strings.Contains(output, "Notification sent") {
+		t.Errorf("expected output to contain 'Notification sent', got %q", output)
+	}
+}
+
+func TestHandleEvent_NotifyFailed(t *testing.T) {
+	var buf bytes.Buffer
+	prog := progress.New(&buf, false)
+	state, err := pipeline.LoadOrCreate(t.TempDir(), "NOTIFY-2")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	event := pipeline.Event{
+		Kind: pipeline.EventNotifyFailed,
+		Data: map[string]any{"error": "connection refused"},
+	}
+	handleEvent(context.Background(), nil, nil, state, prog, event)
+
+	output := buf.String()
+	if !strings.Contains(output, "Notification failed") {
+		t.Errorf("expected output to contain 'Notification failed', got %q", output)
+	}
+	if !strings.Contains(output, "connection refused") {
+		t.Errorf("expected output to contain error message, got %q", output)
+	}
+}

--- a/cmd/soda/validate.go
+++ b/cmd/soda/validate.go
@@ -78,6 +78,9 @@ func runValidate(w io.Writer, errW io.Writer, cfg *config.Config, pipelineName s
 	// Stage 5: Context files
 	validateContextFiles(w, result, cfg)
 
+	// Stage 6: Notify hooks
+	validateNotify(w, result, cfg)
+
 	// Print summary
 	fmt.Fprintln(w)
 	for _, warn := range result.warnings {
@@ -224,4 +227,31 @@ func validateContextFiles(w io.Writer, result *validationResult, cfg *config.Con
 		fmt.Fprintf(w, "✓ context: %d of %d file(s) found (%d missing)\n",
 			len(cfg.Context)-missing, len(cfg.Context), missing)
 	}
+}
+
+// validateNotify checks notify hook configuration for obvious errors.
+func validateNotify(w io.Writer, result *validationResult, cfg *config.Config) {
+	if cfg.Notify.Webhook == nil && cfg.Notify.Script == nil {
+		fmt.Fprintln(w, "✓ notify: no hooks configured")
+		return
+	}
+
+	hooks := 0
+	if cfg.Notify.Webhook != nil {
+		hooks++
+		if cfg.Notify.Webhook.URL == "" {
+			result.addWarning("notify: webhook configured but URL is empty")
+		} else if !strings.HasPrefix(cfg.Notify.Webhook.URL, "http://") && !strings.HasPrefix(cfg.Notify.Webhook.URL, "https://") {
+			result.addWarning("notify: webhook URL %q does not start with http:// or https://", cfg.Notify.Webhook.URL)
+		}
+	}
+
+	if cfg.Notify.Script != nil {
+		hooks++
+		if cfg.Notify.Script.Command == "" {
+			result.addWarning("notify: script configured but command is empty")
+		}
+	}
+
+	fmt.Fprintf(w, "✓ notify: %d hook(s) configured\n", hooks)
 }

--- a/cmd/soda/validate.go
+++ b/cmd/soda/validate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -231,7 +232,8 @@ func validateContextFiles(w io.Writer, result *validationResult, cfg *config.Con
 
 // validateNotify checks notify hook configuration for obvious errors.
 func validateNotify(w io.Writer, result *validationResult, cfg *config.Config) {
-	if cfg.Notify.Webhook == nil && cfg.Notify.Script == nil {
+	if cfg.Notify.Webhook == nil && cfg.Notify.Script == nil &&
+		cfg.Notify.OnFinish == nil && cfg.Notify.OnFailure == nil {
 		fmt.Fprintln(w, "✓ notify: no hooks configured")
 		return
 	}
@@ -239,19 +241,56 @@ func validateNotify(w io.Writer, result *validationResult, cfg *config.Config) {
 	hooks := 0
 	if cfg.Notify.Webhook != nil {
 		hooks++
-		if cfg.Notify.Webhook.URL == "" {
-			result.addWarning("notify: webhook configured but URL is empty")
-		} else if !strings.HasPrefix(cfg.Notify.Webhook.URL, "http://") && !strings.HasPrefix(cfg.Notify.Webhook.URL, "https://") {
-			result.addWarning("notify: webhook URL %q does not start with http:// or https://", cfg.Notify.Webhook.URL)
-		}
+		validateNotifyWebhook(result, "notify", cfg.Notify.Webhook)
 	}
 
 	if cfg.Notify.Script != nil {
 		hooks++
-		if cfg.Notify.Script.Command == "" {
-			result.addWarning("notify: script configured but command is empty")
+		validateNotifyScript(result, "notify", cfg.Notify.Script)
+	}
+
+	if cfg.Notify.OnFinish != nil {
+		hooks++
+		if cfg.Notify.OnFinish.Webhook != nil {
+			validateNotifyWebhook(result, "notify.on_finish", cfg.Notify.OnFinish.Webhook)
+		}
+		if cfg.Notify.OnFinish.Script != nil {
+			validateNotifyScript(result, "notify.on_finish", cfg.Notify.OnFinish.Script)
+		}
+	}
+
+	if cfg.Notify.OnFailure != nil {
+		hooks++
+		if cfg.Notify.OnFailure.Webhook != nil {
+			validateNotifyWebhook(result, "notify.on_failure", cfg.Notify.OnFailure.Webhook)
+		}
+		if cfg.Notify.OnFailure.Script != nil {
+			validateNotifyScript(result, "notify.on_failure", cfg.Notify.OnFailure.Script)
 		}
 	}
 
 	fmt.Fprintf(w, "✓ notify: %d hook(s) configured\n", hooks)
+}
+
+// validateNotifyWebhook checks a webhook config for obvious errors.
+func validateNotifyWebhook(result *validationResult, prefix string, wh *config.WebhookNotifyConfig) {
+	if wh.URL == "" {
+		result.addWarning("%s: webhook configured but URL is empty", prefix)
+	} else if !strings.HasPrefix(wh.URL, "http://") && !strings.HasPrefix(wh.URL, "https://") {
+		result.addWarning("%s: webhook URL %q does not start with http:// or https://", prefix, wh.URL)
+	}
+}
+
+// validateNotifyScript checks a script config for obvious errors, including
+// whether the binary exists on disk.
+func validateNotifyScript(result *validationResult, prefix string, sc *config.ScriptNotifyConfig) {
+	if sc.Command == "" {
+		result.addWarning("%s: script configured but command is empty", prefix)
+		return
+	}
+	parts := strings.Fields(sc.Command)
+	binary := parts[0]
+	if _, err := exec.LookPath(binary); err != nil {
+		result.addWarning("%s: script binary %q not found in PATH: %v", prefix, binary, err)
+	}
 }

--- a/cmd/soda/validate_test.go
+++ b/cmd/soda/validate_test.go
@@ -376,3 +376,141 @@ func TestRunValidate_ErrorOutput(t *testing.T) {
 		t.Error("expected config valid on stdout")
 	}
 }
+
+func TestValidateNotify_NoHooksConfigured(t *testing.T) {
+	cfg := &config.Config{}
+	result := &validationResult{}
+	var buf bytes.Buffer
+	validateNotify(&buf, result, cfg)
+
+	if result.hasErrors() {
+		t.Error("expected no errors")
+	}
+	if len(result.warnings) > 0 {
+		t.Errorf("expected no warnings, got: %v", result.warnings)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "no hooks configured") {
+		t.Errorf("expected 'no hooks configured', got: %s", output)
+	}
+}
+
+func TestValidateNotify_ValidWebhook(t *testing.T) {
+	cfg := &config.Config{
+		Notify: config.NotifyConfig{
+			Webhook: &config.WebhookNotifyConfig{
+				URL: "https://hooks.example.com/soda",
+			},
+		},
+	}
+	result := &validationResult{}
+	var buf bytes.Buffer
+	validateNotify(&buf, result, cfg)
+
+	if result.hasErrors() {
+		t.Error("expected no errors")
+	}
+	if len(result.warnings) > 0 {
+		t.Errorf("expected no warnings, got: %v", result.warnings)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "1 hook(s) configured") {
+		t.Errorf("expected '1 hook(s) configured', got: %s", output)
+	}
+}
+
+func TestValidateNotify_EmptyWebhookURL(t *testing.T) {
+	cfg := &config.Config{
+		Notify: config.NotifyConfig{
+			Webhook: &config.WebhookNotifyConfig{URL: ""},
+		},
+	}
+	result := &validationResult{}
+	var buf bytes.Buffer
+	validateNotify(&buf, result, cfg)
+
+	if len(result.warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %d: %v", len(result.warnings), result.warnings)
+	}
+	if !strings.Contains(result.warnings[0], "URL is empty") {
+		t.Errorf("warning should mention empty URL, got: %s", result.warnings[0])
+	}
+}
+
+func TestValidateNotify_BadWebhookScheme(t *testing.T) {
+	cfg := &config.Config{
+		Notify: config.NotifyConfig{
+			Webhook: &config.WebhookNotifyConfig{URL: "ftp://example.com"},
+		},
+	}
+	result := &validationResult{}
+	var buf bytes.Buffer
+	validateNotify(&buf, result, cfg)
+
+	if len(result.warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %d: %v", len(result.warnings), result.warnings)
+	}
+	if !strings.Contains(result.warnings[0], "does not start with http") {
+		t.Errorf("warning should mention scheme, got: %s", result.warnings[0])
+	}
+}
+
+func TestValidateNotify_EmptyScriptCommand(t *testing.T) {
+	cfg := &config.Config{
+		Notify: config.NotifyConfig{
+			Script: &config.ScriptNotifyConfig{Command: ""},
+		},
+	}
+	result := &validationResult{}
+	var buf bytes.Buffer
+	validateNotify(&buf, result, cfg)
+
+	if len(result.warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %d: %v", len(result.warnings), result.warnings)
+	}
+	if !strings.Contains(result.warnings[0], "command is empty") {
+		t.Errorf("warning should mention empty command, got: %s", result.warnings[0])
+	}
+}
+
+func TestValidateNotify_BothHooks(t *testing.T) {
+	cfg := &config.Config{
+		Notify: config.NotifyConfig{
+			Webhook: &config.WebhookNotifyConfig{URL: "https://example.com"},
+			Script:  &config.ScriptNotifyConfig{Command: "echo done"},
+		},
+	}
+	result := &validationResult{}
+	var buf bytes.Buffer
+	validateNotify(&buf, result, cfg)
+
+	if len(result.warnings) > 0 {
+		t.Errorf("expected no warnings, got: %v", result.warnings)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "2 hook(s) configured") {
+		t.Errorf("expected '2 hook(s) configured', got: %s", output)
+	}
+}
+
+func TestRunValidate_WithNotifyHooks(t *testing.T) {
+	cfg := &config.Config{
+		TicketSource: "github",
+		Mode:         "autonomous",
+		Model:        "claude-sonnet-4-20250514",
+		Notify: config.NotifyConfig{
+			Webhook: &config.WebhookNotifyConfig{URL: "https://example.com/hook"},
+		},
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := runValidate(&stdout, &stderr, cfg, "")
+	if err != nil {
+		t.Fatalf("runValidate() error: %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "✓ notify: 1 hook(s) configured") {
+		t.Errorf("expected notify valid message, got: %s", output)
+	}
+}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -142,6 +142,22 @@ monitor:
   # If unset, all commenters are treated as authoritative.
   # codeowners: .github/CODEOWNERS
 
+# Notification hooks — fired on pipeline completion (success or failure).
+# Both webhook and script may be configured; they fire independently.
+# Notifications are best-effort: failures are logged but do not affect
+# the pipeline's exit status.
+notify:
+  # HTTP POST webhook — receives a JSON payload with pipeline results.
+  webhook:
+    url: https://hooks.example.com/soda
+    headers:
+      Authorization: "Bearer your-token"
+
+  # Shell script callback — receives the same JSON payload on stdin.
+  # Useful for desktop notifications, Slack messages, or custom integrations.
+  script:
+    command: "./scripts/on-complete.sh"
+
 # Prompt overrides (optional)
 # Place custom prompts in ~/.config/soda/prompts/<phase>.md
 # They take precedence over built-in prompts.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	PhaseContext map[string][]string `yaml:"phase_context"`
 	Repos        []RepoConfig        `yaml:"repos"`
 	Monitor      MonitorConfig       `yaml:"monitor"`
+	Notify       NotifyConfig        `yaml:"notify"`
 }
 
 // MonitorConfig holds monitor phase settings loaded from the config file.
@@ -35,6 +36,24 @@ type MonitorConfig struct {
 	SelfUser   string   `yaml:"self_user"`  // PR author username for self-comment filtering
 	BotUsers   []string `yaml:"bot_users"`  // known bot usernames to filter out
 	CODEOWNERS string   `yaml:"codeowners"` // path to CODEOWNERS file for authority resolution
+}
+
+// NotifyConfig holds notification hook settings for pipeline completion.
+// Both webhook and script may be configured; they fire independently.
+type NotifyConfig struct {
+	Webhook *WebhookNotifyConfig `yaml:"webhook,omitempty"` // HTTP POST notification
+	Script  *ScriptNotifyConfig  `yaml:"script,omitempty"`  // shell script callback
+}
+
+// WebhookNotifyConfig configures an HTTP POST webhook fired on pipeline completion.
+type WebhookNotifyConfig struct {
+	URL     string            `yaml:"url"`               // target URL (required)
+	Headers map[string]string `yaml:"headers,omitempty"` // extra HTTP headers (e.g., Authorization)
+}
+
+// ScriptNotifyConfig configures a script callback fired on pipeline completion.
+type ScriptNotifyConfig struct {
+	Command string `yaml:"command"` // shell command to execute; receives JSON on stdin
 }
 
 // JiraConfig holds Jira ticket source settings.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,8 +41,16 @@ type MonitorConfig struct {
 // NotifyConfig holds notification hook settings for pipeline completion.
 // Both webhook and script may be configured; they fire independently.
 type NotifyConfig struct {
-	Webhook *WebhookNotifyConfig `yaml:"webhook,omitempty"` // HTTP POST notification
-	Script  *ScriptNotifyConfig  `yaml:"script,omitempty"`  // shell script callback
+	Webhook   *WebhookNotifyConfig `yaml:"webhook,omitempty"`    // HTTP POST notification (fires on any completion)
+	Script    *ScriptNotifyConfig  `yaml:"script,omitempty"`     // script callback (fires on any completion)
+	OnFinish  *NotifyHookConfig    `yaml:"on_finish,omitempty"`  // fires on any pipeline completion
+	OnFailure *NotifyHookConfig    `yaml:"on_failure,omitempty"` // fires only on failed or timeout
+}
+
+// NotifyHookConfig groups a webhook and script for a single trigger condition.
+type NotifyHookConfig struct {
+	Webhook *WebhookNotifyConfig `yaml:"webhook,omitempty"`
+	Script  *ScriptNotifyConfig  `yaml:"script,omitempty"`
 }
 
 // WebhookNotifyConfig configures an HTTP POST webhook fired on pipeline completion.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -132,6 +132,22 @@ func TestLoad(t *testing.T) {
 				if cfg.Monitor.CODEOWNERS != ".github/CODEOWNERS" {
 					t.Errorf("Monitor.CODEOWNERS = %q, want %q", cfg.Monitor.CODEOWNERS, ".github/CODEOWNERS")
 				}
+				// Notify config
+				if cfg.Notify.Webhook == nil {
+					t.Fatal("Notify.Webhook is nil, want non-nil")
+				}
+				if cfg.Notify.Webhook.URL != "https://hooks.example.com/soda" {
+					t.Errorf("Notify.Webhook.URL = %q, want %q", cfg.Notify.Webhook.URL, "https://hooks.example.com/soda")
+				}
+				if cfg.Notify.Webhook.Headers["Authorization"] != "Bearer secret-token" {
+					t.Errorf("Notify.Webhook.Headers[Authorization] = %q, want %q", cfg.Notify.Webhook.Headers["Authorization"], "Bearer secret-token")
+				}
+				if cfg.Notify.Script == nil {
+					t.Fatal("Notify.Script is nil, want non-nil")
+				}
+				if cfg.Notify.Script.Command != "./scripts/on-complete.sh" {
+					t.Errorf("Notify.Script.Command = %q, want %q", cfg.Notify.Script.Command, "./scripts/on-complete.sh")
+				}
 			},
 		},
 		{
@@ -153,6 +169,13 @@ func TestLoad(t *testing.T) {
 				}
 				if len(cfg.Monitor.BotUsers) != 0 {
 					t.Errorf("len(Monitor.BotUsers) = %d, want 0", len(cfg.Monitor.BotUsers))
+				}
+				// Notify config should be zero-valued when not in file.
+				if cfg.Notify.Webhook != nil {
+					t.Errorf("Notify.Webhook = %v, want nil", cfg.Notify.Webhook)
+				}
+				if cfg.Notify.Script != nil {
+					t.Errorf("Notify.Script = %v, want nil", cfg.Notify.Script)
 				}
 			},
 		},

--- a/internal/config/testdata/valid.yaml
+++ b/internal/config/testdata/valid.yaml
@@ -68,3 +68,10 @@ monitor:
     - dependabot
     - renovate
   codeowners: .github/CODEOWNERS
+notify:
+  webhook:
+    url: https://hooks.example.com/soda
+    headers:
+      Authorization: "Bearer secret-token"
+  script:
+    command: "./scripts/on-complete.sh"

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -1443,10 +1443,13 @@ func (e *Engine) buildPipelineResult(runErr error) PipelineResult {
 	phases := make(map[string]any, len(meta.Phases))
 	for name, ps := range meta.Phases {
 		phases[name] = map[string]any{
-			"status":      string(ps.Status),
-			"cost":        ps.Cost,
-			"duration_ms": ps.DurationMs,
-			"generation":  ps.Generation,
+			"status":          string(ps.Status),
+			"cost":            ps.Cost,
+			"duration_ms":     ps.DurationMs,
+			"generation":      ps.Generation,
+			"tokens_in":       ps.TokensIn,
+			"tokens_out":      ps.TokensOut,
+			"cache_tokens_in": ps.CacheTokensIn,
 		}
 	}
 

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -65,6 +65,7 @@ type EngineConfig struct {
 	BotUsers               []string          // known bot usernames to filter
 	Stderr                 io.Writer         // destination for warning messages; defaults to os.Stderr
 	TokenBudget            TokenBudgetConfig // prompt token budget estimation; zero value disables checks
+	Notify                 NotifyConfig      // notification hooks fired on pipeline completion; zero value disables
 }
 
 // TokenBudgetConfig configures the prompt-size estimation check.
@@ -108,6 +109,7 @@ type Engine struct {
 	inCheckpoint     bool      // true while blocked on <-confirmCh; guarded by pauseMu
 	pipelineStart    time.Time // wall-clock time when applyPipelineTimeout was called
 	pipelineDeadline time.Time // deadline set by applyPipelineTimeout; zero if no timeout
+	notifier         *Notifier // pipeline completion notifier; nil means no notifications
 }
 
 // NewEngine creates an Engine with sensible defaults for sleep and jitter.
@@ -125,10 +127,11 @@ func NewEngine(r runner.Runner, state *State, cfg EngineConfig) *Engine {
 	}
 
 	e := &Engine{
-		runner: r,
-		config: cfg,
-		state:  state,
-		apiSem: NewSemaphore(cfg.MaxAPIConcurrency),
+		runner:   r,
+		config:   cfg,
+		state:    state,
+		apiSem:   NewSemaphore(cfg.MaxAPIConcurrency),
+		notifier: NewNotifier(cfg.Notify),
 	}
 	e.pauseCond = sync.NewCond(&e.pauseMu)
 
@@ -328,10 +331,12 @@ func (e *Engine) Run(ctx context.Context) error {
 		if !errors.As(wrapped, &pte) {
 			e.emit(Event{Kind: EventEngineFailed, Data: map[string]any{"error": wrapped.Error()}})
 		}
+		e.sendNotification(wrapped)
 		return wrapped
 	}
 
 	e.emit(Event{Kind: EventEngineCompleted})
+	e.sendNotification(nil)
 	return nil
 }
 
@@ -404,10 +409,12 @@ func (e *Engine) Resume(ctx context.Context, fromPhase string) error {
 		if !errors.As(wrapped, &pte) {
 			e.emit(Event{Kind: EventEngineFailed, Data: map[string]any{"error": wrapped.Error()}})
 		}
+		e.sendNotification(wrapped)
 		return wrapped
 	}
 
 	e.emit(Event{Kind: EventEngineCompleted})
+	e.sendNotification(nil)
 	return nil
 }
 
@@ -1369,5 +1376,69 @@ func (e *Engine) recoverCrashedPhases() {
 		crashErr := fmt.Errorf("process crashed while phase was running (recovered on restart)")
 		_ = e.state.MarkFailed(phase.Name, crashErr)
 		e.emitPhaseFailed(phase.Name, crashErr)
+	}
+}
+
+// sendNotification fires the configured notification hooks with a summary of
+// the pipeline outcome. Notifications are best-effort: errors are emitted as
+// events but do not affect the pipeline's return value.
+func (e *Engine) sendNotification(runErr error) {
+	if e.notifier == nil {
+		return
+	}
+
+	result := e.buildPipelineResult(runErr)
+
+	// Use a detached context so notifications are not cancelled by the
+	// pipeline's context (which may already be done on failure/timeout).
+	ctx, cancel := context.WithTimeout(context.Background(), defaultNotifyTimeout)
+	defer cancel()
+
+	if err := e.notifier.Notify(ctx, result); err != nil {
+		e.emit(Event{
+			Kind: EventNotifyFailed,
+			Data: map[string]any{"error": err.Error()},
+		})
+		return
+	}
+
+	e.emit(Event{Kind: EventNotifySuccess})
+}
+
+// buildPipelineResult constructs a PipelineResult from the current engine state.
+func (e *Engine) buildPipelineResult(runErr error) PipelineResult {
+	meta := e.state.Meta()
+
+	status := "success"
+	var errMsg string
+	if runErr != nil {
+		status = "failed"
+		errMsg = runErr.Error()
+	}
+
+	var duration string
+	if !e.pipelineStart.IsZero() {
+		duration = e.now().Sub(e.pipelineStart).Truncate(time.Second).String()
+	}
+
+	phases := make(map[string]any, len(meta.Phases))
+	for name, ps := range meta.Phases {
+		phases[name] = map[string]any{
+			"status":      string(ps.Status),
+			"cost":        ps.Cost,
+			"duration_ms": ps.DurationMs,
+			"generation":  ps.Generation,
+		}
+	}
+
+	return PipelineResult{
+		Ticket:    meta.Ticket,
+		Summary:   meta.Summary,
+		Branch:    meta.Branch,
+		Status:    status,
+		Error:     errMsg,
+		TotalCost: meta.TotalCost,
+		Duration:  duration,
+		Phases:    phases,
 	}
 }

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -1412,8 +1412,27 @@ func (e *Engine) buildPipelineResult(runErr error) PipelineResult {
 	status := "success"
 	var errMsg string
 	if runErr != nil {
-		status = "failed"
 		errMsg = runErr.Error()
+		var pte *PipelineTimeoutError
+		if errors.As(runErr, &pte) {
+			status = "timeout"
+		} else {
+			// Check for partial: some phases completed, some failed.
+			hasCompleted := false
+			hasFailed := false
+			for _, ps := range meta.Phases {
+				if ps.Status == PhaseCompleted {
+					hasCompleted = true
+				} else if ps.Status == PhaseFailed {
+					hasFailed = true
+				}
+			}
+			if hasCompleted && hasFailed {
+				status = "partial"
+			} else {
+				status = "failed"
+			}
+		}
 	}
 
 	var duration string

--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -7,6 +7,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -6270,4 +6273,344 @@ func TestEngine_TokenBudgetCalibrationNotEmittedWhenZeroTokens(t *testing.T) {
 			t.Error("unexpected token_budget_calibration event when TokensIn is zero")
 		}
 	}
+}
+
+func TestEngine_NotificationOnSuccess(t *testing.T) {
+	phases := []PhaseConfig{
+		{
+			Name:   "triage",
+			Prompt: "triage.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"triage": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"automatable":true}`),
+					RawText: "Triage: automatable",
+					CostUSD: 0.10,
+				},
+			}},
+		},
+	}
+
+	var events []Event
+	var webhookPayload []byte
+	srv := newTestWebhookServer(t, func(body []byte) {
+		webhookPayload = body
+	})
+	defer srv.Close()
+
+	engine, _ := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.Notify = NotifyConfig{
+			Webhook: &WebhookNotifyConfig{URL: srv.URL},
+		}
+		cfg.OnEvent = func(e Event) {
+			events = append(events, e)
+		}
+	})
+
+	err := engine.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+
+	// Verify webhook was called.
+	if webhookPayload == nil {
+		t.Fatal("expected webhook to be called")
+	}
+
+	var result PipelineResult
+	if err := json.Unmarshal(webhookPayload, &result); err != nil {
+		t.Fatalf("unmarshal webhook payload: %v", err)
+	}
+	if result.Status != "success" {
+		t.Errorf("Status = %q, want %q", result.Status, "success")
+	}
+	if result.Ticket != "TEST-1" {
+		t.Errorf("Ticket = %q, want %q", result.Ticket, "TEST-1")
+	}
+
+	// Verify EventNotifySuccess was emitted.
+	found := false
+	for _, ev := range events {
+		if ev.Kind == EventNotifySuccess {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected EventNotifySuccess event")
+	}
+}
+
+func TestEngine_NotificationOnFailure(t *testing.T) {
+	phases := []PhaseConfig{
+		{
+			Name:   "triage",
+			Prompt: "triage.md",
+			Retry:  RetryConfig{Transient: 0, Parse: 0, Semantic: 0},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"triage": {{
+				result: nil,
+				err:    fmt.Errorf("API unavailable"),
+			}},
+		},
+	}
+
+	var events []Event
+	var webhookPayload []byte
+	srv := newTestWebhookServer(t, func(body []byte) {
+		webhookPayload = body
+	})
+	defer srv.Close()
+
+	engine, _ := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.Notify = NotifyConfig{
+			Webhook: &WebhookNotifyConfig{URL: srv.URL},
+		}
+		cfg.OnEvent = func(e Event) {
+			events = append(events, e)
+		}
+	})
+
+	err := engine.Run(context.Background())
+	if err == nil {
+		t.Fatal("expected Run() to return an error")
+	}
+
+	// Verify webhook was called with failure status.
+	if webhookPayload == nil {
+		t.Fatal("expected webhook to be called on failure")
+	}
+
+	var result PipelineResult
+	if err := json.Unmarshal(webhookPayload, &result); err != nil {
+		t.Fatalf("unmarshal webhook payload: %v", err)
+	}
+	if result.Status != "failed" {
+		t.Errorf("Status = %q, want %q", result.Status, "failed")
+	}
+	if result.Error == "" {
+		t.Error("expected Error to be non-empty on failure")
+	}
+
+	// Verify EventNotifySuccess was emitted (notification delivery succeeded).
+	found := false
+	for _, ev := range events {
+		if ev.Kind == EventNotifySuccess {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected EventNotifySuccess event even when pipeline fails")
+	}
+}
+
+func TestEngine_NotificationWebhookError(t *testing.T) {
+	phases := []PhaseConfig{
+		{
+			Name:   "triage",
+			Prompt: "triage.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"triage": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"automatable":true}`),
+					RawText: "Triage: automatable",
+					CostUSD: 0.10,
+				},
+			}},
+		},
+	}
+
+	var events []Event
+	engine, _ := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.Notify = NotifyConfig{
+			Webhook: &WebhookNotifyConfig{URL: "http://127.0.0.1:0/nonexistent"},
+		}
+		cfg.OnEvent = func(e Event) {
+			events = append(events, e)
+		}
+	})
+
+	// Pipeline should succeed even when notification fails.
+	err := engine.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run() error: %v — notification failure should not fail pipeline", err)
+	}
+
+	// Verify EventNotifyFailed was emitted.
+	found := false
+	for _, ev := range events {
+		if ev.Kind == EventNotifyFailed {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected EventNotifyFailed event when webhook is unreachable")
+	}
+}
+
+func TestEngine_NoNotificationWithoutConfig(t *testing.T) {
+	phases := []PhaseConfig{
+		{
+			Name:   "triage",
+			Prompt: "triage.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"triage": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"automatable":true}`),
+					RawText: "Triage: automatable",
+					CostUSD: 0.10,
+				},
+			}},
+		},
+	}
+
+	var events []Event
+	engine, _ := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+		// Notify is zero-value (no hooks configured).
+		cfg.OnEvent = func(e Event) {
+			events = append(events, e)
+		}
+	})
+
+	err := engine.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+
+	// Verify no notification events were emitted.
+	for _, ev := range events {
+		if ev.Kind == EventNotifySuccess || ev.Kind == EventNotifyFailed {
+			t.Errorf("unexpected notification event %q when no hooks configured", ev.Kind)
+		}
+	}
+}
+
+func TestEngine_NotificationOnResume(t *testing.T) {
+	phases := []PhaseConfig{
+		{
+			Name:   "triage",
+			Prompt: "triage.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+		{
+			Name:      "plan",
+			Prompt:    "plan.md",
+			DependsOn: []string{"triage"},
+			Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"triage": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"automatable":true}`),
+					RawText: "Triage: automatable",
+					CostUSD: 0.10,
+				},
+			}},
+			"plan": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"tasks":["task1"]}`),
+					RawText: "Plan: one task",
+					CostUSD: 0.20,
+				},
+			}},
+		},
+	}
+
+	var webhookPayload []byte
+	srv := newTestWebhookServer(t, func(body []byte) {
+		webhookPayload = body
+	})
+	defer srv.Close()
+
+	engine, state := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.Notify = NotifyConfig{
+			Webhook: &WebhookNotifyConfig{URL: srv.URL},
+		}
+	})
+
+	// Run triage first to populate state.
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("initial Run() error: %v", err)
+	}
+
+	// First webhook call is from Run — reset.
+	webhookPayload = nil
+
+	// Create a new engine for resume (simulates a restart).
+	mock2 := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"plan": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"tasks":["task1"]}`),
+					RawText: "Plan: one task",
+					CostUSD: 0.20,
+				},
+			}},
+		},
+	}
+
+	engine2, _ := setupEngine(t, phases, mock2, func(cfg *EngineConfig) {
+		cfg.Notify = NotifyConfig{
+			Webhook: &WebhookNotifyConfig{URL: srv.URL},
+		}
+	})
+	// Swap the state to the one with triage already completed.
+	engine2.state = state
+
+	err := engine2.Resume(context.Background(), "plan")
+	if err != nil {
+		t.Fatalf("Resume() error: %v", err)
+	}
+
+	if webhookPayload == nil {
+		t.Fatal("expected webhook to be called on Resume completion")
+	}
+
+	var result PipelineResult
+	if err := json.Unmarshal(webhookPayload, &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if result.Status != "success" {
+		t.Errorf("Status = %q, want %q", result.Status, "success")
+	}
+}
+
+// newTestWebhookServer creates a test HTTP server that calls onBody with the
+// request body for each POST request.
+func newTestWebhookServer(t *testing.T, onBody func([]byte)) *httpTestServer {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		onBody(body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	return &httpTestServer{Server: srv}
+}
+
+type httpTestServer struct {
+	*httptest.Server
 }

--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -6599,6 +6599,67 @@ func TestEngine_NotificationOnResume(t *testing.T) {
 	}
 }
 
+func TestEngine_NotificationPartialStatus(t *testing.T) {
+	phases := []PhaseConfig{
+		{
+			Name:   "triage",
+			Prompt: "triage.md",
+			Retry:  RetryConfig{Transient: 0, Parse: 0, Semantic: 0},
+		},
+		{
+			Name:      "plan",
+			Prompt:    "plan.md",
+			DependsOn: []string{"triage"},
+			Retry:     RetryConfig{Transient: 0, Parse: 0, Semantic: 0},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"triage": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"automatable":true}`),
+					RawText: "Triage: automatable",
+					CostUSD: 0.10,
+				},
+			}},
+			"plan": {{
+				result: nil,
+				err:    fmt.Errorf("plan phase error"),
+			}},
+		},
+	}
+
+	var webhookPayload []byte
+	srv := newTestWebhookServer(t, func(body []byte) {
+		webhookPayload = body
+	})
+	defer srv.Close()
+
+	engine, _ := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.Notify = NotifyConfig{
+			Webhook: &WebhookNotifyConfig{URL: srv.URL},
+		}
+	})
+
+	err := engine.Run(context.Background())
+	if err == nil {
+		t.Fatal("expected Run() to return an error")
+	}
+
+	if webhookPayload == nil {
+		t.Fatal("expected webhook to be called")
+	}
+
+	var result PipelineResult
+	if err := json.Unmarshal(webhookPayload, &result); err != nil {
+		t.Fatalf("unmarshal webhook payload: %v", err)
+	}
+	if result.Status != "partial" {
+		t.Errorf("Status = %q, want %q", result.Status, "partial")
+	}
+}
+
 // newTestWebhookServer creates a test HTTP server that calls onBody with the
 // request body for each POST request.
 func newTestWebhookServer(t *testing.T, onBody func([]byte)) *httpTestServer {

--- a/internal/pipeline/events.go
+++ b/internal/pipeline/events.go
@@ -91,6 +91,8 @@ const (
 	EventImplementNoChanges       = "implement_no_changes"
 	EventTokenBudgetWarning       = "token_budget_warning"
 	EventTokenBudgetCalibration   = "token_budget_calibration"
+	EventNotifySuccess            = "notify_success"
+	EventNotifyFailed             = "notify_failed"
 )
 
 // FormatEvent formats an event as a compact, human-readable line:

--- a/internal/pipeline/notify.go
+++ b/internal/pipeline/notify.go
@@ -16,6 +16,14 @@ import (
 // Both Webhook and Script may be set; they fire independently.
 // Mirrors config.NotifyConfig — kept separate to avoid cross-package imports.
 type NotifyConfig struct {
+	Webhook   *WebhookNotifyConfig // fires on any completion
+	Script    *ScriptNotifyConfig  // fires on any completion
+	OnFinish  *NotifyHookConfig    // fires on any completion
+	OnFailure *NotifyHookConfig    // fires only on failed or timeout
+}
+
+// NotifyHookConfig groups a webhook and script for a single trigger condition.
+type NotifyHookConfig struct {
 	Webhook *WebhookNotifyConfig
 	Script  *ScriptNotifyConfig
 }
@@ -57,7 +65,7 @@ type Notifier struct {
 
 // NewNotifier creates a Notifier. Returns nil if no notifications are configured.
 func NewNotifier(cfg NotifyConfig) *Notifier {
-	if cfg.Webhook == nil && cfg.Script == nil {
+	if cfg.Webhook == nil && cfg.Script == nil && cfg.OnFinish == nil && cfg.OnFailure == nil {
 		return nil
 	}
 	return &Notifier{
@@ -96,27 +104,64 @@ func (n *Notifier) Notify(ctx context.Context, result PipelineResult) error {
 		}
 	}
 
+	// OnFinish fires on any completion.
+	if n.config.OnFinish != nil {
+		if n.config.OnFinish.Webhook != nil && n.config.OnFinish.Webhook.URL != "" {
+			if err := n.sendWebhookTo(ctx, n.config.OnFinish.Webhook, payload); err != nil {
+				errs = append(errs, fmt.Errorf("on_finish webhook: %w", err))
+			}
+		}
+		if n.config.OnFinish.Script != nil && n.config.OnFinish.Script.Command != "" {
+			if err := n.runScriptCmd(ctx, n.config.OnFinish.Script.Command, payload); err != nil {
+				errs = append(errs, fmt.Errorf("on_finish script: %w", err))
+			}
+		}
+	}
+
+	// OnFailure fires only on failed or timeout status.
+	if n.config.OnFailure != nil && (result.Status == "failed" || result.Status == "timeout") {
+		if n.config.OnFailure.Webhook != nil && n.config.OnFailure.Webhook.URL != "" {
+			if err := n.sendWebhookTo(ctx, n.config.OnFailure.Webhook, payload); err != nil {
+				errs = append(errs, fmt.Errorf("on_failure webhook: %w", err))
+			}
+		}
+		if n.config.OnFailure.Script != nil && n.config.OnFailure.Script.Command != "" {
+			if err := n.runScriptCmd(ctx, n.config.OnFailure.Script.Command, payload); err != nil {
+				errs = append(errs, fmt.Errorf("on_failure script: %w", err))
+			}
+		}
+	}
+
 	if len(errs) == 1 {
 		return fmt.Errorf("notify: %w", errs[0])
 	}
 	if len(errs) > 1 {
-		return fmt.Errorf("notify: multiple errors: %v, %v", errs[0], errs[1])
+		msgs := make([]string, len(errs))
+		for i, e := range errs {
+			msgs[i] = e.Error()
+		}
+		return fmt.Errorf("notify: multiple errors: %s", strings.Join(msgs, "; "))
 	}
 	return nil
 }
 
 // sendWebhook sends an HTTP POST with the JSON payload to the configured URL.
 func (n *Notifier) sendWebhook(ctx context.Context, payload []byte) error {
+	return n.sendWebhookTo(ctx, n.config.Webhook, payload)
+}
+
+// sendWebhookTo sends an HTTP POST with the JSON payload to the given webhook config.
+func (n *Notifier) sendWebhookTo(ctx context.Context, wh *WebhookNotifyConfig, payload []byte) error {
 	ctx, cancel := context.WithTimeout(ctx, n.timeout)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, n.config.Webhook.URL, bytes.NewReader(payload))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, wh.URL, bytes.NewReader(payload))
 	if err != nil {
 		return fmt.Errorf("create request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	for k, v := range n.config.Webhook.Headers {
+	for k, v := range wh.Headers {
 		req.Header.Set(k, v)
 	}
 
@@ -137,10 +182,15 @@ func (n *Notifier) sendWebhook(ctx context.Context, payload []byte) error {
 // runScript executes the configured command with the JSON payload on stdin.
 // The command is split into binary + args and executed directly without a shell.
 func (n *Notifier) runScript(ctx context.Context, payload []byte) error {
+	return n.runScriptCmd(ctx, n.config.Script.Command, payload)
+}
+
+// runScriptCmd executes the given command string with the JSON payload on stdin.
+func (n *Notifier) runScriptCmd(ctx context.Context, command string, payload []byte) error {
 	ctx, cancel := context.WithTimeout(ctx, n.timeout)
 	defer cancel()
 
-	parts := strings.Fields(n.config.Script.Command)
+	parts := strings.Fields(command)
 	if len(parts) == 0 {
 		return fmt.Errorf("script command is empty")
 	}
@@ -152,7 +202,7 @@ func (n *Notifier) runScript(ctx context.Context, payload []byte) error {
 	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("execute %q: %w (stderr: %s)", n.config.Script.Command, err, bytes.TrimSpace(stderr.Bytes()))
+		return fmt.Errorf("execute %q: %w (stderr: %s)", command, err, bytes.TrimSpace(stderr.Bytes()))
 	}
 	return nil
 }

--- a/internal/pipeline/notify.go
+++ b/internal/pipeline/notify.go
@@ -46,7 +46,7 @@ type PipelineResult struct {
 // defaultNotifyTimeout is the maximum time allowed for a single webhook or
 // script notification. Notifications are best-effort and must not block the
 // pipeline for extended periods.
-const defaultNotifyTimeout = 30 * time.Second
+const defaultNotifyTimeout = 10 * time.Second
 
 // Notifier sends pipeline completion notifications via webhook and/or script.
 type Notifier struct {

--- a/internal/pipeline/notify.go
+++ b/internal/pipeline/notify.go
@@ -1,0 +1,149 @@
+package pipeline
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os/exec"
+	"time"
+)
+
+// NotifyConfig configures notification hooks fired on pipeline completion.
+// Both Webhook and Script may be set; they fire independently.
+// Mirrors config.NotifyConfig — kept separate to avoid cross-package imports.
+type NotifyConfig struct {
+	Webhook *WebhookNotifyConfig
+	Script  *ScriptNotifyConfig
+}
+
+// WebhookNotifyConfig configures an HTTP POST webhook notification.
+type WebhookNotifyConfig struct {
+	URL     string
+	Headers map[string]string
+}
+
+// ScriptNotifyConfig configures a script callback notification.
+type ScriptNotifyConfig struct {
+	Command string
+}
+
+// PipelineResult is the JSON payload sent to notification hooks.
+type PipelineResult struct {
+	Ticket    string         `json:"ticket"`
+	Summary   string         `json:"summary,omitempty"`
+	Branch    string         `json:"branch,omitempty"`
+	Status    string         `json:"status"` // "success" or "failed"
+	Error     string         `json:"error,omitempty"`
+	TotalCost float64        `json:"total_cost"`
+	Duration  string         `json:"duration"`
+	Phases    map[string]any `json:"phases,omitempty"`
+}
+
+// defaultNotifyTimeout is the maximum time allowed for a single webhook or
+// script notification. Notifications are best-effort and must not block the
+// pipeline for extended periods.
+const defaultNotifyTimeout = 30 * time.Second
+
+// Notifier sends pipeline completion notifications via webhook and/or script.
+type Notifier struct {
+	config     NotifyConfig
+	httpClient *http.Client
+	timeout    time.Duration
+}
+
+// NewNotifier creates a Notifier. Returns nil if no notifications are configured.
+func NewNotifier(cfg NotifyConfig) *Notifier {
+	if cfg.Webhook == nil && cfg.Script == nil {
+		return nil
+	}
+	return &Notifier{
+		config: cfg,
+		httpClient: &http.Client{
+			Timeout: defaultNotifyTimeout,
+		},
+		timeout: defaultNotifyTimeout,
+	}
+}
+
+// Notify sends the pipeline result to all configured notification hooks.
+// Errors from individual hooks are collected and returned as a combined error.
+// Notifications are best-effort: the caller should log but not fail on errors.
+func (n *Notifier) Notify(ctx context.Context, result PipelineResult) error {
+	if n == nil {
+		return nil
+	}
+
+	payload, err := json.Marshal(result)
+	if err != nil {
+		return fmt.Errorf("notify: marshal payload: %w", err)
+	}
+
+	var errs []error
+
+	if n.config.Webhook != nil && n.config.Webhook.URL != "" {
+		if err := n.sendWebhook(ctx, payload); err != nil {
+			errs = append(errs, fmt.Errorf("webhook: %w", err))
+		}
+	}
+
+	if n.config.Script != nil && n.config.Script.Command != "" {
+		if err := n.runScript(ctx, payload); err != nil {
+			errs = append(errs, fmt.Errorf("script: %w", err))
+		}
+	}
+
+	if len(errs) == 1 {
+		return fmt.Errorf("notify: %w", errs[0])
+	}
+	if len(errs) > 1 {
+		return fmt.Errorf("notify: multiple errors: %v, %v", errs[0], errs[1])
+	}
+	return nil
+}
+
+// sendWebhook sends an HTTP POST with the JSON payload to the configured URL.
+func (n *Notifier) sendWebhook(ctx context.Context, payload []byte) error {
+	ctx, cancel := context.WithTimeout(ctx, n.timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, n.config.Webhook.URL, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	for k, v := range n.config.Webhook.Headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := n.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("send request: %w", err)
+	}
+	defer resp.Body.Close()
+	// Drain body to enable connection reuse.
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("server returned %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// runScript executes the configured command with the JSON payload on stdin.
+func (n *Notifier) runScript(ctx context.Context, payload []byte) error {
+	ctx, cancel := context.WithTimeout(ctx, n.timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "sh", "-c", n.config.Script.Command)
+	cmd.Stdin = bytes.NewReader(payload)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("execute %q: %w (output: %s)", n.config.Script.Command, err, bytes.TrimSpace(output))
+	}
+	return nil
+}

--- a/internal/pipeline/notify.go
+++ b/internal/pipeline/notify.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"os/exec"
+	"strings"
 	"time"
 )
 
@@ -134,16 +135,24 @@ func (n *Notifier) sendWebhook(ctx context.Context, payload []byte) error {
 }
 
 // runScript executes the configured command with the JSON payload on stdin.
+// The command is split into binary + args and executed directly without a shell.
 func (n *Notifier) runScript(ctx context.Context, payload []byte) error {
 	ctx, cancel := context.WithTimeout(ctx, n.timeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "sh", "-c", n.config.Script.Command)
+	parts := strings.Fields(n.config.Script.Command)
+	if len(parts) == 0 {
+		return fmt.Errorf("script command is empty")
+	}
+
+	cmd := exec.CommandContext(ctx, parts[0], parts[1:]...)
 	cmd.Stdin = bytes.NewReader(payload)
 
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("execute %q: %w (output: %s)", n.config.Script.Command, err, bytes.TrimSpace(output))
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("execute %q: %w (stderr: %s)", n.config.Script.Command, err, bytes.TrimSpace(stderr.Bytes()))
 	}
 	return nil
 }

--- a/internal/pipeline/notify_test.go
+++ b/internal/pipeline/notify_test.go
@@ -142,11 +142,9 @@ func TestNotifier_ScriptSuccess(t *testing.T) {
 	outDir := t.TempDir()
 	outFile := filepath.Join(outDir, "notify.json")
 
-	// Script reads stdin and writes it to a file
-	cmd := "cat > " + outFile
-
+	// Script reads stdin and writes it to a file (tee works without shell)
 	n := NewNotifier(NotifyConfig{
-		Script: &ScriptNotifyConfig{Command: cmd},
+		Script: &ScriptNotifyConfig{Command: "tee " + outFile},
 	})
 
 	result := PipelineResult{
@@ -179,7 +177,7 @@ func TestNotifier_ScriptFailure(t *testing.T) {
 	}
 
 	n := NewNotifier(NotifyConfig{
-		Script: &ScriptNotifyConfig{Command: "exit 1"},
+		Script: &ScriptNotifyConfig{Command: "false"},
 	})
 
 	err := n.Notify(context.Background(), PipelineResult{Ticket: "X-1", Status: "failed"})
@@ -208,7 +206,7 @@ func TestNotifier_BothWebhookAndScript(t *testing.T) {
 
 	n := NewNotifier(NotifyConfig{
 		Webhook: &WebhookNotifyConfig{URL: srv.URL},
-		Script:  &ScriptNotifyConfig{Command: "cat > " + outFile},
+		Script:  &ScriptNotifyConfig{Command: "tee " + outFile},
 	})
 
 	err := n.Notify(context.Background(), PipelineResult{Ticket: "BOTH-1", Status: "success"})

--- a/internal/pipeline/notify_test.go
+++ b/internal/pipeline/notify_test.go
@@ -263,6 +263,20 @@ func TestNotifier_EmptyCommandSkipsScript(t *testing.T) {
 	}
 }
 
+func TestNotifier_MissingScriptBinary(t *testing.T) {
+	n := NewNotifier(NotifyConfig{
+		Script: &ScriptNotifyConfig{Command: "/nonexistent/binary/path-that-does-not-exist"},
+	})
+
+	err := n.Notify(context.Background(), PipelineResult{Ticket: "X-1", Status: "success"})
+	if err == nil {
+		t.Fatal("expected error for nonexistent script binary")
+	}
+	if !strings.Contains(err.Error(), "script") {
+		t.Errorf("error should mention script, got: %v", err)
+	}
+}
+
 func TestPipelineResult_JSONRoundTrip(t *testing.T) {
 	result := PipelineResult{
 		Ticket:    "RT-1",

--- a/internal/pipeline/notify_test.go
+++ b/internal/pipeline/notify_test.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestNewNotifier_NilWhenEmpty(t *testing.T) {
@@ -260,6 +261,38 @@ func TestNotifier_EmptyCommandSkipsScript(t *testing.T) {
 	err := n.Notify(context.Background(), PipelineResult{Ticket: "X-1", Status: "success"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNotifier_WebhookTimeout(t *testing.T) {
+	// Create a server that hangs until signalled to stop.
+	hangCh := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-hangCh:
+		case <-r.Context().Done():
+		}
+	}))
+	// Close hangCh first so handler unblocks, then close the server.
+	defer func() {
+		close(hangCh)
+		srv.Close()
+	}()
+
+	n := NewNotifier(NotifyConfig{
+		Webhook: &WebhookNotifyConfig{URL: srv.URL},
+	})
+
+	// Override timeout to something very short so the test completes quickly.
+	n.timeout = 50 * time.Millisecond
+	n.httpClient = &http.Client{Timeout: 50 * time.Millisecond}
+
+	err := n.Notify(context.Background(), PipelineResult{Ticket: "X-1", Status: "success"})
+	if err == nil {
+		t.Fatal("expected timeout error for hanging server")
+	}
+	if !strings.Contains(err.Error(), "webhook") {
+		t.Errorf("error should mention webhook, got: %v", err)
 	}
 }
 

--- a/internal/pipeline/notify_test.go
+++ b/internal/pipeline/notify_test.go
@@ -1,0 +1,311 @@
+package pipeline
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestNewNotifier_NilWhenEmpty(t *testing.T) {
+	n := NewNotifier(NotifyConfig{})
+	if n != nil {
+		t.Fatal("expected nil notifier when no hooks configured")
+	}
+}
+
+func TestNewNotifier_NonNilWithWebhook(t *testing.T) {
+	n := NewNotifier(NotifyConfig{
+		Webhook: &WebhookNotifyConfig{URL: "http://example.com"},
+	})
+	if n == nil {
+		t.Fatal("expected non-nil notifier")
+	}
+}
+
+func TestNewNotifier_NonNilWithScript(t *testing.T) {
+	n := NewNotifier(NotifyConfig{
+		Script: &ScriptNotifyConfig{Command: "echo hello"},
+	})
+	if n == nil {
+		t.Fatal("expected non-nil notifier")
+	}
+}
+
+func TestNotifier_NilReceiverSafe(t *testing.T) {
+	var n *Notifier
+	err := n.Notify(context.Background(), PipelineResult{Ticket: "X-1"})
+	if err != nil {
+		t.Fatalf("nil notifier should return nil, got: %v", err)
+	}
+}
+
+func TestNotifier_WebhookSuccess(t *testing.T) {
+	var receivedBody []byte
+	var receivedHeaders http.Header
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHeaders = r.Header.Clone()
+		body, _ := io.ReadAll(r.Body)
+		receivedBody = body
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	n := NewNotifier(NotifyConfig{
+		Webhook: &WebhookNotifyConfig{
+			URL: srv.URL,
+			Headers: map[string]string{
+				"X-Custom": "test-value",
+			},
+		},
+	})
+
+	result := PipelineResult{
+		Ticket:    "TEST-42",
+		Summary:   "Test ticket",
+		Status:    "success",
+		TotalCost: 1.23,
+		Duration:  "2m30s",
+	}
+
+	err := n.Notify(context.Background(), result)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify payload
+	var got PipelineResult
+	if err := json.Unmarshal(receivedBody, &got); err != nil {
+		t.Fatalf("unmarshal received body: %v", err)
+	}
+	if got.Ticket != "TEST-42" {
+		t.Errorf("Ticket = %q, want %q", got.Ticket, "TEST-42")
+	}
+	if got.Status != "success" {
+		t.Errorf("Status = %q, want %q", got.Status, "success")
+	}
+	if got.TotalCost != 1.23 {
+		t.Errorf("TotalCost = %f, want 1.23", got.TotalCost)
+	}
+
+	// Verify headers
+	if receivedHeaders.Get("Content-Type") != "application/json" {
+		t.Errorf("Content-Type = %q, want %q", receivedHeaders.Get("Content-Type"), "application/json")
+	}
+	if receivedHeaders.Get("X-Custom") != "test-value" {
+		t.Errorf("X-Custom = %q, want %q", receivedHeaders.Get("X-Custom"), "test-value")
+	}
+}
+
+func TestNotifier_WebhookServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	n := NewNotifier(NotifyConfig{
+		Webhook: &WebhookNotifyConfig{URL: srv.URL},
+	})
+
+	err := n.Notify(context.Background(), PipelineResult{Ticket: "X-1", Status: "success"})
+	if err == nil {
+		t.Fatal("expected error for 500 response")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("error should mention status code, got: %v", err)
+	}
+}
+
+func TestNotifier_WebhookBadURL(t *testing.T) {
+	n := NewNotifier(NotifyConfig{
+		Webhook: &WebhookNotifyConfig{URL: "http://127.0.0.1:0/nonexistent"},
+	})
+
+	err := n.Notify(context.Background(), PipelineResult{Ticket: "X-1", Status: "failed"})
+	if err == nil {
+		t.Fatal("expected error for unreachable URL")
+	}
+}
+
+func TestNotifier_ScriptSuccess(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sh not available on windows")
+	}
+
+	outDir := t.TempDir()
+	outFile := filepath.Join(outDir, "notify.json")
+
+	// Script reads stdin and writes it to a file
+	cmd := "cat > " + outFile
+
+	n := NewNotifier(NotifyConfig{
+		Script: &ScriptNotifyConfig{Command: cmd},
+	})
+
+	result := PipelineResult{
+		Ticket: "SCRIPT-1",
+		Status: "success",
+	}
+
+	err := n.Notify(context.Background(), result)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify the script received the payload
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("read output file: %v", err)
+	}
+	var got PipelineResult
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if got.Ticket != "SCRIPT-1" {
+		t.Errorf("Ticket = %q, want %q", got.Ticket, "SCRIPT-1")
+	}
+}
+
+func TestNotifier_ScriptFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sh not available on windows")
+	}
+
+	n := NewNotifier(NotifyConfig{
+		Script: &ScriptNotifyConfig{Command: "exit 1"},
+	})
+
+	err := n.Notify(context.Background(), PipelineResult{Ticket: "X-1", Status: "failed"})
+	if err == nil {
+		t.Fatal("expected error for failing script")
+	}
+	if !strings.Contains(err.Error(), "script") {
+		t.Errorf("error should mention script, got: %v", err)
+	}
+}
+
+func TestNotifier_BothWebhookAndScript(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sh not available on windows")
+	}
+
+	var webhookCalled bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		webhookCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	outDir := t.TempDir()
+	outFile := filepath.Join(outDir, "notify.json")
+
+	n := NewNotifier(NotifyConfig{
+		Webhook: &WebhookNotifyConfig{URL: srv.URL},
+		Script:  &ScriptNotifyConfig{Command: "cat > " + outFile},
+	})
+
+	err := n.Notify(context.Background(), PipelineResult{Ticket: "BOTH-1", Status: "success"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !webhookCalled {
+		t.Error("webhook was not called")
+	}
+	if _, err := os.Stat(outFile); err != nil {
+		t.Errorf("script did not create output file: %v", err)
+	}
+}
+
+func TestNotifier_ContextCancelled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	n := NewNotifier(NotifyConfig{
+		Webhook: &WebhookNotifyConfig{URL: srv.URL},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	err := n.Notify(ctx, PipelineResult{Ticket: "X-1", Status: "failed"})
+	if err == nil {
+		t.Fatal("expected error for cancelled context")
+	}
+}
+
+func TestNotifier_EmptyURLSkipsWebhook(t *testing.T) {
+	n := NewNotifier(NotifyConfig{
+		Webhook: &WebhookNotifyConfig{URL: ""},
+	})
+	// Should not be nil because the struct is non-nil, but the empty URL
+	// should be a no-op.
+	err := n.Notify(context.Background(), PipelineResult{Ticket: "X-1", Status: "success"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNotifier_EmptyCommandSkipsScript(t *testing.T) {
+	n := NewNotifier(NotifyConfig{
+		Script: &ScriptNotifyConfig{Command: ""},
+	})
+	err := n.Notify(context.Background(), PipelineResult{Ticket: "X-1", Status: "success"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPipelineResult_JSONRoundTrip(t *testing.T) {
+	result := PipelineResult{
+		Ticket:    "RT-1",
+		Summary:   "Test ticket",
+		Branch:    "soda/RT-1",
+		Status:    "failed",
+		Error:     "budget exceeded",
+		TotalCost: 15.50,
+		Duration:  "5m23s",
+		Phases: map[string]any{
+			"triage":    map[string]any{"status": "completed"},
+			"implement": map[string]any{"status": "failed"},
+		},
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var got PipelineResult
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if got.Ticket != result.Ticket {
+		t.Errorf("Ticket = %q, want %q", got.Ticket, result.Ticket)
+	}
+	if got.Status != result.Status {
+		t.Errorf("Status = %q, want %q", got.Status, result.Status)
+	}
+	if got.Error != result.Error {
+		t.Errorf("Error = %q, want %q", got.Error, result.Error)
+	}
+	if got.TotalCost != result.TotalCost {
+		t.Errorf("TotalCost = %f, want %f", got.TotalCost, result.TotalCost)
+	}
+	if got.Duration != result.Duration {
+		t.Errorf("Duration = %q, want %q", got.Duration, result.Duration)
+	}
+	if len(got.Phases) != 2 {
+		t.Errorf("len(Phases) = %d, want 2", len(got.Phases))
+	}
+}


### PR DESCRIPTION
## Summary

Script callback + webhook notification on pipeline completion/failure. Best-effort — notification failures never block the pipeline.

## Changes

- `internal/pipeline/notify.go` — Notifier with webhook POST + script execution
- `internal/config/config.go` — NotificationsConfig (webhook, script, on_finish, on_failure)
- `cmd/soda/run.go` — wire config into EngineConfig, convertNotifyConfig
- `cmd/soda/validate.go` — Stage 6 validates notification config
- Status enum: success, failed, timeout, partial
- Script via exec.Command (no shell — injection-safe)
- Webhook with 10s default timeout
- Per-phase token fields with cache breakdown in payload
- on_finish (fires always) + on_failure (fires on failed/timeout) handlers
- Tests: notify_test.go + engine notification tests + validation tests

Closes #376