### PR TITLE
feat(monitor): auto-merge safeguard logic, events, config, doctor check [#436]

### DIFF
--- a/cmd/soda/doctor.go
+++ b/cmd/soda/doctor.go
@@ -91,6 +91,7 @@ func runDoctor(w io.Writer, env *doctorEnv) error {
 		checkConfigValid,
 		checkGh,
 		checkGhAuth,
+		checkBranchProtection,
 		checkNode,
 	}
 
@@ -347,6 +348,73 @@ func checkGhAuth(env *doctorEnv) checkResult {
 		passed:   true,
 		required: required,
 		detail:   "authenticated",
+	}
+}
+
+// checkBranchProtection warns when the target repo's default branch has
+// dismiss_stale_reviews enabled, which can cause auto-merge to fail after
+// new pushes. Skipped when gh is not found or the config is unavailable.
+// This is an optional (warning-only) check.
+func checkBranchProtection(env *doctorEnv) checkResult {
+	if _, err := env.LookPath("gh"); err != nil {
+		return checkResult{
+			name:    "branch-protection",
+			skipped: true,
+			detail:  "skipped (gh not found)",
+		}
+	}
+
+	// Require a parsed config with GitHub repo info.
+	if env.ParsedConfig == nil {
+		return checkResult{
+			name:    "branch-protection",
+			skipped: true,
+			detail:  "skipped (no config parsed)",
+		}
+	}
+
+	owner := env.ParsedConfig.GitHub.Owner
+	repo := env.ParsedConfig.GitHub.Repo
+	if owner == "" || repo == "" {
+		return checkResult{
+			name:    "branch-protection",
+			skipped: true,
+			detail:  "skipped (github owner/repo not configured)",
+		}
+	}
+
+	// Query branch protection for the default branch (main).
+	// Use gh api to check the protection rules.
+	out, err := env.RunCmd("gh", "api", fmt.Sprintf("repos/%s/%s/branches/main/protection", owner, repo))
+	if err != nil {
+		// 404 or error means no branch protection — that's fine.
+		if strings.Contains(strings.ToLower(out), "not found") || strings.Contains(strings.ToLower(out), "404") {
+			return checkResult{
+				name:   "branch-protection",
+				passed: true,
+				detail: "no branch protection rules on main",
+			}
+		}
+		return checkResult{
+			name:    "branch-protection",
+			skipped: true,
+			detail:  fmt.Sprintf("skipped (could not query branch protection: %v)", err),
+		}
+	}
+
+	if strings.Contains(out, "dismiss_stale_reviews") && strings.Contains(out, "true") {
+		return checkResult{
+			name:   "branch-protection",
+			passed: false,
+			detail: "dismiss_stale_reviews is enabled on main — auto-merge may fail after new pushes",
+			fix:    "consider disabling dismiss_stale_reviews or using a merge queue",
+		}
+	}
+
+	return checkResult{
+		name:   "branch-protection",
+		passed: true,
+		detail: "no dismiss_stale_reviews on main",
 	}
 }
 

--- a/cmd/soda/doctor_test.go
+++ b/cmd/soda/doctor_test.go
@@ -45,7 +45,12 @@ func allPassEnv() *doctorEnv {
 			return mockFileInfo{name: name, isDir: strings.HasSuffix(name, "soda") && !strings.HasSuffix(name, ".yaml")}, nil
 		},
 		LoadConfig: func(path string) (*config.Config, error) {
-			return &config.Config{}, nil
+			return &config.Config{
+				GitHub: config.GitHubTicketConfig{
+					Owner: "test-org",
+					Repo:  "test-repo",
+				},
+			}, nil
 		},
 		UserConfigDir: func() (string, error) {
 			return "/home/testuser/.config", nil
@@ -1015,5 +1020,96 @@ func TestRunDoctor_ClaudeMissing_SkipsClaudeVersion(t *testing.T) {
 	// claude itself should fail
 	if !strings.Contains(out, "✗ claude:") {
 		t.Errorf("expected claude check to fail, got:\n%s", out)
+	}
+}
+
+// --- checkBranchProtection tests ---
+
+func TestCheckBranchProtection_SkippedWhenGhMissing(t *testing.T) {
+	env := allPassEnv()
+	env.LookPath = func(file string) (string, error) {
+		if file == "gh" {
+			return "", errors.New("not found")
+		}
+		return "/usr/bin/" + file, nil
+	}
+	r := checkBranchProtection(env)
+	if !r.skipped {
+		t.Error("expected branch-protection to be skipped when gh is missing")
+	}
+}
+
+func TestCheckBranchProtection_SkippedWhenNoConfig(t *testing.T) {
+	env := allPassEnv()
+	env.ParsedConfig = nil
+	r := checkBranchProtection(env)
+	if !r.skipped {
+		t.Error("expected branch-protection to be skipped when config is nil")
+	}
+}
+
+func TestCheckBranchProtection_SkippedWhenNoOwnerRepo(t *testing.T) {
+	env := allPassEnv()
+	env.ParsedConfig = &config.Config{}
+	r := checkBranchProtection(env)
+	if !r.skipped {
+		t.Error("expected branch-protection to be skipped when owner/repo is empty")
+	}
+}
+
+func TestCheckBranchProtection_NoBranchProtection(t *testing.T) {
+	env := allPassEnv()
+	env.ParsedConfig = &config.Config{
+		GitHub: config.GitHubTicketConfig{Owner: "org", Repo: "repo"},
+	}
+	env.RunCmd = func(name string, args ...string) (string, error) {
+		if name == "gh" && len(args) > 1 && args[0] == "api" {
+			return "Not Found", errors.New("exit status 1")
+		}
+		return "", nil
+	}
+	r := checkBranchProtection(env)
+	if !r.passed {
+		t.Errorf("expected branch-protection to pass when no protection rules, got: %+v", r)
+	}
+}
+
+func TestCheckBranchProtection_DismissStaleReviewsEnabled(t *testing.T) {
+	env := allPassEnv()
+	env.ParsedConfig = &config.Config{
+		GitHub: config.GitHubTicketConfig{Owner: "org", Repo: "repo"},
+	}
+	env.RunCmd = func(name string, args ...string) (string, error) {
+		if name == "gh" && len(args) > 1 && args[0] == "api" {
+			return `{"required_pull_request_reviews":{"dismiss_stale_reviews":true}}`, nil
+		}
+		return "", nil
+	}
+	r := checkBranchProtection(env)
+	if r.passed {
+		t.Error("expected branch-protection to warn when dismiss_stale_reviews is enabled")
+	}
+	if !strings.Contains(r.detail, "dismiss_stale_reviews") {
+		t.Errorf("expected detail to mention dismiss_stale_reviews, got: %q", r.detail)
+	}
+	if r.fix == "" {
+		t.Error("expected a fix suggestion")
+	}
+}
+
+func TestCheckBranchProtection_NoStaleReviews(t *testing.T) {
+	env := allPassEnv()
+	env.ParsedConfig = &config.Config{
+		GitHub: config.GitHubTicketConfig{Owner: "org", Repo: "repo"},
+	}
+	env.RunCmd = func(name string, args ...string) (string, error) {
+		if name == "gh" && len(args) > 1 && args[0] == "api" {
+			return `{"required_pull_request_reviews":{"dismiss_stale_reviews":false}}`, nil
+		}
+		return "", nil
+	}
+	r := checkBranchProtection(env)
+	if !r.passed {
+		t.Errorf("expected branch-protection to pass when dismiss_stale_reviews is false, got: %+v", r)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,10 +32,13 @@ type Config struct {
 // MonitorConfig holds monitor phase settings loaded from the config file.
 // These values are wired into EngineConfig at startup.
 type MonitorConfig struct {
-	Profile    string   `yaml:"profile"`    // monitor profile preset: conservative, smart, aggressive
-	SelfUser   string   `yaml:"self_user"`  // PR author username for self-comment filtering
-	BotUsers   []string `yaml:"bot_users"`  // known bot usernames to filter out
-	CODEOWNERS string   `yaml:"codeowners"` // path to CODEOWNERS file for authority resolution
+	Profile          string   `yaml:"profile"`            // monitor profile preset: conservative, smart, aggressive
+	SelfUser         string   `yaml:"self_user"`          // PR author username for self-comment filtering
+	BotUsers         []string `yaml:"bot_users"`          // known bot usernames to filter out
+	CODEOWNERS       string   `yaml:"codeowners"`         // path to CODEOWNERS file for authority resolution
+	MergeMethod      string   `yaml:"merge_method"`       // merge method: "merge", "squash", "rebase"; defaults to "squash"
+	MergeLabels      []string `yaml:"merge_labels"`       // required PR labels before auto-merge proceeds
+	AutoMergeTimeout string   `yaml:"auto_merge_timeout"` // max wait after approval before giving up (Go duration string); defaults to "30m"
 }
 
 // NotifyConfig holds notification hook settings for pipeline completion.

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -66,6 +66,9 @@ type EngineConfig struct {
 	Stderr                 io.Writer         // destination for warning messages; defaults to os.Stderr
 	TokenBudget            TokenBudgetConfig // prompt token budget estimation; zero value disables checks
 	Notify                 NotifyConfig      // notification hooks fired on pipeline completion; zero value disables
+	MergeMethod            string            // merge method: "merge", "squash", "rebase"; defaults to "squash"
+	MergeLabels            []string          // required PR labels before auto-merge proceeds
+	AutoMergeTimeout       time.Duration     // max wait after approval before giving up; defaults to 30m
 }
 
 // TokenBudgetConfig configures the prompt-size estimation check.

--- a/internal/pipeline/events.go
+++ b/internal/pipeline/events.go
@@ -93,6 +93,10 @@ const (
 	EventTokenBudgetCalibration   = "token_budget_calibration"
 	EventNotifySuccess            = "notify_success"
 	EventNotifyFailed             = "notify_failed"
+	EventAutoMergeCompleted       = "auto_merge_completed"
+	EventAutoMergeBlocked         = "auto_merge_blocked"
+	EventAutoMergeDryRun          = "auto_merge_dry_run"
+	EventRebaseConflict           = "rebase_conflict"
 )
 
 // FormatEvent formats an event as a compact, human-readable line:

--- a/internal/pipeline/github_poller.go
+++ b/internal/pipeline/github_poller.go
@@ -50,9 +50,15 @@ func parsePRRef(prURL string) (owner, repo, number string, err error) {
 
 // ghPR is the response from gh pr view.
 type ghPR struct {
-	State          string `json:"state"`          // "OPEN", "CLOSED", "MERGED"
-	ReviewDecision string `json:"reviewDecision"` // "APPROVED", "CHANGES_REQUESTED", "REVIEW_REQUIRED", ""
-	HeadRefOid     string `json:"headRefOid"`     // SHA of the PR head commit
+	State          string    `json:"state"`          // "OPEN", "CLOSED", "MERGED"
+	ReviewDecision string    `json:"reviewDecision"` // "APPROVED", "CHANGES_REQUESTED", "REVIEW_REQUIRED", ""
+	HeadRefOid     string    `json:"headRefOid"`     // SHA of the PR head commit
+	Labels         []ghLabel `json:"labels"`         // labels applied to the PR
+}
+
+// ghLabel is a single label from gh pr view --json labels.
+type ghLabel struct {
+	Name string `json:"name"`
 }
 
 // ghCheck is a single CI check from the PR status.
@@ -105,7 +111,7 @@ func (p *GitHubPRPoller) GetPRStatus(ctx context.Context, prURL string) (*PRStat
 	out, err := exec.CommandContext(ctx, p.command,
 		"pr", "view", number,
 		"--repo", nwoRef,
-		"--json", "state,reviewDecision,headRefOid",
+		"--json", "state,reviewDecision,headRefOid,labels",
 	).Output()
 	if err != nil {
 		return nil, fmt.Errorf("monitor: get PR status: %w: %s", err, ghStderr(err))
@@ -119,11 +125,17 @@ func (p *GitHubPRPoller) GetPRStatus(ctx context.Context, prURL string) (*PRStat
 	state := strings.ToLower(pr.State)
 	approved := strings.EqualFold(pr.ReviewDecision, "APPROVED")
 
+	var labels []string
+	for _, l := range pr.Labels {
+		labels = append(labels, l.Name)
+	}
+
 	return &PRStatus{
 		State:          state,
 		Approved:       approved,
 		ReviewDecision: pr.ReviewDecision,
 		HeadSHA:        pr.HeadRefOid,
+		Labels:         labels,
 	}, nil
 }
 

--- a/internal/pipeline/monitor.go
+++ b/internal/pipeline/monitor.go
@@ -14,10 +14,11 @@ import (
 type MonitorStatus string
 
 const (
-	MonitorPolling   MonitorStatus = "polling"
-	MonitorCompleted MonitorStatus = "completed"
-	MonitorFailed    MonitorStatus = "failed"
-	MonitorMaxRounds MonitorStatus = "max_rounds"
+	MonitorPolling        MonitorStatus = "polling"
+	MonitorCompleted      MonitorStatus = "completed"
+	MonitorFailed         MonitorStatus = "failed"
+	MonitorMaxRounds      MonitorStatus = "max_rounds"
+	MonitorRebaseConflict MonitorStatus = "rebase_conflict"
 )
 
 // MonitorState holds the persistent state of the monitor polling loop.
@@ -36,6 +37,16 @@ type MonitorState struct {
 	LastPolledAt time.Time     `json:"last_polled_at"`
 	StartedAt    time.Time     `json:"started_at"`
 	Status       MonitorStatus `json:"status"`
+
+	// ApprovalTime records when the PR was first observed as approved.
+	// Used by auto-merge to compute timeout relative to approval, not poll start.
+	ApprovalTime *time.Time `json:"approval_time,omitempty"`
+	// HasUnreviewedComments is true when new comments arrived after approval.
+	// Auto-merge blocks until comments are resolved.
+	HasUnreviewedComments bool `json:"has_unreviewed_comments,omitempty"`
+	// DryRunLogged tracks whether the dry-run event has been emitted for this
+	// approval cycle, avoiding duplicate events.
+	DryRunLogged bool `json:"dry_run_logged,omitempty"`
 }
 
 // PRPoller polls a pull request for changes.
@@ -84,10 +95,11 @@ var ErrPRAlreadyMerged = errors.New("monitor: pull request was already merged")
 
 // PRStatus holds the current state of a pull request.
 type PRStatus struct {
-	State          string // "open", "closed", "merged"
-	Approved       bool   // true if at least one approving review
-	ReviewDecision string // raw review decision: "APPROVED", "CHANGES_REQUESTED", "REVIEW_REQUIRED", ""
-	HeadSHA        string // SHA of the PR's head commit (headRefOid)
+	State          string   // "open", "closed", "merged"
+	Approved       bool     // true if at least one approving review
+	ReviewDecision string   // raw review decision: "APPROVED", "CHANGES_REQUESTED", "REVIEW_REQUIRED", ""
+	HeadSHA        string   // SHA of the PR's head commit (headRefOid)
+	Labels         []string // labels applied to the PR
 }
 
 // PRComment represents a review comment on a pull request.

--- a/internal/pipeline/monitor_merge.go
+++ b/internal/pipeline/monitor_merge.go
@@ -64,7 +64,7 @@ func (e *Engine) tryAutoMerge(
 
 	// --- 2. Label check ---
 	requiredLabels := e.mergeLabels(polling)
-	if len(requiredLabels) > 0 && prStatus != nil {
+	if prStatus != nil {
 		missing := missingLabels(requiredLabels, prStatus.Labels)
 		if len(missing) > 0 {
 			e.emit(Event{
@@ -227,13 +227,21 @@ func (e *Engine) mergeMethod(polling *PollingConfig) string {
 	return "squash"
 }
 
+// defaultMergeLabels is the set of labels required for auto-merge when
+// merge_labels is not explicitly configured. There is no escape hatch:
+// setting merge_labels to an empty list still falls through to this default.
+var defaultMergeLabels = []string{"auto-merge-ok"}
+
 // mergeLabels returns the configured required merge labels.
-// Checks PollingConfig first, then EngineConfig.
+// Checks PollingConfig first, then EngineConfig, then defaultMergeLabels.
 func (e *Engine) mergeLabels(polling *PollingConfig) []string {
 	if polling != nil && len(polling.MergeLabels) > 0 {
 		return polling.MergeLabels
 	}
-	return e.config.MergeLabels
+	if len(e.config.MergeLabels) > 0 {
+		return e.config.MergeLabels
+	}
+	return defaultMergeLabels
 }
 
 // autoMergeTimeout returns the configured auto-merge timeout.

--- a/internal/pipeline/monitor_merge.go
+++ b/internal/pipeline/monitor_merge.go
@@ -1,0 +1,264 @@
+package pipeline
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// defaultAutoMergeTimeout is used when AutoMergeTimeout is not configured.
+const defaultAutoMergeTimeout = 30 * time.Minute
+
+// autoMergeResult describes the outcome of an auto-merge attempt.
+type autoMergeResult struct {
+	// Merged is true when the PR was successfully merged (or was already merged).
+	Merged bool
+	// Blocked is true when a safeguard prevented merging (labels, CI, etc.).
+	Blocked bool
+	// BlockReason describes why the merge was blocked, when Blocked is true.
+	BlockReason string
+	// RebaseConflict is true when a merge conflict was detected.
+	RebaseConflict bool
+	// DryRun is true when the merge would proceed but auto_merge is not enabled.
+	DryRun bool
+	// TimedOut is true when the auto-merge timeout expired.
+	TimedOut bool
+}
+
+// tryAutoMerge runs the auto-merge safeguard chain. The chain is:
+//
+//  1. Timeout — reject if too long since approval
+//  2. Labels — reject if required labels are missing
+//  3. Approval — reject if PR is not approved
+//  4. CI freshness — reject if CI commit SHA ≠ PR head SHA
+//  5. Branch protection — warn if dismiss_stale_reviews is on
+//  6. Dry-run — if auto_merge is not enabled, log what would happen
+//  7. Merge — attempt the merge, mapping conflicts to rebase events
+//
+// Each step either returns a blocking result or falls through to the next.
+func (e *Engine) tryAutoMerge(
+	ctx context.Context,
+	phaseName string,
+	monState *MonitorState,
+	prStatus *PRStatus,
+	ciStatus *CIStatus,
+	polling *PollingConfig,
+) autoMergeResult {
+	now := e.now()
+
+	// --- 1. Timeout check ---
+	timeout := e.autoMergeTimeout(polling)
+	if monState.ApprovalTime != nil && now.Sub(*monState.ApprovalTime) >= timeout {
+		e.emit(Event{
+			Phase: phaseName,
+			Kind:  EventAutoMergeBlocked,
+			Data: map[string]any{
+				"reason":  "timeout",
+				"elapsed": now.Sub(*monState.ApprovalTime).String(),
+				"timeout": timeout.String(),
+			},
+		})
+		return autoMergeResult{Blocked: true, BlockReason: "auto-merge timeout exceeded", TimedOut: true}
+	}
+
+	// --- 2. Label check ---
+	requiredLabels := e.mergeLabels(polling)
+	if len(requiredLabels) > 0 && prStatus != nil {
+		missing := missingLabels(requiredLabels, prStatus.Labels)
+		if len(missing) > 0 {
+			e.emit(Event{
+				Phase: phaseName,
+				Kind:  EventAutoMergeBlocked,
+				Data: map[string]any{
+					"reason":  "missing_labels",
+					"missing": missing,
+				},
+			})
+			return autoMergeResult{Blocked: true, BlockReason: fmt.Sprintf("missing required labels: %v", missing)}
+		}
+	}
+
+	// --- 3. Approval check ---
+	if prStatus == nil || !prStatus.Approved {
+		e.emit(Event{
+			Phase: phaseName,
+			Kind:  EventAutoMergeBlocked,
+			Data:  map[string]any{"reason": "not_approved"},
+		})
+		return autoMergeResult{Blocked: true, BlockReason: "PR not approved"}
+	}
+
+	// --- 4. CI freshness check ---
+	if ciStatus == nil || ciStatus.Overall != "success" {
+		reason := "ci_not_green"
+		overall := "unknown"
+		if ciStatus != nil {
+			overall = ciStatus.Overall
+		}
+		e.emit(Event{
+			Phase: phaseName,
+			Kind:  EventAutoMergeBlocked,
+			Data: map[string]any{
+				"reason":    reason,
+				"ci_status": overall,
+			},
+		})
+		return autoMergeResult{Blocked: true, BlockReason: fmt.Sprintf("CI status is %s, not success", overall)}
+	}
+
+	// CI SHA freshness: ensure CI ran against the current head commit.
+	if prStatus.HeadSHA != "" && ciStatus.CommitSHA != "" && prStatus.HeadSHA != ciStatus.CommitSHA {
+		e.emit(Event{
+			Phase: phaseName,
+			Kind:  EventAutoMergeBlocked,
+			Data: map[string]any{
+				"reason":   "ci_sha_stale",
+				"head_sha": prStatus.HeadSHA,
+				"ci_sha":   ciStatus.CommitSHA,
+			},
+		})
+		return autoMergeResult{Blocked: true, BlockReason: "CI ran against stale commit"}
+	}
+
+	// --- 5. Branch protection check ---
+	if validator, ok := e.config.PRPoller.(MergeValidator); ok {
+		if err := validator.ValidateMergePrerequisites(ctx, monState.PRURL); err != nil {
+			e.emit(Event{
+				Phase: phaseName,
+				Kind:  EventMonitorWarning,
+				Data: map[string]any{
+					"warning": fmt.Sprintf("branch protection: %v", err),
+				},
+			})
+			// This is a warning, not a blocking condition — the merge may
+			// still succeed if the protection rule doesn't apply to the actor.
+		}
+	}
+
+	// --- 6. Dry-run check ---
+	autoMergeEnabled := polling != nil && polling.AutoMerge
+	if !autoMergeEnabled {
+		if !monState.DryRunLogged {
+			e.emit(Event{
+				Phase: phaseName,
+				Kind:  EventAutoMergeDryRun,
+				Data: map[string]any{
+					"merge_method": e.mergeMethod(polling),
+					"message":      "all safeguards passed; would merge if auto_merge were enabled",
+				},
+			})
+			monState.DryRunLogged = true
+		}
+		return autoMergeResult{DryRun: true}
+	}
+
+	// --- 7. Merge ---
+	method := e.mergeMethod(polling)
+	err := e.config.PRPoller.MergePR(ctx, monState.PRURL, method)
+	if err == nil {
+		e.emit(Event{
+			Phase: phaseName,
+			Kind:  EventAutoMergeCompleted,
+			Data: map[string]any{
+				"merge_method": method,
+			},
+		})
+		return autoMergeResult{Merged: true}
+	}
+
+	// Handle sentinel errors.
+	if errors.Is(err, ErrPRAlreadyMerged) {
+		e.emit(Event{
+			Phase: phaseName,
+			Kind:  EventAutoMergeCompleted,
+			Data: map[string]any{
+				"merge_method": method,
+				"note":         "already merged by someone else",
+			},
+		})
+		return autoMergeResult{Merged: true}
+	}
+
+	if errors.Is(err, ErrMergeConflict) {
+		e.emit(Event{
+			Phase: phaseName,
+			Kind:  EventRebaseConflict,
+			Data: map[string]any{
+				"error": err.Error(),
+			},
+		})
+		return autoMergeResult{RebaseConflict: true}
+	}
+
+	if errors.Is(err, ErrPRClosed) {
+		e.emit(Event{
+			Phase: phaseName,
+			Kind:  EventAutoMergeBlocked,
+			Data: map[string]any{
+				"reason": "pr_closed",
+				"error":  err.Error(),
+			},
+		})
+		return autoMergeResult{Blocked: true, BlockReason: "PR is closed"}
+	}
+
+	// Unknown merge error — emit warning and block.
+	e.emit(Event{
+		Phase: phaseName,
+		Kind:  EventAutoMergeBlocked,
+		Data: map[string]any{
+			"reason": "merge_failed",
+			"error":  err.Error(),
+		},
+	})
+	return autoMergeResult{Blocked: true, BlockReason: err.Error()}
+}
+
+// mergeMethod returns the configured merge method, defaulting to "squash".
+// Checks PollingConfig first, then EngineConfig.
+func (e *Engine) mergeMethod(polling *PollingConfig) string {
+	if polling != nil && polling.MergeMethod != "" {
+		return polling.MergeMethod
+	}
+	if e.config.MergeMethod != "" {
+		return e.config.MergeMethod
+	}
+	return "squash"
+}
+
+// mergeLabels returns the configured required merge labels.
+// Checks PollingConfig first, then EngineConfig.
+func (e *Engine) mergeLabels(polling *PollingConfig) []string {
+	if polling != nil && len(polling.MergeLabels) > 0 {
+		return polling.MergeLabels
+	}
+	return e.config.MergeLabels
+}
+
+// autoMergeTimeout returns the configured auto-merge timeout.
+// Checks PollingConfig first, then EngineConfig, then defaults.
+func (e *Engine) autoMergeTimeout(polling *PollingConfig) time.Duration {
+	if polling != nil && polling.AutoMergeTimeout.Duration > 0 {
+		return polling.AutoMergeTimeout.Duration
+	}
+	if e.config.AutoMergeTimeout > 0 {
+		return e.config.AutoMergeTimeout
+	}
+	return defaultAutoMergeTimeout
+}
+
+// missingLabels returns elements from required that are not in actual.
+func missingLabels(required, actual []string) []string {
+	have := make(map[string]bool, len(actual))
+	for _, l := range actual {
+		have[l] = true
+	}
+	var missing []string
+	for _, r := range required {
+		if !have[r] {
+			missing = append(missing, r)
+		}
+	}
+	return missing
+}

--- a/internal/pipeline/monitor_merge_test.go
+++ b/internal/pipeline/monitor_merge_test.go
@@ -1,0 +1,471 @@
+package pipeline
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// --- missingLabels tests ---
+
+func TestMissingLabels_AllPresent(t *testing.T) {
+	got := missingLabels([]string{"ready", "approved"}, []string{"ready", "approved", "extra"})
+	if len(got) != 0 {
+		t.Errorf("expected no missing labels, got %v", got)
+	}
+}
+
+func TestMissingLabels_SomeMissing(t *testing.T) {
+	got := missingLabels([]string{"ready", "approved"}, []string{"ready"})
+	if len(got) != 1 || got[0] != "approved" {
+		t.Errorf("expected [approved], got %v", got)
+	}
+}
+
+func TestMissingLabels_AllMissing(t *testing.T) {
+	got := missingLabels([]string{"ready"}, nil)
+	if len(got) != 1 || got[0] != "ready" {
+		t.Errorf("expected [ready], got %v", got)
+	}
+}
+
+// --- mergeMethod tests ---
+
+func TestMergeMethod_DefaultSquash(t *testing.T) {
+	engine, _ := setupEngine(t, nil, nil)
+	got := engine.mergeMethod(nil)
+	if got != "squash" {
+		t.Errorf("expected squash, got %s", got)
+	}
+}
+
+func TestMergeMethod_PollingOverrides(t *testing.T) {
+	engine, _ := setupEngine(t, nil, nil)
+	polling := &PollingConfig{MergeMethod: "rebase"}
+	got := engine.mergeMethod(polling)
+	if got != "rebase" {
+		t.Errorf("expected rebase, got %s", got)
+	}
+}
+
+func TestMergeMethod_EngineConfigFallback(t *testing.T) {
+	engine, _ := setupEngine(t, nil, nil, func(cfg *EngineConfig) {
+		cfg.MergeMethod = "merge"
+	})
+	got := engine.mergeMethod(&PollingConfig{}) // empty polling method
+	if got != "merge" {
+		t.Errorf("expected merge, got %s", got)
+	}
+}
+
+// --- autoMergeTimeout tests ---
+
+func TestAutoMergeTimeout_Default(t *testing.T) {
+	engine, _ := setupEngine(t, nil, nil)
+	got := engine.autoMergeTimeout(nil)
+	if got != defaultAutoMergeTimeout {
+		t.Errorf("expected %v, got %v", defaultAutoMergeTimeout, got)
+	}
+}
+
+func TestAutoMergeTimeout_PollingOverrides(t *testing.T) {
+	engine, _ := setupEngine(t, nil, nil)
+	polling := &PollingConfig{AutoMergeTimeout: Duration{Duration: 10 * time.Minute}}
+	got := engine.autoMergeTimeout(polling)
+	if got != 10*time.Minute {
+		t.Errorf("expected 10m, got %v", got)
+	}
+}
+
+func TestAutoMergeTimeout_EngineConfigFallback(t *testing.T) {
+	engine, _ := setupEngine(t, nil, nil, func(cfg *EngineConfig) {
+		cfg.AutoMergeTimeout = 45 * time.Minute
+	})
+	got := engine.autoMergeTimeout(&PollingConfig{}) // zero timeout
+	if got != 45*time.Minute {
+		t.Errorf("expected 45m, got %v", got)
+	}
+}
+
+// --- tryAutoMerge safeguard chain tests ---
+
+func setupMergeEngine(t *testing.T, poller PRPoller, opts ...func(*EngineConfig)) (*Engine, *[]Event) {
+	t.Helper()
+	var events []Event
+	engine, _ := setupEngine(t, nil, nil, func(cfg *EngineConfig) {
+		cfg.PRPoller = poller
+		cfg.OnEvent = func(e Event) {
+			events = append(events, e)
+		}
+		cfg.SleepFunc = func(time.Duration) {}
+		for _, opt := range opts {
+			opt(cfg)
+		}
+	})
+	return engine, &events
+}
+
+func TestTryAutoMerge_Timeout(t *testing.T) {
+	poller := &mockPRPoller{}
+	engine, events := setupMergeEngine(t, poller)
+
+	past := time.Now().Add(-1 * time.Hour)
+	monState := &MonitorState{
+		PRURL:        "https://github.com/o/r/pull/1",
+		ApprovalTime: &past,
+	}
+	prStatus := &PRStatus{State: "open", Approved: true}
+	ciStatus := &CIStatus{Overall: "success"}
+	polling := &PollingConfig{AutoMerge: true, AutoMergeTimeout: Duration{Duration: 30 * time.Minute}}
+
+	result := engine.tryAutoMerge(context.Background(), "monitor", monState, prStatus, ciStatus, polling)
+	if !result.TimedOut {
+		t.Error("expected timeout")
+	}
+	if !result.Blocked {
+		t.Error("expected blocked")
+	}
+	if !hasEventKind(*events, EventAutoMergeBlocked) {
+		t.Error("expected auto_merge_blocked event")
+	}
+}
+
+func TestTryAutoMerge_MissingLabels(t *testing.T) {
+	poller := &mockPRPoller{}
+	engine, events := setupMergeEngine(t, poller)
+
+	now := time.Now()
+	monState := &MonitorState{
+		PRURL:        "https://github.com/o/r/pull/1",
+		ApprovalTime: &now,
+	}
+	prStatus := &PRStatus{State: "open", Approved: true, Labels: []string{"wip"}}
+	ciStatus := &CIStatus{Overall: "success"}
+	polling := &PollingConfig{
+		AutoMerge:        true,
+		MergeLabels:      []string{"ready-to-merge"},
+		AutoMergeTimeout: Duration{Duration: 30 * time.Minute},
+	}
+
+	result := engine.tryAutoMerge(context.Background(), "monitor", monState, prStatus, ciStatus, polling)
+	if !result.Blocked {
+		t.Error("expected blocked due to missing labels")
+	}
+	if !hasEventKind(*events, EventAutoMergeBlocked) {
+		t.Error("expected auto_merge_blocked event")
+	}
+}
+
+func TestTryAutoMerge_NotApproved(t *testing.T) {
+	poller := &mockPRPoller{}
+	engine, _ := setupMergeEngine(t, poller)
+
+	now := time.Now()
+	monState := &MonitorState{
+		PRURL:        "https://github.com/o/r/pull/1",
+		ApprovalTime: &now,
+	}
+	prStatus := &PRStatus{State: "open", Approved: false}
+	ciStatus := &CIStatus{Overall: "success"}
+	polling := &PollingConfig{AutoMerge: true, AutoMergeTimeout: Duration{Duration: 30 * time.Minute}}
+
+	result := engine.tryAutoMerge(context.Background(), "monitor", monState, prStatus, ciStatus, polling)
+	if !result.Blocked {
+		t.Error("expected blocked due to not approved")
+	}
+}
+
+func TestTryAutoMerge_CINotGreen(t *testing.T) {
+	poller := &mockPRPoller{}
+	engine, events := setupMergeEngine(t, poller)
+
+	now := time.Now()
+	monState := &MonitorState{
+		PRURL:        "https://github.com/o/r/pull/1",
+		ApprovalTime: &now,
+	}
+	prStatus := &PRStatus{State: "open", Approved: true, HeadSHA: "abc123"}
+	ciStatus := &CIStatus{Overall: "pending", CommitSHA: "abc123"}
+	polling := &PollingConfig{AutoMerge: true, AutoMergeTimeout: Duration{Duration: 30 * time.Minute}}
+
+	result := engine.tryAutoMerge(context.Background(), "monitor", monState, prStatus, ciStatus, polling)
+	if !result.Blocked {
+		t.Error("expected blocked due to CI not green")
+	}
+	if !hasEventKind(*events, EventAutoMergeBlocked) {
+		t.Error("expected auto_merge_blocked event")
+	}
+}
+
+func TestTryAutoMerge_CISHAStale(t *testing.T) {
+	poller := &mockPRPoller{}
+	engine, events := setupMergeEngine(t, poller)
+
+	now := time.Now()
+	monState := &MonitorState{
+		PRURL:        "https://github.com/o/r/pull/1",
+		ApprovalTime: &now,
+	}
+	prStatus := &PRStatus{State: "open", Approved: true, HeadSHA: "abc123"}
+	ciStatus := &CIStatus{Overall: "success", CommitSHA: "old999"}
+	polling := &PollingConfig{AutoMerge: true, AutoMergeTimeout: Duration{Duration: 30 * time.Minute}}
+
+	result := engine.tryAutoMerge(context.Background(), "monitor", monState, prStatus, ciStatus, polling)
+	if !result.Blocked {
+		t.Error("expected blocked due to stale CI SHA")
+	}
+	found := false
+	for _, ev := range *events {
+		if ev.Kind == EventAutoMergeBlocked {
+			if ev.Data["reason"] == "ci_sha_stale" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Error("expected auto_merge_blocked event with reason=ci_sha_stale")
+	}
+}
+
+func TestTryAutoMerge_DryRun(t *testing.T) {
+	poller := &mockPRPoller{}
+	engine, events := setupMergeEngine(t, poller)
+
+	now := time.Now()
+	monState := &MonitorState{
+		PRURL:        "https://github.com/o/r/pull/1",
+		ApprovalTime: &now,
+	}
+	prStatus := &PRStatus{State: "open", Approved: true, HeadSHA: "abc123"}
+	ciStatus := &CIStatus{Overall: "success", CommitSHA: "abc123"}
+	polling := &PollingConfig{AutoMerge: false, AutoMergeTimeout: Duration{Duration: 30 * time.Minute}} // auto_merge disabled
+
+	result := engine.tryAutoMerge(context.Background(), "monitor", monState, prStatus, ciStatus, polling)
+	if !result.DryRun {
+		t.Error("expected dry run when auto_merge is disabled")
+	}
+	if !hasEventKind(*events, EventAutoMergeDryRun) {
+		t.Error("expected auto_merge_dry_run event")
+	}
+	if !monState.DryRunLogged {
+		t.Error("expected DryRunLogged to be set")
+	}
+}
+
+func TestTryAutoMerge_DryRunNotDuplicated(t *testing.T) {
+	poller := &mockPRPoller{}
+	engine, events := setupMergeEngine(t, poller)
+
+	now := time.Now()
+	monState := &MonitorState{
+		PRURL:        "https://github.com/o/r/pull/1",
+		ApprovalTime: &now,
+		DryRunLogged: true, // already logged
+	}
+	prStatus := &PRStatus{State: "open", Approved: true, HeadSHA: "abc123"}
+	ciStatus := &CIStatus{Overall: "success", CommitSHA: "abc123"}
+	polling := &PollingConfig{AutoMerge: false, AutoMergeTimeout: Duration{Duration: 30 * time.Minute}}
+
+	result := engine.tryAutoMerge(context.Background(), "monitor", monState, prStatus, ciStatus, polling)
+	if !result.DryRun {
+		t.Error("expected dry run")
+	}
+	if hasEventKind(*events, EventAutoMergeDryRun) {
+		t.Error("expected no duplicate dry_run event when DryRunLogged is already true")
+	}
+}
+
+func TestTryAutoMerge_MergeSuccess(t *testing.T) {
+	poller := &mockPRPoller{}
+	engine, events := setupMergeEngine(t, poller)
+
+	now := time.Now()
+	monState := &MonitorState{
+		PRURL:        "https://github.com/o/r/pull/1",
+		ApprovalTime: &now,
+	}
+	prStatus := &PRStatus{State: "open", Approved: true, HeadSHA: "abc123"}
+	ciStatus := &CIStatus{Overall: "success", CommitSHA: "abc123"}
+	polling := &PollingConfig{AutoMerge: true, AutoMergeTimeout: Duration{Duration: 30 * time.Minute}}
+
+	result := engine.tryAutoMerge(context.Background(), "monitor", monState, prStatus, ciStatus, polling)
+	if !result.Merged {
+		t.Error("expected merge success")
+	}
+	if !hasEventKind(*events, EventAutoMergeCompleted) {
+		t.Error("expected auto_merge_completed event")
+	}
+	// Verify MergePR was called with correct method
+	if len(poller.mergeCalls) != 1 {
+		t.Fatalf("expected 1 merge call, got %d", len(poller.mergeCalls))
+	}
+	if poller.mergeCalls[0].Method != "squash" {
+		t.Errorf("expected squash method, got %s", poller.mergeCalls[0].Method)
+	}
+}
+
+func TestTryAutoMerge_AlreadyMerged(t *testing.T) {
+	poller := &mockPRPoller{
+		mergeErr: ErrPRAlreadyMerged,
+	}
+	engine, events := setupMergeEngine(t, poller)
+
+	now := time.Now()
+	monState := &MonitorState{
+		PRURL:        "https://github.com/o/r/pull/1",
+		ApprovalTime: &now,
+	}
+	prStatus := &PRStatus{State: "open", Approved: true, HeadSHA: "abc123"}
+	ciStatus := &CIStatus{Overall: "success", CommitSHA: "abc123"}
+	polling := &PollingConfig{AutoMerge: true, AutoMergeTimeout: Duration{Duration: 30 * time.Minute}}
+
+	result := engine.tryAutoMerge(context.Background(), "monitor", monState, prStatus, ciStatus, polling)
+	if !result.Merged {
+		t.Error("expected merged=true for already-merged PR")
+	}
+	if !hasEventKind(*events, EventAutoMergeCompleted) {
+		t.Error("expected auto_merge_completed event")
+	}
+}
+
+func TestTryAutoMerge_MergeConflict(t *testing.T) {
+	poller := &mockPRPoller{
+		mergeErr: ErrMergeConflict,
+	}
+	engine, events := setupMergeEngine(t, poller)
+
+	now := time.Now()
+	monState := &MonitorState{
+		PRURL:        "https://github.com/o/r/pull/1",
+		ApprovalTime: &now,
+	}
+	prStatus := &PRStatus{State: "open", Approved: true, HeadSHA: "abc123"}
+	ciStatus := &CIStatus{Overall: "success", CommitSHA: "abc123"}
+	polling := &PollingConfig{AutoMerge: true, AutoMergeTimeout: Duration{Duration: 30 * time.Minute}}
+
+	result := engine.tryAutoMerge(context.Background(), "monitor", monState, prStatus, ciStatus, polling)
+	if !result.RebaseConflict {
+		t.Error("expected rebase conflict")
+	}
+	if !hasEventKind(*events, EventRebaseConflict) {
+		t.Error("expected rebase_conflict event")
+	}
+}
+
+func TestTryAutoMerge_PRClosed(t *testing.T) {
+	poller := &mockPRPoller{
+		mergeErr: ErrPRClosed,
+	}
+	engine, events := setupMergeEngine(t, poller)
+
+	now := time.Now()
+	monState := &MonitorState{
+		PRURL:        "https://github.com/o/r/pull/1",
+		ApprovalTime: &now,
+	}
+	prStatus := &PRStatus{State: "open", Approved: true, HeadSHA: "abc123"}
+	ciStatus := &CIStatus{Overall: "success", CommitSHA: "abc123"}
+	polling := &PollingConfig{AutoMerge: true, AutoMergeTimeout: Duration{Duration: 30 * time.Minute}}
+
+	result := engine.tryAutoMerge(context.Background(), "monitor", monState, prStatus, ciStatus, polling)
+	if !result.Blocked {
+		t.Error("expected blocked for closed PR")
+	}
+	if !hasEventKind(*events, EventAutoMergeBlocked) {
+		t.Error("expected auto_merge_blocked event")
+	}
+}
+
+func TestTryAutoMerge_CustomMergeMethod(t *testing.T) {
+	poller := &mockPRPoller{}
+	engine, _ := setupMergeEngine(t, poller)
+
+	now := time.Now()
+	monState := &MonitorState{
+		PRURL:        "https://github.com/o/r/pull/1",
+		ApprovalTime: &now,
+	}
+	prStatus := &PRStatus{State: "open", Approved: true, HeadSHA: "abc123"}
+	ciStatus := &CIStatus{Overall: "success", CommitSHA: "abc123"}
+	polling := &PollingConfig{
+		AutoMerge:        true,
+		MergeMethod:      "rebase",
+		AutoMergeTimeout: Duration{Duration: 30 * time.Minute},
+	}
+
+	result := engine.tryAutoMerge(context.Background(), "monitor", monState, prStatus, ciStatus, polling)
+	if !result.Merged {
+		t.Error("expected merge success")
+	}
+	if len(poller.mergeCalls) != 1 {
+		t.Fatalf("expected 1 merge call, got %d", len(poller.mergeCalls))
+	}
+	if poller.mergeCalls[0].Method != "rebase" {
+		t.Errorf("expected rebase method, got %s", poller.mergeCalls[0].Method)
+	}
+}
+
+func TestTryAutoMerge_LabelsPassWhenPresent(t *testing.T) {
+	poller := &mockPRPoller{}
+	engine, _ := setupMergeEngine(t, poller)
+
+	now := time.Now()
+	monState := &MonitorState{
+		PRURL:        "https://github.com/o/r/pull/1",
+		ApprovalTime: &now,
+	}
+	prStatus := &PRStatus{
+		State:    "open",
+		Approved: true,
+		HeadSHA:  "abc123",
+		Labels:   []string{"ready-to-merge", "ci-green"},
+	}
+	ciStatus := &CIStatus{Overall: "success", CommitSHA: "abc123"}
+	polling := &PollingConfig{
+		AutoMerge:        true,
+		MergeLabels:      []string{"ready-to-merge"},
+		AutoMergeTimeout: Duration{Duration: 30 * time.Minute},
+	}
+
+	result := engine.tryAutoMerge(context.Background(), "monitor", monState, prStatus, ciStatus, polling)
+	if !result.Merged {
+		t.Error("expected merge success when all required labels are present")
+	}
+}
+
+func TestTryAutoMerge_NilCIStatus(t *testing.T) {
+	poller := &mockPRPoller{}
+	engine, events := setupMergeEngine(t, poller)
+
+	now := time.Now()
+	monState := &MonitorState{
+		PRURL:        "https://github.com/o/r/pull/1",
+		ApprovalTime: &now,
+	}
+	prStatus := &PRStatus{State: "open", Approved: true}
+	polling := &PollingConfig{AutoMerge: true, AutoMergeTimeout: Duration{Duration: 30 * time.Minute}}
+
+	result := engine.tryAutoMerge(context.Background(), "monitor", monState, prStatus, nil, polling)
+	if !result.Blocked {
+		t.Error("expected blocked when CI status is nil")
+	}
+	found := false
+	for _, ev := range *events {
+		if ev.Kind == EventAutoMergeBlocked && ev.Data["reason"] == "ci_not_green" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected auto_merge_blocked with reason ci_not_green")
+	}
+}
+
+// hasEventKind checks if any event in the slice has the given kind.
+func hasEventKind(events []Event, kind string) bool {
+	for _, e := range events {
+		if e.Kind == kind {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/pipeline/monitor_merge_test.go
+++ b/internal/pipeline/monitor_merge_test.go
@@ -2,9 +2,20 @@ package pipeline
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 )
+
+// mockPRPollerWithValidator extends mockPRPoller to also implement MergeValidator.
+type mockPRPollerWithValidator struct {
+	*mockPRPoller
+	validateErr error
+}
+
+func (m *mockPRPollerWithValidator) ValidateMergePrerequisites(ctx context.Context, prURL string) error {
+	return m.validateErr
+}
 
 // --- missingLabels tests ---
 
@@ -457,6 +468,73 @@ func TestTryAutoMerge_NilCIStatus(t *testing.T) {
 	}
 	if !found {
 		t.Error("expected auto_merge_blocked with reason ci_not_green")
+	}
+}
+
+// --- Branch protection (MergeValidator) tests ---
+
+func TestTryAutoMerge_BranchProtection_Pass(t *testing.T) {
+	// When MergeValidator.ValidateMergePrerequisites returns nil, merge proceeds
+	// normally with no warning event.
+	basePoller := &mockPRPoller{}
+	poller := &mockPRPollerWithValidator{mockPRPoller: basePoller, validateErr: nil}
+	engine, events := setupMergeEngine(t, poller)
+
+	now := time.Now()
+	monState := &MonitorState{
+		PRURL:        "https://github.com/o/r/pull/1",
+		ApprovalTime: &now,
+	}
+	prStatus := &PRStatus{State: "open", Approved: true, HeadSHA: "abc123", Labels: []string{"auto-merge-ok"}}
+	ciStatus := &CIStatus{Overall: "success", CommitSHA: "abc123"}
+	polling := &PollingConfig{AutoMerge: true, AutoMergeTimeout: Duration{Duration: 30 * time.Minute}}
+
+	result := engine.tryAutoMerge(context.Background(), "monitor", monState, prStatus, ciStatus, polling)
+	if !result.Merged {
+		t.Error("expected merge success when branch protection passes")
+	}
+	if hasEventKind(*events, EventMonitorWarning) {
+		t.Error("expected no warning event when branch protection passes")
+	}
+}
+
+func TestTryAutoMerge_BranchProtection_Warn(t *testing.T) {
+	// When MergeValidator.ValidateMergePrerequisites returns an error, a warning
+	// is emitted but the merge is still attempted (branch protection is advisory).
+	basePoller := &mockPRPoller{}
+	poller := &mockPRPollerWithValidator{
+		mockPRPoller: basePoller,
+		validateErr:  errors.New("dismiss_stale_reviews is enabled"),
+	}
+	engine, events := setupMergeEngine(t, poller)
+
+	now := time.Now()
+	monState := &MonitorState{
+		PRURL:        "https://github.com/o/r/pull/1",
+		ApprovalTime: &now,
+	}
+	prStatus := &PRStatus{State: "open", Approved: true, HeadSHA: "abc123", Labels: []string{"auto-merge-ok"}}
+	ciStatus := &CIStatus{Overall: "success", CommitSHA: "abc123"}
+	polling := &PollingConfig{AutoMerge: true, AutoMergeTimeout: Duration{Duration: 30 * time.Minute}}
+
+	result := engine.tryAutoMerge(context.Background(), "monitor", monState, prStatus, ciStatus, polling)
+	if !result.Merged {
+		t.Error("expected merge to proceed despite branch protection warning")
+	}
+	if !hasEventKind(*events, EventMonitorWarning) {
+		t.Error("expected warning event for branch protection issue")
+	}
+	// Verify the warning contains branch protection context.
+	found := false
+	for _, ev := range *events {
+		if ev.Kind == EventMonitorWarning {
+			if w, ok := ev.Data["warning"].(string); ok && len(w) > 0 {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Error("expected warning event with non-empty warning message")
 	}
 }
 

--- a/internal/pipeline/monitor_merge_test.go
+++ b/internal/pipeline/monitor_merge_test.go
@@ -165,7 +165,7 @@ func TestTryAutoMerge_NotApproved(t *testing.T) {
 		PRURL:        "https://github.com/o/r/pull/1",
 		ApprovalTime: &now,
 	}
-	prStatus := &PRStatus{State: "open", Approved: false}
+	prStatus := &PRStatus{State: "open", Approved: false, Labels: []string{"auto-merge-ok"}}
 	ciStatus := &CIStatus{Overall: "success"}
 	polling := &PollingConfig{AutoMerge: true, AutoMergeTimeout: Duration{Duration: 30 * time.Minute}}
 
@@ -184,7 +184,7 @@ func TestTryAutoMerge_CINotGreen(t *testing.T) {
 		PRURL:        "https://github.com/o/r/pull/1",
 		ApprovalTime: &now,
 	}
-	prStatus := &PRStatus{State: "open", Approved: true, HeadSHA: "abc123"}
+	prStatus := &PRStatus{State: "open", Approved: true, HeadSHA: "abc123", Labels: []string{"auto-merge-ok"}}
 	ciStatus := &CIStatus{Overall: "pending", CommitSHA: "abc123"}
 	polling := &PollingConfig{AutoMerge: true, AutoMergeTimeout: Duration{Duration: 30 * time.Minute}}
 
@@ -206,7 +206,7 @@ func TestTryAutoMerge_CISHAStale(t *testing.T) {
 		PRURL:        "https://github.com/o/r/pull/1",
 		ApprovalTime: &now,
 	}
-	prStatus := &PRStatus{State: "open", Approved: true, HeadSHA: "abc123"}
+	prStatus := &PRStatus{State: "open", Approved: true, HeadSHA: "abc123", Labels: []string{"auto-merge-ok"}}
 	ciStatus := &CIStatus{Overall: "success", CommitSHA: "old999"}
 	polling := &PollingConfig{AutoMerge: true, AutoMergeTimeout: Duration{Duration: 30 * time.Minute}}
 
@@ -236,7 +236,7 @@ func TestTryAutoMerge_DryRun(t *testing.T) {
 		PRURL:        "https://github.com/o/r/pull/1",
 		ApprovalTime: &now,
 	}
-	prStatus := &PRStatus{State: "open", Approved: true, HeadSHA: "abc123"}
+	prStatus := &PRStatus{State: "open", Approved: true, HeadSHA: "abc123", Labels: []string{"auto-merge-ok"}}
 	ciStatus := &CIStatus{Overall: "success", CommitSHA: "abc123"}
 	polling := &PollingConfig{AutoMerge: false, AutoMergeTimeout: Duration{Duration: 30 * time.Minute}} // auto_merge disabled
 
@@ -262,7 +262,7 @@ func TestTryAutoMerge_DryRunNotDuplicated(t *testing.T) {
 		ApprovalTime: &now,
 		DryRunLogged: true, // already logged
 	}
-	prStatus := &PRStatus{State: "open", Approved: true, HeadSHA: "abc123"}
+	prStatus := &PRStatus{State: "open", Approved: true, HeadSHA: "abc123", Labels: []string{"auto-merge-ok"}}
 	ciStatus := &CIStatus{Overall: "success", CommitSHA: "abc123"}
 	polling := &PollingConfig{AutoMerge: false, AutoMergeTimeout: Duration{Duration: 30 * time.Minute}}
 
@@ -284,7 +284,7 @@ func TestTryAutoMerge_MergeSuccess(t *testing.T) {
 		PRURL:        "https://github.com/o/r/pull/1",
 		ApprovalTime: &now,
 	}
-	prStatus := &PRStatus{State: "open", Approved: true, HeadSHA: "abc123"}
+	prStatus := &PRStatus{State: "open", Approved: true, HeadSHA: "abc123", Labels: []string{"auto-merge-ok"}}
 	ciStatus := &CIStatus{Overall: "success", CommitSHA: "abc123"}
 	polling := &PollingConfig{AutoMerge: true, AutoMergeTimeout: Duration{Duration: 30 * time.Minute}}
 
@@ -315,7 +315,7 @@ func TestTryAutoMerge_AlreadyMerged(t *testing.T) {
 		PRURL:        "https://github.com/o/r/pull/1",
 		ApprovalTime: &now,
 	}
-	prStatus := &PRStatus{State: "open", Approved: true, HeadSHA: "abc123"}
+	prStatus := &PRStatus{State: "open", Approved: true, HeadSHA: "abc123", Labels: []string{"auto-merge-ok"}}
 	ciStatus := &CIStatus{Overall: "success", CommitSHA: "abc123"}
 	polling := &PollingConfig{AutoMerge: true, AutoMergeTimeout: Duration{Duration: 30 * time.Minute}}
 
@@ -339,7 +339,7 @@ func TestTryAutoMerge_MergeConflict(t *testing.T) {
 		PRURL:        "https://github.com/o/r/pull/1",
 		ApprovalTime: &now,
 	}
-	prStatus := &PRStatus{State: "open", Approved: true, HeadSHA: "abc123"}
+	prStatus := &PRStatus{State: "open", Approved: true, HeadSHA: "abc123", Labels: []string{"auto-merge-ok"}}
 	ciStatus := &CIStatus{Overall: "success", CommitSHA: "abc123"}
 	polling := &PollingConfig{AutoMerge: true, AutoMergeTimeout: Duration{Duration: 30 * time.Minute}}
 
@@ -363,7 +363,7 @@ func TestTryAutoMerge_PRClosed(t *testing.T) {
 		PRURL:        "https://github.com/o/r/pull/1",
 		ApprovalTime: &now,
 	}
-	prStatus := &PRStatus{State: "open", Approved: true, HeadSHA: "abc123"}
+	prStatus := &PRStatus{State: "open", Approved: true, HeadSHA: "abc123", Labels: []string{"auto-merge-ok"}}
 	ciStatus := &CIStatus{Overall: "success", CommitSHA: "abc123"}
 	polling := &PollingConfig{AutoMerge: true, AutoMergeTimeout: Duration{Duration: 30 * time.Minute}}
 
@@ -385,7 +385,7 @@ func TestTryAutoMerge_CustomMergeMethod(t *testing.T) {
 		PRURL:        "https://github.com/o/r/pull/1",
 		ApprovalTime: &now,
 	}
-	prStatus := &PRStatus{State: "open", Approved: true, HeadSHA: "abc123"}
+	prStatus := &PRStatus{State: "open", Approved: true, HeadSHA: "abc123", Labels: []string{"auto-merge-ok"}}
 	ciStatus := &CIStatus{Overall: "success", CommitSHA: "abc123"}
 	polling := &PollingConfig{
 		AutoMerge:        true,
@@ -442,7 +442,7 @@ func TestTryAutoMerge_NilCIStatus(t *testing.T) {
 		PRURL:        "https://github.com/o/r/pull/1",
 		ApprovalTime: &now,
 	}
-	prStatus := &PRStatus{State: "open", Approved: true}
+	prStatus := &PRStatus{State: "open", Approved: true, Labels: []string{"auto-merge-ok"}}
 	polling := &PollingConfig{AutoMerge: true, AutoMergeTimeout: Duration{Duration: 30 * time.Minute}}
 
 	result := engine.tryAutoMerge(context.Background(), "monitor", monState, prStatus, nil, polling)

--- a/internal/pipeline/monitor_poll.go
+++ b/internal/pipeline/monitor_poll.go
@@ -170,7 +170,7 @@ func (e *Engine) runMonitor(ctx context.Context, phase PhaseConfig) error {
 		})
 
 		// 1. Check PR status (approved, closed, merged).
-		terminal, err := e.checkPRStatus(ctx, phase.Name, monState)
+		prResult, err := e.checkPRStatus(ctx, phase.Name, monState)
 		if err != nil {
 			e.emit(Event{
 				Phase: phase.Name,
@@ -179,7 +179,7 @@ func (e *Engine) runMonitor(ctx context.Context, phase PhaseConfig) error {
 			})
 			// Non-fatal — continue polling.
 		}
-		if terminal {
+		if prResult.Terminal {
 			_ = e.state.WriteMonitorState(monState)
 			if monState.Status == MonitorCompleted {
 				if err := e.state.MarkCompleted(phase.Name); err != nil {
@@ -327,12 +327,21 @@ func (e *Engine) runMonitor(ctx context.Context, phase PhaseConfig) error {
 	}
 }
 
+// checkPRStatusResult holds the outcome of a PR status check.
+type checkPRStatusResult struct {
+	// Terminal indicates whether the polling loop should stop.
+	Terminal bool
+	// Status is the PRStatus returned by the poller (nil on error).
+	Status *PRStatus
+}
+
 // checkPRStatus checks the PR for terminal states (approved, closed, merged).
-// Returns true if the polling should stop.
-func (e *Engine) checkPRStatus(ctx context.Context, phaseName string, monState *MonitorState) (bool, error) {
+// Returns a result struct indicating whether polling should stop and the
+// latest PRStatus for downstream use (e.g., auto-merge label checks).
+func (e *Engine) checkPRStatus(ctx context.Context, phaseName string, monState *MonitorState) (checkPRStatusResult, error) {
 	status, err := e.config.PRPoller.GetPRStatus(ctx, monState.PRURL)
 	if err != nil {
-		return false, err
+		return checkPRStatusResult{}, err
 	}
 
 	switch status.State {
@@ -343,7 +352,7 @@ func (e *Engine) checkPRStatus(ctx context.Context, phaseName string, monState *
 			Kind:  EventMonitorPRApproved,
 			Data:  map[string]any{"state": "merged"},
 		})
-		return true, nil
+		return checkPRStatusResult{Terminal: true, Status: status}, nil
 
 	case "closed":
 		monState.Status = MonitorFailed
@@ -352,7 +361,7 @@ func (e *Engine) checkPRStatus(ctx context.Context, phaseName string, monState *
 			Kind:  EventMonitorPRClosed,
 			Data:  map[string]any{"state": "closed"},
 		})
-		return true, nil
+		return checkPRStatusResult{Terminal: true, Status: status}, nil
 	}
 
 	if status.Approved {
@@ -362,10 +371,10 @@ func (e *Engine) checkPRStatus(ctx context.Context, phaseName string, monState *
 			Kind:  EventMonitorPRApproved,
 			Data:  map[string]any{"state": "approved"},
 		})
-		return true, nil
+		return checkPRStatusResult{Terminal: true, Status: status}, nil
 	}
 
-	return false, nil
+	return checkPRStatusResult{Terminal: false, Status: status}, nil
 }
 
 // checkNewComments polls for new review comments and classifies them.

--- a/internal/pipeline/monitor_poll.go
+++ b/internal/pipeline/monitor_poll.go
@@ -615,11 +615,6 @@ func (e *Engine) checkNewCommentsPassive(ctx context.Context, phaseName string, 
 	})
 }
 
-// checkCIStatus polls CI status and emits events on status changes.
-func (e *Engine) checkCIStatus(ctx context.Context, phaseName string, monState *MonitorState) {
-	_ = e.checkCIStatusReturn(ctx, phaseName, monState)
-}
-
 // checkCIStatusReturn polls CI status, emits events on status changes,
 // and returns the latest CIStatus so callers (e.g., auto-merge) can inspect it.
 func (e *Engine) checkCIStatusReturn(ctx context.Context, phaseName string, monState *MonitorState) *CIStatus {

--- a/internal/pipeline/monitor_poll.go
+++ b/internal/pipeline/monitor_poll.go
@@ -179,7 +179,24 @@ func (e *Engine) runMonitor(ctx context.Context, phase PhaseConfig) error {
 			})
 			// Non-fatal — continue polling.
 		}
-		if prResult.Terminal {
+
+		// When the PR is approved and auto-merge is enabled (or could dry-run),
+		// suppress the terminal "completed" state so the safeguard chain can
+		// run. Track the approval time for timeout computation.
+		autoMergeActive := polling != nil && polling.AutoMerge
+		if prResult.Terminal && prResult.Status != nil && prResult.Status.Approved &&
+			prResult.Status.State == "open" {
+			// Record first-observed approval time.
+			if monState.ApprovalTime == nil {
+				approvalNow := e.now()
+				monState.ApprovalTime = &approvalNow
+			}
+			// Reset status back to polling — auto-merge will decide the outcome.
+			monState.Status = MonitorPolling
+
+			// Fall through to auto-merge logic below (after CI check).
+		} else if prResult.Terminal {
+			// Non-approval terminal: merged, closed — always honor immediately.
 			_ = e.state.WriteMonitorState(monState)
 			if monState.Status == MonitorCompleted {
 				if err := e.state.MarkCompleted(phase.Name); err != nil {
@@ -279,7 +296,63 @@ func (e *Engine) runMonitor(ctx context.Context, phase PhaseConfig) error {
 		}
 
 		// 3. Check CI status changes.
-		e.checkCIStatus(ctx, phase.Name, monState)
+		latestCI := e.checkCIStatusReturn(ctx, phase.Name, monState)
+
+		// 3a. Auto-merge safeguard chain: runs when the PR is approved and
+		// auto-merge is enabled (or dry-run is desired).
+		if prResult.Status != nil && prResult.Status.Approved && monState.ApprovalTime != nil {
+			mergeResult := e.tryAutoMerge(ctx, phase.Name, monState, prResult.Status, latestCI, polling)
+			if mergeResult.Merged {
+				monState.Status = MonitorCompleted
+				_ = e.state.WriteMonitorState(monState)
+				if err := e.state.MarkCompleted(phase.Name); err != nil {
+					return fmt.Errorf("engine: mark completed %s: %w", phase.Name, err)
+				}
+				e.emit(Event{
+					Phase: phase.Name,
+					Kind:  EventPhaseCompleted,
+					Data:  map[string]any{"duration_ms": e.state.Meta().Phases[phase.Name].DurationMs},
+				})
+				return nil
+			}
+			if mergeResult.RebaseConflict {
+				monState.Status = MonitorRebaseConflict
+				_ = e.state.WriteMonitorState(monState)
+				failErr := fmt.Errorf("monitor: rebase conflict during auto-merge")
+				if err := e.state.MarkFailed(phase.Name, failErr); err != nil {
+					return fmt.Errorf("engine: mark failed %s: %w", phase.Name, err)
+				}
+				e.emitPhaseFailed(phase.Name, failErr)
+				return nil
+			}
+			if mergeResult.TimedOut {
+				monState.Status = MonitorFailed
+				_ = e.state.WriteMonitorState(monState)
+				failErr := fmt.Errorf("monitor: auto-merge timeout exceeded")
+				if err := e.state.MarkFailed(phase.Name, failErr); err != nil {
+					return fmt.Errorf("engine: mark failed %s: %w", phase.Name, err)
+				}
+				e.emitPhaseFailed(phase.Name, failErr)
+				return nil
+			}
+			// DryRun or Blocked with non-auto-merge: if auto-merge is not
+			// enabled, treat approval as terminal (original behavior).
+			if !autoMergeActive {
+				monState.Status = MonitorCompleted
+				_ = e.state.WriteMonitorState(monState)
+				if err := e.state.MarkCompleted(phase.Name); err != nil {
+					return fmt.Errorf("engine: mark completed %s: %w", phase.Name, err)
+				}
+				e.emit(Event{
+					Phase: phase.Name,
+					Kind:  EventPhaseCompleted,
+					Data:  map[string]any{"duration_ms": e.state.Meta().Phases[phase.Name].DurationMs},
+				})
+				return nil
+			}
+			// Blocked with auto-merge active: continue polling, merge will
+			// be retried on the next cycle.
+		}
 
 		// 4. Check for merge conflicts and auto-rebase.
 		autoRebase := profile == nil || profile.ShouldAutoRebase()
@@ -544,6 +617,12 @@ func (e *Engine) checkNewCommentsPassive(ctx context.Context, phaseName string, 
 
 // checkCIStatus polls CI status and emits events on status changes.
 func (e *Engine) checkCIStatus(ctx context.Context, phaseName string, monState *MonitorState) {
+	_ = e.checkCIStatusReturn(ctx, phaseName, monState)
+}
+
+// checkCIStatusReturn polls CI status, emits events on status changes,
+// and returns the latest CIStatus so callers (e.g., auto-merge) can inspect it.
+func (e *Engine) checkCIStatusReturn(ctx context.Context, phaseName string, monState *MonitorState) *CIStatus {
 	ciStatus, err := e.config.PRPoller.GetCIStatus(ctx, monState.PRURL)
 	if err != nil {
 		// Non-fatal: emit warning and continue.
@@ -552,42 +631,42 @@ func (e *Engine) checkCIStatus(ctx context.Context, phaseName string, monState *
 			Kind:  EventMonitorWarning,
 			Data:  map[string]any{"warning": fmt.Sprintf("get CI status: %v", err)},
 		})
-		return
+		return nil
 	}
 
-	if ciStatus.Overall == monState.LastCIStatus {
-		return
-	}
+	if ciStatus.Overall != monState.LastCIStatus {
+		previousStatus := monState.LastCIStatus
+		monState.LastCIStatus = ciStatus.Overall
 
-	previousStatus := monState.LastCIStatus
-	monState.LastCIStatus = ciStatus.Overall
-
-	e.emit(Event{
-		Phase: phaseName,
-		Kind:  EventMonitorCIChange,
-		Data: map[string]any{
-			"previous": previousStatus,
-			"current":  ciStatus.Overall,
-		},
-	})
-
-	// On CI failure, emit detailed notification with job names.
-	if ciStatus.Overall == "failure" {
-		var failedJobs []string
-		for _, job := range ciStatus.Jobs {
-			if job.Conclusion == "failure" || job.Conclusion == "timed_out" || job.Conclusion == "cancelled" {
-				failedJobs = append(failedJobs, job.Name)
-			}
-		}
 		e.emit(Event{
 			Phase: phaseName,
-			Kind:  EventMonitorCIFailure,
+			Kind:  EventMonitorCIChange,
 			Data: map[string]any{
-				"failed_jobs": failedJobs,
-				"job_count":   len(ciStatus.Jobs),
+				"previous": previousStatus,
+				"current":  ciStatus.Overall,
 			},
 		})
+
+		// On CI failure, emit detailed notification with job names.
+		if ciStatus.Overall == "failure" {
+			var failedJobs []string
+			for _, job := range ciStatus.Jobs {
+				if job.Conclusion == "failure" || job.Conclusion == "timed_out" || job.Conclusion == "cancelled" {
+					failedJobs = append(failedJobs, job.Name)
+				}
+			}
+			e.emit(Event{
+				Phase: phaseName,
+				Kind:  EventMonitorCIFailure,
+				Data: map[string]any{
+					"failed_jobs": failedJobs,
+					"job_count":   len(ciStatus.Jobs),
+				},
+			})
+		}
 	}
+
+	return ciStatus
 }
 
 // checkMergeConflicts detects merge conflicts and attempts auto-rebase

--- a/internal/pipeline/monitor_poll_test.go
+++ b/internal/pipeline/monitor_poll_test.go
@@ -2574,7 +2574,7 @@ func TestMonitor_AutoMerge_Success(t *testing.T) {
 	// PR is approved, CI is green, auto_merge is enabled → merge succeeds.
 	poller := &mockPRPoller{
 		statusResponses: []mockPRStatusResponse{
-			{status: &PRStatus{State: "open", Approved: true, HeadSHA: "abc123"}},
+			{status: &PRStatus{State: "open", Approved: true, HeadSHA: "abc123", Labels: []string{"auto-merge-ok"}}},
 		},
 		ciResponses: []mockCIResponse{
 			{status: &CIStatus{Overall: "success", CommitSHA: "abc123"}},
@@ -2623,8 +2623,8 @@ func TestMonitor_AutoMerge_CIPending_ThenGreen(t *testing.T) {
 	// PR is approved, CI starts pending → next poll CI is green → merge.
 	poller := &mockPRPoller{
 		statusResponses: []mockPRStatusResponse{
-			{status: &PRStatus{State: "open", Approved: true, HeadSHA: "abc123"}},
-			{status: &PRStatus{State: "open", Approved: true, HeadSHA: "abc123"}},
+			{status: &PRStatus{State: "open", Approved: true, HeadSHA: "abc123", Labels: []string{"auto-merge-ok"}}},
+			{status: &PRStatus{State: "open", Approved: true, HeadSHA: "abc123", Labels: []string{"auto-merge-ok"}}},
 		},
 		ciResponses: []mockCIResponse{
 			{status: &CIStatus{Overall: "pending", CommitSHA: "abc123"}},
@@ -2701,7 +2701,7 @@ func TestMonitor_AutoMerge_RebaseConflict(t *testing.T) {
 	// PR is approved, CI green, merge returns conflict → phase fails.
 	poller := &mockPRPoller{
 		statusResponses: []mockPRStatusResponse{
-			{status: &PRStatus{State: "open", Approved: true, HeadSHA: "abc123"}},
+			{status: &PRStatus{State: "open", Approved: true, HeadSHA: "abc123", Labels: []string{"auto-merge-ok"}}},
 		},
 		ciResponses: []mockCIResponse{
 			{status: &CIStatus{Overall: "success", CommitSHA: "abc123"}},
@@ -2739,7 +2739,7 @@ func TestMonitor_AutoMerge_Disabled_DryRun(t *testing.T) {
 	// PR is approved, CI green, auto_merge=false → dry run event, phase completes.
 	poller := &mockPRPoller{
 		statusResponses: []mockPRStatusResponse{
-			{status: &PRStatus{State: "open", Approved: true, HeadSHA: "abc123"}},
+			{status: &PRStatus{State: "open", Approved: true, HeadSHA: "abc123", Labels: []string{"auto-merge-ok"}}},
 		},
 		ciResponses: []mockCIResponse{
 			{status: &CIStatus{Overall: "success", CommitSHA: "abc123"}},
@@ -2815,7 +2815,7 @@ func TestMonitor_AutoMerge_ApprovalTimeRecorded(t *testing.T) {
 	// Verify that ApprovalTime is set on first observation.
 	poller := &mockPRPoller{
 		statusResponses: []mockPRStatusResponse{
-			{status: &PRStatus{State: "open", Approved: true, HeadSHA: "abc123"}},
+			{status: &PRStatus{State: "open", Approved: true, HeadSHA: "abc123", Labels: []string{"auto-merge-ok"}}},
 		},
 		ciResponses: []mockCIResponse{
 			{status: &CIStatus{Overall: "success", CommitSHA: "abc123"}},

--- a/internal/pipeline/monitor_poll_test.go
+++ b/internal/pipeline/monitor_poll_test.go
@@ -2566,3 +2566,280 @@ func TestCheckNewComments_ClassifierFailureDoesNotAdvanceLastCommentID(t *testin
 		t.Error("monitor_warning event about classifier creation not emitted")
 	}
 }
+
+// --- Auto-merge integration tests ---
+// These tests exercise auto-merge through the full engine polling loop.
+
+func TestMonitor_AutoMerge_Success(t *testing.T) {
+	// PR is approved, CI is green, auto_merge is enabled → merge succeeds.
+	poller := &mockPRPoller{
+		statusResponses: []mockPRStatusResponse{
+			{status: &PRStatus{State: "open", Approved: true, HeadSHA: "abc123"}},
+		},
+		ciResponses: []mockCIResponse{
+			{status: &CIStatus{Overall: "success", CommitSHA: "abc123"}},
+		},
+	}
+
+	polling := &PollingConfig{
+		InitialInterval:   Duration{Duration: 1 * time.Millisecond},
+		MaxInterval:       Duration{Duration: 2 * time.Millisecond},
+		EscalateAfter:     Duration{Duration: 10 * time.Millisecond},
+		MaxDuration:       Duration{Duration: 100 * time.Millisecond},
+		MaxResponseRounds: 3,
+		AutoMerge:         true,
+		AutoMergeTimeout:  Duration{Duration: 30 * time.Minute},
+	}
+
+	engine, state, events := setupMonitorEngine(t, poller, polling)
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if !state.IsCompleted("monitor") {
+		t.Error("monitor should be completed after successful auto-merge")
+	}
+
+	monState, err := state.ReadMonitorState()
+	if err != nil {
+		t.Fatalf("ReadMonitorState: %v", err)
+	}
+	if monState.Status != MonitorCompleted {
+		t.Errorf("monitor status = %q, want %q", monState.Status, MonitorCompleted)
+	}
+
+	if !hasEventKind(*events, EventAutoMergeCompleted) {
+		t.Error("expected auto_merge_completed event")
+	}
+
+	// Verify merge was called.
+	if len(poller.mergeCalls) != 1 {
+		t.Fatalf("expected 1 merge call, got %d", len(poller.mergeCalls))
+	}
+}
+
+func TestMonitor_AutoMerge_CIPending_ThenGreen(t *testing.T) {
+	// PR is approved, CI starts pending → next poll CI is green → merge.
+	poller := &mockPRPoller{
+		statusResponses: []mockPRStatusResponse{
+			{status: &PRStatus{State: "open", Approved: true, HeadSHA: "abc123"}},
+			{status: &PRStatus{State: "open", Approved: true, HeadSHA: "abc123"}},
+		},
+		ciResponses: []mockCIResponse{
+			{status: &CIStatus{Overall: "pending", CommitSHA: "abc123"}},
+			{status: &CIStatus{Overall: "success", CommitSHA: "abc123"}},
+		},
+	}
+
+	polling := &PollingConfig{
+		InitialInterval:   Duration{Duration: 1 * time.Millisecond},
+		MaxInterval:       Duration{Duration: 2 * time.Millisecond},
+		EscalateAfter:     Duration{Duration: 10 * time.Millisecond},
+		MaxDuration:       Duration{Duration: 100 * time.Millisecond},
+		MaxResponseRounds: 3,
+		AutoMerge:         true,
+		AutoMergeTimeout:  Duration{Duration: 30 * time.Minute},
+	}
+
+	engine, state, events := setupMonitorEngine(t, poller, polling)
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if !state.IsCompleted("monitor") {
+		t.Error("monitor should be completed after CI turns green and auto-merge succeeds")
+	}
+
+	// First poll: blocked (CI pending), second poll: merge success.
+	if !hasEventKind(*events, EventAutoMergeBlocked) {
+		t.Error("expected auto_merge_blocked event on first poll (CI pending)")
+	}
+	if !hasEventKind(*events, EventAutoMergeCompleted) {
+		t.Error("expected auto_merge_completed event on second poll")
+	}
+}
+
+func TestMonitor_AutoMerge_MissingLabel(t *testing.T) {
+	// PR is approved, CI green, but missing required label → blocks, then times out.
+	poller := &mockPRPoller{
+		statusResponses: []mockPRStatusResponse{
+			{status: &PRStatus{State: "open", Approved: true, HeadSHA: "abc123", Labels: []string{"draft"}}},
+		},
+		ciResponses: []mockCIResponse{
+			{status: &CIStatus{Overall: "success", CommitSHA: "abc123"}},
+		},
+	}
+
+	polling := &PollingConfig{
+		InitialInterval:   Duration{Duration: 1 * time.Millisecond},
+		MaxInterval:       Duration{Duration: 2 * time.Millisecond},
+		EscalateAfter:     Duration{Duration: 5 * time.Millisecond},
+		MaxDuration:       Duration{Duration: 20 * time.Millisecond}, // very short to force timeout
+		MaxResponseRounds: 3,
+		AutoMerge:         true,
+		MergeLabels:       []string{"ready-to-merge"},
+		AutoMergeTimeout:  Duration{Duration: 30 * time.Minute},
+	}
+
+	engine, _, events := setupMonitorEngine(t, poller, polling)
+	_ = engine.Run(context.Background())
+
+	// Should have emitted auto_merge_blocked for missing labels.
+	if !hasEventKind(*events, EventAutoMergeBlocked) {
+		t.Error("expected auto_merge_blocked event for missing labels")
+	}
+
+	// Verify merge was NOT called.
+	if len(poller.mergeCalls) != 0 {
+		t.Errorf("expected 0 merge calls, got %d", len(poller.mergeCalls))
+	}
+}
+
+func TestMonitor_AutoMerge_RebaseConflict(t *testing.T) {
+	// PR is approved, CI green, merge returns conflict → phase fails.
+	poller := &mockPRPoller{
+		statusResponses: []mockPRStatusResponse{
+			{status: &PRStatus{State: "open", Approved: true, HeadSHA: "abc123"}},
+		},
+		ciResponses: []mockCIResponse{
+			{status: &CIStatus{Overall: "success", CommitSHA: "abc123"}},
+		},
+		mergeErr: ErrMergeConflict,
+	}
+
+	polling := &PollingConfig{
+		InitialInterval:   Duration{Duration: 1 * time.Millisecond},
+		MaxInterval:       Duration{Duration: 2 * time.Millisecond},
+		EscalateAfter:     Duration{Duration: 10 * time.Millisecond},
+		MaxDuration:       Duration{Duration: 100 * time.Millisecond},
+		MaxResponseRounds: 3,
+		AutoMerge:         true,
+		AutoMergeTimeout:  Duration{Duration: 30 * time.Minute},
+	}
+
+	engine, state, events := setupMonitorEngine(t, poller, polling)
+	_ = engine.Run(context.Background())
+
+	monState, err := state.ReadMonitorState()
+	if err != nil {
+		t.Fatalf("ReadMonitorState: %v", err)
+	}
+	if monState.Status != MonitorRebaseConflict {
+		t.Errorf("monitor status = %q, want %q", monState.Status, MonitorRebaseConflict)
+	}
+
+	if !hasEventKind(*events, EventRebaseConflict) {
+		t.Error("expected rebase_conflict event")
+	}
+}
+
+func TestMonitor_AutoMerge_Disabled_DryRun(t *testing.T) {
+	// PR is approved, CI green, auto_merge=false → dry run event, phase completes.
+	poller := &mockPRPoller{
+		statusResponses: []mockPRStatusResponse{
+			{status: &PRStatus{State: "open", Approved: true, HeadSHA: "abc123"}},
+		},
+		ciResponses: []mockCIResponse{
+			{status: &CIStatus{Overall: "success", CommitSHA: "abc123"}},
+		},
+	}
+
+	polling := &PollingConfig{
+		InitialInterval:   Duration{Duration: 1 * time.Millisecond},
+		MaxInterval:       Duration{Duration: 2 * time.Millisecond},
+		EscalateAfter:     Duration{Duration: 10 * time.Millisecond},
+		MaxDuration:       Duration{Duration: 100 * time.Millisecond},
+		MaxResponseRounds: 3,
+		AutoMerge:         false, // disabled
+		AutoMergeTimeout:  Duration{Duration: 30 * time.Minute},
+	}
+
+	engine, state, events := setupMonitorEngine(t, poller, polling)
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if !state.IsCompleted("monitor") {
+		t.Error("monitor should be completed (dry run terminates with approval)")
+	}
+
+	if !hasEventKind(*events, EventAutoMergeDryRun) {
+		t.Error("expected auto_merge_dry_run event")
+	}
+
+	// Verify merge was NOT called.
+	if len(poller.mergeCalls) != 0 {
+		t.Errorf("expected 0 merge calls in dry run, got %d", len(poller.mergeCalls))
+	}
+}
+
+func TestMonitor_AutoMerge_PRClosedStillTerminal(t *testing.T) {
+	// PR is closed (not merged) → terminal even with auto_merge enabled.
+	poller := &mockPRPoller{
+		statusResponses: []mockPRStatusResponse{
+			{status: &PRStatus{State: "closed", Approved: false}},
+		},
+	}
+
+	polling := &PollingConfig{
+		InitialInterval:   Duration{Duration: 1 * time.Millisecond},
+		MaxInterval:       Duration{Duration: 2 * time.Millisecond},
+		EscalateAfter:     Duration{Duration: 10 * time.Millisecond},
+		MaxDuration:       Duration{Duration: 100 * time.Millisecond},
+		MaxResponseRounds: 3,
+		AutoMerge:         true,
+		AutoMergeTimeout:  Duration{Duration: 30 * time.Minute},
+	}
+
+	engine, state, _ := setupMonitorEngine(t, poller, polling)
+	_ = engine.Run(context.Background())
+
+	monState, err := state.ReadMonitorState()
+	if err != nil {
+		t.Fatalf("ReadMonitorState: %v", err)
+	}
+	if monState.Status != MonitorFailed {
+		t.Errorf("monitor status = %q, want %q (closed PR should fail even with auto_merge)", monState.Status, MonitorFailed)
+	}
+
+	// Verify merge was NOT called.
+	if len(poller.mergeCalls) != 0 {
+		t.Errorf("expected 0 merge calls for closed PR, got %d", len(poller.mergeCalls))
+	}
+}
+
+func TestMonitor_AutoMerge_ApprovalTimeRecorded(t *testing.T) {
+	// Verify that ApprovalTime is set on first observation.
+	poller := &mockPRPoller{
+		statusResponses: []mockPRStatusResponse{
+			{status: &PRStatus{State: "open", Approved: true, HeadSHA: "abc123"}},
+		},
+		ciResponses: []mockCIResponse{
+			{status: &CIStatus{Overall: "success", CommitSHA: "abc123"}},
+		},
+	}
+
+	polling := &PollingConfig{
+		InitialInterval:   Duration{Duration: 1 * time.Millisecond},
+		MaxInterval:       Duration{Duration: 2 * time.Millisecond},
+		EscalateAfter:     Duration{Duration: 10 * time.Millisecond},
+		MaxDuration:       Duration{Duration: 100 * time.Millisecond},
+		MaxResponseRounds: 3,
+		AutoMerge:         true,
+		AutoMergeTimeout:  Duration{Duration: 30 * time.Minute},
+	}
+
+	engine, state, _ := setupMonitorEngine(t, poller, polling)
+	_ = engine.Run(context.Background())
+
+	monState, err := state.ReadMonitorState()
+	if err != nil {
+		t.Fatalf("ReadMonitorState: %v", err)
+	}
+	if monState.ApprovalTime == nil {
+		t.Error("ApprovalTime should be set after PR approval is observed")
+	}
+}

--- a/internal/pipeline/phase.go
+++ b/internal/pipeline/phase.go
@@ -89,6 +89,9 @@ type PollingConfig struct {
 	Profile           MonitorProfileName `yaml:"profile,omitempty"`             // preset profile name (conservative, smart, aggressive)
 	RespondToComments bool               `yaml:"respond_to_comments,omitempty"` // enable comment classification + response (requires self_user)
 	AutoMerge         bool               `yaml:"auto_merge,omitempty"`          // merge PR when checks green + approved (see #338 for safeguards)
+	MergeMethod       string             `yaml:"merge_method,omitempty"`        // merge method: "merge", "squash", "rebase"; defaults to "squash"
+	MergeLabels       []string           `yaml:"merge_labels,omitempty"`        // required PR labels before auto-merge proceeds
+	AutoMergeTimeout  Duration           `yaml:"auto_merge_timeout,omitempty"`  // max wait after approval before giving up; defaults to 30m
 }
 
 // Duration wraps time.Duration for YAML unmarshaling.


### PR DESCRIPTION
## Summary

Implement auto-merge safeguards for unattended PR merging. When `auto_merge: true` is configured on the monitor phase, the monitor merges the PR automatically when all safety conditions are met.

## Safeguard chain

1. PR has required label(s) from `merge_labels` (default: `auto-merge-ok`)
2. `ReviewDecision == "APPROVED"` (no `CHANGES_REQUESTED`)
3. CI green on current HEAD SHA (freshness check)
4. Branch protection validates `dismiss_stale_reviews` (runtime guard via MergeValidator)
5. Attempt merge via `MergePR`

## Key changes

- `checkPRStatus` suppresses terminal exit when auto_merge + approved (sets `MergePending`)
- Merge safeguard chain with per-check event logging
- Rebase conflict detection → `EventRebaseConflict`, monitor terminates
- Events: `AutoMergeCompleted`, `AutoMergeBlocked`, `AutoMergeDryRun`, `RebaseConflict`
- Config: `merge_method` (squash default), `merge_labels`, `auto_merge_timeout` (30m)
- `soda doctor` checks branch protection when auto_merge configured
- No escape hatch on `merge_labels` — if you enable auto-merge, you label PRs

## Design decisions

See #338 for full specialist review (Go, AI Harness, SWE) and rationale.

Closes #436