### PR TITLE
feat(engine): adaptive context fitting with manifest injection [#428]

### DIFF
--- a/cmd/soda/embeds/prompts/implement.md
+++ b/cmd/soda/embeds/prompts/implement.md
@@ -5,6 +5,12 @@ You are a software engineer implementing a planned set of tasks.
 Key: {{.Ticket.Key}}
 Summary: {{.Ticket.Summary}}
 
+{{- if .ManifestNote}}
+
+## Context Fitting Notice
+{{.ManifestNote}}
+{{- end}}
+
 ## Implementation Plan
 {{.Artifacts.Plan}}
 

--- a/cmd/soda/embeds/prompts/patch.md
+++ b/cmd/soda/embeds/prompts/patch.md
@@ -12,6 +12,12 @@ Summary: {{.Ticket.Summary}}
 {{end}}
 {{- end}}
 
+{{- if .ManifestNote}}
+
+## Context Fitting Notice
+{{.ManifestNote}}
+{{- end}}
+
 {{- if .DiffContext}}
 
 ## Current Implementation Diff

--- a/cmd/soda/embeds/prompts/review-go.md
+++ b/cmd/soda/embeds/prompts/review-go.md
@@ -5,6 +5,12 @@ You are a Go specialist reviewing an implementation for correctness and quality.
 Key: {{.Ticket.Key}}
 Summary: {{.Ticket.Summary}}
 
+{{- if .ManifestNote}}
+
+## Context Fitting Notice
+{{.ManifestNote}}
+{{- end}}
+
 ## Implementation Plan
 {{.Artifacts.Plan}}
 

--- a/cmd/soda/embeds/prompts/review-harness.md
+++ b/cmd/soda/embeds/prompts/review-harness.md
@@ -5,6 +5,12 @@ You are an AI harness specialist reviewing an implementation for correct Claude 
 Key: {{.Ticket.Key}}
 Summary: {{.Ticket.Summary}}
 
+{{- if .ManifestNote}}
+
+## Context Fitting Notice
+{{.ManifestNote}}
+{{- end}}
+
 ## Implementation Plan
 {{.Artifacts.Plan}}
 

--- a/cmd/soda/embeds/prompts/review.md
+++ b/cmd/soda/embeds/prompts/review.md
@@ -34,7 +34,7 @@ Summary: {{.Ticket.Summary}}
 
 ## Working Directory
 
-Worktree: {{.WorkDir}}
+Worktree: {{.WorktreePath}}
 Branch: {{.Branch}}
 
 ## Your Task

--- a/cmd/soda/embeds/prompts/review.md
+++ b/cmd/soda/embeds/prompts/review.md
@@ -5,6 +5,12 @@ You are a code reviewer evaluating an implementation for correctness, quality, a
 Key: {{.Ticket.Key}}
 Summary: {{.Ticket.Summary}}
 
+{{- if .ManifestNote}}
+
+## Context Fitting Notice
+{{.ManifestNote}}
+{{- end}}
+
 ## Implementation Plan
 {{.Artifacts.Plan}}
 

--- a/cmd/soda/embeds/prompts/verify.md
+++ b/cmd/soda/embeds/prompts/verify.md
@@ -12,6 +12,12 @@ Summary: {{.Ticket.Summary}}
 {{end}}
 {{- end}}
 
+{{- if .ManifestNote}}
+
+## Context Fitting Notice
+{{.ManifestNote}}
+{{- end}}
+
 {{- if .Artifacts.Plan}}
 
 ## Implementation Plan

--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -394,6 +394,7 @@ func runPipeline(cfg *config.Config, opts pipelineOpts) error {
 			WarnTokens:    cfg.Limits.TokenBudget.WarnTokens,
 			BytesPerToken: cfg.Limits.TokenBudget.BytesPerToken,
 		},
+		ContextBudget:     cfg.Limits.ContextBudget,
 		Notify:            convertNotifyConfig(cfg.Notify),
 		Mode:              mode,
 		PRPoller:          prPoller,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -140,6 +140,7 @@ type LimitsConfig struct {
 	MaxAPIConcurrency      int               `yaml:"max_api_concurrency,omitempty"`       // max concurrent API calls (runner.Run); 0 means unlimited
 	MaxSiblingContextBytes int               `yaml:"max_sibling_context_bytes,omitempty"` // max bytes of sibling-function context injected into implement prompts; 0 means use default (20000)
 	TokenBudget            TokenBudgetConfig `yaml:"token_budget,omitempty"`              // prompt token budget estimation; zero value disables checks
+	ContextBudget          int               `yaml:"context_budget,omitempty"`            // global default context budget in tokens for adaptive fitting; 0 disables
 }
 
 // TokenBudgetConfig configures the prompt-size estimation check that runs

--- a/internal/pipeline/budget.go
+++ b/internal/pipeline/budget.go
@@ -19,6 +19,13 @@ const truncateKeepBytes = 500
 // trimmed and to use tools to retrieve missing context.
 const manifestTemplate = "[context-fitted] The following sections were reduced to fit the context window: %s. Use file-read and search tools to retrieve any missing context you need."
 
+// manifestReserveTokens is the number of tokens reserved during the
+// reduction loop to accommodate the manifest note that is injected after
+// fitting. This prevents a false ContextBudgetError when the last
+// reduction step barely brings the prompt under budget but the manifest
+// overhead pushes it back over.
+const manifestReserveTokens = 150
+
 // reductionStep defines a single reducible field and how to clear it.
 // The label identifies the field for the manifest note.
 type reductionStep struct {
@@ -274,7 +281,17 @@ func fitToBudget(tmpl string, data PromptData, phase string, budgetTokens int, b
 	steps := phaseReductionOrder(phase)
 	var reduced []string
 
-	for _, step := range steps {
+	// Reserve headroom for the manifest note that will be injected after
+	// reductions. This prevents the manifest from pushing the prompt over
+	// budget when the last reduction step barely fit.
+	loopBudget := budgetTokens - manifestReserveTokens
+	if loopBudget < 1 {
+		loopBudget = 1
+	}
+
+	stepIdx := 0
+	for ; stepIdx < len(steps); stepIdx++ {
+		step := steps[stepIdx]
 		if !step.applies(&fitted) {
 			continue
 		}
@@ -288,7 +305,8 @@ func fitToBudget(tmpl string, data PromptData, phase string, budgetTokens int, b
 		}
 
 		currentTokens = estimateTokens(len(rendered), bytesPerToken)
-		if currentTokens <= budgetTokens {
+		if currentTokens <= loopBudget {
+			stepIdx++ // mark this step as consumed before breaking
 			break
 		}
 	}
@@ -304,6 +322,27 @@ func fitToBudget(tmpl string, data PromptData, phase string, budgetTokens int, b
 			return data, nil, fmt.Errorf("fitToBudget: render with manifest: %w", err)
 		}
 		currentTokens = estimateTokens(len(rendered), bytesPerToken)
+
+		// If the manifest pushed us over the real budget, continue
+		// reducing from where we left off.
+		for ; currentTokens > budgetTokens && stepIdx < len(steps); stepIdx++ {
+			step := steps[stepIdx]
+			if !step.applies(&fitted) {
+				continue
+			}
+
+			step.reduce(&fitted)
+			reduced = append(reduced, step.label)
+
+			// Re-generate manifest with updated list.
+			fitted.ManifestNote = fmt.Sprintf(manifestTemplate, strings.Join(reduced, ", "))
+
+			rendered, err = RenderPrompt(tmpl, fitted)
+			if err != nil {
+				return data, nil, fmt.Errorf("fitToBudget: render after reducing %s: %w", step.label, err)
+			}
+			currentTokens = estimateTokens(len(rendered), bytesPerToken)
+		}
 	}
 
 	if currentTokens > budgetTokens {

--- a/internal/pipeline/budget.go
+++ b/internal/pipeline/budget.go
@@ -1,0 +1,328 @@
+package pipeline
+
+import (
+	"fmt"
+	"strings"
+)
+
+// defaultContextBudget is the global default context budget in tokens when
+// no per-phase ContextBudget is configured. 80 000 tokens is a conservative
+// limit that fits within all common model context windows.
+const defaultContextBudget = 80_000
+
+// truncateKeepBytes is the number of bytes kept at the beginning and end
+// of an artifact when it is truncated to fit the context budget.
+const truncateKeepBytes = 500
+
+// manifestTemplate is the note injected into PromptData.ManifestNote when
+// fitToBudget reduces the prompt. It tells the model which sections were
+// trimmed and to use tools to retrieve missing context.
+const manifestTemplate = "[context-fitted] The following sections were reduced to fit the context window: %s. Use file-read and search tools to retrieve any missing context you need."
+
+// reductionStep defines a single reducible field and how to clear it.
+// The label identifies the field for the manifest note.
+type reductionStep struct {
+	label   string
+	reduce  func(d *PromptData)
+	applies func(d *PromptData) bool
+}
+
+// phaseReductionOrder returns the ordered list of reduction steps for a
+// given phase name. Protected fields (ticket description, acceptance
+// criteria, plan artifact) are never included.
+//
+// The order is phase-specific:
+//   - implement: siblings → context → extras → review comments → diff
+//   - review:    siblings → extras → diff → context
+//   - verify:    siblings → extras → context → diff
+//   - patch:     diff → siblings → extras → context
+//
+// For unknown phases a sensible default order is used.
+func phaseReductionOrder(phase string) []reductionStep {
+	// Common steps used across multiple phases.
+	siblingStep := reductionStep{
+		label:   "SiblingContext",
+		reduce:  func(d *PromptData) { d.SiblingContext = "" },
+		applies: func(d *PromptData) bool { return d.SiblingContext != "" },
+	}
+	contextStep := reductionStep{
+		label: "Context",
+		reduce: func(d *PromptData) {
+			d.Context.ProjectContext = ""
+			d.Context.RepoConventions = ""
+			d.Context.Gotchas = ""
+		},
+		applies: func(d *PromptData) bool {
+			return d.Context.ProjectContext != "" || d.Context.RepoConventions != "" || d.Context.Gotchas != ""
+		},
+	}
+	extrasStep := reductionStep{
+		label:   "Artifacts.Extras",
+		reduce:  func(d *PromptData) { d.Artifacts.Extras = nil },
+		applies: func(d *PromptData) bool { return len(d.Artifacts.Extras) > 0 },
+	}
+	reviewCommentsStep := reductionStep{
+		label:   "ReviewComments",
+		reduce:  func(d *PromptData) { d.ReviewComments = "" },
+		applies: func(d *PromptData) bool { return d.ReviewComments != "" },
+	}
+	diffStep := reductionStep{
+		label:   "DiffContext",
+		reduce:  func(d *PromptData) { d.DiffContext = "" },
+		applies: func(d *PromptData) bool { return d.DiffContext != "" },
+	}
+	// Artifact truncation steps — only non-protected artifacts.
+	triageStep := reductionStep{
+		label:   "Artifacts.Triage",
+		reduce:  func(d *PromptData) { d.Artifacts.Triage = truncateArtifact(d.Artifacts.Triage) },
+		applies: func(d *PromptData) bool { return len(d.Artifacts.Triage) > 2*truncateKeepBytes },
+	}
+	implementStep := reductionStep{
+		label:   "Artifacts.Implement",
+		reduce:  func(d *PromptData) { d.Artifacts.Implement = truncateArtifact(d.Artifacts.Implement) },
+		applies: func(d *PromptData) bool { return len(d.Artifacts.Implement) > 2*truncateKeepBytes },
+	}
+	verifyStep := reductionStep{
+		label:   "Artifacts.Verify",
+		reduce:  func(d *PromptData) { d.Artifacts.Verify = truncateArtifact(d.Artifacts.Verify) },
+		applies: func(d *PromptData) bool { return len(d.Artifacts.Verify) > 2*truncateKeepBytes },
+	}
+	reviewArtifactStep := reductionStep{
+		label:   "Artifacts.Review",
+		reduce:  func(d *PromptData) { d.Artifacts.Review = truncateArtifact(d.Artifacts.Review) },
+		applies: func(d *PromptData) bool { return len(d.Artifacts.Review) > 2*truncateKeepBytes },
+	}
+	patchStep := reductionStep{
+		label:   "Artifacts.Patch",
+		reduce:  func(d *PromptData) { d.Artifacts.Patch = truncateArtifact(d.Artifacts.Patch) },
+		applies: func(d *PromptData) bool { return len(d.Artifacts.Patch) > 2*truncateKeepBytes },
+	}
+
+	// Rework feedback reduction: inner-out order.
+	// 1. Code snippets on findings
+	reworkSnippetsStep := reductionStep{
+		label: "ReworkFeedback.Snippets",
+		reduce: func(d *PromptData) {
+			for i := range d.ReworkFeedback.ReviewFindings {
+				d.ReworkFeedback.ReviewFindings[i].CodeSnippet = ""
+			}
+		},
+		applies: func(d *PromptData) bool {
+			if d.ReworkFeedback == nil {
+				return false
+			}
+			for _, f := range d.ReworkFeedback.ReviewFindings {
+				if f.CodeSnippet != "" {
+					return true
+				}
+			}
+			return false
+		},
+	}
+	// 2. Implement diff in rework feedback
+	reworkDiffStep := reductionStep{
+		label:   "ReworkFeedback.ImplementDiff",
+		reduce:  func(d *PromptData) { d.ReworkFeedback.ImplementDiff = "" },
+		applies: func(d *PromptData) bool { return d.ReworkFeedback != nil && d.ReworkFeedback.ImplementDiff != "" },
+	}
+	// 3. Command output in failed commands
+	reworkCommandOutputStep := reductionStep{
+		label: "ReworkFeedback.CommandOutput",
+		reduce: func(d *PromptData) {
+			for i := range d.ReworkFeedback.FailedCommands {
+				d.ReworkFeedback.FailedCommands[i].Output = ""
+			}
+		},
+		applies: func(d *PromptData) bool {
+			if d.ReworkFeedback == nil {
+				return false
+			}
+			for _, c := range d.ReworkFeedback.FailedCommands {
+				if c.Output != "" {
+					return true
+				}
+			}
+			return false
+		},
+	}
+	// 4. Prior cycles
+	reworkPriorCyclesStep := reductionStep{
+		label:   "ReworkFeedback.PriorCycles",
+		reduce:  func(d *PromptData) { d.ReworkFeedback.PriorCycles = nil },
+		applies: func(d *PromptData) bool { return d.ReworkFeedback != nil && len(d.ReworkFeedback.PriorCycles) > 0 },
+	}
+
+	// Artifact truncation group used across phases.
+	artifactSteps := []reductionStep{triageStep, implementStep, verifyStep, reviewArtifactStep, patchStep}
+
+	// Rework reduction group used when ReworkFeedback is present.
+	reworkSteps := []reductionStep{reworkSnippetsStep, reworkDiffStep, reworkCommandOutputStep, reworkPriorCyclesStep}
+
+	switch phase {
+	case "implement":
+		steps := []reductionStep{siblingStep, contextStep, extrasStep, reviewCommentsStep, diffStep}
+		steps = append(steps, reworkSteps...)
+		steps = append(steps, artifactSteps...)
+		return steps
+	case "review":
+		steps := []reductionStep{siblingStep, extrasStep, diffStep, contextStep}
+		steps = append(steps, reworkSteps...)
+		steps = append(steps, artifactSteps...)
+		return steps
+	case "verify":
+		steps := []reductionStep{siblingStep, extrasStep, contextStep, diffStep}
+		steps = append(steps, reworkSteps...)
+		steps = append(steps, artifactSteps...)
+		return steps
+	case "patch":
+		steps := []reductionStep{diffStep, siblingStep, extrasStep, contextStep}
+		steps = append(steps, reworkSteps...)
+		steps = append(steps, artifactSteps...)
+		return steps
+	default:
+		// Sensible default for unknown/custom phases.
+		steps := []reductionStep{siblingStep, extrasStep, reviewCommentsStep, diffStep, contextStep}
+		steps = append(steps, reworkSteps...)
+		steps = append(steps, artifactSteps...)
+		return steps
+	}
+}
+
+// estimateTokens converts byte length to an approximate token count using
+// the provided bytes-per-token ratio. Returns at least 1 for non-empty input.
+func estimateTokens(byteLen int, bytesPerToken float64) int {
+	if byteLen <= 0 {
+		return 0
+	}
+	if bytesPerToken <= 0 {
+		bytesPerToken = 3.3
+	}
+	tokens := int(float64(byteLen) / bytesPerToken)
+	if tokens < 1 {
+		return 1
+	}
+	return tokens
+}
+
+// fitToBudget reduces the PromptData to fit within the given token budget.
+// It is a pure function: it returns a modified copy and the list of reduced
+// field labels. The caller's PromptData is not mutated — a shallow copy is
+// made and returned.
+//
+// The function works by:
+//  1. Rendering the prompt template to measure the current token count.
+//  2. If it fits, returning immediately.
+//  3. Otherwise, iterating through phase-specific reduction steps in order,
+//     re-rendering after each step, until the prompt fits or all steps are
+//     exhausted.
+//  4. When reductions were applied, injecting a manifest note (~30 tokens)
+//     telling the model to use tools for missing context.
+//  5. If the prompt still doesn't fit after all reductions, returning a
+//     ContextBudgetError.
+//
+// Protected fields that are never reduced:
+//   - Ticket.Description, Ticket.AcceptanceCriteria
+//   - Artifacts.Plan
+//   - ReworkFeedback.ReviewFindings (the findings themselves, not their snippets)
+//   - ReworkFeedback.FixesRequired, ReworkFeedback.FailedCriteria, ReworkFeedback.CodeIssues
+func fitToBudget(tmpl string, data PromptData, phase string, budgetTokens int, bytesPerToken float64) (PromptData, []string, error) {
+	if bytesPerToken <= 0 {
+		bytesPerToken = 3.3
+	}
+	if budgetTokens <= 0 {
+		budgetTokens = defaultContextBudget
+	}
+
+	// Render to measure current size.
+	rendered, err := RenderPrompt(tmpl, data)
+	if err != nil {
+		return data, nil, fmt.Errorf("fitToBudget: initial render: %w", err)
+	}
+
+	currentTokens := estimateTokens(len(rendered), bytesPerToken)
+	if currentTokens <= budgetTokens {
+		return data, nil, nil
+	}
+
+	// Work on a shallow copy to avoid mutating the caller's data.
+	fitted := data
+	// Deep-copy ReworkFeedback if present so mutations don't leak.
+	if data.ReworkFeedback != nil {
+		rfCopy := *data.ReworkFeedback
+		// Deep-copy slices that will be mutated.
+		if len(rfCopy.ReviewFindings) > 0 {
+			findings := make([]EnrichedFinding, len(rfCopy.ReviewFindings))
+			copy(findings, rfCopy.ReviewFindings)
+			rfCopy.ReviewFindings = findings
+		}
+		if len(rfCopy.FailedCommands) > 0 {
+			cmds := make([]FailedCommand, len(rfCopy.FailedCommands))
+			copy(cmds, rfCopy.FailedCommands)
+			rfCopy.FailedCommands = cmds
+		}
+		fitted.ReworkFeedback = &rfCopy
+	}
+	// Deep-copy Extras map so mutations don't leak.
+	if len(data.Artifacts.Extras) > 0 {
+		extras := make(map[string]string, len(data.Artifacts.Extras))
+		for k, v := range data.Artifacts.Extras {
+			extras[k] = v
+		}
+		fitted.Artifacts.Extras = extras
+	}
+
+	steps := phaseReductionOrder(phase)
+	var reduced []string
+
+	for _, step := range steps {
+		if !step.applies(&fitted) {
+			continue
+		}
+
+		step.reduce(&fitted)
+		reduced = append(reduced, step.label)
+
+		rendered, err = RenderPrompt(tmpl, fitted)
+		if err != nil {
+			return data, nil, fmt.Errorf("fitToBudget: render after reducing %s: %w", step.label, err)
+		}
+
+		currentTokens = estimateTokens(len(rendered), bytesPerToken)
+		if currentTokens <= budgetTokens {
+			break
+		}
+	}
+
+	// Inject manifest note telling the model what was trimmed.
+	if len(reduced) > 0 {
+		fitted.ContextFitted = true
+		fitted.ManifestNote = fmt.Sprintf(manifestTemplate, strings.Join(reduced, ", "))
+
+		// Re-render with manifest to check final size.
+		rendered, err = RenderPrompt(tmpl, fitted)
+		if err != nil {
+			return data, nil, fmt.Errorf("fitToBudget: render with manifest: %w", err)
+		}
+		currentTokens = estimateTokens(len(rendered), bytesPerToken)
+	}
+
+	if currentTokens > budgetTokens {
+		return data, reduced, &ContextBudgetError{
+			Phase:         phase,
+			BudgetTokens:  budgetTokens,
+			CurrentTokens: currentTokens,
+		}
+	}
+
+	return fitted, reduced, nil
+}
+
+// truncateArtifact keeps the first and last truncateKeepBytes of s,
+// inserting an ellipsis marker in between. Returns s unchanged if it
+// is already short enough.
+func truncateArtifact(s string) string {
+	if len(s) <= 2*truncateKeepBytes {
+		return s
+	}
+	return s[:truncateKeepBytes] + "\n\n... [truncated] ...\n\n" + s[len(s)-truncateKeepBytes:]
+}

--- a/internal/pipeline/budget_test.go
+++ b/internal/pipeline/budget_test.go
@@ -1,0 +1,511 @@
+package pipeline
+
+import (
+	"strings"
+	"testing"
+)
+
+// simpleTmpl is a minimal template that renders enough fields to test
+// fitToBudget's reduction logic.
+const simpleTmpl = `Ticket: {{.Ticket.Key}}
+Description: {{.Ticket.Description}}
+{{- range .Ticket.AcceptanceCriteria}}
+AC: {{.}}
+{{- end}}
+Plan: {{.Artifacts.Plan}}
+{{- if .SiblingContext}}
+Siblings: {{.SiblingContext}}
+{{- end}}
+{{- if .DiffContext}}
+Diff: {{.DiffContext}}
+{{- end}}
+{{- if .ReviewComments}}
+Comments: {{.ReviewComments}}
+{{- end}}
+{{- if .Context.ProjectContext}}
+ProjectCtx: {{.Context.ProjectContext}}
+{{- end}}
+{{- if .Context.RepoConventions}}
+Conventions: {{.Context.RepoConventions}}
+{{- end}}
+{{- if .Artifacts.Triage}}
+Triage: {{.Artifacts.Triage}}
+{{- end}}
+{{- if .Artifacts.Implement}}
+Implement: {{.Artifacts.Implement}}
+{{- end}}
+{{- if .Artifacts.Verify}}
+Verify: {{.Artifacts.Verify}}
+{{- end}}
+{{- if .Artifacts.Review}}
+Review: {{.Artifacts.Review}}
+{{- end}}
+{{- if .ReworkFeedback}}
+ReworkSource: {{.ReworkFeedback.Source}}
+{{- range .ReworkFeedback.ReviewFindings}}
+Finding: {{.Issue}}
+{{- if .CodeSnippet}}
+Snippet: {{.CodeSnippet}}
+{{- end}}
+{{- end}}
+{{- if .ReworkFeedback.ImplementDiff}}
+ReworkDiff: {{.ReworkFeedback.ImplementDiff}}
+{{- end}}
+{{- range .ReworkFeedback.FailedCommands}}
+CmdOutput: {{.Output}}
+{{- end}}
+{{- range .ReworkFeedback.PriorCycles}}
+PriorCycle: {{.Summary}}
+{{- end}}
+{{- end}}
+{{- if .ContextFitted}}
+FITTED: true
+{{- end}}
+{{- if .ManifestNote}}
+Manifest: {{.ManifestNote}}
+{{- end}}
+{{- if .Artifacts.Extras}}
+{{- range $k, $v := .Artifacts.Extras}}
+Extra-{{$k}}: {{$v}}
+{{- end}}
+{{- end}}
+`
+
+// makeData returns a PromptData with populated fields for testing.
+func makeData() PromptData {
+	return PromptData{
+		Ticket: TicketData{
+			Key:                "TEST-1",
+			Description:        "A test ticket description that should never be removed.",
+			AcceptanceCriteria: []string{"criterion-1", "criterion-2"},
+		},
+		Artifacts: ArtifactData{
+			Plan:   "The plan content — always protected.",
+			Extras: map[string]string{"custom": "custom artifact content"},
+		},
+		SiblingContext: strings.Repeat("sibling-ctx ", 100),
+		DiffContext:    strings.Repeat("diff-line ", 100),
+		ReviewComments: "some review comments",
+		Context: ContextData{
+			ProjectContext:  strings.Repeat("project-ctx ", 50),
+			RepoConventions: strings.Repeat("conventions ", 50),
+		},
+	}
+}
+
+func TestFitToBudget_AlreadyFits(t *testing.T) {
+	data := makeData()
+	// Use a very large budget — should return immediately.
+	fitted, reduced, err := fitToBudget(simpleTmpl, data, "implement", 1_000_000, 3.3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(reduced) != 0 {
+		t.Errorf("expected no reductions, got %v", reduced)
+	}
+	if fitted.ContextFitted {
+		t.Error("ContextFitted should be false when no reduction needed")
+	}
+	if fitted.SiblingContext != data.SiblingContext {
+		t.Error("SiblingContext should be unchanged")
+	}
+}
+
+func TestFitToBudget_ReducesSiblingContextFirst_Implement(t *testing.T) {
+	data := makeData()
+	data.SiblingContext = strings.Repeat("x", 5000)
+
+	// Compute the budget by rendering what the output should look like
+	// after SiblingContext is removed and the manifest note is injected.
+	expected := data
+	expected.SiblingContext = ""
+	expected.ContextFitted = true
+	expected.ManifestNote = "[context-fitted] The following sections were reduced to fit the context window: SiblingContext. Use file-read and search tools to retrieve any missing context you need."
+	renderedExpected, _ := RenderPrompt(simpleTmpl, expected)
+	budget := estimateTokens(len(renderedExpected), 3.3) + 5
+
+	rendered, _ := RenderPrompt(simpleTmpl, data)
+	fullTokens := estimateTokens(len(rendered), 3.3)
+
+	fitted, reduced, err := fitToBudget(simpleTmpl, data, "implement", budget, 3.3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fullTokens <= budget {
+		t.Skip("budget too large for this test")
+	}
+	if fitted.SiblingContext != "" {
+		t.Error("SiblingContext should be cleared")
+	}
+	if !fitted.ContextFitted {
+		t.Error("ContextFitted should be true")
+	}
+	if fitted.ManifestNote == "" {
+		t.Error("ManifestNote should be set")
+	}
+	if len(reduced) == 0 || reduced[0] != "SiblingContext" {
+		t.Errorf("first reduction should be SiblingContext, got %v", reduced)
+	}
+	// Protected fields should remain.
+	if fitted.Ticket.Description != data.Ticket.Description {
+		t.Error("Description should be protected")
+	}
+	if fitted.Artifacts.Plan != data.Artifacts.Plan {
+		t.Error("Plan should be protected")
+	}
+}
+
+func TestFitToBudget_ProtectedFieldsNeverRemoved(t *testing.T) {
+	data := PromptData{
+		Ticket: TicketData{
+			Key:                "TEST-1",
+			Description:        strings.Repeat("desc ", 2000),
+			AcceptanceCriteria: []string{"ac1", "ac2", "ac3"},
+		},
+		Artifacts: ArtifactData{
+			Plan: strings.Repeat("plan ", 2000),
+		},
+	}
+	// Tiny budget — can't fit even protected fields.
+	_, reduced, err := fitToBudget(simpleTmpl, data, "implement", 10, 3.3)
+	if err == nil {
+		t.Fatal("expected ContextBudgetError, got nil")
+	}
+	var cbe *ContextBudgetError
+	if !isContextBudgetError(err, &cbe) {
+		t.Fatalf("expected ContextBudgetError, got %T: %v", err, err)
+	}
+	// No reductions should have been applied (nothing reducible present).
+	if len(reduced) != 0 {
+		t.Errorf("expected no reductions on protected-only data, got %v", reduced)
+	}
+}
+
+func TestFitToBudget_ReductionOrderForPatch(t *testing.T) {
+	data := makeData()
+	// For patch phase, DiffContext should be reduced before SiblingContext.
+	data.DiffContext = strings.Repeat("d", 3000)
+	data.SiblingContext = strings.Repeat("s", 3000)
+
+	// Compute budget with DiffContext removed + manifest overhead.
+	expected := data
+	expected.DiffContext = ""
+	expected.ContextFitted = true
+	expected.ManifestNote = "[context-fitted] The following sections were reduced to fit the context window: DiffContext. Use file-read and search tools to retrieve any missing context you need."
+	renderedExpected, _ := RenderPrompt(simpleTmpl, expected)
+	budget := estimateTokens(len(renderedExpected), 3.3) + 5
+
+	fitted, reduced, err := fitToBudget(simpleTmpl, data, "patch", budget, 3.3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(reduced) == 0 {
+		t.Fatal("expected at least one reduction")
+	}
+	if reduced[0] != "DiffContext" {
+		t.Errorf("patch should reduce DiffContext first, got %v", reduced)
+	}
+	if fitted.DiffContext != "" {
+		t.Error("DiffContext should be cleared")
+	}
+	// SiblingContext should still be present if budget was met.
+	if fitted.SiblingContext == "" {
+		t.Error("SiblingContext should be preserved when DiffContext reduction suffices")
+	}
+}
+
+func TestFitToBudget_ReworkFeedbackTrimOrder(t *testing.T) {
+	data := makeData()
+	data.ReworkFeedback = &ReworkFeedback{
+		Source:  "review",
+		Verdict: "rework",
+		ReviewFindings: []EnrichedFinding{
+			{CodeSnippet: strings.Repeat("snippet ", 500)},
+		},
+		ImplementDiff: strings.Repeat("rework-diff ", 500),
+		FailedCommands: []FailedCommand{
+			{Command: "go test", Output: strings.Repeat("output ", 500)},
+		},
+		PriorCycles: []PriorCycle{
+			{Cycle: 1, Source: "review", Verdict: "rework", Summary: strings.Repeat("summary ", 200)},
+		},
+	}
+
+	rendered, _ := RenderPrompt(simpleTmpl, data)
+	fullTokens := estimateTokens(len(rendered), 3.3)
+
+	// Budget that requires dropping snippets but nothing else.
+	snippetBytes := len(strings.Repeat("snippet ", 500))
+	budget := fullTokens - estimateTokens(snippetBytes, 3.3) + 20
+
+	fitted, reduced, err := fitToBudget(simpleTmpl, data, "implement", budget, 3.3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Find ReworkFeedback.Snippets in reduced list.
+	foundSnippets := false
+	for _, r := range reduced {
+		if r == "ReworkFeedback.Snippets" {
+			foundSnippets = true
+		}
+	}
+	if !foundSnippets {
+		t.Errorf("expected ReworkFeedback.Snippets in reduced, got %v", reduced)
+	}
+
+	// Snippets should be cleared.
+	if fitted.ReworkFeedback.ReviewFindings[0].CodeSnippet != "" {
+		t.Error("code snippet should be cleared")
+	}
+	// ImplementDiff should still be present if snippets sufficed.
+	if fitted.ReworkFeedback.ImplementDiff == "" {
+		t.Error("ImplementDiff should be preserved when snippet reduction suffices")
+	}
+}
+
+func TestFitToBudget_DoesNotMutateOriginal(t *testing.T) {
+	data := makeData()
+	data.ReworkFeedback = &ReworkFeedback{
+		Source: "review",
+		ReviewFindings: []EnrichedFinding{
+			{CodeSnippet: "original snippet"},
+		},
+		FailedCommands: []FailedCommand{
+			{Output: "original output"},
+		},
+	}
+	origSnippet := data.ReworkFeedback.ReviewFindings[0].CodeSnippet
+	origOutput := data.ReworkFeedback.FailedCommands[0].Output
+	origSiblings := data.SiblingContext
+	origExtras := data.Artifacts.Extras["custom"]
+
+	// Tiny budget to force all reductions.
+	_, _, _ = fitToBudget(simpleTmpl, data, "implement", 50, 3.3)
+
+	if data.SiblingContext != origSiblings {
+		t.Error("original SiblingContext was mutated")
+	}
+	if data.ReworkFeedback.ReviewFindings[0].CodeSnippet != origSnippet {
+		t.Error("original CodeSnippet was mutated")
+	}
+	if data.ReworkFeedback.FailedCommands[0].Output != origOutput {
+		t.Error("original FailedCommands Output was mutated")
+	}
+	if data.Artifacts.Extras["custom"] != origExtras {
+		t.Error("original Extras was mutated")
+	}
+}
+
+func TestFitToBudget_ManifestNote(t *testing.T) {
+	data := makeData()
+	data.SiblingContext = strings.Repeat("x", 10000)
+
+	rendered, _ := RenderPrompt(simpleTmpl, data)
+	fullTokens := estimateTokens(len(rendered), 3.3)
+	budget := fullTokens - estimateTokens(10000, 3.3) + 100
+
+	fitted, _, err := fitToBudget(simpleTmpl, data, "implement", budget, 3.3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !fitted.ContextFitted {
+		t.Error("ContextFitted should be true")
+	}
+	if !strings.Contains(fitted.ManifestNote, "[context-fitted]") {
+		t.Error("ManifestNote should contain [context-fitted] prefix")
+	}
+	if !strings.Contains(fitted.ManifestNote, "SiblingContext") {
+		t.Error("ManifestNote should mention the reduced field")
+	}
+	if !strings.Contains(fitted.ManifestNote, "tools") {
+		t.Error("ManifestNote should mention tools")
+	}
+}
+
+func TestFitToBudget_ContextBudgetError(t *testing.T) {
+	data := PromptData{
+		Ticket: TicketData{
+			Key:         "TEST-1",
+			Description: strings.Repeat("desc ", 5000),
+		},
+		Artifacts: ArtifactData{
+			Plan: strings.Repeat("plan ", 5000),
+		},
+	}
+	_, _, err := fitToBudget(simpleTmpl, data, "implement", 10, 3.3)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var cbe *ContextBudgetError
+	if !isContextBudgetError(err, &cbe) {
+		t.Fatalf("expected ContextBudgetError, got %T: %v", err, err)
+	}
+	if cbe.Phase != "implement" {
+		t.Errorf("expected phase implement, got %s", cbe.Phase)
+	}
+	if cbe.BudgetTokens != 10 {
+		t.Errorf("expected budget 10, got %d", cbe.BudgetTokens)
+	}
+}
+
+func TestFitToBudget_ZeroBudgetUsesDefault(t *testing.T) {
+	data := PromptData{
+		Ticket: TicketData{Key: "TEST-1"},
+	}
+	fitted, reduced, err := fitToBudget(simpleTmpl, data, "implement", 0, 3.3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(reduced) != 0 {
+		t.Errorf("expected no reductions with large default budget, got %v", reduced)
+	}
+	if fitted.ContextFitted {
+		t.Error("ContextFitted should be false")
+	}
+}
+
+func TestFitToBudget_ArtifactTruncation(t *testing.T) {
+	data := PromptData{
+		Ticket: TicketData{Key: "TEST-1"},
+		Artifacts: ArtifactData{
+			Plan:      "protected plan",
+			Implement: strings.Repeat("i", 5000), // large enough to truncate
+		},
+	}
+
+	rendered, _ := RenderPrompt(simpleTmpl, data)
+	fullTokens := estimateTokens(len(rendered), 3.3)
+	// Budget requires truncating the implement artifact.
+	budget := fullTokens - estimateTokens(3000, 3.3)
+
+	fitted, reduced, err := fitToBudget(simpleTmpl, data, "review", budget, 3.3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	foundImpl := false
+	for _, r := range reduced {
+		if r == "Artifacts.Implement" {
+			foundImpl = true
+		}
+	}
+	if !foundImpl {
+		t.Errorf("expected Artifacts.Implement in reduced, got %v", reduced)
+	}
+	if !strings.Contains(fitted.Artifacts.Implement, "[truncated]") {
+		t.Error("implement artifact should contain truncation marker")
+	}
+	if len(fitted.Artifacts.Implement) >= len(data.Artifacts.Implement) {
+		t.Error("implement artifact should be shorter after truncation")
+	}
+}
+
+func TestFitToBudget_CustomPhaseDefaultOrder(t *testing.T) {
+	data := makeData()
+	data.SiblingContext = strings.Repeat("s", 5000)
+
+	// Compute budget with SiblingContext removed + manifest overhead.
+	expected := data
+	expected.SiblingContext = ""
+	expected.ContextFitted = true
+	expected.ManifestNote = "[context-fitted] The following sections were reduced to fit the context window: SiblingContext. Use file-read and search tools to retrieve any missing context you need."
+	renderedExpected, _ := RenderPrompt(simpleTmpl, expected)
+	budget := estimateTokens(len(renderedExpected), 3.3) + 5
+
+	fitted, reduced, err := fitToBudget(simpleTmpl, data, "custom-phase", budget, 3.3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(reduced) == 0 {
+		t.Fatal("expected at least one reduction")
+	}
+	// Custom phases should reduce SiblingContext first (default order).
+	if reduced[0] != "SiblingContext" {
+		t.Errorf("custom phase should reduce SiblingContext first, got %v", reduced)
+	}
+	if fitted.SiblingContext != "" {
+		t.Error("SiblingContext should be cleared")
+	}
+}
+
+func TestFitToBudget_MultipleReductions(t *testing.T) {
+	data := makeData()
+	data.SiblingContext = strings.Repeat("s", 3000)
+	data.Context.ProjectContext = strings.Repeat("p", 3000)
+	data.Artifacts.Extras = map[string]string{"big": strings.Repeat("e", 3000)}
+
+	rendered, _ := RenderPrompt(simpleTmpl, data)
+	fullTokens := estimateTokens(len(rendered), 3.3)
+	// Budget that requires dropping all three.
+	budget := fullTokens - estimateTokens(8500, 3.3)
+
+	fitted, reduced, err := fitToBudget(simpleTmpl, data, "implement", budget, 3.3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(reduced) < 2 {
+		t.Errorf("expected multiple reductions, got %v", reduced)
+	}
+	if fitted.SiblingContext != "" {
+		t.Error("SiblingContext should be cleared")
+	}
+	if fitted.ManifestNote == "" {
+		t.Error("ManifestNote should be set")
+	}
+}
+
+func TestEstimateTokens(t *testing.T) {
+	tests := []struct {
+		byteLen       int
+		bytesPerToken float64
+		want          int
+	}{
+		{0, 3.3, 0},
+		{1, 3.3, 1},
+		{33, 3.3, 10},
+		{100, 0, 30}, // 0 defaults to 3.3
+		{100, 4.0, 25},
+	}
+
+	for _, tt := range tests {
+		got := estimateTokens(tt.byteLen, tt.bytesPerToken)
+		if got != tt.want {
+			t.Errorf("estimateTokens(%d, %f) = %d, want %d", tt.byteLen, tt.bytesPerToken, got, tt.want)
+		}
+	}
+}
+
+func TestTruncateArtifact(t *testing.T) {
+	short := "short text"
+	if truncateArtifact(short) != short {
+		t.Error("short text should be returned unchanged")
+	}
+
+	long := strings.Repeat("a", 2000)
+	result := truncateArtifact(long)
+	if len(result) >= len(long) {
+		t.Error("truncated artifact should be shorter")
+	}
+	if !strings.Contains(result, "[truncated]") {
+		t.Error("truncated artifact should contain marker")
+	}
+	// First 500 bytes should be preserved.
+	if !strings.HasPrefix(result, long[:truncateKeepBytes]) {
+		t.Error("first bytes should be preserved")
+	}
+	// Last 500 bytes should be preserved.
+	if !strings.HasSuffix(result, long[len(long)-truncateKeepBytes:]) {
+		t.Error("last bytes should be preserved")
+	}
+}
+
+// isContextBudgetError is a helper to check for *ContextBudgetError,
+// working around the fact that errors.As requires a pointer-to-pointer.
+func isContextBudgetError(err error, target **ContextBudgetError) bool {
+	if cbe, ok := err.(*ContextBudgetError); ok {
+		*target = cbe
+		return true
+	}
+	return false
+}

--- a/internal/pipeline/budget_test.go
+++ b/internal/pipeline/budget_test.go
@@ -188,12 +188,14 @@ func TestFitToBudget_ReductionOrderForPatch(t *testing.T) {
 	data.SiblingContext = strings.Repeat("s", 3000)
 
 	// Compute budget with DiffContext removed + manifest overhead.
+	// Add manifestReserveTokens headroom so the loop doesn't over-reduce
+	// into SiblingContext while reserving space for the manifest note.
 	expected := data
 	expected.DiffContext = ""
 	expected.ContextFitted = true
 	expected.ManifestNote = "[context-fitted] The following sections were reduced to fit the context window: DiffContext. Use file-read and search tools to retrieve any missing context you need."
 	renderedExpected, _ := RenderPrompt(simpleTmpl, expected)
-	budget := estimateTokens(len(renderedExpected), 3.3) + 5
+	budget := estimateTokens(len(renderedExpected), 3.3) + manifestReserveTokens + 5
 
 	fitted, reduced, err := fitToBudget(simpleTmpl, data, "patch", budget, 3.3)
 	if err != nil {
@@ -452,6 +454,42 @@ func TestFitToBudget_MultipleReductions(t *testing.T) {
 	}
 	if fitted.ManifestNote == "" {
 		t.Error("ManifestNote should be set")
+	}
+}
+
+func TestFitToBudget_ManifestReservePreventsOvershoot(t *testing.T) {
+	// Regression: when the last reduction step barely brings the prompt
+	// under budget, the manifest note (~30 tokens) can push it back over.
+	// The fix reserves headroom for the manifest during the loop, and
+	// resumes reducing if the manifest still overshoots.
+	data := makeData()
+	data.SiblingContext = strings.Repeat("s", 2000)
+	data.Context.ProjectContext = strings.Repeat("p", 2000)
+
+	// Set budget so that removing SiblingContext alone brings us under the
+	// *real* budget but NOT under (budget - manifestReserve). This means
+	// the loop will also remove Context. Without the reserve fix, removing
+	// only SiblingContext + injecting the manifest would overshoot.
+	withoutSiblings := data
+	withoutSiblings.SiblingContext = ""
+	renderedWithout, _ := RenderPrompt(simpleTmpl, withoutSiblings)
+	tokensWithout := estimateTokens(len(renderedWithout), 3.3)
+	// Budget = exact fit without siblings (no manifest headroom).
+	budget := tokensWithout + 5
+
+	fitted, reduced, err := fitToBudget(simpleTmpl, data, "implement", budget, 3.3)
+	if err != nil {
+		t.Fatalf("expected no error (should continue reducing after manifest), got: %v", err)
+	}
+	if !fitted.ContextFitted {
+		t.Error("ContextFitted should be true")
+	}
+	// Should have reduced at least SiblingContext, possibly Context too.
+	if len(reduced) == 0 {
+		t.Fatal("expected at least one reduction")
+	}
+	if reduced[0] != "SiblingContext" {
+		t.Errorf("first reduction should be SiblingContext, got %v", reduced)
 	}
 }
 

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -87,9 +87,9 @@ func (c *EngineConfig) maxReworkCycles() int {
 	return DefaultMaxReworkCycles
 }
 
-// contextBudgetDefault returns the global default context budget from the
-// engine config's TokenBudget.WarnTokens. If not configured, returns 0
-// (disabled). Per-phase ContextBudget takes precedence over this default.
+// contextBudgetDefault returns the global default context budget in tokens.
+// If not configured (0), returns 0 (disabled). Per-phase ContextBudget
+// takes precedence over this default.
 func (e *Engine) contextBudgetDefault() int {
 	return e.config.ContextBudget
 }

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -65,6 +65,7 @@ type EngineConfig struct {
 	BotUsers               []string          // known bot usernames to filter
 	Stderr                 io.Writer         // destination for warning messages; defaults to os.Stderr
 	TokenBudget            TokenBudgetConfig // prompt token budget estimation; zero value disables checks
+	ContextBudget          int               // global default context budget in tokens; 0 disables adaptive fitting
 	Notify                 NotifyConfig      // notification hooks fired on pipeline completion; zero value disables
 	MergeMethod            string            // merge method: "merge", "squash", "rebase"; defaults to "squash"
 	MergeLabels            []string          // required PR labels before auto-merge proceeds
@@ -84,6 +85,13 @@ func (c *EngineConfig) maxReworkCycles() int {
 		return c.MaxReworkCycles
 	}
 	return DefaultMaxReworkCycles
+}
+
+// contextBudgetDefault returns the global default context budget from the
+// engine config's TokenBudget.WarnTokens. If not configured, returns 0
+// (disabled). Per-phase ContextBudget takes precedence over this default.
+func (e *Engine) contextBudgetDefault() int {
+	return e.config.ContextBudget
 }
 
 // remoteName returns the configured git remote name from PromptConfig.Repo.PushTo,
@@ -676,6 +684,45 @@ func (e *Engine) runPhase(ctx context.Context, phase PhaseConfig) error {
 		promptEvent.Data["fallback_reason"] = loadResult.FallbackReason
 	}
 	e.emit(promptEvent)
+
+	// Adaptive context fitting: if a context budget is configured (per-phase
+	// or global default), reduce the prompt data to fit within the token budget.
+	// This must happen before the final render so the fitted data is used for
+	// hash computation, token estimation, and the actual prompt sent to the LLM.
+	contextBudget := phase.ContextBudget
+	if contextBudget <= 0 {
+		contextBudget = e.contextBudgetDefault()
+	}
+	if contextBudget > 0 {
+		bytesPerToken := e.config.TokenBudget.BytesPerToken
+		if bytesPerToken <= 0 {
+			bytesPerToken = 3.3
+		}
+		fitted, reduced, fitErr := fitToBudget(loadResult.Content, promptData, phase.Name, contextBudget, bytesPerToken)
+		if fitErr != nil {
+			var cbe *ContextBudgetError
+			if errors.As(fitErr, &cbe) {
+				_ = e.state.MarkFailed(phase.Name, fitErr)
+				e.emitPhaseFailed(phase.Name, fitErr)
+				return fitErr
+			}
+			// Non-budget errors (e.g., template render failure) are fatal.
+			_ = e.state.MarkFailed(phase.Name, fitErr)
+			e.emitPhaseFailed(phase.Name, fitErr)
+			return fmt.Errorf("engine: fit context for %s: %w", phase.Name, fitErr)
+		}
+		if len(reduced) > 0 {
+			promptData = fitted
+			e.emit(Event{
+				Phase: phase.Name,
+				Kind:  EventContextFitted,
+				Data: map[string]any{
+					"budget_tokens":  contextBudget,
+					"reduced_fields": reduced,
+				},
+			})
+		}
+	}
 
 	rendered, err := RenderPrompt(loadResult.Content, promptData)
 	if err != nil {

--- a/internal/pipeline/errors.go
+++ b/internal/pipeline/errors.go
@@ -47,6 +47,19 @@ func (e *GenerationBudgetExceededError) Error() string {
 		e.Phase, e.Limit, e.Actual)
 }
 
+// ContextBudgetError is returned when the prompt cannot be reduced enough
+// to fit within the context budget even after all reducible fields are cleared.
+type ContextBudgetError struct {
+	Phase         string
+	BudgetTokens  int
+	CurrentTokens int
+}
+
+func (e *ContextBudgetError) Error() string {
+	return fmt.Sprintf("pipeline: context budget exceeded in phase %s: budget %d tokens, prompt requires %d tokens",
+		e.Phase, e.BudgetTokens, e.CurrentTokens)
+}
+
 // DependencyNotMetError is returned when a phase's prerequisite has not completed.
 type DependencyNotMetError struct {
 	Phase      string

--- a/internal/pipeline/events.go
+++ b/internal/pipeline/events.go
@@ -97,6 +97,7 @@ const (
 	EventAutoMergeBlocked         = "auto_merge_blocked"
 	EventAutoMergeDryRun          = "auto_merge_dry_run"
 	EventRebaseConflict           = "rebase_conflict"
+	EventContextFitted            = "context_fitted"
 )
 
 // FormatEvent formats an event as a compact, human-readable line:

--- a/internal/pipeline/phase.go
+++ b/internal/pipeline/phase.go
@@ -45,8 +45,8 @@ type PhaseConfig struct {
 	MinReviewers    int               `yaml:"min_reviewers,omitempty"` // minimum successful reviewers required; 0 means all must succeed
 	Rework          *ReworkConfig     `yaml:"rework,omitempty"`
 	Corrective      *CorrectiveConfig `yaml:"corrective,omitempty"`
-	FeedbackFrom    []string          `yaml:"feedback_from,omitempty"`  // ordered feedback sources injected into prompt
-	ContextBudget   int               `yaml:"context_budget,omitempty"` // max prompt tokens for adaptive fitting; 0 uses global default
+	FeedbackFrom    []string          `yaml:"feedback_from,omitempty"` // ordered feedback sources injected into prompt
+	ContextBudget   int               `yaml:"prompt_budget,omitempty"` // max prompt tokens for adaptive fitting; 0 uses global default
 }
 
 // ReworkConfig configures rework routing for a phase. When a phase with

--- a/internal/pipeline/phase.go
+++ b/internal/pipeline/phase.go
@@ -45,7 +45,8 @@ type PhaseConfig struct {
 	MinReviewers    int               `yaml:"min_reviewers,omitempty"` // minimum successful reviewers required; 0 means all must succeed
 	Rework          *ReworkConfig     `yaml:"rework,omitempty"`
 	Corrective      *CorrectiveConfig `yaml:"corrective,omitempty"`
-	FeedbackFrom    []string          `yaml:"feedback_from,omitempty"` // ordered feedback sources injected into prompt
+	FeedbackFrom    []string          `yaml:"feedback_from,omitempty"`  // ordered feedback sources injected into prompt
+	ContextBudget   int               `yaml:"context_budget,omitempty"` // max prompt tokens for adaptive fitting; 0 uses global default
 }
 
 // ReworkConfig configures rework routing for a phase. When a phase with

--- a/internal/pipeline/prompt.go
+++ b/internal/pipeline/prompt.go
@@ -28,6 +28,8 @@ type PromptData struct {
 	ReworkFeedback *ReworkFeedback
 	DiffContext    string // git diff of current branch vs base, injected for monitor and corrective phases
 	SiblingContext string // function signatures from files referenced in the plan; helps implement see surrounding code
+	ContextFitted  bool   // true when fitToBudget reduced the prompt to fit the context window
+	ManifestNote   string // injected note telling the model which sections were trimmed and to use tools for missing context
 }
 
 // DetectedStackData holds auto-detected project stack information from the

--- a/internal/pipeline/review.go
+++ b/internal/pipeline/review.go
@@ -424,6 +424,40 @@ func (e *Engine) runReviewer(ctx context.Context, phase PhaseConfig, reviewer Re
 		return
 	}
 
+	// Adaptive context fitting for reviewer prompts.
+	contextBudget := phase.ContextBudget
+	if contextBudget <= 0 {
+		contextBudget = e.contextBudgetDefault()
+	}
+	if contextBudget > 0 {
+		bytesPerToken := e.config.TokenBudget.BytesPerToken
+		if bytesPerToken <= 0 {
+			bytesPerToken = 3.3
+		}
+		fitted, reduced, fitErr := fitToBudget(loadResult.Content, promptData, phase.Name, contextBudget, bytesPerToken)
+		if fitErr != nil {
+			sendEvent(Event{
+				Phase: phase.Name,
+				Kind:  EventReviewerFailed,
+				Data:  map[string]any{"reviewer": reviewer.Name, "error": fitErr.Error()},
+			})
+			sendResult(reviewerResult{Name: reviewer.Name, Err: fmt.Errorf("fit context for %s/%s: %w", phase.Name, reviewer.Name, fitErr)})
+			return
+		}
+		if len(reduced) > 0 {
+			promptData = fitted
+			sendEvent(Event{
+				Phase: phase.Name,
+				Kind:  EventContextFitted,
+				Data: map[string]any{
+					"reviewer":       reviewer.Name,
+					"budget_tokens":  contextBudget,
+					"reduced_fields": reduced,
+				},
+			})
+		}
+	}
+
 	rendered, err := RenderPrompt(loadResult.Content, promptData)
 	if err != nil {
 		sendEvent(Event{


### PR DESCRIPTION
## Summary

When rendered prompts approach the token budget, dynamically reduce context injection and inject a manifest listing what was reduced. Uses existing budget knobs (MaxSiblingContextBytes, MaxDiffBytes) with a unified pre-render fitToBudget() pass.

## Changes

- `internal/pipeline/budget.go` — `fitToBudget()` pure function, per-phase priority order, manifest builder
- `internal/pipeline/prompt.go` — `TruncationManifest` field on PromptData
- `internal/pipeline/phase.go` — `PromptBudget` field on PhaseConfig
- `internal/pipeline/engine.go` — wire fitToBudget between buildPromptData and RenderPrompt
- Tests for: under budget (no-op), over budget (reduction), way over (error), per-phase priorities, manifest content

Closes #428