### PR TITLE
feat(auth): apiKeyHelper support + auth documentation and doctor check [#433]

### DIFF
--- a/cmd/soda/doctor.go
+++ b/cmd/soda/doctor.go
@@ -33,6 +33,7 @@ type doctorEnv struct {
 	LoadConfig    func(path string) (*config.Config, error)
 	UserConfigDir func() (string, error)
 	UserHomeDir   func() (string, error)
+	Getenv        func(key string) string // injectable os.Getenv for testable env checks
 
 	// ParsedConfig is populated by checkConfigValid on success.
 	// Downstream checks use it to adjust their required status.
@@ -58,7 +59,17 @@ func defaultDoctorEnv() *doctorEnv {
 		LoadConfig:    config.Load,
 		UserConfigDir: os.UserConfigDir,
 		UserHomeDir:   os.UserHomeDir,
+		Getenv:        os.Getenv,
 	}
+}
+
+// getenv returns the value of the environment variable key using the
+// injected Getenv function, falling back to os.Getenv when not set.
+func (e *doctorEnv) getenv(key string) string {
+	if e.Getenv != nil {
+		return e.Getenv(key)
+	}
+	return os.Getenv(key)
 }
 
 func newDoctorCmd() *cobra.Command {
@@ -89,6 +100,7 @@ func runDoctor(w io.Writer, env *doctorEnv) error {
 		checkClaudeVersion,
 		checkConfig,
 		checkConfigValid,
+		checkClaudeAuth,
 		checkGh,
 		checkGhAuth,
 		checkBranchProtection,
@@ -293,6 +305,64 @@ func compareSemver(a, b string) int {
 		}
 	}
 	return 0
+}
+
+// checkClaudeAuth verifies that Claude Code has a valid authentication
+// method configured. The precedence chain mirrors how soda resolves
+// credentials at runtime:
+//
+//  1. Proxy enabled in config → pass (proxy handles credentials)
+//  2. ANTHROPIC_API_KEY env var set → pass
+//  3. CLAUDE_CODE_USE_VERTEX env var set → pass (Vertex/GCP auth)
+//  4. auth.api_key_helper in config → pass
+//  5. None of the above → fail
+//
+// This check is optional (warning-only) because authentication can also
+// be configured via Claude Code's own settings files or login flow.
+func checkClaudeAuth(env *doctorEnv) checkResult {
+	// 1. Proxy enabled — credentials are managed by the proxy.
+	if env.ParsedConfig != nil && env.ParsedConfig.Sandbox.Proxy.Enabled {
+		return checkResult{
+			name:   "claude-auth",
+			passed: true,
+			detail: "proxy enabled (credentials managed by proxy)",
+		}
+	}
+
+	// 2. ANTHROPIC_API_KEY env var.
+	if env.getenv("ANTHROPIC_API_KEY") != "" {
+		return checkResult{
+			name:   "claude-auth",
+			passed: true,
+			detail: "ANTHROPIC_API_KEY is set",
+		}
+	}
+
+	// 3. Vertex / GCP auth.
+	if env.getenv("CLAUDE_CODE_USE_VERTEX") != "" {
+		return checkResult{
+			name:   "claude-auth",
+			passed: true,
+			detail: "CLAUDE_CODE_USE_VERTEX is set (Vertex AI auth)",
+		}
+	}
+
+	// 4. api_key_helper in config.
+	if env.ParsedConfig != nil && env.ParsedConfig.Auth.ApiKeyHelper != "" {
+		return checkResult{
+			name:   "claude-auth",
+			passed: true,
+			detail: fmt.Sprintf("api_key_helper configured: %s", env.ParsedConfig.Auth.ApiKeyHelper),
+		}
+	}
+
+	// 5. No auth method found.
+	return checkResult{
+		name:   "claude-auth",
+		passed: false,
+		detail: "no authentication method detected",
+		fix:    "set ANTHROPIC_API_KEY, configure auth.api_key_helper in soda.yaml, enable sandbox proxy, or run: claude login",
+	}
 }
 
 // checkGh verifies that the GitHub CLI is available in PATH.

--- a/cmd/soda/doctor_test.go
+++ b/cmd/soda/doctor_test.go
@@ -58,6 +58,13 @@ func allPassEnv() *doctorEnv {
 		UserHomeDir: func() (string, error) {
 			return "/home/testuser", nil
 		},
+		Getenv: func(key string) string {
+			// Default: ANTHROPIC_API_KEY is set so claude-auth passes.
+			if key == "ANTHROPIC_API_KEY" {
+				return "sk-test-key"
+			}
+			return ""
+		},
 	}
 }
 
@@ -1024,6 +1031,141 @@ func TestRunDoctor_ClaudeMissing_SkipsClaudeVersion(t *testing.T) {
 }
 
 // --- checkBranchProtection tests ---
+
+// --- checkClaudeAuth tests ---
+
+func TestCheckClaudeAuth_ProxyEnabled(t *testing.T) {
+	env := allPassEnv()
+	env.ParsedConfig = &config.Config{
+		Sandbox: config.SandboxConfig{
+			Proxy: config.SandboxProxyConfig{Enabled: true},
+		},
+	}
+	env.Getenv = func(key string) string { return "" }
+	r := checkClaudeAuth(env)
+	if !r.passed {
+		t.Error("expected claude-auth to pass when proxy is enabled")
+	}
+	if !strings.Contains(r.detail, "proxy") {
+		t.Errorf("expected detail to mention proxy, got: %q", r.detail)
+	}
+}
+
+func TestCheckClaudeAuth_APIKeySet(t *testing.T) {
+	env := allPassEnv()
+	env.Getenv = func(key string) string {
+		if key == "ANTHROPIC_API_KEY" {
+			return "sk-ant-test"
+		}
+		return ""
+	}
+	r := checkClaudeAuth(env)
+	if !r.passed {
+		t.Error("expected claude-auth to pass when ANTHROPIC_API_KEY is set")
+	}
+	if !strings.Contains(r.detail, "ANTHROPIC_API_KEY") {
+		t.Errorf("expected detail to mention ANTHROPIC_API_KEY, got: %q", r.detail)
+	}
+}
+
+func TestCheckClaudeAuth_VertexSet(t *testing.T) {
+	env := allPassEnv()
+	env.Getenv = func(key string) string {
+		if key == "CLAUDE_CODE_USE_VERTEX" {
+			return "1"
+		}
+		return ""
+	}
+	r := checkClaudeAuth(env)
+	if !r.passed {
+		t.Error("expected claude-auth to pass when CLAUDE_CODE_USE_VERTEX is set")
+	}
+	if !strings.Contains(r.detail, "Vertex") {
+		t.Errorf("expected detail to mention Vertex, got: %q", r.detail)
+	}
+}
+
+func TestCheckClaudeAuth_ApiKeyHelper(t *testing.T) {
+	env := allPassEnv()
+	env.ParsedConfig = &config.Config{
+		Auth: config.AuthConfig{ApiKeyHelper: "/usr/local/bin/get-key"},
+	}
+	env.Getenv = func(key string) string { return "" }
+	r := checkClaudeAuth(env)
+	if !r.passed {
+		t.Error("expected claude-auth to pass when api_key_helper is configured")
+	}
+	if !strings.Contains(r.detail, "api_key_helper") {
+		t.Errorf("expected detail to mention api_key_helper, got: %q", r.detail)
+	}
+}
+
+func TestCheckClaudeAuth_NoAuth(t *testing.T) {
+	env := allPassEnv()
+	env.ParsedConfig = &config.Config{}
+	env.Getenv = func(key string) string { return "" }
+	r := checkClaudeAuth(env)
+	if r.passed {
+		t.Error("expected claude-auth to fail when no auth method is configured")
+	}
+	if r.fix == "" {
+		t.Error("expected fix suggestion when auth fails")
+	}
+}
+
+func TestCheckClaudeAuth_NilConfig(t *testing.T) {
+	env := allPassEnv()
+	env.ParsedConfig = nil
+	env.Getenv = func(key string) string { return "" }
+	r := checkClaudeAuth(env)
+	if r.passed {
+		t.Error("expected claude-auth to fail when ParsedConfig is nil and no env vars set")
+	}
+}
+
+func TestCheckClaudeAuth_PrecedenceProxyOverAPIKey(t *testing.T) {
+	env := allPassEnv()
+	env.ParsedConfig = &config.Config{
+		Sandbox: config.SandboxConfig{
+			Proxy: config.SandboxProxyConfig{Enabled: true},
+		},
+	}
+	env.Getenv = func(key string) string {
+		if key == "ANTHROPIC_API_KEY" {
+			return "sk-ant-test"
+		}
+		return ""
+	}
+	r := checkClaudeAuth(env)
+	if !r.passed {
+		t.Error("expected claude-auth to pass")
+	}
+	// Should report proxy, not API key — proxy takes precedence.
+	if !strings.Contains(r.detail, "proxy") {
+		t.Errorf("expected proxy to take precedence, got: %q", r.detail)
+	}
+}
+
+func TestCheckClaudeAuth_PrecedenceAPIKeyOverHelper(t *testing.T) {
+	env := allPassEnv()
+	env.ParsedConfig = &config.Config{
+		Auth: config.AuthConfig{ApiKeyHelper: "/bin/helper"},
+	}
+	env.Getenv = func(key string) string {
+		if key == "ANTHROPIC_API_KEY" {
+			return "sk-ant-test"
+		}
+		return ""
+	}
+	r := checkClaudeAuth(env)
+	if !r.passed {
+		t.Error("expected claude-auth to pass")
+	}
+	// Should report API key, not helper — API key takes precedence.
+	if !strings.Contains(r.detail, "ANTHROPIC_API_KEY") {
+		t.Errorf("expected ANTHROPIC_API_KEY to take precedence, got: %q", r.detail)
+	}
+}
 
 func TestCheckBranchProtection_SkippedWhenGhMissing(t *testing.T) {
 	env := allPassEnv()

--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -396,6 +396,7 @@ func runPipeline(cfg *config.Config, opts pipelineOpts) error {
 		},
 		ContextBudget:     cfg.Limits.ContextBudget,
 		Notify:            convertNotifyConfig(cfg.Notify),
+		ApiKeyHelper:      cfg.Auth.ApiKeyHelper,
 		Mode:              mode,
 		PRPoller:          prPoller,
 		SelfUser:          selfUser,

--- a/cmd/soda/spec.go
+++ b/cmd/soda/spec.go
@@ -103,6 +103,7 @@ func runSpec(cmd *cobra.Command, cfg *config.Config, description string, autoCon
 		AllowedTools: []string{"Read", "Glob", "Grep", "Bash(ls:*)", "Bash(wc:*)", "Bash(head:*)", "Bash(git:*)"},
 		WorkDir:      workDir,
 		Model:        cfg.Model,
+		ApiKeyHelper: cfg.Auth.ApiKeyHelper,
 	})
 	if err != nil {
 		return fmt.Errorf("spec: claude run: %w", err)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -29,6 +29,14 @@ mode: autonomous   # or "checkpoint"
 # Model (used for all phases in v1)
 model: claude-opus-4-6
 
+# Authentication — optional keychain/vault-based credential injection.
+# When api_key_helper is set, SODA writes a Claude Code settings file
+# with apiKeyHelper pointing to this script. The script must print a
+# valid API key to stdout. This avoids exporting ANTHROPIC_API_KEY in
+# the shell environment.
+# auth:
+#   api_key_helper: /usr/local/bin/get-api-key
+
 # Sandbox (via go-arapuca)
 sandbox:
   enabled: true

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -86,7 +86,9 @@ auth:
 
 When `api_key_helper` is set, SODA writes a temporary Claude Code settings file with `apiKeyHelper` pointing to the configured script. Claude Code invokes the script before each API call to obtain a fresh key. This avoids storing long-lived keys in environment variables.
 
-Example helper script (`~/.local/bin/get-claude-key`):
+> **Path requirement:** The path must be absolute (e.g., `/home/user/.local/bin/get-claude-key`). A leading `~/` is expanded to your home directory automatically, but relative paths like `./scripts/get-key` are not supported and will cause sandbox errors.
+
+Example helper script (`/home/user/.local/bin/get-claude-key`):
 
 ```bash
 #!/bin/bash
@@ -96,7 +98,9 @@ security find-generic-password -s "anthropic-api-key" -w
 
 ```yaml
 auth:
-  api_key_helper: ~/.local/bin/get-claude-key
+  api_key_helper: /home/user/.local/bin/get-claude-key
+  # or use ~/ shorthand (expanded automatically):
+  # api_key_helper: ~/.local/bin/get-claude-key
 ```
 
 Run `soda doctor` to verify your authentication setup — the `claude-auth` check

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -68,6 +68,42 @@ Multiple extraction strategies are tried in order — description markers, then 
 
 ---
 
+### Authentication
+
+SODA resolves Claude Code credentials using the following precedence chain
+(first match wins):
+
+1. **Sandbox proxy** (`sandbox.proxy.enabled: true`) — the proxy injects credentials on the host side; no API key needed inside the sandbox.
+2. **`ANTHROPIC_API_KEY`** environment variable — the simplest method for direct API access.
+3. **Vertex AI** (`CLAUDE_CODE_USE_VERTEX` env var) — uses Google Cloud Application Default Credentials.
+4. **`auth.api_key_helper`** — a script that prints an API key to stdout, useful for keychain/vault integration.
+5. **Claude Code login** — if none of the above are set, Claude Code falls back to its own `claude login` session.
+
+```yaml
+auth:
+  api_key_helper: string   # path to a script/binary that prints an API key to stdout (optional)
+```
+
+When `api_key_helper` is set, SODA writes a temporary Claude Code settings file with `apiKeyHelper` pointing to the configured script. Claude Code invokes the script before each API call to obtain a fresh key. This avoids storing long-lived keys in environment variables.
+
+Example helper script (`~/.local/bin/get-claude-key`):
+
+```bash
+#!/bin/bash
+# Fetch API key from macOS Keychain
+security find-generic-password -s "anthropic-api-key" -w
+```
+
+```yaml
+auth:
+  api_key_helper: ~/.local/bin/get-claude-key
+```
+
+Run `soda doctor` to verify your authentication setup — the `claude-auth` check
+reports which method was detected.
+
+---
+
 ### Model
 
 ```yaml

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -27,6 +27,16 @@ Verify your installation:
 claude --version
 ```
 
+**Authentication:** SODA needs a way to authenticate with the Anthropic API.
+The simplest method is to set the `ANTHROPIC_API_KEY` environment variable:
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+```
+
+For keychain or vault-based workflows, you can configure `auth.api_key_helper`
+in `soda.yaml` instead — see [Configuration: Authentication](configuration.md#authentication).
+
 ### 2. `gh` CLI — installed and authenticated
 
 SODA uses `gh` to fetch GitHub issues and create pull requests.
@@ -171,11 +181,12 @@ is ready to run the pipeline.
 ✓ git-repo: inside a git repository
 ✓ claude: /usr/local/bin/claude
 ✓ claude-version: 2.1.81
+✓ config: soda.yaml (local)
+✓ config-valid: soda.yaml parses successfully
+✓ claude-auth: ANTHROPIC_API_KEY is set
 ✓ gh: /usr/local/bin/gh
 ✓ gh-auth: authenticated
 ⚠ node: not found in PATH (optional, needed only for sandboxed execution)
-✓ config: soda.yaml (local)
-✓ config-valid: soda.yaml parses successfully
 
 All checks passed
 ```

--- a/internal/claude/args.go
+++ b/internal/claude/args.go
@@ -31,6 +31,9 @@ func BuildArgs(opts RunOpts, model string) []string {
 	if opts.SystemPromptPath != "" {
 		args = append(args, "--system-prompt-file", opts.SystemPromptPath)
 	}
+	if opts.SettingsPath != "" {
+		args = append(args, "--settings-path", opts.SettingsPath)
+	}
 	if opts.OutputSchema != "" {
 		args = append(args, "--json-schema", opts.OutputSchema)
 	}

--- a/internal/claude/args_test.go
+++ b/internal/claude/args_test.go
@@ -94,6 +94,24 @@ func TestBuildArgs(t *testing.T) {
 				"--model",
 			},
 		},
+		{
+			name:  "settings_path_included",
+			model: "",
+			opts: RunOpts{
+				SettingsPath: "/tmp/settings.json",
+			},
+			contains: []string{
+				"--settings-path", "/tmp/settings.json",
+			},
+		},
+		{
+			name:  "empty_settings_path_omits_flag",
+			model: "",
+			opts:  RunOpts{SettingsPath: ""},
+			excludes: []string{
+				"--settings-path",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/claude/types.go
+++ b/internal/claude/types.go
@@ -8,6 +8,7 @@ import (
 // RunOpts holds per-invocation configuration for a single phase run.
 type RunOpts struct {
 	SystemPromptPath string        // path to system prompt file
+	SettingsPath     string        // path to Claude Code settings JSON (--settings-path)
 	OutputSchema     string        // JSON schema string passed to --json-schema
 	AllowedTools     []string      // tool names for --allowed-tools
 	MaxBudgetUSD     *float64      // nil = omit flag; non-nil = emit value

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -258,7 +259,24 @@ func Load(path string) (*Config, error) {
 		return nil, fmt.Errorf("config: parse %s: %w", path, err)
 	}
 
+	// Expand ~ prefix in paths that users commonly set to home-relative values.
+	cfg.Auth.ApiKeyHelper = expandHome(cfg.Auth.ApiKeyHelper)
+
 	return &cfg, nil
+}
+
+// expandHome expands a leading "~/" in path to the current user's home
+// directory. Go does not perform shell-style tilde expansion, so paths
+// like "~/bin/get-key" would fail at runtime without this helper. If the
+// home directory cannot be determined, the path is returned unchanged.
+func expandHome(path string) string {
+	if strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err == nil {
+			return filepath.Join(home, path[2:])
+		}
+	}
+	return path
 }
 
 // DefaultPath returns the default config file path: ~/.config/soda/config.yaml.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	GitHub       GitHubTicketConfig  `yaml:"github"`
 	Mode         string              `yaml:"mode"`
 	Model        string              `yaml:"model"`
+	Auth         AuthConfig          `yaml:"auth"`
 	Sandbox      SandboxConfig       `yaml:"sandbox"`
 	Limits       LimitsConfig        `yaml:"limits"`
 	PhasesPath   string              `yaml:"phases_path"`  // explicit path to pipeline YAML; overrides CWD discovery
@@ -27,6 +28,15 @@ type Config struct {
 	Repos        []RepoConfig        `yaml:"repos"`
 	Monitor      MonitorConfig       `yaml:"monitor"`
 	Notify       NotifyConfig        `yaml:"notify"`
+}
+
+// AuthConfig holds authentication settings for the Claude Code CLI.
+// ApiKeyHelper is the path to a script or binary that prints an API key
+// to stdout. When set, SODA writes a Claude Code settings file with
+// apiKeyHelper pointing to this path, enabling keychain/vault-based
+// credential injection without exporting ANTHROPIC_API_KEY.
+type AuthConfig struct {
+	ApiKeyHelper string `yaml:"api_key_helper,omitempty"`
 }
 
 // MonitorConfig holds monitor phase settings loaded from the config file.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -378,6 +378,59 @@ func TestMarshalRoundTrip_MonitorConfig(t *testing.T) {
 	}
 }
 
+func TestExpandHome(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("cannot determine home directory")
+	}
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"~/bin/get-key", filepath.Join(home, "bin/get-key")},
+		{"~/.local/bin/helper", filepath.Join(home, ".local/bin/helper")},
+		{"/usr/local/bin/helper", "/usr/local/bin/helper"},
+		{"relative/path", "relative/path"},
+		{"", ""},
+		{"~", "~"},                 // bare ~ without slash is NOT expanded
+		{"~user/bin", "~user/bin"}, // ~user syntax is NOT expanded
+	}
+
+	for _, tt := range tests {
+		got := expandHome(tt.input)
+		if got != tt.want {
+			t.Errorf("expandHome(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestLoad_TildeExpansion(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("cannot determine home directory")
+	}
+
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "soda.yaml")
+	content := `auth:
+  api_key_helper: ~/.local/bin/get-key
+`
+	if err := os.WriteFile(cfgFile, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(cfgFile)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	want := filepath.Join(home, ".local/bin/get-key")
+	if cfg.Auth.ApiKeyHelper != want {
+		t.Errorf("Auth.ApiKeyHelper = %q, want %q (tilde should be expanded)", cfg.Auth.ApiKeyHelper, want)
+	}
+}
+
 func TestRepoConfigFieldParity(t *testing.T) {
 	configType := reflect.TypeOf(RepoConfig{})
 	pipelineType := reflect.TypeOf(pipeline.RepoConfig{})

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -35,6 +35,9 @@ func TestLoad(t *testing.T) {
 				if cfg.Model != "claude-opus-4-6" {
 					t.Errorf("Model = %q, want %q", cfg.Model, "claude-opus-4-6")
 				}
+				if cfg.Auth.ApiKeyHelper != "/usr/local/bin/get-api-key" {
+					t.Errorf("Auth.ApiKeyHelper = %q, want %q", cfg.Auth.ApiKeyHelper, "/usr/local/bin/get-api-key")
+				}
 				if cfg.Limits.MaxCostPerTicket != 15.0 {
 					t.Errorf("MaxCostPerTicket = %f, want 15.0", cfg.Limits.MaxCostPerTicket)
 				}
@@ -159,6 +162,10 @@ func TestLoad(t *testing.T) {
 				}
 				if len(cfg.Repos) != 0 {
 					t.Errorf("len(Repos) = %d, want 0", len(cfg.Repos))
+				}
+				// Auth config should be zero-valued when not in file.
+				if cfg.Auth.ApiKeyHelper != "" {
+					t.Errorf("Auth.ApiKeyHelper = %q, want empty", cfg.Auth.ApiKeyHelper)
 				}
 				// Monitor config should be zero-valued when not in file.
 				if cfg.Monitor.SelfUser != "" {

--- a/internal/config/testdata/valid.yaml
+++ b/internal/config/testdata/valid.yaml
@@ -25,6 +25,8 @@ github:
     end_marker: "<!-- plan:end -->"
 mode: autonomous
 model: claude-opus-4-6
+auth:
+  api_key_helper: /usr/local/bin/get-api-key
 sandbox:
   enabled: true
   binary: agent-node

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -67,6 +67,7 @@ type EngineConfig struct {
 	TokenBudget            TokenBudgetConfig // prompt token budget estimation; zero value disables checks
 	ContextBudget          int               // global default context budget in tokens; 0 disables adaptive fitting
 	Notify                 NotifyConfig      // notification hooks fired on pipeline completion; zero value disables
+	ApiKeyHelper           string            // path to script that prints an API key; wired into runner.RunOpts
 	MergeMethod            string            // merge method: "merge", "squash", "rebase"; defaults to "squash"
 	MergeLabels            []string          // required PR labels before auto-merge proceeds
 	AutoMergeTimeout       time.Duration     // max wait after approval before giving up; defaults to 30m
@@ -797,6 +798,7 @@ func (e *Engine) runPhase(ctx context.Context, phase PhaseConfig) error {
 		Model:        model,
 		Timeout:      phase.Timeout.Duration,
 		OnChunk:      e.makeOnChunk(ctx, phase.Name),
+		ApiKeyHelper: e.config.ApiKeyHelper,
 	}
 
 	// Run with retry.

--- a/internal/runner/claude.go
+++ b/internal/runner/claude.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -37,6 +38,18 @@ func (r *ClaudeRunner) Run(ctx context.Context, opts RunOpts) (*RunResult, error
 	if opts.MaxBudgetUSD > 0 {
 		budget := opts.MaxBudgetUSD
 		claudeOpts.MaxBudgetUSD = &budget
+	}
+
+	// When ApiKeyHelper is set, write a temporary Claude Code settings file
+	// and pass its path via --settings-path. Follows the same temp-file
+	// pattern as the system prompt below.
+	if opts.ApiKeyHelper != "" {
+		settingsPath, err := writeSettingsFile(opts.WorkDir, opts.ApiKeyHelper)
+		if err != nil {
+			return nil, fmt.Errorf("claude runner: write settings file: %w", err)
+		}
+		defer os.Remove(settingsPath)
+		claudeOpts.SettingsPath = settingsPath
 	}
 
 	// claude.Runner expects a file path for the system prompt, not content.
@@ -91,6 +104,42 @@ func mapClaudeError(err error) error {
 		}
 	}
 	return err
+}
+
+// writeSettingsFile writes a Claude Code settings JSON file with an apiKeyHelper
+// entry and returns its absolute path. The caller is responsible for removing
+// the file after use.
+func writeSettingsFile(dir, apiKeyHelper string) (string, error) {
+	if dir == "" {
+		dir = os.TempDir()
+	}
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return "", err
+	}
+
+	settings := map[string]string{
+		"apiKeyHelper": apiKeyHelper,
+	}
+	data, err := json.Marshal(settings)
+	if err != nil {
+		return "", err
+	}
+
+	f, err := os.CreateTemp(abs, "soda-settings-*.json")
+	if err != nil {
+		return "", err
+	}
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		os.Remove(f.Name())
+		return "", err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(f.Name())
+		return "", err
+	}
+	return f.Name(), nil
 }
 
 // writeSystemPromptFile writes content to a temp file in dir and returns its absolute path.

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -24,6 +24,7 @@ type RunOpts struct {
 	Model        string        // model to use
 	Timeout      time.Duration // phase timeout
 	OnChunk      func(string)  // called for each streamed output line; may be nil
+	ApiKeyHelper string        // path to a script that prints an API key to stdout
 }
 
 // RunResult holds the parsed response from a phase execution.

--- a/internal/runner/settings_test.go
+++ b/internal/runner/settings_test.go
@@ -1,0 +1,68 @@
+package runner
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteSettingsFile(t *testing.T) {
+	t.Run("writes_valid_json_with_apiKeyHelper", func(t *testing.T) {
+		dir := t.TempDir()
+		helper := "/usr/local/bin/get-api-key"
+
+		path, err := writeSettingsFile(dir, helper)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer os.Remove(path)
+
+		if !filepath.IsAbs(path) {
+			t.Errorf("path is not absolute: %s", path)
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("failed to read settings file: %v", err)
+		}
+
+		var settings map[string]string
+		if err := json.Unmarshal(data, &settings); err != nil {
+			t.Fatalf("failed to parse settings JSON: %v", err)
+		}
+
+		if got := settings["apiKeyHelper"]; got != helper {
+			t.Errorf("apiKeyHelper = %q, want %q", got, helper)
+		}
+	})
+
+	t.Run("file_is_removable", func(t *testing.T) {
+		dir := t.TempDir()
+
+		path, err := writeSettingsFile(dir, "/bin/helper")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if err := os.Remove(path); err != nil {
+			t.Errorf("failed to remove settings file: %v", err)
+		}
+
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Errorf("settings file still exists after removal")
+		}
+	})
+
+	t.Run("falls_back_to_os_tempdir_when_dir_empty", func(t *testing.T) {
+		path, err := writeSettingsFile("", "/bin/helper")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer os.Remove(path)
+
+		if !filepath.IsAbs(path) {
+			t.Errorf("path is not absolute: %s", path)
+		}
+	})
+}

--- a/internal/sandbox/runner.go
+++ b/internal/sandbox/runner.go
@@ -105,6 +105,10 @@ func (r *Runner) Run(ctx context.Context, opts runner.RunOpts) (*runner.RunResul
 	var settingsPath string
 	var extraReadForHelper []string
 	if opts.ApiKeyHelper != "" {
+		if !filepath.IsAbs(opts.ApiKeyHelper) {
+			return nil, fmt.Errorf("sandbox: ApiKeyHelper must be an absolute path, got %q", opts.ApiKeyHelper)
+		}
+
 		settingsData, jsonErr := json.Marshal(map[string]string{
 			"apiKeyHelper": opts.ApiKeyHelper,
 		})
@@ -123,10 +127,7 @@ func (r *Runner) Run(ctx context.Context, opts runner.RunOpts) (*runner.RunResul
 		sf.Close()
 
 		// Allow the sandbox to read the helper script's parent directory.
-		helperDir := filepath.Dir(opts.ApiKeyHelper)
-		if filepath.IsAbs(helperDir) {
-			extraReadForHelper = append(extraReadForHelper, helperDir)
-		}
+		extraReadForHelper = append(extraReadForHelper, filepath.Dir(opts.ApiKeyHelper))
 	}
 
 	// Build Claude CLI args via exported BuildArgs.

--- a/internal/sandbox/runner.go
+++ b/internal/sandbox/runner.go
@@ -5,6 +5,7 @@ package sandbox
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -97,6 +98,37 @@ func (r *Runner) Run(ctx context.Context, opts runner.RunOpts) (*runner.RunResul
 		// No need for deferred Remove — tmpDir cleanup handles it.
 	}
 
+	// When ApiKeyHelper is set, write a settings JSON file in tmpDir so
+	// Claude Code picks up the apiKeyHelper configuration. Also add the
+	// helper script's parent directory to extra read paths so the sandbox
+	// allows the CLI to execute it.
+	var settingsPath string
+	var extraReadForHelper []string
+	if opts.ApiKeyHelper != "" {
+		settingsData, jsonErr := json.Marshal(map[string]string{
+			"apiKeyHelper": opts.ApiKeyHelper,
+		})
+		if jsonErr != nil {
+			return nil, fmt.Errorf("sandbox: marshal settings JSON: %w", jsonErr)
+		}
+		sf, sfErr := os.CreateTemp(tmpDir, ".soda-settings-*.json")
+		if sfErr != nil {
+			return nil, fmt.Errorf("sandbox: create settings file: %w", sfErr)
+		}
+		settingsPath = sf.Name()
+		if _, wErr := sf.Write(settingsData); wErr != nil {
+			sf.Close()
+			return nil, fmt.Errorf("sandbox: write settings file: %w", wErr)
+		}
+		sf.Close()
+
+		// Allow the sandbox to read the helper script's parent directory.
+		helperDir := filepath.Dir(opts.ApiKeyHelper)
+		if filepath.IsAbs(helperDir) {
+			extraReadForHelper = append(extraReadForHelper, helperDir)
+		}
+	}
+
 	// Build Claude CLI args via exported BuildArgs.
 	var budgetPtr *float64
 	if opts.MaxBudgetUSD > 0 {
@@ -104,6 +136,7 @@ func (r *Runner) Run(ctx context.Context, opts runner.RunOpts) (*runner.RunResul
 	}
 	claudeOpts := claude.RunOpts{
 		SystemPromptPath: sysPromptPath,
+		SettingsPath:     settingsPath,
 		OutputSchema:     opts.OutputSchema,
 		AllowedTools:     opts.AllowedTools,
 		MaxBudgetUSD:     budgetPtr,
@@ -114,8 +147,11 @@ func (r *Runner) Run(ctx context.Context, opts runner.RunOpts) (*runner.RunResul
 	// Append user prompt as positional arg (stdin workaround — see issue #2 Fix 4).
 	args = append(args, "-p", opts.UserPrompt)
 
-	// Build sandbox profile.
-	sp := buildSandboxPaths(opts.WorkDir, tmpDir, r.claudeRead, r.config.ExtraReadPaths, r.config.ExtraWritePaths)
+	// Build sandbox profile. Include helper script's parent dir in extra read paths.
+	// Copy the slice to avoid mutating r.config.ExtraReadPaths across calls.
+	combinedExtraRead := append([]string{}, r.config.ExtraReadPaths...)
+	combinedExtraRead = append(combinedExtraRead, extraReadForHelper...)
+	sp := buildSandboxPaths(opts.WorkDir, tmpDir, r.claudeRead, combinedExtraRead, r.config.ExtraWritePaths)
 
 	useNetNS := r.config.UseNetNS
 	var llmProxy *proxy.Proxy


### PR DESCRIPTION
## Summary

Add apiKeyHelper support for Claude Code authentication in --bare mode. Documents auth requirements and improves soda doctor auth checks.

## Changes

- `auth.api_key_helper` config field in soda.yaml
- `--settings` JSON constructed and passed to Claude CLI when helper configured
- Helper script path added to sandbox read paths
- `soda doctor` checks auth with clear fix suggestions
- Auth precedence: proxy → API key → Vertex → apiKeyHelper → error
- Documentation of --bare auth requirements

Closes #433