### PR TITLE
fix(ci): add linux-amd64 binary to release matrix

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,10 @@ jobs:
         include:
           - goos: linux
             goarch: amd64
+            cgo: "0"
+            suffix: linux-amd64
+          - goos: linux
+            goarch: amd64
             cgo: "1"
             suffix: linux-amd64-sandbox
           - goos: linux


### PR DESCRIPTION
## Problem

Every release since v0.1.0 shipped without a Linux x86_64 binary. The only linux-amd64 entry in the release matrix was the sandbox build (CGO=1), which always fails due to go-arapuca LFS. Linux x86_64 users — the primary platform — had no binary to download.

## Fix

Add a `linux-amd64` (CGO=0, no sandbox) entry to the matrix alongside the existing `linux-amd64-sandbox` (CGO=1) entry. Both build independently. If sandbox fails, the non-sandbox binary still ships.