### PR TITLE
chore: upgrade go-arapuca v0.2.0, replace LFS with pkg-config build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -154,8 +154,9 @@ jobs:
 
       - name: Build and install libarapuca
         run: |
-          git clone --depth 1 --branch v0.1.1 https://github.com/sergio-correia/arapuca /tmp/arapuca
+          git clone https://github.com/sergio-correia/arapuca /tmp/arapuca
           cd /tmp/arapuca
+          git checkout de97447cec63161bf4a209ac1a45cf4f40693099
           cargo install cbindgen
           make install PREFIX=$HOME/.local
           echo "PKG_CONFIG_PATH=$HOME/.local/lib/pkgconfig" >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -150,11 +150,11 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y gcc pkg-config
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Build and install libarapuca
         run: |
-          git clone --depth 1 https://github.com/sergio-correia/arapuca /tmp/arapuca
+          git clone --depth 1 --branch v0.1.1 https://github.com/sergio-correia/arapuca /tmp/arapuca
           cd /tmp/arapuca
           cargo install cbindgen
           make install PREFIX=$HOME/.local

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -138,7 +138,6 @@ jobs:
     name: Integration (Sandbox)
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    continue-on-error: true  # LFS fetch for go-arapuca is fragile (see gotcha #22)
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -147,25 +146,19 @@ jobs:
           go-version: "1.25"
           cache: true
 
-      - name: Install curl
-        run: sudo apt-get update && sudo apt-get install -y curl
+      - name: Install build dependencies
+        run: sudo apt-get update && sudo apt-get install -y gcc pkg-config
 
-      - name: Fetch go-arapuca LFS binary
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build and install libarapuca
         run: |
-          mod_dir="$(go env GOMODCACHE)/github.com/sergio-correia/go-arapuca@$(go list -m -f '{{.Version}}' github.com/sergio-correia/go-arapuca)"
-          lib_path="${mod_dir}/lib/linux_amd64/libarapuca.a"
-          if [ -f "$lib_path" ] && file "$lib_path" | grep -q "ASCII"; then
-            oid=$(awk '/^oid sha256:/{print substr($2,8)}' "$lib_path")
-            url="https://github.com/sergio-correia/go-arapuca.git/info/lfs/objects/batch"
-            download_url=$(curl -s -X POST "$url" \
-              -H "Content-Type: application/vnd.git-lfs+json" \
-              -d "{\"operation\":\"download\",\"objects\":[{\"oid\":\"${oid}\",\"size\":1}]}" \
-              | python3 -c "import sys,json; print(json.load(sys.stdin)['objects'][0]['actions']['download']['href'])")
-            chmod u+w "$(dirname "$lib_path")"
-            chmod u+w "$lib_path"
-            curl -sL "$download_url" -o "$lib_path"
-            echo "Fetched libarapuca.a ($(wc -c < "$lib_path") bytes)"
-          fi
+          git clone --depth 1 https://github.com/sergio-correia/arapuca /tmp/arapuca
+          cd /tmp/arapuca
+          cargo install cbindgen
+          make install PREFIX=$HOME/.local
+          echo "PKG_CONFIG_PATH=$HOME/.local/lib/pkgconfig" >> "$GITHUB_ENV"
 
       - name: Run sandbox integration tests
         env:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -77,8 +77,9 @@ jobs:
       - name: Build and install libarapuca (cgo builds)
         if: matrix.cgo == '1'
         run: |
-          git clone --depth 1 --branch v0.1.1 https://github.com/sergio-correia/arapuca /tmp/arapuca
+          git clone https://github.com/sergio-correia/arapuca /tmp/arapuca
           cd /tmp/arapuca
+          git checkout de97447cec63161bf4a209ac1a45cf4f40693099
           cargo install cbindgen
           make install PREFIX=$HOME/.local
           echo "PKG_CONFIG_PATH=$HOME/.local/lib/pkgconfig" >> "$GITHUB_ENV"

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -68,25 +68,20 @@ jobs:
 
       - name: Install gcc (cgo builds)
         if: matrix.cgo == '1'
-        run: sudo apt-get update && sudo apt-get install -y gcc
+        run: sudo apt-get update && sudo apt-get install -y gcc pkg-config
 
-      - name: Fetch go-arapuca LFS binary (cgo builds)
+      - name: Install Rust toolchain (cgo builds)
+        if: matrix.cgo == '1'
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build and install libarapuca (cgo builds)
         if: matrix.cgo == '1'
         run: |
-          mod_dir="$(go env GOMODCACHE)/github.com/sergio-correia/go-arapuca@$(go list -m -f '{{.Version}}' github.com/sergio-correia/go-arapuca)"
-          lib_path="${mod_dir}/lib/linux_amd64/libarapuca.a"
-          if [ -f "$lib_path" ] && file "$lib_path" | grep -q "ASCII"; then
-            oid=$(awk '/^oid sha256:/{print substr($2,8)}' "$lib_path")
-            url="https://github.com/sergio-correia/go-arapuca.git/info/lfs/objects/batch"
-            download_url=$(curl -s -X POST "$url" \
-              -H "Content-Type: application/vnd.git-lfs+json" \
-              -d "{\"operation\":\"download\",\"objects\":[{\"oid\":\"${oid}\",\"size\":1}]}" \
-              | python3 -c "import sys,json; print(json.load(sys.stdin)['objects'][0]['actions']['download']['href'])")
-            chmod u+w "$(dirname "$lib_path")"
-            chmod u+w "$lib_path"
-            curl -sL "$download_url" -o "$lib_path"
-            echo "Fetched libarapuca.a ($(wc -c < "$lib_path") bytes)"
-          fi
+          git clone --depth 1 https://github.com/sergio-correia/arapuca /tmp/arapuca
+          cd /tmp/arapuca
+          cargo install cbindgen
+          make install PREFIX=$HOME/.local
+          echo "PKG_CONFIG_PATH=$HOME/.local/lib/pkgconfig" >> "$GITHUB_ENV"
 
       - name: Build
         env:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -72,12 +72,12 @@ jobs:
 
       - name: Install Rust toolchain (cgo builds)
         if: matrix.cgo == '1'
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Build and install libarapuca (cgo builds)
         if: matrix.cgo == '1'
         run: |
-          git clone --depth 1 https://github.com/sergio-correia/arapuca /tmp/arapuca
+          git clone --depth 1 --branch v0.1.1 https://github.com/sergio-correia/arapuca /tmp/arapuca
           cd /tmp/arapuca
           cargo install cbindgen
           make install PREFIX=$HOME/.local

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,36 +50,20 @@ jobs:
 
       - name: Install gcc (cgo builds)
         if: matrix.cgo == '1'
-        run: sudo apt-get update && sudo apt-get install -y gcc
+        run: sudo apt-get update && sudo apt-get install -y gcc pkg-config
 
-      - name: Fetch go-arapuca LFS binary (cgo builds)
+      - name: Install Rust toolchain (cgo builds)
         if: matrix.cgo == '1'
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ github.token }}
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build and install libarapuca (cgo builds)
+        if: matrix.cgo == '1'
         run: |
-          mod_dir="$(go env GOMODCACHE)/github.com/sergio-correia/go-arapuca@$(go list -m -f '{{.Version}}' github.com/sergio-correia/go-arapuca)"
-          lib_path="${mod_dir}/lib/linux_amd64/libarapuca.a"
-          if [ -f "$lib_path" ] && file "$lib_path" | grep -q "ASCII"; then
-            oid=$(awk '/^oid sha256:/{print substr($2,8)}' "$lib_path")
-            url="https://github.com/sergio-correia/go-arapuca.git/info/lfs/objects/batch"
-            response=$(curl -s -X POST "$url" \
-              -H "Content-Type: application/vnd.git-lfs+json" \
-              -H "Authorization: Bearer ${GH_TOKEN}" \
-              -d "{\"operation\":\"download\",\"objects\":[{\"oid\":\"${oid}\",\"size\":1}]}")
-            download_url=$(echo "$response" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['objects'][0]['actions']['download']['href'])" 2>/dev/null) || {
-              echo "::warning::Failed to fetch LFS binary — sandbox build will be skipped"
-              echo "LFS API response: $response"
-              exit 1
-            }
-            chmod u+w "$(dirname "$lib_path")"
-            chmod u+w "$lib_path"
-            curl -sfL "$download_url" -o "$lib_path" || {
-              echo "ERROR: Failed to download libarapuca.a from LFS"
-              exit 1
-            }
-            echo "Fetched libarapuca.a ($(wc -c < "$lib_path") bytes)"
-          fi
+          git clone --depth 1 https://github.com/sergio-correia/arapuca /tmp/arapuca
+          cd /tmp/arapuca
+          cargo install cbindgen
+          make install PREFIX=$HOME/.local
+          echo "PKG_CONFIG_PATH=$HOME/.local/lib/pkgconfig" >> "$GITHUB_ENV"
 
       - name: Build
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,12 +54,12 @@ jobs:
 
       - name: Install Rust toolchain (cgo builds)
         if: matrix.cgo == '1'
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Build and install libarapuca (cgo builds)
         if: matrix.cgo == '1'
         run: |
-          git clone --depth 1 https://github.com/sergio-correia/arapuca /tmp/arapuca
+          git clone --depth 1 --branch v0.1.1 https://github.com/sergio-correia/arapuca /tmp/arapuca
           cd /tmp/arapuca
           cargo install cbindgen
           make install PREFIX=$HOME/.local

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,8 +59,9 @@ jobs:
       - name: Build and install libarapuca (cgo builds)
         if: matrix.cgo == '1'
         run: |
-          git clone --depth 1 --branch v0.1.1 https://github.com/sergio-correia/arapuca /tmp/arapuca
+          git clone https://github.com/sergio-correia/arapuca /tmp/arapuca
           cd /tmp/arapuca
+          git checkout de97447cec63161bf4a209ac1a45cf4f40693099
           cargo install cbindgen
           make install PREFIX=$HOME/.local
           echo "PKG_CONFIG_PATH=$HOME/.local/lib/pkgconfig" >> "$GITHUB_ENV"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **go-arapuca upgraded v0.1.1 → v0.2.0** — switches from vendored static library
+  (git-lfs, permanently broken in Go module proxy) to `pkg-config` build. The sandbox
+  binary is now built from source via the `arapuca` Rust crate. End-user binaries remain
+  fully self-contained (static linking).
+- **CI: replaced LFS fetch workaround** with `make install` from arapuca source in all
+  workflows (release, nightly, CI). Sandbox builds now succeed reliably.
+- **Release workflow**: uploads assets to existing releases (supports manual creation
+  with milestone titles), adds linux-amd64 non-sandbox binary to matrix.
+
 ## [0.3.0] — "Right-Sized" - 2026-04-28
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/mattn/go-isatty v0.0.21
-	github.com/sergio-correia/go-arapuca v0.1.1
+	github.com/sergio-correia/go-arapuca v0.2.0
 	github.com/spf13/cobra v1.10.2
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/sergio-correia/go-arapuca v0.1.1 h1:9JiazgSiWj2Kcej3Z+yQkJbJNI1GRnxpExw3LWmddnE=
-github.com/sergio-correia/go-arapuca v0.1.1/go.mod h1:n3QwYrcRa8hGT5Xc6T1OAogHNzn/lTm5XaQmQhOJhuM=
+github.com/sergio-correia/go-arapuca v0.2.0 h1:uQa5J4i2xBtHjxffbBcXHcGp+AS0WeuZ9GJP+XWw/UI=
+github.com/sergio-correia/go-arapuca v0.2.0/go.mod h1:n3QwYrcRa8hGT5Xc6T1OAogHNzn/lTm5XaQmQhOJhuM=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=


### PR DESCRIPTION
## Summary

Upgrade go-arapuca from v0.1.1 (vendored LFS binary, permanently broken in Go module proxy) to v0.2.0 (pkg-config, build from source).

## Problem

Every CI sandbox build has failed since v0.1.0. The Go module proxy cached the LFS pointer at v0.1.1 tag time — `go mod download` always gets a 133-byte text file instead of the 22MB static library. No linux-amd64-sandbox binary has ever shipped in a release.

## Fix

- **go.mod**: `go-arapuca v0.1.1 → v0.2.0`
- **All CI workflows**: replace fragile LFS fetch workaround with reliable Rust build-from-source (`make install` from arapuca crate)
- **ci.yaml**: remove `continue-on-error` on sandbox integration job (builds are reliable now)
- **CHANGELOG**: document the upgrade

## Build prerequisites (sandbox)

```bash
# One-time setup
git clone https://github.com/sergio-correia/arapuca /tmp/arapuca
cd /tmp/arapuca && cargo install cbindgen && make install PREFIX=$HOME/.local
export PKG_CONFIG_PATH=$HOME/.local/lib/pkgconfig

# Build soda with sandbox
CGO_ENABLED=1 go build -ldflags "-s -w" -o soda ./cmd/soda
```

End-user binaries are fully self-contained — `libarapuca.a` is statically linked.