### PR TITLE
fix(sandbox): resolve Vertex global region for proxy and model validation

### DIFF
--- a/internal/sandbox/resolve.go
+++ b/internal/sandbox/resolve.go
@@ -134,10 +134,39 @@ func claudeEnv(tmpDir string, opts runner.RunOpts, claudeBin, proxyURL string) [
 				"ANTHROPIC_VERTEX_BASE_URL="+proxyURL,
 				"CLAUDE_CODE_SKIP_VERTEX_AUTH=1",
 			)
-			for _, key := range []string{"VERTEXAI_PROJECT", "VERTEXAI_LOCATION", "CLOUD_ML_REGION", "ANTHROPIC_VERTEX_PROJECT_ID"} {
+			// Resolve the Vertex region. Claude Code validates model
+			// availability directly (bypassing the proxy) using
+			// CLOUD_ML_REGION. The "global" region doesn't host models,
+			// so we fall back to the proxy's upstream region.
+			region := os.Getenv("CLOUD_ML_REGION")
+			if region == "" || region == "global" {
+				region = os.Getenv("VERTEXAI_LOCATION")
+			}
+			if region == "" || region == "global" {
+				region = "us-east5"
+			}
+			for _, key := range []string{"VERTEXAI_PROJECT", "ANTHROPIC_VERTEX_PROJECT_ID"} {
 				if val := os.Getenv(key); val != "" {
 					env = append(env, key+"="+val)
 				}
+			}
+			env = append(env,
+				"VERTEXAI_LOCATION="+region,
+				"CLOUD_ML_REGION="+region,
+			)
+			// Claude Code validates model availability against the Vertex
+			// model catalog using ADC. Since HOME is overridden to tmpDir,
+			// the default ADC path (~/.config/gcloud/application_default_credentials.json)
+			// is unreachable. Point GOOGLE_APPLICATION_CREDENTIALS at the real file.
+			if os.Getenv("GOOGLE_APPLICATION_CREDENTIALS") == "" {
+				if realHome, err := os.UserHomeDir(); err == nil {
+					adcPath := filepath.Join(realHome, ".config", "gcloud", "application_default_credentials.json")
+					if _, err := os.Stat(adcPath); err == nil {
+						env = append(env, "GOOGLE_APPLICATION_CREDENTIALS="+adcPath)
+					}
+				}
+			} else {
+				env = append(env, "GOOGLE_APPLICATION_CREDENTIALS="+os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"))
 			}
 		} else {
 			// Direct Anthropic mode: fake API key + base URL.

--- a/internal/sandbox/runner.go
+++ b/internal/sandbox/runner.go
@@ -152,6 +152,25 @@ func (r *Runner) Run(ctx context.Context, opts runner.RunOpts) (*runner.RunResul
 	// Copy the slice to avoid mutating r.config.ExtraReadPaths across calls.
 	combinedExtraRead := append([]string{}, r.config.ExtraReadPaths...)
 	combinedExtraRead = append(combinedExtraRead, extraReadForHelper...)
+
+	// Vertex mode: Claude Code reads ~/.claude/claude.settings for Vertex
+	// env vars (project, region) and validates model availability against
+	// the Vertex model catalog using ADC. Since HOME is overridden to
+	// tmpDir inside the sandbox, both paths are unreachable without
+	// explicit read access. The proxy handles inference auth, but the
+	// model catalog pre-check and settings need filesystem access.
+	if os.Getenv("CLAUDE_CODE_USE_VERTEX") != "" {
+		if home, err := os.UserHomeDir(); err == nil {
+			gcloudDir := filepath.Join(home, ".config", "gcloud")
+			if _, err := os.Stat(gcloudDir); err == nil {
+				combinedExtraRead = append(combinedExtraRead, gcloudDir)
+			}
+			claudeDir := filepath.Join(home, ".claude")
+			if _, err := os.Stat(claudeDir); err == nil {
+				combinedExtraRead = append(combinedExtraRead, claudeDir)
+			}
+		}
+	}
 	sp := buildSandboxPaths(opts.WorkDir, tmpDir, r.claudeRead, combinedExtraRead, r.config.ExtraWritePaths)
 
 	useNetNS := r.config.UseNetNS
@@ -172,11 +191,13 @@ func (r *Runner) Run(ctx context.Context, opts runner.RunOpts) (*runner.RunResul
 
 		if os.Getenv("CLAUDE_CODE_USE_VERTEX") != "" {
 			// Vertex mode: resolve upstream URL and token source from ADC.
+			// The "global" region is used for billing/routing but doesn't
+			// host model endpoints. Fall back to a real region.
 			region := os.Getenv("CLOUD_ML_REGION")
-			if region == "" {
+			if region == "" || region == "global" {
 				region = os.Getenv("VERTEXAI_LOCATION")
 			}
-			if region == "" {
+			if region == "" || region == "global" {
 				region = "us-east5"
 			}
 			proxyCfg.UpstreamURL = fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1", region)

--- a/soda.yaml
+++ b/soda.yaml
@@ -19,6 +19,8 @@ sandbox:
     memory_mb: 2048
     cpu_percent: 200
     max_pids: 256
+  proxy:
+    enabled: true
 
 # Budget
 limits:


### PR DESCRIPTION
## Summary

- Fixes sandbox pipeline failures when `CLOUD_ML_REGION=global` — the "global" region is valid for Vertex AI billing but doesn't host model endpoints, causing Claude Code to report "model not available"
- Adds `~/.config/gcloud/` and `~/.claude/` to sandbox read paths for ADC and settings access in Vertex mode
- Enables proxy in `soda.yaml` for Vertex credential isolation

Closes #469

## Test plan

- [x] `go test ./internal/sandbox/` passes
- [x] Pipeline runs successfully with `CLOUD_ML_REGION=global` and proxy enabled
- [x] Pipeline runs successfully with `CLOUD_ML_REGION=us-east5` (no regression)
- [ ] Verify billing attribution is unaffected (global region stays in host env)


💖 Generated with Crush


Assisted-by: Claude Opus 4.6 via Crush <crush@charm.land>