### PR TITLE
feat(engine): prioritize rework snippet budget by finding severity (#474)

### DIFF
--- a/internal/pipeline/feedback.go
+++ b/internal/pipeline/feedback.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/decko/soda/schemas"
@@ -189,9 +190,11 @@ func findingBudgetCap(severity string) int {
 // what was previously reported. Only critical/major findings are
 // included to keep prompt context focused.
 //
-// Each finding is enriched with file content: full-file when budget allows,
-// falling back to ±5 lines when budget is exhausted. Same-file findings
-// share the cached content to avoid duplicate reads.
+// Findings are sorted by severity (critical first) so higher-priority
+// findings consume budget first. Each finding is enriched with file
+// content up to a severity-dependent cap (10KB critical, 5KB major),
+// falling back to a ±contextLines snippet when budget is exhausted.
+// Same-file findings share the cached raw content to avoid duplicate reads.
 func (e *Engine) extractReviewFeedback() *ReworkFeedback {
 	raw, err := e.state.ReadResult("review")
 	if err != nil {
@@ -211,9 +214,16 @@ func (e *Engine) extractReviewFeedback() *ReworkFeedback {
 		Source:  "review",
 	}
 
+	// Sort findings so critical issues are processed first and consume
+	// budget before lower-severity findings (stable to preserve original
+	// order within the same severity).
+	sort.SliceStable(result.Findings, func(i, j int) bool {
+		return severityRank(result.Findings[i].Severity) < severityRank(result.Findings[j].Severity)
+	})
+
 	workDir := e.workDir(PhaseConfig{})
 	budgetRemaining := maxFeedbackContextBytes
-	fileCache := make(map[string]string) // file path → cached content
+	rawCache := make(map[string]string) // file path → raw file content
 
 	// Only include critical and major findings, enriched with code context.
 	for _, finding := range result.Findings {
@@ -224,7 +234,7 @@ func (e *Engine) extractReviewFeedback() *ReworkFeedback {
 
 		ef := EnrichedFinding{ReviewFinding: finding}
 		if finding.File != "" {
-			ef.CodeSnippet = readFileForFinding(workDir, finding.File, finding.Line, &budgetRemaining, fileCache)
+			ef.CodeSnippet = readFileForFinding(workDir, finding.File, finding.Line, finding.Severity, &budgetRemaining, rawCache)
 		}
 		fb.ReviewFindings = append(fb.ReviewFindings, ef)
 	}
@@ -235,39 +245,69 @@ func (e *Engine) extractReviewFeedback() *ReworkFeedback {
 	return fb
 }
 
-// readFileForFinding returns file content for a review finding. It tries
-// full-file injection first (if budget allows), falling back to ±5 lines.
-// Same-file findings reuse cached content without consuming extra budget.
-func readFileForFinding(workDir, file string, line int, budgetRemaining *int, cache map[string]string) string {
-	// Check cache first — same file referenced by multiple findings.
-	if cached, ok := cache[file]; ok {
-		return cached
+// readFileForFinding returns file content for a review finding. The raw
+// file is cached on first read; subsequent calls for the same file
+// (possibly with a different severity) extract a severity-appropriate
+// window from the cached content without re-charging the budget.
+//
+// On a cache miss the full file is read and stored in rawCache. The
+// returned content is capped to findingBudgetCap(severity) bytes
+// (truncated to the last newline within the cap) and charged against
+// budgetRemaining. If the capped content exceeds the remaining budget,
+// a snippet of ±contextLines(severity) around the finding line is
+// returned instead (free — not charged).
+//
+// On a cache hit the same per-finding cap is applied to the already-
+// cached raw content, but no budget is charged (the file's bytes were
+// already counted on first access).
+func readFileForFinding(workDir, file string, line int, severity string, budgetRemaining *int, rawCache map[string]string) string {
+	raw, cached := rawCache[file]
+
+	if !cached {
+		resolved := filepath.Clean(filepath.Join(workDir, file))
+		if !strings.HasPrefix(resolved, filepath.Clean(workDir)+string(filepath.Separator)) {
+			return ""
+		}
+
+		data, err := os.ReadFile(resolved)
+		if err != nil {
+			return ""
+		}
+
+		raw = string(data)
+		rawCache[file] = raw
 	}
 
-	resolved := filepath.Clean(filepath.Join(workDir, file))
-	if !strings.HasPrefix(resolved, filepath.Clean(workDir)+string(filepath.Separator)) {
+	// Apply the per-finding cap, truncating to the last newline within the cap.
+	cap := findingBudgetCap(severity)
+	effective := raw
+	if len(effective) > cap {
+		effective = effective[:cap]
+		if idx := strings.LastIndex(effective, "\n"); idx > 0 {
+			effective = effective[:idx+1]
+		}
+	}
+
+	if cached {
+		// Cache hit — return severity-appropriate window without charging budget.
+		if effective != "" {
+			return effective
+		}
+		if line > 0 {
+			return extractSnippet(raw, line, contextLines(severity))
+		}
 		return ""
 	}
 
-	data, err := os.ReadFile(resolved)
-	if err != nil {
-		return ""
+	// Cache miss — charge budget if the effective content fits.
+	if len(effective) <= *budgetRemaining {
+		*budgetRemaining -= len(effective)
+		return effective
 	}
 
-	content := string(data)
-
-	// If the full file fits within budget, use it.
-	if len(data) <= *budgetRemaining {
-		*budgetRemaining -= len(data)
-		cache[file] = content
-		return content
-	}
-
-	// Budget exhausted for full file — fall back to ±5 lines snippet.
+	// Budget exhausted for capped content — fall back to snippet (free).
 	if line > 0 {
-		snippet := extractSnippet(content, line, 5)
-		cache[file] = snippet
-		return snippet
+		return extractSnippet(raw, line, contextLines(severity))
 	}
 
 	return ""

--- a/internal/pipeline/feedback.go
+++ b/internal/pipeline/feedback.go
@@ -279,7 +279,7 @@ func readFileForFinding(workDir, file string, line int, severity string, budgetR
 		raw = string(data)
 	}
 
-	cap := findingBudgetCap(severity)
+	budgetCap := findingBudgetCap(severity)
 
 	if cached {
 		// Cache hit — extract a window centered on the finding line, capped
@@ -287,8 +287,8 @@ func readFileForFinding(workDir, file string, line int, severity string, budgetR
 		// file when the finding is beyond the cap boundary.
 		if line > 0 {
 			snippet := extractSnippet(raw, line, contextLines(severity))
-			if len(snippet) > cap {
-				snippet = snippet[:cap]
+			if len(snippet) > budgetCap {
+				snippet = snippet[:budgetCap]
 				if idx := strings.LastIndex(snippet, "\n"); idx > 0 {
 					snippet = snippet[:idx+1]
 				}
@@ -296,8 +296,8 @@ func readFileForFinding(workDir, file string, line int, severity string, budgetR
 			return snippet
 		}
 		// No line info — return head of file, capped.
-		if len(raw) > cap {
-			raw = raw[:cap]
+		if len(raw) > budgetCap {
+			raw = raw[:budgetCap]
 			if idx := strings.LastIndex(raw, "\n"); idx > 0 {
 				raw = raw[:idx+1]
 			}
@@ -310,18 +310,18 @@ func readFileForFinding(workDir, file string, line int, severity string, budgetR
 	// the finding line (same logic as cache-hit path) so the LLM sees the
 	// relevant code regardless of where the finding is in the file.
 	var effective string
-	if len(raw) > cap && line > 0 {
+	if len(raw) > budgetCap && line > 0 {
 		effective = extractSnippet(raw, line, contextLines(severity))
-		if len(effective) > cap {
-			effective = effective[:cap]
+		if len(effective) > budgetCap {
+			effective = effective[:budgetCap]
 			if idx := strings.LastIndex(effective, "\n"); idx > 0 {
 				effective = effective[:idx+1]
 			}
 		}
 	} else {
 		effective = raw
-		if len(effective) > cap {
-			effective = effective[:cap]
+		if len(effective) > budgetCap {
+			effective = effective[:budgetCap]
 			if idx := strings.LastIndex(effective, "\n"); idx > 0 {
 				effective = effective[:idx+1]
 			}

--- a/internal/pipeline/feedback.go
+++ b/internal/pipeline/feedback.go
@@ -282,9 +282,14 @@ func readFileForFinding(workDir, file string, line int, severity string, budgetR
 	budgetCap := findingBudgetCap(severity)
 
 	if cached {
-		// Cache hit — extract a window centered on the finding line, capped
-		// to the per-finding budget. This avoids returning the head of the
-		// file when the finding is beyond the cap boundary.
+		// Cache hit — file was already paid for on first access.
+		// If the file fits within the per-finding cap, return the full
+		// content (consistent with cache-miss semantics for sub-cap files).
+		if len(raw) <= budgetCap {
+			return raw
+		}
+		// File exceeds cap — extract a window centered on the finding line
+		// to avoid returning the head when the finding is beyond the boundary.
 		if line > 0 {
 			snippet := extractSnippet(raw, line, contextLines(severity))
 			if len(snippet) > budgetCap {
@@ -296,13 +301,11 @@ func readFileForFinding(workDir, file string, line int, severity string, budgetR
 			return snippet
 		}
 		// No line info — return head of file, capped.
-		if len(raw) > budgetCap {
-			raw = raw[:budgetCap]
-			if idx := strings.LastIndex(raw, "\n"); idx > 0 {
-				raw = raw[:idx+1]
-			}
+		capped := raw[:budgetCap]
+		if idx := strings.LastIndex(capped, "\n"); idx > 0 {
+			capped = capped[:idx+1]
 		}
-		return raw
+		return capped
 	}
 
 	// Cache miss — extract a line-centered snippet capped to per-finding budget.

--- a/internal/pipeline/feedback.go
+++ b/internal/pipeline/feedback.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/decko/soda/schemas"
 )
@@ -174,10 +175,36 @@ func contextLines(severity string) int {
 
 // findingBudgetCap returns the maximum bytes a single finding may inject.
 func findingBudgetCap(severity string) int {
-	if strings.ToLower(severity) == "critical" {
+	switch strings.ToLower(severity) {
+	case "critical":
 		return criticalFindingCapBytes
+	case "major":
+		return majorFindingCapBytes
+	default:
+		return majorFindingCapBytes
 	}
-	return majorFindingCapBytes
+}
+
+// capToLine truncates s to at most maxBytes, breaking at the last newline
+// boundary within the cap. If s has no newlines, the result is truncated
+// at a UTF-8 rune boundary to avoid producing invalid output.
+// Returns s unchanged if len(s) <= maxBytes.
+func capToLine(s string, maxBytes int) string {
+	if len(s) <= maxBytes {
+		return s
+	}
+	truncated := s[:maxBytes]
+	if idx := strings.LastIndex(truncated, "\n"); idx >= 0 {
+		return truncated[:idx+1]
+	}
+	// No newline — trim incomplete trailing rune by walking back past
+	// continuation bytes (10xxxxxx) and their leading byte if the
+	// sequence is incomplete.
+	end := maxBytes
+	for end > 0 && !utf8.Valid([]byte(truncated[:end])) {
+		end--
+	}
+	return truncated[:end]
 }
 
 // extractReviewFeedback reads the review result and returns structured
@@ -245,23 +272,23 @@ func (e *Engine) extractReviewFeedback() *ReworkFeedback {
 	return fb
 }
 
-// readFileForFinding returns file content for a review finding. The raw
-// file is cached in rawCache only after a successful budget charge;
-// subsequent calls for the same file (possibly with a different severity)
-// extract a severity-appropriate window from the cached content without
-// re-charging the budget.
+// readFileForFinding returns file content for a review finding. It is not
+// concurrency-safe — it must be called sequentially within a single
+// extractReviewFeedback invocation.
+//
+// The raw file is cached in rawCache only after a successful budget charge.
+// For files smaller than the per-finding cap, the full content is cached.
+// For larger files, only the resolved path is cached (as a sentinel) to
+// avoid pinning large buffers; subsequent calls re-read from disk.
 //
 // On a cache miss the full file is read. The returned content is capped
-// to findingBudgetCap(severity) bytes (truncated to the last newline
-// within the cap) and charged against budgetRemaining. If the charge
-// succeeds, the raw content is stored in rawCache for future lookups.
-// If the capped content exceeds the remaining budget, a snippet of
-// ±contextLines(severity) around the finding line is returned instead
-// (free — not charged, not cached).
+// via capToLine to findingBudgetCap(severity) bytes and charged against
+// budgetRemaining. If the capped content exceeds the remaining budget,
+// a snippet of ±contextLines(severity) around the finding line is returned
+// instead (free — not charged, not cached).
 //
-// On a cache hit the same per-finding cap is applied to the already-
-// cached raw content, but no budget is charged (the file's bytes were
-// already counted on first access).
+// On a cache hit no budget is charged (the file's bytes were already
+// counted on first access).
 func readFileForFinding(workDir, file string, line int, severity string, budgetRemaining *int, rawCache map[string]string) string {
 	raw, cached := rawCache[file]
 
@@ -283,72 +310,34 @@ func readFileForFinding(workDir, file string, line int, severity string, budgetR
 
 	if cached {
 		// Cache hit — file was already paid for on first access.
-		// If the file fits within the per-finding cap, return the full
-		// content (consistent with cache-miss semantics for sub-cap files).
 		if len(raw) <= budgetCap {
 			return raw
 		}
-		// File exceeds cap — extract a window centered on the finding line
-		// to avoid returning the head when the finding is beyond the boundary.
+		// File exceeds cap — extract a window centered on the finding line.
 		if line > 0 {
-			snippet := extractSnippet(raw, line, contextLines(severity))
-			if len(snippet) > budgetCap {
-				snippet = snippet[:budgetCap]
-				if idx := strings.LastIndex(snippet, "\n"); idx > 0 {
-					snippet = snippet[:idx+1]
-				}
-			}
-			return snippet
+			return capToLine(extractSnippet(raw, line, contextLines(severity)), budgetCap)
 		}
-		// No line info — return head of file, capped.
-		capped := raw[:budgetCap]
-		if idx := strings.LastIndex(capped, "\n"); idx > 0 {
-			capped = capped[:idx+1]
-		}
-		return capped
+		return capToLine(raw, budgetCap)
 	}
 
-	// Cache miss — extract a line-centered snippet capped to per-finding budget.
-	// When the file exceeds the cap and we have a line number, center on
-	// the finding line (same logic as cache-hit path) so the LLM sees the
-	// relevant code regardless of where the finding is in the file.
+	// Cache miss — extract line-centered or head content, capped.
 	var effective string
 	if len(raw) > budgetCap && line > 0 {
-		effective = extractSnippet(raw, line, contextLines(severity))
-		if len(effective) > budgetCap {
-			effective = effective[:budgetCap]
-			if idx := strings.LastIndex(effective, "\n"); idx > 0 {
-				effective = effective[:idx+1]
-			}
-		}
+		effective = capToLine(extractSnippet(raw, line, contextLines(severity)), budgetCap)
 	} else {
-		effective = raw
-		if len(effective) > budgetCap {
-			effective = effective[:budgetCap]
-			if idx := strings.LastIndex(effective, "\n"); idx > 0 {
-				effective = effective[:idx+1]
-			}
-		}
+		effective = capToLine(raw, budgetCap)
 	}
 
-	// Cache miss — charge budget if the effective content fits.
+	// Charge budget if the effective content fits.
 	if len(effective) <= *budgetRemaining {
 		*budgetRemaining -= len(effective)
-		rawCache[file] = raw // store full content for future cache hits
+		rawCache[file] = raw
 		return effective
 	}
 
-	// Budget exhausted for capped content — fall back to snippet (free),
-	// still respecting the per-finding cap.
+	// Budget exhausted — fall back to snippet (free), still capped.
 	if line > 0 {
-		snippet := extractSnippet(raw, line, contextLines(severity))
-		if len(snippet) > budgetCap {
-			snippet = snippet[:budgetCap]
-			if idx := strings.LastIndex(snippet, "\n"); idx > 0 {
-				snippet = snippet[:idx+1]
-			}
-		}
-		return snippet
+		return capToLine(extractSnippet(raw, line, contextLines(severity)), budgetCap)
 	}
 
 	return ""

--- a/internal/pipeline/feedback.go
+++ b/internal/pipeline/feedback.go
@@ -305,19 +305,33 @@ func readFileForFinding(workDir, file string, line int, severity string, budgetR
 		return raw
 	}
 
-	// Cache miss — apply per-finding cap, truncating to last newline.
-	effective := raw
-	if len(effective) > cap {
-		effective = effective[:cap]
-		if idx := strings.LastIndex(effective, "\n"); idx > 0 {
-			effective = effective[:idx+1]
+	// Cache miss — extract a line-centered snippet capped to per-finding budget.
+	// When the file exceeds the cap and we have a line number, center on
+	// the finding line (same logic as cache-hit path) so the LLM sees the
+	// relevant code regardless of where the finding is in the file.
+	var effective string
+	if len(raw) > cap && line > 0 {
+		effective = extractSnippet(raw, line, contextLines(severity))
+		if len(effective) > cap {
+			effective = effective[:cap]
+			if idx := strings.LastIndex(effective, "\n"); idx > 0 {
+				effective = effective[:idx+1]
+			}
+		}
+	} else {
+		effective = raw
+		if len(effective) > cap {
+			effective = effective[:cap]
+			if idx := strings.LastIndex(effective, "\n"); idx > 0 {
+				effective = effective[:idx+1]
+			}
 		}
 	}
 
 	// Cache miss — charge budget if the effective content fits.
 	if len(effective) <= *budgetRemaining {
 		*budgetRemaining -= len(effective)
-		rawCache[file] = raw // mark file as "paid for"
+		rawCache[file] = raw // store full content for future cache hits
 		return effective
 	}
 

--- a/internal/pipeline/feedback.go
+++ b/internal/pipeline/feedback.go
@@ -246,16 +246,18 @@ func (e *Engine) extractReviewFeedback() *ReworkFeedback {
 }
 
 // readFileForFinding returns file content for a review finding. The raw
-// file is cached on first read; subsequent calls for the same file
-// (possibly with a different severity) extract a severity-appropriate
-// window from the cached content without re-charging the budget.
+// file is cached in rawCache only after a successful budget charge;
+// subsequent calls for the same file (possibly with a different severity)
+// extract a severity-appropriate window from the cached content without
+// re-charging the budget.
 //
-// On a cache miss the full file is read and stored in rawCache. The
-// returned content is capped to findingBudgetCap(severity) bytes
-// (truncated to the last newline within the cap) and charged against
-// budgetRemaining. If the capped content exceeds the remaining budget,
-// a snippet of ±contextLines(severity) around the finding line is
-// returned instead (free — not charged).
+// On a cache miss the full file is read. The returned content is capped
+// to findingBudgetCap(severity) bytes (truncated to the last newline
+// within the cap) and charged against budgetRemaining. If the charge
+// succeeds, the raw content is stored in rawCache for future lookups.
+// If the capped content exceeds the remaining budget, a snippet of
+// ±contextLines(severity) around the finding line is returned instead
+// (free — not charged, not cached).
 //
 // On a cache hit the same per-finding cap is applied to the already-
 // cached raw content, but no budget is charged (the file's bytes were
@@ -275,7 +277,6 @@ func readFileForFinding(workDir, file string, line int, severity string, budgetR
 		}
 
 		raw = string(data)
-		rawCache[file] = raw
 	}
 
 	// Apply the per-finding cap, truncating to the last newline within the cap.
@@ -302,6 +303,7 @@ func readFileForFinding(workDir, file string, line int, severity string, budgetR
 	// Cache miss — charge budget if the effective content fits.
 	if len(effective) <= *budgetRemaining {
 		*budgetRemaining -= len(effective)
+		rawCache[file] = raw // mark file as "paid for"
 		return effective
 	}
 

--- a/internal/pipeline/feedback.go
+++ b/internal/pipeline/feedback.go
@@ -338,9 +338,17 @@ func readFileForFinding(workDir, file string, line int, severity string, budgetR
 		return effective
 	}
 
-	// Budget exhausted for capped content — fall back to snippet (free).
+	// Budget exhausted for capped content — fall back to snippet (free),
+	// still respecting the per-finding cap.
 	if line > 0 {
-		return extractSnippet(raw, line, contextLines(severity))
+		snippet := extractSnippet(raw, line, contextLines(severity))
+		if len(snippet) > budgetCap {
+			snippet = snippet[:budgetCap]
+			if idx := strings.LastIndex(snippet, "\n"); idx > 0 {
+				snippet = snippet[:idx+1]
+			}
+		}
+		return snippet
 	}
 
 	return ""

--- a/internal/pipeline/feedback.go
+++ b/internal/pipeline/feedback.go
@@ -279,25 +279,39 @@ func readFileForFinding(workDir, file string, line int, severity string, budgetR
 		raw = string(data)
 	}
 
-	// Apply the per-finding cap, truncating to the last newline within the cap.
 	cap := findingBudgetCap(severity)
+
+	if cached {
+		// Cache hit — extract a window centered on the finding line, capped
+		// to the per-finding budget. This avoids returning the head of the
+		// file when the finding is beyond the cap boundary.
+		if line > 0 {
+			snippet := extractSnippet(raw, line, contextLines(severity))
+			if len(snippet) > cap {
+				snippet = snippet[:cap]
+				if idx := strings.LastIndex(snippet, "\n"); idx > 0 {
+					snippet = snippet[:idx+1]
+				}
+			}
+			return snippet
+		}
+		// No line info — return head of file, capped.
+		if len(raw) > cap {
+			raw = raw[:cap]
+			if idx := strings.LastIndex(raw, "\n"); idx > 0 {
+				raw = raw[:idx+1]
+			}
+		}
+		return raw
+	}
+
+	// Cache miss — apply per-finding cap, truncating to last newline.
 	effective := raw
 	if len(effective) > cap {
 		effective = effective[:cap]
 		if idx := strings.LastIndex(effective, "\n"); idx > 0 {
 			effective = effective[:idx+1]
 		}
-	}
-
-	if cached {
-		// Cache hit — return severity-appropriate window without charging budget.
-		if effective != "" {
-			return effective
-		}
-		if line > 0 {
-			return extractSnippet(raw, line, contextLines(severity))
-		}
-		return ""
 	}
 
 	// Cache miss — charge budget if the effective content fits.

--- a/internal/pipeline/feedback.go
+++ b/internal/pipeline/feedback.go
@@ -137,6 +137,48 @@ func (e *Engine) extractVerifyFeedback() *ReworkFeedback {
 // into rework feedback across all findings. Prevents context bloat.
 const maxFeedbackContextBytes = 30 * 1024 // 30KB
 
+// Per-finding caps limit how much file content a single finding can inject.
+// Critical findings get a larger window because they are highest priority.
+const (
+	criticalFindingCapBytes = 10 * 1024 // 10KB
+	majorFindingCapBytes    = 5 * 1024  // 5KB
+)
+
+// severityRank returns a sort key for finding severity.
+// Lower rank = higher priority. Critical findings are processed first
+// so they consume budget before lower-severity findings.
+func severityRank(severity string) int {
+	switch strings.ToLower(severity) {
+	case "critical":
+		return 0
+	case "major":
+		return 1
+	default:
+		return 2
+	}
+}
+
+// contextLines returns the ± line window for snippet fallback by severity.
+// Critical findings get a wider window for more surrounding context.
+func contextLines(severity string) int {
+	switch strings.ToLower(severity) {
+	case "critical":
+		return 15
+	case "major":
+		return 10
+	default:
+		return 5
+	}
+}
+
+// findingBudgetCap returns the maximum bytes a single finding may inject.
+func findingBudgetCap(severity string) int {
+	if strings.ToLower(severity) == "critical" {
+		return criticalFindingCapBytes
+	}
+	return majorFindingCapBytes
+}
+
 // extractReviewFeedback reads the review result and returns structured
 // feedback when the verdict is "rework". Returns nil if no review result
 // exists or the verdict is not "rework".

--- a/internal/pipeline/feedback_test.go
+++ b/internal/pipeline/feedback_test.go
@@ -902,6 +902,34 @@ func TestReadFileForFinding(t *testing.T) {
 		}
 	})
 
+	t.Run("cache_hit_sub_cap_file_returns_full_content", func(t *testing.T) {
+		dir := t.TempDir()
+		// 80-line file, ~32 chars/line → ~2.5KB, smaller than majorCap (5KB).
+		var fileLines []string
+		for i := 1; i <= 80; i++ {
+			fileLines = append(fileLines, fmt.Sprintf("line-%03d %s", i, strings.Repeat("w", 20)))
+		}
+		content := strings.Join(fileLines, "\n") + "\n"
+		if err := os.WriteFile(filepath.Join(dir, "small.go"), []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		budget := 50000
+		cache := make(map[string]string)
+
+		// Cache miss at line 10 — returns full file (sub-cap).
+		got1 := readFileForFinding(dir, "small.go", 10, "major", &budget, cache)
+		// Cache hit at line 70 — should also return full file, not a snippet.
+		got2 := readFileForFinding(dir, "small.go", 70, "major", &budget, cache)
+
+		if len(got1) != len(got2) {
+			t.Errorf("sub-cap file: cache miss (%d bytes) and cache hit (%d bytes) should return same size", len(got1), len(got2))
+		}
+		if !strings.Contains(got2, "line-001") || !strings.Contains(got2, "line-080") {
+			t.Error("cache hit on sub-cap file should return full content including first and last lines")
+		}
+	})
+
 	t.Run("fallback_context_window_by_severity", func(t *testing.T) {
 		dir := t.TempDir()
 		// 100-line file.

--- a/internal/pipeline/feedback_test.go
+++ b/internal/pipeline/feedback_test.go
@@ -711,8 +711,8 @@ func TestReadFileForFinding(t *testing.T) {
 		budgetAfterFirst := budget
 		got2 := readFileForFinding(dir, "shared.go", 2, "major", &budget, cache)
 
-		if got1 != got2 {
-			t.Errorf("same file should return same content: %q vs %q", got1, got2)
+		if got1 == "" || got2 == "" {
+			t.Errorf("both calls should return content: got1=%q, got2=%q", got1, got2)
 		}
 		if budget != budgetAfterFirst {
 			t.Errorf("second read should not consume budget: %d vs %d", budget, budgetAfterFirst)

--- a/internal/pipeline/feedback_test.go
+++ b/internal/pipeline/feedback_test.go
@@ -723,6 +723,50 @@ func TestReadFileForFinding(t *testing.T) {
 		}
 	})
 
+	t.Run("no_cache_on_budget_exhaustion", func(t *testing.T) {
+		// Regression: when budget is exhausted on a cache miss, the file must
+		// NOT be cached. A second finding for the same file should also fall
+		// back to a snippet, not return full capped content for free.
+		dir := t.TempDir()
+		var fileLines []string
+		for i := 1; i <= 100; i++ {
+			fileLines = append(fileLines, strings.Repeat("z", 50))
+		}
+		content := strings.Join(fileLines, "\n")
+		writeFile(t, dir, "expensive.go", content)
+
+		budget := 0 // budget already exhausted
+		cache := make(map[string]string)
+
+		// First call: cache miss, budget exhausted → snippet fallback, NOT cached.
+		got1 := readFileForFinding(dir, "expensive.go", 50, "major", &budget, cache)
+		if got1 == "" {
+			t.Fatal("first call should return snippet fallback")
+		}
+		if len(got1) > majorFindingCapBytes {
+			t.Errorf("first call returned %d bytes, want ≤ %d (snippet)", len(got1), majorFindingCapBytes)
+		}
+
+		// Second call: should also be a cache miss (file was not cached),
+		// also falls back to snippet — no budget bypass.
+		got2 := readFileForFinding(dir, "expensive.go", 50, "major", &budget, cache)
+		if got2 == "" {
+			t.Fatal("second call should return snippet fallback")
+		}
+		// Both calls should return the same snippet.
+		if got1 != got2 {
+			t.Errorf("both calls should return same snippet, got %d vs %d bytes", len(got1), len(got2))
+		}
+		if budget != 0 {
+			t.Errorf("budget should remain 0, got %d", budget)
+		}
+
+		// Verify the file was NOT cached.
+		if _, inCache := cache["expensive.go"]; inCache {
+			t.Error("file should NOT be in cache after budget-exhausted fallback")
+		}
+	})
+
 	t.Run("nonexistent_file_returns_empty", func(t *testing.T) {
 		dir := t.TempDir()
 		budget := 1000

--- a/internal/pipeline/feedback_test.go
+++ b/internal/pipeline/feedback_test.go
@@ -876,6 +876,32 @@ func TestReadFileForFinding(t *testing.T) {
 		}
 	})
 
+	t.Run("cache_miss_line_beyond_cap_centers_on_line", func(t *testing.T) {
+		dir := t.TempDir()
+		// 300-line file, ~80 chars/line → ~24KB. Larger than both caps.
+		var fileLines []string
+		for i := 1; i <= 300; i++ {
+			fileLines = append(fileLines, fmt.Sprintf("line-%03d %s", i, strings.Repeat("z", 70)))
+		}
+		content := strings.Join(fileLines, "\n") + "\n"
+		if err := os.WriteFile(filepath.Join(dir, "service.go"), []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		budget := 50000
+		cache := make(map[string]string)
+
+		// Cache miss, major finding at line 200. The file exceeds majorCap (5KB),
+		// so the returned content should be centered on line 200, not the head.
+		got := readFileForFinding(dir, "service.go", 200, "major", &budget, cache)
+		if !strings.Contains(got, "line-200") {
+			t.Errorf("cache miss at line 200 should contain line-200, got snippet starting with: %q", got[:min(80, len(got))])
+		}
+		if strings.Contains(got, "line-001") {
+			t.Error("cache miss at line 200 should NOT contain line-001 (should not return head)")
+		}
+	})
+
 	t.Run("fallback_context_window_by_severity", func(t *testing.T) {
 		dir := t.TempDir()
 		// 100-line file.

--- a/internal/pipeline/feedback_test.go
+++ b/internal/pipeline/feedback_test.go
@@ -536,7 +536,7 @@ func TestReadFileForFinding(t *testing.T) {
 
 		budget := 1000
 		cache := make(map[string]string)
-		got := readFileForFinding(dir, "small.go", 3, &budget, cache)
+		got := readFileForFinding(dir, "small.go", 3, "major", &budget, cache)
 
 		if got != content {
 			t.Errorf("got %q, want full file content", got)
@@ -548,7 +548,9 @@ func TestReadFileForFinding(t *testing.T) {
 
 	t.Run("falls_back_to_snippet_when_over_budget", func(t *testing.T) {
 		dir := t.TempDir()
-		// 20-line file — snippet at line 10 with ±5 context = 11 lines, not all 20.
+		// 20-line file — snippet at line 10 with ±5 context (minor) = 11 lines, not all 20.
+		// Using "minor" severity to keep the ±5 fallback window so the snippet
+		// is clearly shorter than the full 20-line file.
 		var longLines []string
 		for i := 1; i <= 20; i++ {
 			longLines = append(longLines, strings.Repeat("x", 10))
@@ -558,7 +560,7 @@ func TestReadFileForFinding(t *testing.T) {
 
 		budget := 50 // too small for full file (~220 bytes)
 		cache := make(map[string]string)
-		got := readFileForFinding(dir, "big.go", 10, &budget, cache)
+		got := readFileForFinding(dir, "big.go", 10, "minor", &budget, cache)
 
 		if got == content {
 			t.Error("should NOT return full file when over budget")
@@ -581,9 +583,9 @@ func TestReadFileForFinding(t *testing.T) {
 		budget := 1000
 		cache := make(map[string]string)
 
-		got1 := readFileForFinding(dir, "shared.go", 1, &budget, cache)
+		got1 := readFileForFinding(dir, "shared.go", 1, "major", &budget, cache)
 		budgetAfterFirst := budget
-		got2 := readFileForFinding(dir, "shared.go", 2, &budget, cache)
+		got2 := readFileForFinding(dir, "shared.go", 2, "major", &budget, cache)
 
 		if got1 != got2 {
 			t.Errorf("same file should return same content: %q vs %q", got1, got2)
@@ -608,12 +610,12 @@ func TestReadFileForFinding(t *testing.T) {
 		budget := 120 // enough for first file (101 bytes) but not second (~220 bytes)
 		cache := make(map[string]string)
 
-		got1 := readFileForFinding(dir, "first.go", 1, &budget, cache)
+		got1 := readFileForFinding(dir, "first.go", 1, "major", &budget, cache)
 		if got1 != file1Content {
 			t.Error("first file should get full content")
 		}
 
-		got2 := readFileForFinding(dir, "second.go", 15, &budget, cache)
+		got2 := readFileForFinding(dir, "second.go", 15, "major", &budget, cache)
 		if got2 == file2Content {
 			t.Error("second file should NOT get full content (over budget)")
 		}
@@ -626,7 +628,7 @@ func TestReadFileForFinding(t *testing.T) {
 		dir := t.TempDir()
 		budget := 1000
 		cache := make(map[string]string)
-		got := readFileForFinding(dir, "nope.go", 1, &budget, cache)
+		got := readFileForFinding(dir, "nope.go", 1, "major", &budget, cache)
 		if got != "" {
 			t.Errorf("expected empty for nonexistent file, got: %q", got)
 		}
@@ -640,7 +642,7 @@ func TestReadFileForFinding(t *testing.T) {
 
 		budget := 1000
 		cache := make(map[string]string)
-		got := readFileForFinding(dir, "../secret.txt", 1, &budget, cache)
+		got := readFileForFinding(dir, "../secret.txt", 1, "major", &budget, cache)
 		if got != "" {
 			t.Errorf("expected empty for path traversal, got: %q", got)
 		}

--- a/internal/pipeline/feedback_test.go
+++ b/internal/pipeline/feedback_test.go
@@ -972,6 +972,53 @@ func TestReadFileForFinding(t *testing.T) {
 	})
 }
 
+func TestCapToLine(t *testing.T) {
+	t.Run("under_cap_unchanged", func(t *testing.T) {
+		got := capToLine("abc\ndef\n", 100)
+		if got != "abc\ndef\n" {
+			t.Errorf("under-cap should return unchanged, got %q", got)
+		}
+	})
+
+	t.Run("truncates_at_last_newline", func(t *testing.T) {
+		got := capToLine("line1\nline2\nline3\n", 12)
+		if got != "line1\nline2\n" {
+			t.Errorf("should truncate at last newline within cap, got %q", got)
+		}
+	})
+
+	t.Run("newline_at_position_zero", func(t *testing.T) {
+		got := capToLine("\nrest of content here", 5)
+		if got != "\n" {
+			t.Errorf("should truncate at newline at position 0, got %q", got)
+		}
+	})
+
+	t.Run("no_newlines_rune_safe", func(t *testing.T) {
+		got := capToLine("abcdefghij", 5)
+		if got != "abcde" {
+			t.Errorf("no newlines should truncate at byte boundary, got %q", got)
+		}
+	})
+
+	t.Run("no_newlines_multibyte_rune_safe", func(t *testing.T) {
+		// "héllo" — é is 2 bytes (0xC3 0xA9), so bytes are: h(1) é(2) l(1) l(1) o(1) = 6 bytes
+		// Cap at 2 bytes: "h" + first byte of é → should back up to not split the rune
+		got := capToLine("héllo", 2)
+		if got != "h" {
+			t.Errorf("should not split multi-byte rune, got %q (len=%d)", got, len(got))
+		}
+	})
+
+	t.Run("exact_cap_unchanged", func(t *testing.T) {
+		s := "abc\n"
+		got := capToLine(s, len(s))
+		if got != s {
+			t.Errorf("exact cap should return unchanged, got %q", got)
+		}
+	})
+}
+
 func TestExtractSnippet(t *testing.T) {
 	content := "line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\n"
 

--- a/internal/pipeline/feedback_test.go
+++ b/internal/pipeline/feedback_test.go
@@ -117,6 +117,105 @@ func TestExtractReviewFeedback(t *testing.T) {
 			t.Errorf("second finding = %+v, want ai-harness/major", fb.ReviewFindings[1])
 		}
 	})
+
+	t.Run("sort_order_critical_before_major", func(t *testing.T) {
+		stateDir := t.TempDir()
+		state, _ := LoadOrCreate(stateDir, "TEST-1")
+		_ = state.MarkRunning("review")
+		// Input order: major, critical, minor — output should be critical, major
+		// (minor excluded). This verifies the severity sort.
+		reviewResult := `{
+			"verdict": "rework",
+			"findings": [
+				{"source":"a","severity":"major","issue":"second priority"},
+				{"source":"b","severity":"critical","issue":"top priority"},
+				{"source":"c","severity":"minor","issue":"excluded"}
+			]
+		}`
+		_ = state.WriteResult("review", json.RawMessage(reviewResult))
+		_ = state.MarkCompleted("review")
+
+		engine := &Engine{state: state, config: EngineConfig{}}
+		fb := engine.extractReviewFeedback()
+		if fb == nil {
+			t.Fatal("expected non-nil feedback for rework verdict")
+		}
+
+		if len(fb.ReviewFindings) != 2 {
+			t.Fatalf("ReviewFindings count = %d, want 2", len(fb.ReviewFindings))
+		}
+		if fb.ReviewFindings[0].Severity != "critical" {
+			t.Errorf("first finding severity = %q, want critical", fb.ReviewFindings[0].Severity)
+		}
+		if fb.ReviewFindings[1].Severity != "major" {
+			t.Errorf("second finding severity = %q, want major", fb.ReviewFindings[1].Severity)
+		}
+	})
+
+	t.Run("budget_priority_critical_gets_full_file", func(t *testing.T) {
+		workDir := t.TempDir()
+		stateDir := t.TempDir()
+
+		// Create a small critical file (well within budget).
+		criticalContent := "package main\n\nfunc main() {}\n"
+		if err := os.WriteFile(filepath.Join(workDir, "critical.go"), []byte(criticalContent), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create a large major file (~25KB) that won't fit in remaining budget
+		// after the critical file consumes its share.
+		var majorLines []string
+		for i := 0; i < 500; i++ {
+			majorLines = append(majorLines, strings.Repeat("x", 50))
+		}
+		majorContent := strings.Join(majorLines, "\n")
+		if err := os.WriteFile(filepath.Join(workDir, "major.go"), []byte(majorContent), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		state, _ := LoadOrCreate(stateDir, "TEST-1")
+		_ = state.MarkRunning("review")
+		reviewResult := `{
+			"verdict": "rework",
+			"findings": [
+				{"source":"a","severity":"major","file":"major.go","line":250,"issue":"needs work"},
+				{"source":"b","severity":"critical","file":"critical.go","line":3,"issue":"nil deref"}
+			]
+		}`
+		_ = state.WriteResult("review", json.RawMessage(reviewResult))
+		_ = state.MarkCompleted("review")
+
+		engine := &Engine{state: state, config: EngineConfig{WorkDir: workDir}}
+		fb := engine.extractReviewFeedback()
+		if fb == nil {
+			t.Fatal("expected non-nil feedback for rework verdict")
+		}
+
+		if len(fb.ReviewFindings) != 2 {
+			t.Fatalf("ReviewFindings count = %d, want 2", len(fb.ReviewFindings))
+		}
+
+		// Critical finding (sorted first) should get full file content.
+		if fb.ReviewFindings[0].Severity != "critical" {
+			t.Fatalf("first finding severity = %q, want critical", fb.ReviewFindings[0].Severity)
+		}
+		if fb.ReviewFindings[0].CodeSnippet != criticalContent {
+			t.Errorf("critical finding should get full file, got %d bytes", len(fb.ReviewFindings[0].CodeSnippet))
+		}
+
+		// Major finding should get a snippet (file is too large for full injection
+		// after the per-finding cap is applied).
+		if fb.ReviewFindings[1].Severity != "major" {
+			t.Fatalf("second finding severity = %q, want major", fb.ReviewFindings[1].Severity)
+		}
+		majorSnippet := fb.ReviewFindings[1].CodeSnippet
+		if majorSnippet == "" {
+			t.Error("major finding should get snippet fallback, not empty")
+		}
+		if majorSnippet == majorContent {
+			t.Error("major finding should NOT get full file (exceeds per-finding cap)")
+		}
+	})
 }
 
 func TestExtractVerifyFeedback(t *testing.T) {
@@ -645,6 +744,76 @@ func TestReadFileForFinding(t *testing.T) {
 		got := readFileForFinding(dir, "../secret.txt", 1, "major", &budget, cache)
 		if got != "" {
 			t.Errorf("expected empty for path traversal, got: %q", got)
+		}
+	})
+
+	t.Run("cross_severity_cache_same_file_different_content", func(t *testing.T) {
+		dir := t.TempDir()
+		// 7KB file — larger than majorCap (5KB) but smaller than criticalCap (10KB).
+		content := strings.Repeat("x", 7*1024) + "\n"
+		if err := os.WriteFile(filepath.Join(dir, "mid.go"), []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		budget := 50000
+		cache := make(map[string]string)
+
+		// First call with "critical" — file is under criticalCap (10KB), returns full content.
+		got1 := readFileForFinding(dir, "mid.go", 1, "critical", &budget, cache)
+		budgetAfterFirst := budget
+
+		// Second call (same file, "major", cache hit) — returns ≤5KB without charging budget.
+		got2 := readFileForFinding(dir, "mid.go", 1, "major", &budget, cache)
+
+		if len(got1) <= len(got2) {
+			t.Errorf("critical content (%d bytes) should be larger than major content (%d bytes)", len(got1), len(got2))
+		}
+		if len(got2) > majorFindingCapBytes {
+			t.Errorf("major cache hit should be ≤ %d bytes, got %d", majorFindingCapBytes, len(got2))
+		}
+		if budget != budgetAfterFirst {
+			t.Errorf("cache hit should not charge budget: got %d, want %d", budget, budgetAfterFirst)
+		}
+	})
+
+	t.Run("fallback_context_window_by_severity", func(t *testing.T) {
+		dir := t.TempDir()
+		// 100-line file.
+		var fileLines []string
+		for i := 1; i <= 100; i++ {
+			fileLines = append(fileLines, strings.Repeat("y", 20))
+		}
+		content := strings.Join(fileLines, "\n")
+		if err := os.WriteFile(filepath.Join(dir, "big.go"), []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// Budget=0 forces the snippet fallback path on cache miss.
+		budgetZero := 0
+
+		// Critical: ±15 lines around line 50 → lines 35..65 = 31 lines.
+		cache1 := make(map[string]string)
+		gotCritical := readFileForFinding(dir, "big.go", 50, "critical", &budgetZero, cache1)
+		criticalLines := strings.Split(gotCritical, "\n")
+
+		// Major: ±10 lines around line 50 → lines 40..60 = 21 lines.
+		cache2 := make(map[string]string)
+		gotMajor := readFileForFinding(dir, "big.go", 50, "major", &budgetZero, cache2)
+		majorLines := strings.Split(gotMajor, "\n")
+
+		// Minor: ±5 lines around line 50 → lines 45..55 = 11 lines.
+		cache3 := make(map[string]string)
+		gotMinor := readFileForFinding(dir, "big.go", 50, "minor", &budgetZero, cache3)
+		minorLines := strings.Split(gotMinor, "\n")
+
+		if len(criticalLines) != 31 {
+			t.Errorf("critical snippet: got %d lines, want 31 (±15)", len(criticalLines))
+		}
+		if len(majorLines) != 21 {
+			t.Errorf("major snippet: got %d lines, want 21 (±10)", len(majorLines))
+		}
+		if len(minorLines) != 11 {
+			t.Errorf("minor snippet: got %d lines, want 11 (±5)", len(minorLines))
 		}
 	})
 }

--- a/internal/pipeline/feedback_test.go
+++ b/internal/pipeline/feedback_test.go
@@ -156,14 +156,24 @@ func TestExtractReviewFeedback(t *testing.T) {
 		workDir := t.TempDir()
 		stateDir := t.TempDir()
 
-		// Create a small critical file (well within budget).
-		criticalContent := "package main\n\nfunc main() {}\n"
-		if err := os.WriteFile(filepath.Join(workDir, "critical.go"), []byte(criticalContent), 0644); err != nil {
-			t.Fatal(err)
+		// Create 3 critical files, each exactly criticalFindingCapBytes (10KB).
+		// Combined they consume 3×10KB = 30KB = maxFeedbackContextBytes,
+		// fully exhausting the budget so the major finding is forced into
+		// snippet fallback.
+		criticalNames := []string{"crit1.go", "crit2.go", "crit3.go"}
+		criticalContents := make([]string, 3)
+		for i, name := range criticalNames {
+			content := strings.Repeat(string(rune('a'+i)), criticalFindingCapBytes-1) + "\n"
+			criticalContents[i] = content
+			if err := os.WriteFile(filepath.Join(workDir, name), []byte(content), 0644); err != nil {
+				t.Fatal(err)
+			}
 		}
 
-		// Create a large major file (~25KB) that won't fit in remaining budget
-		// after the critical file consumes its share.
+		// Create a large major file (~25KB, 500 lines). After the per-finding
+		// cap (5KB) the effective content won't fit in the remaining budget
+		// (0 bytes), so the major finding must fall back to a ±10 line snippet
+		// around line 250.
 		var majorLines []string
 		for i := 0; i < 500; i++ {
 			majorLines = append(majorLines, strings.Repeat("x", 50))
@@ -175,11 +185,15 @@ func TestExtractReviewFeedback(t *testing.T) {
 
 		state, _ := LoadOrCreate(stateDir, "TEST-1")
 		_ = state.MarkRunning("review")
+		// Input order: major first, then critical — sort must reorder so
+		// critical findings consume budget first.
 		reviewResult := `{
 			"verdict": "rework",
 			"findings": [
 				{"source":"a","severity":"major","file":"major.go","line":250,"issue":"needs work"},
-				{"source":"b","severity":"critical","file":"critical.go","line":3,"issue":"nil deref"}
+				{"source":"b","severity":"critical","file":"crit1.go","line":1,"issue":"nil deref 1"},
+				{"source":"c","severity":"critical","file":"crit2.go","line":1,"issue":"nil deref 2"},
+				{"source":"d","severity":"critical","file":"crit3.go","line":1,"issue":"nil deref 3"}
 			]
 		}`
 		_ = state.WriteResult("review", json.RawMessage(reviewResult))
@@ -191,29 +205,39 @@ func TestExtractReviewFeedback(t *testing.T) {
 			t.Fatal("expected non-nil feedback for rework verdict")
 		}
 
-		if len(fb.ReviewFindings) != 2 {
-			t.Fatalf("ReviewFindings count = %d, want 2", len(fb.ReviewFindings))
+		if len(fb.ReviewFindings) != 4 {
+			t.Fatalf("ReviewFindings count = %d, want 4", len(fb.ReviewFindings))
 		}
 
-		// Critical finding (sorted first) should get full file content.
-		if fb.ReviewFindings[0].Severity != "critical" {
-			t.Fatalf("first finding severity = %q, want critical", fb.ReviewFindings[0].Severity)
-		}
-		if fb.ReviewFindings[0].CodeSnippet != criticalContent {
-			t.Errorf("critical finding should get full file, got %d bytes", len(fb.ReviewFindings[0].CodeSnippet))
+		// All 3 critical findings (sorted first) should get their full file content.
+		for i := 0; i < 3; i++ {
+			if fb.ReviewFindings[i].Severity != "critical" {
+				t.Fatalf("finding[%d] severity = %q, want critical", i, fb.ReviewFindings[i].Severity)
+			}
+			if fb.ReviewFindings[i].CodeSnippet != criticalContents[i] {
+				t.Errorf("critical finding[%d] should get full file (%d bytes), got %d bytes",
+					i, len(criticalContents[i]), len(fb.ReviewFindings[i].CodeSnippet))
+			}
 		}
 
-		// Major finding should get a snippet (file is too large for full injection
-		// after the per-finding cap is applied).
-		if fb.ReviewFindings[1].Severity != "major" {
-			t.Fatalf("second finding severity = %q, want major", fb.ReviewFindings[1].Severity)
+		// Major finding (last, after budget exhausted by 3 critical files)
+		// should get a ±10 line snippet around line 250, NOT the 5KB capped
+		// content from the top of the file.
+		if fb.ReviewFindings[3].Severity != "major" {
+			t.Fatalf("finding[3] severity = %q, want major", fb.ReviewFindings[3].Severity)
 		}
-		majorSnippet := fb.ReviewFindings[1].CodeSnippet
+		majorSnippet := fb.ReviewFindings[3].CodeSnippet
 		if majorSnippet == "" {
-			t.Error("major finding should get snippet fallback, not empty")
+			t.Fatal("major finding should get snippet fallback, not empty")
+		}
+		// A ±10 line snippet around line 250 of a 500-line file = ~21 lines.
+		// If it were capped content (5KB from top of file) it would be ~100 lines.
+		snippetLines := strings.Split(majorSnippet, "\n")
+		if len(snippetLines) != 21 {
+			t.Errorf("major finding snippet should be 21 lines (±10 around line 250), got %d lines", len(snippetLines))
 		}
 		if majorSnippet == majorContent {
-			t.Error("major finding should NOT get full file (exceeds per-finding cap)")
+			t.Error("major finding should NOT get full file")
 		}
 	})
 }

--- a/internal/pipeline/feedback_test.go
+++ b/internal/pipeline/feedback_test.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -841,6 +842,37 @@ func TestReadFileForFinding(t *testing.T) {
 		}
 		if budget != budgetAfterFirst {
 			t.Errorf("cache hit should not charge budget: got %d, want %d", budget, budgetAfterFirst)
+		}
+	})
+
+	t.Run("cache_hit_line_beyond_cap_boundary", func(t *testing.T) {
+		dir := t.TempDir()
+		// 300-line file, ~80 chars/line → ~24KB. Larger than both caps.
+		var fileLines []string
+		for i := 1; i <= 300; i++ {
+			fileLines = append(fileLines, fmt.Sprintf("line-%03d %s", i, strings.Repeat("z", 70)))
+		}
+		content := strings.Join(fileLines, "\n") + "\n"
+		if err := os.WriteFile(filepath.Join(dir, "handler.go"), []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		budget := 50000
+		cache := make(map[string]string)
+
+		// First call: critical finding at line 1 — caches the full file,
+		// returns up to criticalCap bytes from head.
+		got1 := readFileForFinding(dir, "handler.go", 1, "critical", &budget, cache)
+		if !strings.Contains(got1, "line-001") {
+			t.Error("first call should contain line-001")
+		}
+
+		// Second call: major finding at line 200 (cache hit).
+		// The major cap (5KB, ~63 lines) doesn't cover line 200.
+		// The fix should center the snippet on line 200, not return head.
+		got2 := readFileForFinding(dir, "handler.go", 200, "major", &budget, cache)
+		if !strings.Contains(got2, "line-200") {
+			t.Errorf("cache hit at line 200 should contain line-200, got snippet starting with: %q", got2[:min(80, len(got2))])
 		}
 	})
 

--- a/internal/pipeline/prompt.go
+++ b/internal/pipeline/prompt.go
@@ -72,7 +72,7 @@ type ReworkFeedback struct {
 // EnrichedFinding wraps a ReviewFinding with code context for rework prompts.
 type EnrichedFinding struct {
 	schemas.ReviewFinding
-	CodeSnippet string // full file content (budget-controlled) or ±5 lines fallback; empty if unavailable
+	CodeSnippet string // full file content (budget-controlled) or ±15 lines (critical) or ±10 lines (major) fallback; empty if unavailable
 }
 
 // PriorCycle holds a summarized snapshot of feedback from a previous


### PR DESCRIPTION
## Summary

- Sort review findings by severity (critical → major) before budget allocation so higher-priority findings consume budget first
- Add per-finding budget caps (10KB critical, 5KB major) and severity-based fallback context windows (±15/±10/±5 lines)
- Center snippets on finding line (not file head) for both cache-hit and cache-miss paths, with consistent behavior for sub-cap files

## Changes

- `internal/pipeline/feedback.go`: severity sort, `readFileForFinding` rewrite with line-centered capping, `severityRank()`, `contextLines()`, `findingBudgetCap()` helpers
- `internal/pipeline/feedback_test.go`: 13 test cases covering sort order, budget priority, cache correctness, line centering, sub-cap consistency, and fallback capping

## Test plan

- [x] Critical findings processed before major findings in budget loop
- [x] Critical findings get ±15 line context window on fallback
- [x] Major findings get ±10 line context window on fallback
- [x] Same-file findings with different severities get appropriate snippets
- [x] Cache hit on sub-cap file returns full content (consistent with cache miss)
- [x] Cache hit on over-cap file centers snippet on finding line
- [x] Cache miss on over-cap file centers snippet on finding line
- [x] Budget-exhaustion fallback respects per-finding cap
- [x] Total budget stays at 30KB
- [x] `go test ./...` passes

Closes #474

---

Pipeline: soda run 474 ($12.18) + 5 manual fix commits for review findings.