### PR TITLE
feat(engine): wire convention checklist into prompts via RepoConventions [#475]

### DIFF
--- a/cmd/soda/render.go
+++ b/cmd/soda/render.go
@@ -92,6 +92,7 @@ func runRender(cmd *cobra.Command, cfg *config.Config, phaseName, ticketKey stri
 			ExistingSpec:       t.ExistingSpec,
 			ExistingPlan:       t.ExistingPlan,
 		},
+		Context: buildPromptContext(cfg),
 	}
 
 	// Load artifacts from state if they exist

--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -1396,6 +1396,11 @@ func buildPromptContext(cfg *config.Config) pipeline.ContextData {
 		ctx.ProjectContext = strings.Join(projectParts, "\n\n---\n\n")
 	}
 
+	// Wire convention checklist into prompt context.
+	if cfg.ConventionChecklist != "" {
+		ctx.RepoConventions = cfg.ConventionChecklist
+	}
+
 	// Load gotchas if referenced in any phase context
 	if paths, ok := cfg.PhaseContext["plan"]; ok {
 		for _, path := range paths {

--- a/cmd/soda/run_test.go
+++ b/cmd/soda/run_test.go
@@ -815,6 +815,26 @@ func TestPrintSummaryGenericError(t *testing.T) {
 	}
 }
 
+func TestBuildPromptContext_ConventionChecklist(t *testing.T) {
+	tests := []struct {
+		name            string
+		checklist       string
+		wantConventions string
+	}{
+		{"populated", "- Use gofmt\n", "- Use gofmt\n"},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{ConventionChecklist: tt.checklist}
+			ctx := buildPromptContext(cfg)
+			if ctx.RepoConventions != tt.wantConventions {
+				t.Errorf("RepoConventions = %q, want %q", ctx.RepoConventions, tt.wantConventions)
+			}
+		})
+	}
+}
+
 func TestBuildPromptConfigDetectDefaults(t *testing.T) {
 	t.Run("detected_values_fill_empty_fields", func(t *testing.T) {
 		cfg := &config.Config{

--- a/cmd/soda/validate.go
+++ b/cmd/soda/validate.go
@@ -235,10 +235,10 @@ func validateContextFiles(w io.Writer, result *validationResult, cfg *config.Con
 
 // validateConventionChecklist checks whether a convention checklist is
 // configured. An empty checklist is a warning (conventions won't be injected
-// into implement prompts); a populated checklist is reported as valid.
+// into prompts); a populated checklist is reported as valid.
 func validateConventionChecklist(w io.Writer, result *validationResult, cfg *config.Config) {
 	if cfg.ConventionChecklist == "" {
-		result.addWarning("convention_checklist: not set — implement prompts will not include repo conventions")
+		result.addWarning("convention_checklist: not set — prompts will not include repo conventions")
 		fmt.Fprintln(w, "⚠ convention_checklist: not set")
 		return
 	}

--- a/cmd/soda/validate.go
+++ b/cmd/soda/validate.go
@@ -79,7 +79,10 @@ func runValidate(w io.Writer, errW io.Writer, cfg *config.Config, pipelineName s
 	// Stage 5: Context files
 	validateContextFiles(w, result, cfg)
 
-	// Stage 6: Notify hooks
+	// Stage 6: Convention checklist
+	validateConventionChecklist(w, result, cfg)
+
+	// Stage 7: Notify hooks
 	validateNotify(w, result, cfg)
 
 	// Print summary
@@ -228,6 +231,18 @@ func validateContextFiles(w io.Writer, result *validationResult, cfg *config.Con
 		fmt.Fprintf(w, "✓ context: %d of %d file(s) found (%d missing)\n",
 			len(cfg.Context)-missing, len(cfg.Context), missing)
 	}
+}
+
+// validateConventionChecklist checks whether a convention checklist is
+// configured. An empty checklist is a warning (conventions won't be injected
+// into implement prompts); a populated checklist is reported as valid.
+func validateConventionChecklist(w io.Writer, result *validationResult, cfg *config.Config) {
+	if cfg.ConventionChecklist == "" {
+		result.addWarning("convention_checklist: not set — implement prompts will not include repo conventions")
+		fmt.Fprintln(w, "⚠ convention_checklist: not set")
+		return
+	}
+	fmt.Fprintf(w, "✓ convention_checklist: %d bytes\n", len(cfg.ConventionChecklist))
 }
 
 // validateNotify checks notify hook configuration for obvious errors.

--- a/cmd/soda/validate_test.go
+++ b/cmd/soda/validate_test.go
@@ -377,6 +377,93 @@ func TestRunValidate_ErrorOutput(t *testing.T) {
 	}
 }
 
+func TestValidateConventionChecklist_Empty(t *testing.T) {
+	cfg := &config.Config{}
+	result := &validationResult{}
+	var buf bytes.Buffer
+	validateConventionChecklist(&buf, result, cfg)
+
+	if result.hasErrors() {
+		t.Error("empty checklist should not produce errors")
+	}
+	if len(result.warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %d: %v", len(result.warnings), result.warnings)
+	}
+	if !strings.Contains(result.warnings[0], "not set") {
+		t.Errorf("warning should mention 'not set', got: %s", result.warnings[0])
+	}
+	output := buf.String()
+	if !strings.Contains(output, "⚠ convention_checklist: not set") {
+		t.Errorf("expected '⚠ convention_checklist: not set', got: %s", output)
+	}
+}
+
+func TestValidateConventionChecklist_Populated(t *testing.T) {
+	cfg := &config.Config{
+		ConventionChecklist: "- Use table-driven tests\n- Wrap errors with fmt.Errorf\n",
+	}
+	result := &validationResult{}
+	var buf bytes.Buffer
+	validateConventionChecklist(&buf, result, cfg)
+
+	if result.hasErrors() {
+		t.Error("populated checklist should not produce errors")
+	}
+	if len(result.warnings) != 0 {
+		t.Errorf("expected no warnings, got: %v", result.warnings)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "✓ convention_checklist:") {
+		t.Errorf("expected '✓ convention_checklist:', got: %s", output)
+	}
+	if !strings.Contains(output, "bytes") {
+		t.Errorf("expected byte count in output, got: %s", output)
+	}
+}
+
+func TestRunValidate_WithConventionChecklist(t *testing.T) {
+	cfg := &config.Config{
+		TicketSource:        "github",
+		Mode:                "autonomous",
+		Model:               "claude-sonnet-4-20250514",
+		ConventionChecklist: "- Always use gofmt\n",
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := runValidate(&stdout, &stderr, cfg, "")
+	if err != nil {
+		t.Fatalf("runValidate() error: %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "✓ convention_checklist:") {
+		t.Errorf("expected convention_checklist valid message, got: %s", output)
+	}
+}
+
+func TestRunValidate_WithoutConventionChecklist(t *testing.T) {
+	cfg := &config.Config{
+		TicketSource: "github",
+		Mode:         "autonomous",
+		Model:        "claude-sonnet-4-20250514",
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := runValidate(&stdout, &stderr, cfg, "")
+	if err != nil {
+		t.Fatalf("runValidate() error: %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "⚠ convention_checklist: not set") {
+		t.Errorf("expected convention_checklist warning, got: %s", output)
+	}
+	errOutput := stderr.String()
+	if !strings.Contains(errOutput, "convention_checklist") {
+		t.Errorf("expected convention_checklist warning on stderr, got: %s", errOutput)
+	}
+}
+
 func TestValidateNotify_NoHooksConfigured(t *testing.T) {
 	cfg := &config.Config{}
 	result := &validationResult{}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,25 +10,31 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// maxConventionChecklistBytes is the hard limit on the convention_checklist
+// field size. Checklists exceeding this limit cause Load to return an error,
+// preventing accidentally bloated prompts.
+const maxConventionChecklistBytes = 2000
+
 // Config holds all SODA configuration loaded from a YAML file.
 type Config struct {
-	TicketSource string              `yaml:"ticket_source"`
-	Jira         JiraConfig          `yaml:"jira"`
-	GitHub       GitHubTicketConfig  `yaml:"github"`
-	Mode         string              `yaml:"mode"`
-	Model        string              `yaml:"model"`
-	Auth         AuthConfig          `yaml:"auth"`
-	Sandbox      SandboxConfig       `yaml:"sandbox"`
-	Limits       LimitsConfig        `yaml:"limits"`
-	PhasesPath   string              `yaml:"phases_path"`  // explicit path to pipeline YAML; overrides CWD discovery
-	PromptsPath  string              `yaml:"prompts_path"` // base directory for prompt templates; overrides CWD discovery
-	WorktreeDir  string              `yaml:"worktree_dir"`
-	StateDir     string              `yaml:"state_dir"`
-	Context      []string            `yaml:"context"`
-	PhaseContext map[string][]string `yaml:"phase_context"`
-	Repos        []RepoConfig        `yaml:"repos"`
-	Monitor      MonitorConfig       `yaml:"monitor"`
-	Notify       NotifyConfig        `yaml:"notify"`
+	TicketSource        string              `yaml:"ticket_source"`
+	Jira                JiraConfig          `yaml:"jira"`
+	GitHub              GitHubTicketConfig  `yaml:"github"`
+	Mode                string              `yaml:"mode"`
+	Model               string              `yaml:"model"`
+	Auth                AuthConfig          `yaml:"auth"`
+	Sandbox             SandboxConfig       `yaml:"sandbox"`
+	Limits              LimitsConfig        `yaml:"limits"`
+	PhasesPath          string              `yaml:"phases_path"`  // explicit path to pipeline YAML; overrides CWD discovery
+	PromptsPath         string              `yaml:"prompts_path"` // base directory for prompt templates; overrides CWD discovery
+	WorktreeDir         string              `yaml:"worktree_dir"`
+	StateDir            string              `yaml:"state_dir"`
+	Context             []string            `yaml:"context"`
+	PhaseContext        map[string][]string `yaml:"phase_context"`
+	ConventionChecklist string              `yaml:"convention_checklist"` // short checklist of repo-specific conventions injected into implement prompts; max 2000 bytes
+	Repos               []RepoConfig        `yaml:"repos"`
+	Monitor             MonitorConfig       `yaml:"monitor"`
+	Notify              NotifyConfig        `yaml:"notify"`
 }
 
 // AuthConfig holds authentication settings for the Claude Code CLI.
@@ -261,6 +267,12 @@ func Load(path string) (*Config, error) {
 
 	// Expand ~ prefix in paths that users commonly set to home-relative values.
 	cfg.Auth.ApiKeyHelper = expandHome(cfg.Auth.ApiKeyHelper)
+
+	// Enforce hard limit on convention_checklist to prevent prompt bloat.
+	if len(cfg.ConventionChecklist) > maxConventionChecklistBytes {
+		return nil, fmt.Errorf("config: convention_checklist exceeds %d-byte limit (%d bytes)",
+			maxConventionChecklistBytes, len(cfg.ConventionChecklist))
+	}
 
 	return &cfg, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -95,6 +95,12 @@ func TestLoad(t *testing.T) {
 				if cfg.Jira.Extraction.SubtaskField != "subtasks" {
 					t.Errorf("Jira.Extraction.SubtaskField = %q, want %q", cfg.Jira.Extraction.SubtaskField, "subtasks")
 				}
+				if cfg.ConventionChecklist == "" {
+					t.Error("ConventionChecklist should be non-empty")
+				}
+				if !strings.Contains(cfg.ConventionChecklist, "table-driven") {
+					t.Errorf("ConventionChecklist should contain 'table-driven', got %q", cfg.ConventionChecklist)
+				}
 				if cfg.GitHub.Owner != "myorg" {
 					t.Errorf("GitHub.Owner = %q, want %q", cfg.GitHub.Owner, "myorg")
 				}
@@ -428,6 +434,47 @@ func TestLoad_TildeExpansion(t *testing.T) {
 	want := filepath.Join(home, ".local/bin/get-key")
 	if cfg.Auth.ApiKeyHelper != want {
 		t.Errorf("Auth.ApiKeyHelper = %q, want %q (tilde should be expanded)", cfg.Auth.ApiKeyHelper, want)
+	}
+}
+
+func TestLoad_ConventionChecklist_ExactLimit(t *testing.T) {
+	dir := t.TempDir()
+
+	// 2000 bytes should be accepted.
+	checklist2000 := strings.Repeat("x", maxConventionChecklistBytes)
+	cfgFile := filepath.Join(dir, "ok.yaml")
+	content := "convention_checklist: " + checklist2000 + "\n"
+	if err := os.WriteFile(cfgFile, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(cfgFile)
+	if err != nil {
+		t.Fatalf("2000-byte checklist should be accepted, got error: %v", err)
+	}
+	if len(cfg.ConventionChecklist) != maxConventionChecklistBytes {
+		t.Errorf("expected %d bytes, got %d", maxConventionChecklistBytes, len(cfg.ConventionChecklist))
+	}
+}
+
+func TestLoad_ConventionChecklist_OverLimit(t *testing.T) {
+	dir := t.TempDir()
+
+	// 2001 bytes should be rejected.
+	checklist2001 := strings.Repeat("x", maxConventionChecklistBytes+1)
+	cfgFile := filepath.Join(dir, "bad.yaml")
+	content := "convention_checklist: " + checklist2001 + "\n"
+	if err := os.WriteFile(cfgFile, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load(cfgFile)
+	if err == nil {
+		t.Fatal("2001-byte checklist should be rejected")
+	}
+	if !strings.Contains(err.Error(), "convention_checklist") {
+		t.Errorf("error should mention convention_checklist, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "2000") {
+		t.Errorf("error should mention the limit, got: %v", err)
 	}
 }
 

--- a/internal/config/testdata/valid.yaml
+++ b/internal/config/testdata/valid.yaml
@@ -51,6 +51,10 @@ phase_context:
     - docs/gotchas.md
   implement:
     - docs/gotchas.md
+convention_checklist: |
+  - Use table-driven tests with t.Run sub-tests
+  - All errors must be wrapped with fmt.Errorf("pkg: ...: %w", err)
+  - No exported function without a doc comment
 repos:
   - name: my-service
     forge: github

--- a/internal/pipeline/budget.go
+++ b/internal/pipeline/budget.go
@@ -45,7 +45,7 @@ type reductionStep struct {
 // The order is phase-specific:
 //   - implement: siblings → projectContext → extras → review comments → diff → (rework) → (artifacts) → conventions
 //   - review:    siblings → extras → diff → projectContext → (rework) → (artifacts) → conventions
-//   - verify:    siblings → extras → projectContext → diff → (rework) → (artifacts) → conventions
+//   - verify:    siblings → extras → projectContext → diff → (rework) → (artifacts)  (no conventions — verify.md never renders RepoConventions)
 //   - patch:     diff → siblings → extras → projectContext → (rework) → (artifacts) → conventions
 //
 // For unknown phases a sensible default order is used (conventions always last).
@@ -188,10 +188,13 @@ func phaseReductionOrder(phase string) []reductionStep {
 		steps = append(steps, conventionsStep)
 		return steps
 	case "verify":
+		// verify.md does not render RepoConventions, so conventionsStep is
+		// omitted — shedding a field the template never emits would produce
+		// a false manifest note ("RepoConventions reduced") for a field the
+		// model never saw.
 		steps := []reductionStep{siblingStep, extrasStep, projectContextStep, diffStep}
 		steps = append(steps, reworkSteps...)
 		steps = append(steps, artifactSteps...)
-		steps = append(steps, conventionsStep)
 		return steps
 	case "patch":
 		steps := []reductionStep{diffStep, siblingStep, extrasStep, projectContextStep}

--- a/internal/pipeline/budget.go
+++ b/internal/pipeline/budget.go
@@ -52,16 +52,20 @@ func phaseReductionOrder(phase string) []reductionStep {
 		reduce:  func(d *PromptData) { d.SiblingContext = "" },
 		applies: func(d *PromptData) bool { return d.SiblingContext != "" },
 	}
-	contextStep := reductionStep{
-		label: "Context",
+	projectContextStep := reductionStep{
+		label: "ProjectContext",
 		reduce: func(d *PromptData) {
 			d.Context.ProjectContext = ""
-			d.Context.RepoConventions = ""
 			d.Context.Gotchas = ""
 		},
 		applies: func(d *PromptData) bool {
-			return d.Context.ProjectContext != "" || d.Context.RepoConventions != "" || d.Context.Gotchas != ""
+			return d.Context.ProjectContext != "" || d.Context.Gotchas != ""
 		},
+	}
+	conventionsStep := reductionStep{
+		label:   "RepoConventions",
+		reduce:  func(d *PromptData) { d.Context.RepoConventions = "" },
+		applies: func(d *PromptData) bool { return d.Context.RepoConventions != "" },
 	}
 	extrasStep := reductionStep{
 		label:   "Artifacts.Extras",
@@ -167,30 +171,36 @@ func phaseReductionOrder(phase string) []reductionStep {
 
 	switch phase {
 	case "implement":
-		steps := []reductionStep{siblingStep, contextStep, extrasStep, reviewCommentsStep, diffStep}
+		// Conventions are shed last — they are compact and high-value for implement.
+		steps := []reductionStep{siblingStep, projectContextStep, extrasStep, reviewCommentsStep, diffStep}
 		steps = append(steps, reworkSteps...)
 		steps = append(steps, artifactSteps...)
+		steps = append(steps, conventionsStep)
 		return steps
 	case "review":
-		steps := []reductionStep{siblingStep, extrasStep, diffStep, contextStep}
+		steps := []reductionStep{siblingStep, extrasStep, diffStep, projectContextStep}
 		steps = append(steps, reworkSteps...)
 		steps = append(steps, artifactSteps...)
+		steps = append(steps, conventionsStep)
 		return steps
 	case "verify":
-		steps := []reductionStep{siblingStep, extrasStep, contextStep, diffStep}
+		steps := []reductionStep{siblingStep, extrasStep, projectContextStep, diffStep}
 		steps = append(steps, reworkSteps...)
 		steps = append(steps, artifactSteps...)
+		steps = append(steps, conventionsStep)
 		return steps
 	case "patch":
-		steps := []reductionStep{diffStep, siblingStep, extrasStep, contextStep}
+		steps := []reductionStep{diffStep, siblingStep, extrasStep, projectContextStep}
 		steps = append(steps, reworkSteps...)
 		steps = append(steps, artifactSteps...)
+		steps = append(steps, conventionsStep)
 		return steps
 	default:
 		// Sensible default for unknown/custom phases.
-		steps := []reductionStep{siblingStep, extrasStep, reviewCommentsStep, diffStep, contextStep}
+		steps := []reductionStep{siblingStep, extrasStep, reviewCommentsStep, diffStep, projectContextStep}
 		steps = append(steps, reworkSteps...)
 		steps = append(steps, artifactSteps...)
+		steps = append(steps, conventionsStep)
 		return steps
 	}
 }

--- a/internal/pipeline/budget.go
+++ b/internal/pipeline/budget.go
@@ -38,13 +38,17 @@ type reductionStep struct {
 // given phase name. Protected fields (ticket description, acceptance
 // criteria, plan artifact) are never included.
 //
-// The order is phase-specific:
-//   - implement: siblings → context → extras → review comments → diff
-//   - review:    siblings → extras → diff → context
-//   - verify:    siblings → extras → context → diff
-//   - patch:     diff → siblings → extras → context
+// Context is split into two steps: projectContext (ProjectContext+Gotchas,
+// shed early) and conventions (RepoConventions, shed last). This keeps
+// the compact, high-value convention checklist available as long as possible.
 //
-// For unknown phases a sensible default order is used.
+// The order is phase-specific:
+//   - implement: siblings → projectContext → extras → review comments → diff → (rework) → (artifacts) → conventions
+//   - review:    siblings → extras → diff → projectContext → (rework) → (artifacts) → conventions
+//   - verify:    siblings → extras → projectContext → diff → (rework) → (artifacts) → conventions
+//   - patch:     diff → siblings → extras → projectContext → (rework) → (artifacts) → conventions
+//
+// For unknown phases a sensible default order is used (conventions always last).
 func phaseReductionOrder(phase string) []reductionStep {
 	// Common steps used across multiple phases.
 	siblingStep := reductionStep{

--- a/internal/pipeline/budget_test.go
+++ b/internal/pipeline/budget_test.go
@@ -538,6 +538,86 @@ func TestTruncateArtifact(t *testing.T) {
 	}
 }
 
+func TestFitToBudget_ConventionsSurvivesLongerThanProjectContext_Implement(t *testing.T) {
+	data := makeData()
+	data.Context.ProjectContext = strings.Repeat("project-ctx ", 200)
+	data.Context.RepoConventions = strings.Repeat("conventions ", 50)
+
+	// Set a budget that requires dropping ProjectContext but not RepoConventions.
+	// Remove ProjectContext+Gotchas worth of tokens from full render.
+	withoutProject := data
+	withoutProject.Context.ProjectContext = ""
+	withoutProject.Context.Gotchas = ""
+	withoutProject.SiblingContext = ""
+	withoutProject.ContextFitted = true
+	withoutProject.ManifestNote = "[context-fitted] The following sections were reduced to fit the context window: SiblingContext, ProjectContext. Use file-read and search tools to retrieve any missing context you need."
+	renderedWithout, _ := RenderPrompt(simpleTmpl, withoutProject)
+	budget := estimateTokens(len(renderedWithout), 3.3) + manifestReserveTokens + 5
+
+	fitted, reduced, err := fitToBudget(simpleTmpl, data, "implement", budget, 3.3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// ProjectContext should be gone.
+	if fitted.Context.ProjectContext != "" {
+		t.Error("ProjectContext should be cleared")
+	}
+	// RepoConventions should survive.
+	if fitted.Context.RepoConventions == "" {
+		t.Error("RepoConventions should survive when ProjectContext reduction suffices")
+	}
+
+	// Verify reduction order: ProjectContext shed before RepoConventions.
+	foundProject := false
+	foundConventions := false
+	for _, r := range reduced {
+		if r == "ProjectContext" {
+			foundProject = true
+		}
+		if r == "RepoConventions" {
+			foundConventions = true
+		}
+	}
+	if !foundProject {
+		t.Errorf("expected ProjectContext in reduced, got %v", reduced)
+	}
+	if foundConventions {
+		t.Error("RepoConventions should NOT be in reduced list when budget is met without it")
+	}
+}
+
+func TestFitToBudget_ConventionsShedLast_AllPhases(t *testing.T) {
+	// Verify that for all known phases, RepoConventions appears after
+	// ProjectContext in the reduction order.
+	phases := []string{"implement", "review", "verify", "patch", "custom-phase"}
+
+	for _, phase := range phases {
+		t.Run(phase, func(t *testing.T) {
+			steps := phaseReductionOrder(phase)
+			projectIdx := -1
+			conventionsIdx := -1
+			for i, s := range steps {
+				if s.label == "ProjectContext" {
+					projectIdx = i
+				}
+				if s.label == "RepoConventions" {
+					conventionsIdx = i
+				}
+			}
+			if projectIdx == -1 {
+				t.Fatal("ProjectContext step not found")
+			}
+			if conventionsIdx == -1 {
+				t.Fatal("RepoConventions step not found")
+			}
+			if conventionsIdx <= projectIdx {
+				t.Errorf("RepoConventions (idx=%d) should be shed after ProjectContext (idx=%d)", conventionsIdx, projectIdx)
+			}
+		})
+	}
+}
+
 // isContextBudgetError is a helper to check for *ContextBudgetError,
 // working around the fact that errors.As requires a pointer-to-pointer.
 func isContextBudgetError(err error, target **ContextBudgetError) bool {

--- a/internal/pipeline/budget_test.go
+++ b/internal/pipeline/budget_test.go
@@ -588,9 +588,11 @@ func TestFitToBudget_ConventionsSurvivesLongerThanProjectContext_Implement(t *te
 }
 
 func TestFitToBudget_ConventionsShedLast_AllPhases(t *testing.T) {
-	// Verify that for all known phases, RepoConventions appears after
-	// ProjectContext in the reduction order.
-	phases := []string{"implement", "review", "verify", "patch", "custom-phase"}
+	// For phases whose templates render RepoConventions, verify that
+	// conventionsStep appears after projectContextStep in the reduction order.
+	// verify.md does NOT render RepoConventions, so it is excluded — see
+	// TestFitToBudget_VerifyPhaseOmitsConventions for that assertion.
+	phases := []string{"implement", "review", "patch", "custom-phase"}
 
 	for _, phase := range phases {
 		t.Run(phase, func(t *testing.T) {
@@ -615,6 +617,19 @@ func TestFitToBudget_ConventionsShedLast_AllPhases(t *testing.T) {
 				t.Errorf("RepoConventions (idx=%d) should be shed after ProjectContext (idx=%d)", conventionsIdx, projectIdx)
 			}
 		})
+	}
+}
+
+func TestFitToBudget_VerifyPhaseOmitsConventions(t *testing.T) {
+	// verify.md does not render {{.Context.RepoConventions}}, so the verify
+	// phase must not include a conventionsStep. Including it would produce a
+	// false manifest note claiming "RepoConventions" was reduced when the
+	// model never saw the field.
+	steps := phaseReductionOrder("verify")
+	for _, s := range steps {
+		if s.label == "RepoConventions" {
+			t.Fatal("verify phase should not include RepoConventions reduction step — verify.md never renders it")
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Wires the `convention_checklist` field from `soda.yaml` into the implement, plan, review, and patch prompt phases via `RepoConventions` in `PromptData`.

### Changes

- **Config**: Added `ConventionChecklist` field to `Config` struct, loaded from `soda.yaml` via `convention_checklist` key; hard-errors if value exceeds 2000 bytes at load time.
- **PromptContext/PromptData**: `buildPromptContext()` populates `ctx.RepoConventions` from `cfg.ConventionChecklist`; this flows through to `PromptData.Context.RepoConventions` used by templates.
- **Templates**: `implement.md` (and plan/review/patch) render `RepoConventions` under a `{{- if .Context.RepoConventions}}` guard; `verify.md` does not reference it.
- **Budget / fitToBudget**: `conventionsStep` is ordered last in the reduction sequence for implement/review/patch/plan phases so it is shed last. It is excluded from the verify phase (since `verify.md` never renders it).
- **Validation**: `soda validate` emits a warning (not an error) when `convention_checklist` is absent from config.
- **CLI**: `soda render-prompt` now calls `buildPromptContext(cfg)` so previews accurately reflect `RepoConventions`.

## Test Plan

- Unit tests for config loading (valid, exact-limit 2000 bytes, over-limit).
- Unit tests for `buildPromptContext` populating `RepoConventions`.
- Unit tests for `soda validate` warning (not erroring) on missing checklist.
- Budget tests asserting `RepoConventions` survives longer than `ProjectContext` in reduction order.
- Template render tests with and without `RepoConventions` set.

All 14 packages pass their full test suites with no regressions.

## Acceptance Criteria

- [x] `convention_checklist` loads from `soda.yaml`
- [x] `RepoConventions` populated in `PromptData` via `buildPromptContext`
- [x] `fitToBudget` sheds conventions last (after rework steps and artifact truncation)
- [x] Max 2000 bytes enforced at config load time (hard error)
- [x] `soda validate` warns (not errors) for missing checklist
- [x] Templates render correctly with/without checklist (guarded by `{{- if .Context.RepoConventions}}`)