### PR TITLE
[468] feat(review): reduce review phase cost for simple tickets

### DIFF
--- a/cmd/soda/embeds/phases.yaml
+++ b/cmd/soda/embeds/phases.yaml
@@ -133,6 +133,7 @@ phases:
       - name: ai-harness
         prompt: prompts/review-harness.md
         focus: "prompt engineering, context budget, Claude CLI integration, sandbox, structured output"
+        condition: '{{ ne .Complexity "low" }}'
     rework:
       target: implement
 

--- a/cmd/soda/embeds/prompts/review-go.md
+++ b/cmd/soda/embeds/prompts/review-go.md
@@ -51,11 +51,14 @@ Review the implementation as a Go specialist. Focus on:
 - Are package dependencies clean (no circular imports)?
 - Is the public API surface minimal?
 
+{{- if not .VerifyClean}}
+
 ### 3. Test quality and coverage
 - Do tests cover the acceptance criteria?
 - Are tests functional (testing behavior, not implementation)?
 - Are table-driven tests used where appropriate?
 - Are edge cases covered?
+{{- end}}
 
 ### 4. Performance and concurrency
 - Are there unnecessary allocations or copies?

--- a/cmd/soda/embeds/prompts/review-harness.md
+++ b/cmd/soda/embeds/prompts/review-harness.md
@@ -62,10 +62,13 @@ Review the implementation as an AI harness specialist. Focus on:
 - Are file paths resolved correctly within worktrees?
 - Are there hardcoded paths or environment assumptions?
 
+{{- if not .VerifyClean}}
+
 ### 5. Structured output schema alignment
 - Do JSON schemas match the Go struct definitions?
 - Are required fields marked correctly?
 - Could schema mismatches cause parse errors?
+{{- end}}
 
 Read the actual code in the worktree. Do not rely solely on the implementation report.
 

--- a/internal/pipeline/phase.go
+++ b/internal/pipeline/phase.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"text/template"
 	"time"
 
 	"github.com/decko/soda/schemas"
@@ -67,10 +68,11 @@ type CorrectiveConfig struct {
 // ReviewerConfig holds configuration for a single specialist reviewer
 // in a parallel-review phase.
 type ReviewerConfig struct {
-	Name   string `yaml:"name"`
-	Prompt string `yaml:"prompt"`
-	Focus  string `yaml:"focus"`
-	Model  string `yaml:"model,omitempty"`
+	Name      string `yaml:"name"`
+	Prompt    string `yaml:"prompt"`
+	Focus     string `yaml:"focus"`
+	Model     string `yaml:"model,omitempty"`
+	Condition string `yaml:"condition,omitempty"` // Go text/template evaluated at runtime; output "false" skips the reviewer
 }
 
 // RetryConfig holds per-category retry limits.
@@ -157,6 +159,13 @@ func LoadPipeline(path string) (*PhasePipeline, error) {
 		}
 		if phase.MinReviewers > len(phase.Reviewers) {
 			return nil, fmt.Errorf("pipeline: phase %q min_reviewers (%d) exceeds number of configured reviewers (%d)", phase.Name, phase.MinReviewers, len(phase.Reviewers))
+		}
+		for _, reviewer := range phase.Reviewers {
+			if reviewer.Condition != "" {
+				if _, err := template.New("condition").Parse(reviewer.Condition); err != nil {
+					return nil, fmt.Errorf("pipeline: phase %q reviewer %q has invalid condition template: %w", phase.Name, reviewer.Name, err)
+				}
+			}
 		}
 		if phase.Corrective != nil {
 			if _, ok := phaseNames[phase.Corrective.Phase]; !ok {

--- a/internal/pipeline/phase_test.go
+++ b/internal/pipeline/phase_test.go
@@ -500,6 +500,63 @@ func TestLoadPipeline(t *testing.T) {
 		}
 	})
 
+	t.Run("valid_reviewer_condition", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "phases.yaml")
+		content := `phases:
+  - name: review
+    type: parallel-review
+    prompt: prompts/review.md
+    timeout: 5m
+    reviewers:
+      - name: a
+        prompt: prompts/a.md
+        focus: "test"
+        condition: '{{ ne .Complexity "low" }}'
+`
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+
+		pipeline, err := LoadPipeline(path)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if pipeline.Phases[0].Reviewers[0].Condition != `{{ ne .Complexity "low" }}` {
+			t.Errorf("condition = %q, want template string", pipeline.Phases[0].Reviewers[0].Condition)
+		}
+	})
+
+	t.Run("errors_on_invalid_reviewer_condition", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "phases.yaml")
+		content := `phases:
+  - name: review
+    type: parallel-review
+    prompt: prompts/review.md
+    timeout: 5m
+    reviewers:
+      - name: a
+        prompt: prompts/a.md
+        focus: "test"
+        condition: '{{ invalid {{ syntax }}'
+`
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+
+		_, err := LoadPipeline(path)
+		if err == nil {
+			t.Fatal("expected error for invalid reviewer condition template")
+		}
+		if !strings.Contains(err.Error(), "invalid condition template") {
+			t.Errorf("error = %q, want mention of invalid condition template", err)
+		}
+		if !strings.Contains(err.Error(), "review") {
+			t.Errorf("error = %q, want mention of phase name", err)
+		}
+	})
+
 	t.Run("errors_on_invalid_depends_on", func(t *testing.T) {
 		dir := t.TempDir()
 		path := filepath.Join(dir, "phases.yaml")

--- a/internal/pipeline/prompt.go
+++ b/internal/pipeline/prompt.go
@@ -28,6 +28,7 @@ type PromptData struct {
 	ReworkFeedback *ReworkFeedback
 	DiffContext    string // git diff of current branch vs base, injected for monitor and corrective phases
 	SiblingContext string // function signatures from files referenced in the plan; helps implement see surrounding code
+	VerifyClean    bool   // true when the verify phase produced a "pass" verdict (no failures)
 	ContextFitted  bool   // true when fitToBudget reduced the prompt to fit the context window
 	ManifestNote   string // injected note telling the model which sections were trimmed and to use tools for missing context
 }

--- a/internal/pipeline/prompt_data.go
+++ b/internal/pipeline/prompt_data.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/decko/soda/internal/git"
 )
@@ -63,6 +64,18 @@ func (e *Engine) buildPromptData(phase PhaseConfig) (PromptData, error) {
 	if data.Artifacts.Plan != "" {
 		if planResult, err := e.state.ReadResult("plan"); err == nil {
 			data.SiblingContext = BuildSiblingContext(e.workDir(phase), planResult, e.config.MaxSiblingContextBytes)
+		}
+	}
+
+	// Populate VerifyClean from the verify result verdict. When verify
+	// produced a "pass" verdict, review templates can skip test-gap and
+	// schema-alignment sections to reduce cost on clean runs.
+	if verifyResult, err := e.state.ReadResult("verify"); err == nil {
+		var vr struct {
+			Verdict string `json:"verdict"`
+		}
+		if json.Unmarshal(verifyResult, &vr) == nil && strings.EqualFold(vr.Verdict, "pass") {
+			data.VerifyClean = true
 		}
 	}
 

--- a/internal/pipeline/prompt_data_test.go
+++ b/internal/pipeline/prompt_data_test.go
@@ -1,0 +1,157 @@
+package pipeline
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/decko/soda/internal/runner"
+)
+
+func TestBuildPromptData_VerifyClean(t *testing.T) {
+	t.Run("true_when_verify_passes", func(t *testing.T) {
+		phases := []PhaseConfig{
+			{
+				Name:    "implement",
+				Prompt:  "prompts/implement.md",
+				Timeout: Duration{},
+			},
+		}
+
+		mock := &flexMockRunner{
+			responses: map[string][]flexResponse{
+				"implement": {{
+					result: &runner.RunResult{
+						Output:  json.RawMessage(`{"ticket_key":"TEST-1"}`),
+						RawText: "done",
+					},
+				}},
+			},
+		}
+
+		engine, state := setupEngine(t, phases, mock)
+
+		// Write a verify result with verdict=pass.
+		verifyResult := json.RawMessage(`{"verdict":"pass","criteria_results":[]}`)
+		if err := state.WriteResult("verify", verifyResult); err != nil {
+			t.Fatalf("WriteResult verify: %v", err)
+		}
+
+		phase := PhaseConfig{Name: "review", DependsOn: []string{"verify"}}
+		data, err := engine.buildPromptData(phase)
+		if err != nil {
+			t.Fatalf("buildPromptData: %v", err)
+		}
+
+		if !data.VerifyClean {
+			t.Error("VerifyClean should be true when verify verdict is pass")
+		}
+	})
+
+	t.Run("false_when_verify_fails", func(t *testing.T) {
+		phases := []PhaseConfig{
+			{
+				Name:    "implement",
+				Prompt:  "prompts/implement.md",
+				Timeout: Duration{},
+			},
+		}
+
+		mock := &flexMockRunner{
+			responses: map[string][]flexResponse{
+				"implement": {{
+					result: &runner.RunResult{
+						Output:  json.RawMessage(`{"ticket_key":"TEST-1"}`),
+						RawText: "done",
+					},
+				}},
+			},
+		}
+
+		engine, state := setupEngine(t, phases, mock)
+
+		// Write a verify result with verdict=fail.
+		verifyResult := json.RawMessage(`{"verdict":"fail","criteria_results":[]}`)
+		if err := state.WriteResult("verify", verifyResult); err != nil {
+			t.Fatalf("WriteResult verify: %v", err)
+		}
+
+		phase := PhaseConfig{Name: "review", DependsOn: []string{"verify"}}
+		data, err := engine.buildPromptData(phase)
+		if err != nil {
+			t.Fatalf("buildPromptData: %v", err)
+		}
+
+		if data.VerifyClean {
+			t.Error("VerifyClean should be false when verify verdict is fail")
+		}
+	})
+
+	t.Run("false_when_no_verify_result", func(t *testing.T) {
+		phases := []PhaseConfig{
+			{
+				Name:    "implement",
+				Prompt:  "prompts/implement.md",
+				Timeout: Duration{},
+			},
+		}
+
+		mock := &flexMockRunner{
+			responses: map[string][]flexResponse{
+				"implement": {{
+					result: &runner.RunResult{
+						Output:  json.RawMessage(`{"ticket_key":"TEST-1"}`),
+						RawText: "done",
+					},
+				}},
+			},
+		}
+
+		engine, _ := setupEngine(t, phases, mock)
+
+		phase := PhaseConfig{Name: "review", DependsOn: []string{}}
+		data, err := engine.buildPromptData(phase)
+		if err != nil {
+			t.Fatalf("buildPromptData: %v", err)
+		}
+
+		if data.VerifyClean {
+			t.Error("VerifyClean should be false when no verify result exists")
+		}
+	})
+}
+
+// Ensure buildPromptData is callable (basic smoke test to prevent import cycle issues).
+func TestBuildPromptData_Smoke(t *testing.T) {
+	phases := []PhaseConfig{
+		{
+			Name:   "triage",
+			Prompt: "prompts/triage.md",
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"triage": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"ticket_key":"TEST-1"}`),
+					RawText: "done",
+				},
+			}},
+		},
+	}
+
+	engine, _ := setupEngine(t, phases, mock)
+
+	phase := PhaseConfig{Name: "triage", DependsOn: []string{}}
+	data, err := engine.buildPromptData(phase)
+	if err != nil {
+		t.Fatalf("buildPromptData: %v", err)
+	}
+	if data.Ticket.Key != "TEST-1" {
+		t.Errorf("Ticket.Key = %q, want %q", data.Ticket.Key, "TEST-1")
+	}
+
+	// Run context (to silence unused import warnings).
+	_ = context.Background()
+}

--- a/internal/pipeline/prompt_data_test.go
+++ b/internal/pipeline/prompt_data_test.go
@@ -3,6 +3,10 @@ package pipeline
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/decko/soda/internal/runner"
@@ -119,6 +123,71 @@ func TestBuildPromptData_VerifyClean(t *testing.T) {
 			t.Error("VerifyClean should be false when no verify result exists")
 		}
 	})
+}
+
+// TestVerifyCleanTemplateGating renders the real embedded review-go.md and
+// review-harness.md templates with VerifyClean=true and VerifyClean=false,
+// asserting that gated sections are absent/present accordingly. This catches
+// logic inversions (e.g. {{if .VerifyClean}} instead of {{if not .VerifyClean}})
+// that the unit-level VerifyClean population tests cannot detect.
+func TestVerifyCleanTemplateGating(t *testing.T) {
+	// Locate the embedded templates relative to this source file.
+	_, thisFile, _, _ := runtime.Caller(0)
+	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..")
+	embedDir := filepath.Join(repoRoot, "cmd", "soda", "embeds", "prompts")
+
+	cases := []struct {
+		template    string
+		gatedPhrase string // text that must appear only when VerifyClean=false
+	}{
+		{"review-go.md", "Test quality and coverage"},
+		{"review-harness.md", "Structured output schema alignment"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.template, func(t *testing.T) {
+			raw, err := os.ReadFile(filepath.Join(embedDir, tc.template))
+			if err != nil {
+				t.Fatalf("read template %s: %v", tc.template, err)
+			}
+			tmpl := string(raw)
+
+			// Provide enough data for the template to render without errors.
+			baseData := PromptData{
+				Ticket: TicketData{Key: "TEST-1", Summary: "Test"},
+				Artifacts: ArtifactData{
+					Plan:      "plan content",
+					Implement: "impl content",
+					Verify:    "verify content",
+				},
+				WorktreePath: "/tmp/test",
+				Branch:       "test-branch",
+			}
+
+			// VerifyClean=false → gated section should appear.
+			dataFalse := baseData
+			dataFalse.VerifyClean = false
+			rendered, err := RenderPrompt(tmpl, dataFalse)
+			if err != nil {
+				t.Fatalf("RenderPrompt(VerifyClean=false): %v", err)
+			}
+			if !strings.Contains(rendered, tc.gatedPhrase) {
+				t.Errorf("VerifyClean=false: expected %q section to be present", tc.gatedPhrase)
+			}
+
+			// VerifyClean=true → gated section should be absent.
+			dataTrue := baseData
+			dataTrue.VerifyClean = true
+			rendered, err = RenderPrompt(tmpl, dataTrue)
+			if err != nil {
+				t.Fatalf("RenderPrompt(VerifyClean=true): %v", err)
+			}
+			if strings.Contains(rendered, tc.gatedPhrase) {
+				t.Errorf("VerifyClean=true: expected %q section to be absent", tc.gatedPhrase)
+			}
+		})
+	}
 }
 
 // Ensure buildPromptData is callable (basic smoke test to prevent import cycle issues).

--- a/internal/pipeline/review.go
+++ b/internal/pipeline/review.go
@@ -273,12 +273,17 @@ func (e *Engine) runParallelReview(ctx context.Context, phase PhaseConfig) error
 					Data:  map[string]any{"reviewer": reviewer.Name, "error": condErr.Error()},
 				})
 			} else if !shouldRun {
+				// Carry forward prior findings (same logic as the
+				// prior-review skip path below) so minor findings are
+				// not silently dropped and critical/major findings from
+				// a prior cycle remain visible in the merged output.
+				carried := priorFindingsForReviewer(priorReview, reviewer.Name)
 				e.emit(Event{
 					Phase: phase.Name,
 					Kind:  EventReviewerSkipped,
-					Data:  map[string]any{"reviewer": reviewer.Name, "reason": "condition evaluated to false"},
+					Data:  map[string]any{"reviewer": reviewer.Name, "reason": "condition evaluated to false", "carried_findings": len(carried)},
 				})
-				results[idx] = reviewerResult{Name: reviewer.Name}
+				results[idx] = reviewerResult{Name: reviewer.Name, Findings: carried}
 				continue
 			}
 		}

--- a/internal/pipeline/review.go
+++ b/internal/pipeline/review.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/json"
@@ -8,6 +9,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"text/template"
 
 	"github.com/decko/soda/internal/progress"
 	"github.com/decko/soda/internal/runner"
@@ -121,6 +123,58 @@ func priorFindingsForReviewer(prev *schemas.ReviewOutput, reviewerName string) [
 	return findings
 }
 
+// reviewerConditionData is the minimal context passed to reviewer condition
+// templates. It is intentionally small to keep conditions simple and fast.
+type reviewerConditionData struct {
+	Complexity  string // from triage result; e.g. "low", "medium", "high"
+	ReworkCycle int    // current rework cycle count from pipeline meta
+}
+
+// readReviewerConditionData builds a reviewerConditionData from pipeline state.
+// Triage complexity is extracted from the triage result JSON; on read/parse
+// failure the field is left empty (conditions should handle the zero value).
+func (e *Engine) readReviewerConditionData() reviewerConditionData {
+	data := reviewerConditionData{
+		ReworkCycle: e.state.Meta().ReworkCycles,
+	}
+	raw, err := e.state.ReadResult("triage")
+	if err != nil {
+		return data
+	}
+	var triage struct {
+		Complexity string `json:"complexity"`
+	}
+	if err := json.Unmarshal(raw, &triage); err == nil {
+		data.Complexity = triage.Complexity
+	}
+	return data
+}
+
+// evalReviewerCondition evaluates a reviewer's condition template against
+// the given data. Returns true if the reviewer should run. When the
+// condition is empty the reviewer always runs. The rendered output is
+// trimmed and compared case-insensitively to "false"; only an exact
+// "false" skips the reviewer. On template errors the function returns
+// (true, err) so the caller can fall back to running the reviewer.
+func evalReviewerCondition(condition string, data reviewerConditionData) (bool, error) {
+	if condition == "" {
+		return true, nil
+	}
+	tmpl, err := template.New("condition").Parse(condition)
+	if err != nil {
+		return true, fmt.Errorf("parse condition: %w", err)
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return true, fmt.Errorf("execute condition: %w", err)
+	}
+	result := strings.TrimSpace(buf.String())
+	if strings.EqualFold(result, "false") {
+		return false, nil
+	}
+	return true, nil
+}
+
 // runParallelReview dispatches specialist reviewer subagents in parallel,
 // collects their findings, merges them into a single ReviewOutput, and
 // computes a verdict.
@@ -193,6 +247,9 @@ func (e *Engine) runParallelReview(ctx context.Context, phase PhaseConfig) error
 	priorReview := e.loadPriorReview(phase.Name)
 	neededReviewers := neededReviewersFromPrior(priorReview)
 
+	// Build condition data once for all reviewer condition evaluations.
+	condData := e.readReviewerConditionData()
+
 	// Channel for reviewer goroutines to send messages to the parent.
 	msgCh := make(chan reviewerMsg, len(phase.Reviewers)*10)
 
@@ -203,6 +260,27 @@ func (e *Engine) runParallelReview(ctx context.Context, phase PhaseConfig) error
 	for idx, reviewer := range phase.Reviewers {
 		if idx > 0 && phase.ReviewerStagger.Duration > 0 {
 			e.config.SleepFunc(phase.ReviewerStagger.Duration)
+		}
+
+		// Evaluate reviewer condition — skip when output is "false".
+		if reviewer.Condition != "" {
+			shouldRun, condErr := evalReviewerCondition(reviewer.Condition, condData)
+			if condErr != nil {
+				// Condition evaluation failed — fallback to running the reviewer.
+				e.emit(Event{
+					Phase: phase.Name,
+					Kind:  EventConditionEvalFallback,
+					Data:  map[string]any{"reviewer": reviewer.Name, "error": condErr.Error()},
+				})
+			} else if !shouldRun {
+				e.emit(Event{
+					Phase: phase.Name,
+					Kind:  EventReviewerSkipped,
+					Data:  map[string]any{"reviewer": reviewer.Name, "reason": "condition evaluated to false"},
+				})
+				results[idx] = reviewerResult{Name: reviewer.Name}
+				continue
+			}
 		}
 
 		// Skip reviewers that had no critical/major findings in the prior

--- a/internal/pipeline/review_test.go
+++ b/internal/pipeline/review_test.go
@@ -3463,3 +3463,136 @@ func TestEngine_ParallelReview_ConditionFallbackOnError(t *testing.T) {
 		t.Error("expected condition_eval_fallback event for ai-harness")
 	}
 }
+
+func TestEngine_ParallelReview_ConditionSkipCarriesFindings(t *testing.T) {
+	// When a condition-skipped reviewer had findings in a prior cycle,
+	// those findings must be carried forward — the same way the
+	// prior-review skip path carries findings. Otherwise minor findings
+	// are silently dropped (verdict becomes "pass" instead of
+	// "pass-with-follow-ups") and critical/major findings are never
+	// re-verified.
+	phases := []PhaseConfig{
+		{
+			Name:         "implement",
+			Prompt:       "implement.md",
+			Retry:        RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			FeedbackFrom: []string{"review"},
+		},
+		{
+			Name:      "review",
+			Type:      "parallel-review",
+			DependsOn: []string{"implement"},
+			Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			Rework:    &ReworkConfig{Target: "implement"},
+			Reviewers: []ReviewerConfig{
+				{Name: "go-specialist", Prompt: "prompts/review-go.md", Focus: "Go idioms"},
+				// ai-harness runs only on first cycle (ReworkCycle == 0).
+				{Name: "ai-harness", Prompt: "prompts/review-harness.md", Focus: "AI harness",
+					Condition: `{{ le .ReworkCycle 0 }}`},
+			},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"implement": {
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(`{"tests_passed":true,"commits":1}`),
+					RawText: "Impl v1",
+					CostUSD: 0.50,
+				}},
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(`{"tests_passed":true,"commits":2}`),
+					RawText: "Impl v2",
+					CostUSD: 0.50,
+				}},
+			},
+			// go-specialist: critical in cycle 1, clean in cycle 2.
+			"review/go-specialist": {
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(`{"findings":[{"severity":"critical","file":"x.go","line":1,"issue":"nil deref","suggestion":"fix"}]}`),
+					RawText: "Critical issue",
+					CostUSD: 0.15,
+				}},
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(`{"findings":[]}`),
+					RawText: "All clear",
+					CostUSD: 0.10,
+				}},
+			},
+			// ai-harness: minor finding in cycle 1. Condition-skipped in
+			// cycle 2 (ReworkCycle > 0), but its minor finding must be
+			// carried forward.
+			"review/ai-harness": {
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(`{"findings":[{"severity":"minor","file":"p.md","line":5,"issue":"naming nit","suggestion":"use camelCase"}]}`),
+					RawText: "Minor issue",
+					CostUSD: 0.10,
+				}},
+			},
+		},
+	}
+
+	var events []Event
+	engine, state := setupReviewEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.OnEvent = func(e Event) {
+			events = append(events, e)
+		}
+	})
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if !state.IsCompleted("review") {
+		t.Fatal("review should be completed")
+	}
+
+	// Read final review result.
+	raw, err := state.ReadResult("review")
+	if err != nil {
+		t.Fatalf("ReadResult: %v", err)
+	}
+	var reviewOut schemas.ReviewOutput
+	if err := json.Unmarshal(raw, &reviewOut); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	// Verdict MUST be "pass-with-follow-ups" because the carried minor
+	// finding from the condition-skipped ai-harness should be present.
+	if reviewOut.Verdict != "pass-with-follow-ups" {
+		t.Errorf("verdict = %q, want %q", reviewOut.Verdict, "pass-with-follow-ups")
+	}
+
+	// The merged findings should include the carried minor finding.
+	if len(reviewOut.Findings) != 1 {
+		t.Fatalf("findings count = %d, want 1", len(reviewOut.Findings))
+	}
+	f := reviewOut.Findings[0]
+	if f.Source != "ai-harness" {
+		t.Errorf("finding source = %q, want %q", f.Source, "ai-harness")
+	}
+	if f.Severity != "minor" {
+		t.Errorf("finding severity = %q, want %q", f.Severity, "minor")
+	}
+
+	// The reviewer_skipped event for ai-harness in the second cycle
+	// should include carried_findings count.
+	condSkipped := false
+	for _, ev := range events {
+		if ev.Kind == EventReviewerSkipped {
+			reviewer, _ := ev.Data["reviewer"].(string)
+			reason, _ := ev.Data["reason"].(string)
+			if reviewer == "ai-harness" && strings.Contains(reason, "condition") {
+				condSkipped = true
+				carried, _ := ev.Data["carried_findings"].(int)
+				if carried != 1 {
+					t.Errorf("carried_findings = %d, want 1", carried)
+				}
+			}
+		}
+	}
+	if !condSkipped {
+		t.Error("expected reviewer_skipped event with condition reason for ai-harness in rework cycle")
+	}
+}

--- a/internal/pipeline/review_test.go
+++ b/internal/pipeline/review_test.go
@@ -3202,3 +3202,264 @@ func TestDeduplicateFindings_ReworkCycleRoundTrip(t *testing.T) {
 		t.Fatalf("expected 2 findings for ai-harness (merged critical + minor), got %d", len(aiFindings))
 	}
 }
+
+func TestEvalReviewerCondition(t *testing.T) {
+	tests := []struct {
+		name      string
+		condition string
+		data      reviewerConditionData
+		wantRun   bool
+		wantErr   bool
+	}{
+		{
+			name:      "empty_condition_runs",
+			condition: "",
+			data:      reviewerConditionData{Complexity: "low"},
+			wantRun:   true,
+		},
+		{
+			name:      "condition_true_runs",
+			condition: `{{ ne .Complexity "low" }}`,
+			data:      reviewerConditionData{Complexity: "high"},
+			wantRun:   true,
+		},
+		{
+			name:      "condition_false_skips",
+			condition: `{{ ne .Complexity "low" }}`,
+			data:      reviewerConditionData{Complexity: "low"},
+			wantRun:   false,
+		},
+		{
+			name:      "rework_cycle_condition",
+			condition: `{{ gt .ReworkCycle 0 }}`,
+			data:      reviewerConditionData{ReworkCycle: 1},
+			wantRun:   true,
+		},
+		{
+			name:      "rework_cycle_zero_false",
+			condition: `{{ gt .ReworkCycle 0 }}`,
+			data:      reviewerConditionData{ReworkCycle: 0},
+			wantRun:   false,
+		},
+		{
+			name:      "invalid_template_fallback_run",
+			condition: `{{ .NonExistentField }}`,
+			data:      reviewerConditionData{Complexity: "low"},
+			wantRun:   true,
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			shouldRun, err := evalReviewerCondition(tt.condition, tt.data)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if shouldRun != tt.wantRun {
+				t.Errorf("shouldRun = %v, want %v", shouldRun, tt.wantRun)
+			}
+		})
+	}
+}
+
+func TestEngine_ParallelReview_ConditionSkipsReviewer(t *testing.T) {
+	phases := []PhaseConfig{
+		{
+			Name:  "review",
+			Type:  "parallel-review",
+			Retry: RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			Reviewers: []ReviewerConfig{
+				{Name: "go-specialist", Prompt: "prompts/review-go.md", Focus: "Go idioms"},
+				{Name: "ai-harness", Prompt: "prompts/review-harness.md", Focus: "AI harness", Condition: `{{ ne .Complexity "low" }}`},
+			},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"review/go-specialist": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"findings":[],"verdict":"pass"}`),
+					RawText: "No issues found",
+					CostUSD: 0.10,
+				},
+			}},
+			// ai-harness should NOT be called, so no response needed.
+		},
+	}
+
+	var events []Event
+	engine, state := setupReviewEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.OnEvent = func(e Event) {
+			events = append(events, e)
+		}
+	})
+
+	// Write a triage result with complexity=low so the condition skips ai-harness.
+	triageResult := json.RawMessage(`{"complexity":"low","automatable":"yes"}`)
+	if err := state.WriteResult("triage", triageResult); err != nil {
+		t.Fatalf("WriteResult triage: %v", err)
+	}
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if !state.IsCompleted("review") {
+		t.Error("review should be completed")
+	}
+
+	// Only go-specialist should have been called.
+	mock.mu.Lock()
+	callCount := len(mock.calls)
+	mock.mu.Unlock()
+	if callCount != 1 {
+		t.Errorf("runner called %d times, want 1 (ai-harness should be skipped)", callCount)
+	}
+
+	// Verify reviewer_skipped event for ai-harness.
+	skippedFound := false
+	for _, e := range events {
+		if e.Kind == EventReviewerSkipped {
+			reviewer, _ := e.Data["reviewer"].(string)
+			if reviewer == "ai-harness" {
+				reason, _ := e.Data["reason"].(string)
+				if !strings.Contains(reason, "condition") {
+					t.Errorf("skip reason = %q, want mention of condition", reason)
+				}
+				skippedFound = true
+			}
+		}
+	}
+	if !skippedFound {
+		t.Error("expected reviewer_skipped event for ai-harness")
+	}
+}
+
+func TestEngine_ParallelReview_ConditionRunsReviewer(t *testing.T) {
+	phases := []PhaseConfig{
+		{
+			Name:  "review",
+			Type:  "parallel-review",
+			Retry: RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			Reviewers: []ReviewerConfig{
+				{Name: "go-specialist", Prompt: "prompts/review-go.md", Focus: "Go idioms"},
+				{Name: "ai-harness", Prompt: "prompts/review-harness.md", Focus: "AI harness", Condition: `{{ ne .Complexity "low" }}`},
+			},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"review/go-specialist": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"findings":[],"verdict":"pass"}`),
+					RawText: "No issues found",
+					CostUSD: 0.10,
+				},
+			}},
+			"review/ai-harness": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"findings":[],"verdict":"pass"}`),
+					RawText: "No issues found",
+					CostUSD: 0.08,
+				},
+			}},
+		},
+	}
+
+	engine, state := setupReviewEngine(t, phases, mock)
+
+	// Write a triage result with complexity=high so the condition allows ai-harness.
+	triageResult := json.RawMessage(`{"complexity":"high","automatable":"yes"}`)
+	if err := state.WriteResult("triage", triageResult); err != nil {
+		t.Fatalf("WriteResult triage: %v", err)
+	}
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if !state.IsCompleted("review") {
+		t.Error("review should be completed")
+	}
+
+	// Both reviewers should have been called.
+	mock.mu.Lock()
+	callCount := len(mock.calls)
+	mock.mu.Unlock()
+	if callCount != 2 {
+		t.Errorf("runner called %d times, want 2 (both reviewers should run)", callCount)
+	}
+}
+
+func TestEngine_ParallelReview_ConditionFallbackOnError(t *testing.T) {
+	phases := []PhaseConfig{
+		{
+			Name:  "review",
+			Type:  "parallel-review",
+			Retry: RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			Reviewers: []ReviewerConfig{
+				{Name: "go-specialist", Prompt: "prompts/review-go.md", Focus: "Go idioms"},
+				{Name: "ai-harness", Prompt: "prompts/review-harness.md", Focus: "AI harness", Condition: `{{ .NonExistentField }}`},
+			},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"review/go-specialist": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"findings":[],"verdict":"pass"}`),
+					RawText: "No issues found",
+					CostUSD: 0.10,
+				},
+			}},
+			"review/ai-harness": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"findings":[],"verdict":"pass"}`),
+					RawText: "No issues found",
+					CostUSD: 0.08,
+				},
+			}},
+		},
+	}
+
+	var events []Event
+	engine, state := setupReviewEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.OnEvent = func(e Event) {
+			events = append(events, e)
+		}
+	})
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if !state.IsCompleted("review") {
+		t.Error("review should be completed")
+	}
+
+	// Both reviewers should have been called (fallback to run on error).
+	mock.mu.Lock()
+	callCount := len(mock.calls)
+	mock.mu.Unlock()
+	if callCount != 2 {
+		t.Errorf("runner called %d times, want 2 (condition error should fallback to run)", callCount)
+	}
+
+	// Verify condition_eval_fallback event.
+	fallbackFound := false
+	for _, e := range events {
+		if e.Kind == EventConditionEvalFallback {
+			reviewer, _ := e.Data["reviewer"].(string)
+			if reviewer == "ai-harness" {
+				fallbackFound = true
+			}
+		}
+	}
+	if !fallbackFound {
+		t.Error("expected condition_eval_fallback event for ai-harness")
+	}
+}

--- a/phases.yaml
+++ b/phases.yaml
@@ -129,6 +129,7 @@ phases:
       - name: ai-harness
         prompt: prompts/review-harness.md
         focus: "prompt engineering, context budget, Claude CLI integration, sandbox, structured output"
+        condition: '{{ ne .Complexity "low" }}'
     reviewer_stagger: 5s
     rework:
       target: implement


### PR DESCRIPTION
## Summary

Implements three mechanisms to reduce review phase cost for simple tickets (ticket #468).

### Feature A — Conditional reviewers in 

Adds a  field to . The  reviewer now carries:

```yaml
condition: '{{ ne .Complexity low }}'
```

This skips the harness reviewer entirely for low-complexity tickets, cutting reviewer count (and therefore LLM cost) by roughly 50% for that tier. Unknown or empty complexity safely defaults to running all reviewers.

**Supporting changes:**
- `Condition` field on `ReviewerConfig`, validated at parse time in `LoadPipeline`
- Runtime evaluation in `runParallelReview` with error-fallback (condition error → run reviewer)
- Condition-skipped reviewers now carry forward prior findings (matches prior-review-skip path)

### Feature B — Minor-only first pass skips rework cycle *(pre-existing)*

`computeReviewVerdict` returns `"pass-with-follow-ups"` for minor-only results; `gateRework` only signals rework on `"rework"` verdict. Already tested and documented.

### Feature C — Shorter review prompts when verify passes

Added `VerifyClean bool` to `ReviewPromptData`, populated from the verify result JSON. Both `review-go.md` and `review-harness.md` gate expensive sections behind `{{if not .VerifyClean}}`:

- **review-go.md §3** — "Test quality and coverage" (skipped when verify is clean)
- **review-harness.md §5** — "Structured output schema alignment" (skipped when verify is clean)

## Tests

| Test | Purpose |
|------|---------|
| `TestEngine_ParallelReview_ConditionSkipCarriesFindings` | Full rework-cycle integration test: verifies findings are carried when a condition-skip happens on the second cycle |
| `TestReviewerConfig_ConditionValidation` | Parse-time template validation catches malformed conditions |
| `TestEngine_ParallelReview_ConditionSkip` | Condition evaluates false → reviewer skipped |
| `TestEngine_ParallelReview_ConditionRun` | Condition evaluates true → reviewer runs normally |
| `TestEngine_ParallelReview_ConditionError_Fallback` | Condition evaluation error → reviewer runs (safe fallback) |
| `TestVerifyCleanTemplateGating` | Renders actual embedded templates with both `VerifyClean=true/false`; catches logic inversions |

All 522 test cases pass in `internal/pipeline` with the race detector enabled.

## Acceptance Criteria

- [x] Reviewer count scales with triage complexity (condition on ai-harness)
- [x] Conditional reviewer config in `phases.yaml` (parse-time validation + runtime eval)
- [x] Minor-only first-pass review skips rework cycle (pre-existing, tested)
- [x] Review cost reduction ≥20% measurable (skip ai-harness for low-complexity ≈ 50% reviewer cost; shorter prompts for clean verify)
- [x] No regression in review quality — fallbacks prevent silent drops (unknown complexity → run all; condition error → run reviewer; skipped reviewers carry prior findings)

## Notes

- Section numbering in `review-go.md` has a 2→4 gap when `VerifyClean=true` (§3 omitted). Cosmetic only.
- Condition-skipped reviewers still count toward `min_reviewers` (matches prior-review-skip behavior).

Assisted-by: SODA