### PR TITLE
[483] feat(engine): persist full agent transcript for raki retrieval quality metrics

### DIFF
--- a/.claude/skills/soda-pipeline.md
+++ b/.claude/skills/soda-pipeline.md
@@ -16,7 +16,7 @@ Each pipeline phase follows this lifecycle:
 1. Engine calls `buildPromptData()` — assembles ticket, artifacts from prior phases, config, and context
 2. `PromptLoader.Load()` resolves the prompt template (user override > working dir > embedded)
 3. `RenderPrompt()` executes the Go `text/template` against `PromptData`
-4. Runner invokes Claude Code CLI with `--print --bare --output-format json --json-schema <schema>`
+4. Runner invokes Claude Code CLI with `--print --bare --output-format stream-json --json-schema <schema>`
 5. Response is parsed via `claude.ParseResponse()` — extracts structured output, cost, tokens
 6. Result is written atomically to `.soda/<ticket>/<phase>.json`
 7. Engine emits events (`EventPhaseStarted`, `EventPhaseCompleted`, etc.)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ soda (Go CLI/TUI)
        ├── Network namespace (Unix sockets only)
        ├── cgroup resource limits (memory, CPU, PIDs)
        ├── seccomp syscall filter
-       └── claude --print --bare --output-format json --json-schema ...
+       └── claude --print --bare --output-format stream-json --json-schema ...
 ```
 
 ## Pipeline phases
@@ -283,7 +283,7 @@ soda/
 Every phase invokes Claude Code with these flags:
 
 ```
-claude --print --bare --output-format json --json-schema <schema> \
+claude --print --bare --output-format stream-json --json-schema <schema> \
        --system-prompt-file <prompt> --model <model> \
        [--max-budget-usd <budget>] --permission-mode bypassPermissions
 ```
@@ -292,7 +292,7 @@ claude --print --bare --output-format json --json-schema <schema> \
 |------|-----|
 | `--print` | Non-interactive, exit after response |
 | `--bare` | No auto-discovery of CLAUDE.md, plugins, hooks, MCP. SODA controls the full context window. |
-| `--output-format json` | Structured response with `structured_output`, `total_cost_usd`, `usage`, `duration_ms` |
+| `--output-format stream-json` | JSONL per event (enables transcript capture); last line is the result envelope with `structured_output`, `total_cost_usd`, `usage`, `duration_ms` |
 | `--json-schema` | Enforce structured output. CLI validates against schema. No regex parsing needed. |
 | `--system-prompt-file` | Phase role + context as system prompt from file |
 | `--max-budget-usd` | Hard cost cap per phase (omitted when no budget configured) |

--- a/cmd/soda/embeds/claude-code/skills/soda-pipeline/SKILL.md
+++ b/cmd/soda/embeds/claude-code/skills/soda-pipeline/SKILL.md
@@ -18,7 +18,7 @@ Each pipeline phase follows this lifecycle:
 1. Engine calls `buildPromptData()` — assembles ticket, artifacts from prior phases, config, and context
 2. `PromptLoader.Load()` resolves the prompt template (user override > working dir > embedded)
 3. `RenderPrompt()` executes the Go `text/template` against `PromptData`
-4. Runner invokes Claude Code CLI with `--print --bare --output-format json --json-schema <schema>`
+4. Runner invokes Claude Code CLI with `--print --bare --output-format stream-json --json-schema <schema>`
 5. Response is parsed via `claude.ParseResponse()` — extracts structured output, cost, tokens
 6. Result is written atomically to `.soda/<ticket>/<phase>.json`
 7. Engine emits events (`EventPhaseStarted`, `EventPhaseCompleted`, etc.)

--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -24,6 +24,7 @@ import (
 	"github.com/decko/soda/internal/runner"
 	"github.com/decko/soda/internal/sandbox"
 	"github.com/decko/soda/internal/ticket"
+	"github.com/decko/soda/internal/transcript"
 	"github.com/decko/soda/internal/tui"
 	"github.com/decko/soda/schemas"
 	"github.com/mattn/go-isatty"
@@ -377,16 +378,16 @@ func runPipeline(cfg *config.Config, opts pipelineOpts) error {
 	}
 
 	// Resolve transcript level: CLI flag overrides config.
-	transcriptLevel := claude.TranscriptLevel(cfg.Transcript.Level)
+	transcriptLevel := transcript.Level(cfg.Transcript.Level)
 	if opts.transcriptChanged {
-		transcriptLevel = claude.TranscriptLevel(opts.transcript)
+		transcriptLevel = transcript.Level(opts.transcript)
 	}
 	// Validate the resolved level; default to off for unknown values.
 	switch transcriptLevel {
-	case claude.TranscriptTools, claude.TranscriptFull, claude.TranscriptOff:
+	case transcript.Tools, transcript.Full, transcript.Off:
 		// valid
 	case "":
-		transcriptLevel = claude.TranscriptOff
+		transcriptLevel = transcript.Off
 	default:
 		return fmt.Errorf("run: unknown transcript level %q (expected 'tools', 'full', or 'off')", transcriptLevel)
 	}

--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -33,16 +33,18 @@ import (
 // pipelineOpts holds all flag-driven parameters for runPipeline so callers
 // don't need to register or pass a *cobra.Command with the right flags.
 type pipelineOpts struct {
-	ticketKey       string
-	pipelineName    string
-	pipelineChanged bool // true when --pipeline was explicitly passed
-	mode            string
-	modeChanged     bool // true when --mode was explicitly passed
-	fromPhase       string
-	dryRun          bool
-	estimate        bool
-	useMock         bool
-	useTUI          bool
+	ticketKey         string
+	pipelineName      string
+	pipelineChanged   bool // true when --pipeline was explicitly passed
+	mode              string
+	modeChanged       bool // true when --mode was explicitly passed
+	fromPhase         string
+	dryRun            bool
+	estimate          bool
+	useMock           bool
+	useTUI            bool
+	transcript        string // CLI override: "tools", "full", or "off"
+	transcriptChanged bool   // true when --transcript was explicitly passed
 }
 
 // pipelineOptsFromCmd extracts pipelineOpts from Cobra flags registered on the
@@ -55,18 +57,21 @@ func pipelineOptsFromCmd(cmd *cobra.Command, ticketKey string) pipelineOpts {
 	estimate, _ := cmd.Flags().GetBool("estimate")
 	useMock, _ := cmd.Flags().GetBool("mock")
 	useTUI, _ := cmd.Flags().GetBool("tui")
+	transcript, _ := cmd.Flags().GetString("transcript")
 
 	return pipelineOpts{
-		ticketKey:       ticketKey,
-		pipelineName:    pipelineName,
-		pipelineChanged: cmd.Flags().Changed("pipeline"),
-		mode:            mode,
-		modeChanged:     cmd.Flags().Changed("mode"),
-		fromPhase:       fromPhase,
-		dryRun:          dryRun,
-		estimate:        estimate,
-		useMock:         useMock,
-		useTUI:          useTUI,
+		ticketKey:         ticketKey,
+		pipelineName:      pipelineName,
+		pipelineChanged:   cmd.Flags().Changed("pipeline"),
+		mode:              mode,
+		modeChanged:       cmd.Flags().Changed("mode"),
+		fromPhase:         fromPhase,
+		dryRun:            dryRun,
+		estimate:          estimate,
+		useMock:           useMock,
+		useTUI:            useTUI,
+		transcript:        transcript,
+		transcriptChanged: cmd.Flags().Changed("transcript"),
 	}
 }
 
@@ -95,6 +100,7 @@ func newRunCmd() *cobra.Command {
 	cmd.Flags().Bool("mock", false, "use mock runner for testing")
 	cmd.Flags().Bool("tui", false, "use interactive TUI display")
 	cmd.Flags().String("query", "", "search filter for listing tickets (picker mode)")
+	cmd.Flags().String("transcript", "", "transcript capture level: tools, full, or off (overrides config)")
 
 	return cmd
 }
@@ -370,6 +376,21 @@ func runPipeline(cfg *config.Config, opts pipelineOpts) error {
 		maxPipelineDuration = parsed
 	}
 
+	// Resolve transcript level: CLI flag overrides config.
+	transcriptLevel := claude.TranscriptLevel(cfg.Transcript.Level)
+	if opts.transcriptChanged {
+		transcriptLevel = claude.TranscriptLevel(opts.transcript)
+	}
+	// Validate the resolved level; default to off for unknown values.
+	switch transcriptLevel {
+	case claude.TranscriptTools, claude.TranscriptFull, claude.TranscriptOff:
+		// valid
+	case "":
+		transcriptLevel = claude.TranscriptOff
+	default:
+		return fmt.Errorf("run: unknown transcript level %q (expected 'tools', 'full', or 'off')", transcriptLevel)
+	}
+
 	engineCfg := pipeline.EngineConfig{
 		Pipeline:               pl,
 		Loader:                 loader,
@@ -403,6 +424,7 @@ func runPipeline(cfg *config.Config, opts pipelineOpts) error {
 		BotUsers:          botUsers,
 		MonitorProfile:    monitorProfile,
 		AuthorityResolver: authorityResolver,
+		TranscriptLevel:   transcriptLevel,
 		OnEvent: func(event pipeline.Event) {
 			if event.Kind == pipeline.EventPhaseSkipped || event.Kind == pipeline.EventMonitorSkipped {
 				skippedPhases[event.Phase] = true

--- a/cmd/soda/validate.go
+++ b/cmd/soda/validate.go
@@ -85,6 +85,9 @@ func runValidate(w io.Writer, errW io.Writer, cfg *config.Config, pipelineName s
 	// Stage 7: Notify hooks
 	validateNotify(w, result, cfg)
 
+	// Stage 8: Transcript config
+	validateTranscript(w, result, cfg)
+
 	// Print summary
 	fmt.Fprintln(w)
 	for _, warn := range result.warnings {
@@ -307,5 +310,20 @@ func validateNotifyScript(result *validationResult, prefix string, sc *config.Sc
 	binary := parts[0]
 	if _, err := exec.LookPath(binary); err != nil {
 		result.addWarning("%s: script binary %q not found in PATH: %v", prefix, binary, err)
+	}
+}
+
+// validateTranscript checks that the transcript level is a recognized value.
+func validateTranscript(w io.Writer, result *validationResult, cfg *config.Config) {
+	level := cfg.Transcript.Level
+	switch level {
+	case "", "off":
+		fmt.Fprintln(w, "✓ transcript: off (default)")
+	case "tools":
+		fmt.Fprintln(w, "✓ transcript: tools")
+	case "full":
+		fmt.Fprintln(w, "✓ transcript: full")
+	default:
+		result.addError("transcript: unknown level %q (expected 'tools', 'full', or 'off')", level)
 	}
 }

--- a/cmd/soda/validate_test.go
+++ b/cmd/soda/validate_test.go
@@ -601,3 +601,95 @@ func TestRunValidate_WithNotifyHooks(t *testing.T) {
 		t.Errorf("expected notify valid message, got: %s", output)
 	}
 }
+
+func TestValidateTranscript_Default(t *testing.T) {
+	cfg := &config.Config{}
+	result := &validationResult{}
+	var buf bytes.Buffer
+	validateTranscript(&buf, result, cfg)
+
+	if result.hasErrors() {
+		t.Error("expected no errors")
+	}
+	output := buf.String()
+	if !strings.Contains(output, "transcript: off (default)") {
+		t.Errorf("expected 'transcript: off (default)', got: %s", output)
+	}
+}
+
+func TestValidateTranscript_Tools(t *testing.T) {
+	cfg := &config.Config{
+		Transcript: config.TranscriptConfig{Level: "tools"},
+	}
+	result := &validationResult{}
+	var buf bytes.Buffer
+	validateTranscript(&buf, result, cfg)
+
+	if result.hasErrors() {
+		t.Error("expected no errors")
+	}
+	output := buf.String()
+	if !strings.Contains(output, "transcript: tools") {
+		t.Errorf("expected 'transcript: tools', got: %s", output)
+	}
+}
+
+func TestValidateTranscript_Full(t *testing.T) {
+	cfg := &config.Config{
+		Transcript: config.TranscriptConfig{Level: "full"},
+	}
+	result := &validationResult{}
+	var buf bytes.Buffer
+	validateTranscript(&buf, result, cfg)
+
+	if result.hasErrors() {
+		t.Error("expected no errors")
+	}
+	output := buf.String()
+	if !strings.Contains(output, "transcript: full") {
+		t.Errorf("expected 'transcript: full', got: %s", output)
+	}
+}
+
+func TestValidateTranscript_InvalidLevel(t *testing.T) {
+	cfg := &config.Config{
+		Transcript: config.TranscriptConfig{Level: "invalid"},
+	}
+	result := &validationResult{}
+	var buf bytes.Buffer
+	validateTranscript(&buf, result, cfg)
+
+	if !result.hasErrors() {
+		t.Error("expected errors for invalid transcript level")
+	}
+	found := false
+	for _, errMsg := range result.errors {
+		if strings.Contains(errMsg, "unknown level") && strings.Contains(errMsg, "invalid") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected error about unknown level, got: %v", result.errors)
+	}
+}
+
+func TestRunValidate_WithTranscriptConfig(t *testing.T) {
+	cfg := &config.Config{
+		TicketSource: "github",
+		Mode:         "autonomous",
+		Model:        "claude-sonnet-4-20250514",
+		Transcript:   config.TranscriptConfig{Level: "tools"},
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := runValidate(&stdout, &stderr, cfg, "")
+	if err != nil {
+		t.Fatalf("runValidate() error: %v\nstdout: %s\nstderr: %s", err, stdout.String(), stderr.String())
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "✓ transcript: tools") {
+		t.Errorf("expected transcript valid message, got: %s", output)
+	}
+}

--- a/internal/claude/args.go
+++ b/internal/claude/args.go
@@ -24,7 +24,7 @@ func BuildArgs(opts RunOpts, model string) []string {
 	args := []string{
 		"--print",
 		"--bare",
-		"--output-format", "json",
+		"--output-format", "stream-json",
 		"--permission-mode", "bypassPermissions",
 	}
 

--- a/internal/claude/args.go
+++ b/internal/claude/args.go
@@ -9,6 +9,7 @@ import "strconv"
 //
 //	--print                            pre-0.2.x
 //	--output-format json               ≤ v0.2.66
+//	--output-format stream-json        ≤ v0.2.66 (same flag, JSONL variant)
 //	--allowed-tools                    pre-1.0.x
 //	--system-prompt-file               v1.0.55
 //	--permission-mode bypassPermissions ≤ v2.0.x

--- a/internal/claude/args_test.go
+++ b/internal/claude/args_test.go
@@ -27,7 +27,7 @@ func TestBuildArgs(t *testing.T) {
 			contains: []string{
 				"--print",
 				"--bare",
-				"--output-format", "json",
+				"--output-format", "stream-json",
 				"--permission-mode", "bypassPermissions",
 				"--system-prompt-file", "/tmp/prompt.md",
 				"--json-schema", `{"type":"object"}`,
@@ -44,7 +44,7 @@ func TestBuildArgs(t *testing.T) {
 			contains: []string{
 				"--print",
 				"--bare",
-				"--output-format", "json",
+				"--output-format", "stream-json",
 				"--permission-mode", "bypassPermissions",
 			},
 			excludes: []string{

--- a/internal/claude/parser.go
+++ b/internal/claude/parser.go
@@ -78,19 +78,29 @@ func ParseResponse(output []byte) (*RunResult, error) {
 }
 
 // extractJSON finds the JSON response envelope in the output.
-// Strategy 1: try the last non-empty line (common case — envelope on final line).
-// Strategy 2: backward brace scan for multi-line JSON.
+// Strategy 1 (JSONL): scan lines in reverse for a {"type":"result",...} line.
+//
+//	This handles stream-json output where every line is a JSON object.
+//
+// Strategy 2 (legacy): try the last non-empty line as a single JSON envelope.
+// Strategy 3 (fallback): backward brace scan for multi-line JSON.
 func extractJSON(output []byte) ([]byte, error) {
 	if len(output) == 0 {
 		return nil, errNoJSON
 	}
 
-	// Strategy 1: last non-empty line
 	trimmed := bytes.TrimRight(output, " \t\n\r")
 	if len(trimmed) == 0 {
 		return nil, errNoJSON
 	}
 
+	// Strategy 1 (JSONL): scan lines in reverse for a result envelope.
+	// This is the common case with --output-format stream-json.
+	if line := findResultLineReverse(trimmed); line != nil {
+		return line, nil
+	}
+
+	// Strategy 2 (legacy): last non-empty line is the whole envelope.
 	lastNewline := bytes.LastIndexByte(trimmed, '\n')
 	var lastLine []byte
 	if lastNewline == -1 {
@@ -103,8 +113,36 @@ func extractJSON(output []byte) ([]byte, error) {
 		return lastLine, nil
 	}
 
-	// Strategy 2: backward scan — find last '}', try '{' candidates with json.Valid
+	// Strategy 3 (fallback): backward brace scan for multi-line JSON.
 	return extractJSONByDepth(output)
+}
+
+// findResultLineReverse scans lines from the end looking for a result envelope.
+// Returns nil if no result line is found. This avoids the O(n²) backward brace
+// scan in extractJSONByDepth when processing JSONL (stream-json) output.
+func findResultLineReverse(data []byte) []byte {
+	// Scan from end to start, checking each line.
+	end := len(data)
+	for end > 0 {
+		lineStart := bytes.LastIndexByte(data[:end], '\n')
+		var line []byte
+		if lineStart == -1 {
+			line = data[:end]
+		} else {
+			line = data[lineStart+1 : end]
+		}
+
+		line = bytes.TrimSpace(line)
+		if len(line) > 0 && line[0] == '{' && isResultEnvelope(line) {
+			return line
+		}
+
+		if lineStart == -1 {
+			break
+		}
+		end = lineStart
+	}
+	return nil
 }
 
 // isResultEnvelope checks if JSON data contains "type":"result".

--- a/internal/claude/parser_test.go
+++ b/internal/claude/parser_test.go
@@ -138,6 +138,26 @@ func TestParseResponse(t *testing.T) {
 			},
 		},
 		{
+			name:    "stream_json_fake_result_midstream",
+			fixture: "testdata/stream_json_fake_result_midstream.jsonl",
+			checkResult: func(t *testing.T, r *RunResult) {
+				t.Helper()
+				if r.Result != "Complete." {
+					t.Errorf("Result = %q, want %q", r.Result, "Complete.")
+				}
+				if r.CostUSD != 0.03 {
+					t.Errorf("CostUSD = %v, want 0.03", r.CostUSD)
+				}
+				var so map[string]any
+				if err := json.Unmarshal(r.Output, &so); err != nil {
+					t.Fatalf("Output unmarshal: %v", err)
+				}
+				if so["status"] != "ok" {
+					t.Errorf("Output status = %v, want ok", so["status"])
+				}
+			},
+		},
+		{
 			name:    "fake_envelope_in_tool_output",
 			fixture: "testdata/fake_envelope_in_tool_output.txt",
 			checkResult: func(t *testing.T, r *RunResult) {

--- a/internal/claude/parser_test.go
+++ b/internal/claude/parser_test.go
@@ -122,6 +122,22 @@ func TestParseResponse(t *testing.T) {
 			errType: "parse",
 		},
 		{
+			name:    "stream_json",
+			fixture: "testdata/stream_json_success.jsonl",
+			checkResult: func(t *testing.T, r *RunResult) {
+				t.Helper()
+				if r.Result != "Done." {
+					t.Errorf("Result = %q, want %q", r.Result, "Done.")
+				}
+				if r.CostUSD != 0.05 {
+					t.Errorf("CostUSD = %v, want 0.05", r.CostUSD)
+				}
+				if r.Turns != 3 {
+					t.Errorf("Turns = %d, want 3", r.Turns)
+				}
+			},
+		},
+		{
 			name:    "fake_envelope_in_tool_output",
 			fixture: "testdata/fake_envelope_in_tool_output.txt",
 			checkResult: func(t *testing.T, r *RunResult) {

--- a/internal/claude/runner.go
+++ b/internal/claude/runner.go
@@ -216,26 +216,43 @@ func (r *Runner) Stream(ctx context.Context, opts RunOpts, onChunk func(string))
 	var wg sync.WaitGroup
 	wg.Add(2)
 
+	// Determine transcript capture level from opts.
+	transcriptLevel := opts.TranscriptLevel
+	var transcriptEntries []TranscriptEntry
+
 	go func() {
 		defer wg.Done()
 		scanner := bufio.NewScanner(stdout)
 		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024) // 1MB max line
 		for scanner.Scan() {
 			line := scanner.Text()
+			lineBytes := scanner.Bytes()
 			outputBuf.Write([]byte(line))
 			outputBuf.Write([]byte("\n"))
+
+			// Extract human-readable text for the TUI callback.
+			// stream-json lines are JSON objects; extractDisplayText returns
+			// readable text for assistant messages, "" for everything else.
 			if onChunk != nil {
-				func() {
-					defer func() {
-						if r := recover(); r != nil {
-							// Log the panic rather than silently swallowing it.
-							// onChunk may do non-trivial work (e.g., waitIfPaused)
-							// and a panic here could indicate corrupted state.
-							fmt.Fprintf(os.Stderr, "claude: onChunk panic: %v\n", r)
-						}
+				displayText := extractDisplayText(lineBytes)
+				if displayText != "" {
+					func() {
+						defer func() {
+							if r := recover(); r != nil {
+								// Log the panic rather than silently swallowing it.
+								// onChunk may do non-trivial work (e.g., waitIfPaused)
+								// and a panic here could indicate corrupted state.
+								fmt.Fprintf(os.Stderr, "claude: onChunk panic: %v\n", r)
+							}
+						}()
+						onChunk(displayText)
 					}()
-					onChunk(line)
-				}()
+				}
+			}
+
+			// Accumulate transcript entries.
+			if shouldPersist(lineBytes, transcriptLevel) {
+				transcriptEntries = append(transcriptEntries, parseTranscriptEntry(lineBytes)...)
 			}
 		}
 		if err := scanner.Err(); err != nil {
@@ -270,6 +287,7 @@ func (r *Runner) Stream(ctx context.Context, opts RunOpts, onChunk func(string))
 		if outputBuf.Len() > 0 && !outputBuf.overflow {
 			result, parseErr := ParseResponse(outputBuf.Bytes())
 			if parseErr == nil {
+				result.Transcript = transcriptEntries
 				return result, nil
 			}
 		}
@@ -294,7 +312,12 @@ func (r *Runner) Stream(ctx context.Context, opts RunOpts, onChunk func(string))
 		}
 	}
 
-	return ParseResponse(outputBuf.Bytes())
+	result, err := ParseResponse(outputBuf.Bytes())
+	if err != nil {
+		return nil, err
+	}
+	result.Transcript = transcriptEntries
+	return result, nil
 }
 
 // DryRun returns the command that would be executed, without running it.

--- a/internal/claude/runner_test.go
+++ b/internal/claude/runner_test.go
@@ -113,9 +113,15 @@ func TestStream_Success(t *testing.T) {
 	if result.Turns != 3 {
 		t.Errorf("Turns = %d, want 3", result.Turns)
 	}
-	// Should have streaming lines: "Thinking...", "Reading files...", and the JSON line
-	if len(chunks) < 3 {
-		t.Errorf("expected at least 3 chunks, got %d: %v", len(chunks), chunks)
+	// With stream-json, onChunk receives extracted display text from assistant messages.
+	// The mock outputs two assistant text messages ("Thinking..." and "Reading files...").
+	// System and result events produce no display text.
+	if len(chunks) < 2 {
+		t.Errorf("expected at least 2 chunks, got %d: %v", len(chunks), chunks)
+	}
+	// Verify display text extraction works — first chunk should be "Thinking..."
+	if len(chunks) > 0 && chunks[0] != "Thinking..." {
+		t.Errorf("chunks[0] = %q, want %q", chunks[0], "Thinking...")
 	}
 }
 

--- a/internal/claude/runner_test.go
+++ b/internal/claude/runner_test.go
@@ -372,6 +372,74 @@ func TestStream_OnChunkPanic(t *testing.T) {
 	}
 }
 
+func TestStream_TranscriptCapture(t *testing.T) {
+	runner, err := NewRunner(mockBinaryPath(t), "test-model", t.TempDir())
+	if err != nil {
+		t.Fatalf("NewRunner: %v", err)
+	}
+
+	t.Run("tools_level_captures_tool_events", func(t *testing.T) {
+		t.Setenv("MOCK_CLAUDE_MODE", "tool_events")
+
+		result, err := runner.Stream(context.Background(), RunOpts{
+			Timeout:         10 * time.Second,
+			TranscriptLevel: TranscriptTools,
+		}, nil)
+		if err != nil {
+			t.Fatalf("Stream: %v", err)
+		}
+
+		if len(result.Transcript) == 0 {
+			t.Fatal("expected transcript entries at tools level, got none")
+		}
+
+		toolNames := make(map[string]bool)
+		for _, entry := range result.Transcript {
+			if entry.Tool != "" {
+				toolNames[entry.Tool] = true
+			}
+		}
+		if !toolNames["Read"] {
+			t.Error("expected Read tool_use in transcript")
+		}
+		if !toolNames["Bash"] {
+			t.Error("expected Bash tool_use in transcript")
+		}
+	})
+
+	t.Run("off_level_captures_nothing", func(t *testing.T) {
+		t.Setenv("MOCK_CLAUDE_MODE", "tool_events")
+
+		result, err := runner.Stream(context.Background(), RunOpts{
+			Timeout:         10 * time.Second,
+			TranscriptLevel: TranscriptOff,
+		}, nil)
+		if err != nil {
+			t.Fatalf("Stream: %v", err)
+		}
+
+		if len(result.Transcript) != 0 {
+			t.Errorf("expected no transcript at off level, got %d entries", len(result.Transcript))
+		}
+	})
+
+	t.Run("empty_level_captures_nothing", func(t *testing.T) {
+		t.Setenv("MOCK_CLAUDE_MODE", "tool_events")
+
+		result, err := runner.Stream(context.Background(), RunOpts{
+			Timeout: 10 * time.Second,
+			// TranscriptLevel is empty (zero value)
+		}, nil)
+		if err != nil {
+			t.Fatalf("Stream: %v", err)
+		}
+
+		if len(result.Transcript) != 0 {
+			t.Errorf("expected no transcript at empty level, got %d entries", len(result.Transcript))
+		}
+	})
+}
+
 func TestStream_RejectsOversizedSchema(t *testing.T) {
 	runner, err := NewRunner(mockBinaryPath(t), "test-model", t.TempDir())
 	if err != nil {

--- a/internal/claude/testdata/mock_claude.sh
+++ b/internal/claude/testdata/mock_claude.sh
@@ -11,11 +11,13 @@ done
 
 case "${MOCK_CLAUDE_MODE}" in
     success)
-        echo "Thinking..."
-        echo "Reading files..."
+        echo '{"type":"system","subtype":"init","session_id":"test123","tools":["Read","Bash"],"mcp_servers":[]}'
+        echo '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Thinking..."}]}}'
+        echo '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Reading files..."}]}}'
         echo '{"type":"result","subtype":"success","result":"Done.","structured_output":{"key":"value"},"total_cost_usd":0.05,"usage":{"input_tokens":100,"output_tokens":50},"num_turns":3,"duration_ms":5000}'
         ;;
     semantic_error)
+        echo '{"type":"system","subtype":"init","session_id":"test123","tools":[],"mcp_servers":[]}'
         echo '{"type":"result","subtype":"error","result":"Something went wrong."}'
         ;;
     crash_rate_limit)
@@ -33,6 +35,7 @@ case "${MOCK_CLAUDE_MODE}" in
         # Read stdin and include it in the result for verification.
         # NOTE: Only works for simple strings without JSON special chars (" \ etc.)
         STDIN_CONTENT=$(cat)
+        echo '{"type":"system","subtype":"init","session_id":"test123","tools":[],"mcp_servers":[]}'
         printf '{"type":"result","subtype":"success","result":"%s","structured_output":{}}\n' "$STDIN_CONTENT"
         ;;
     signal_kill)

--- a/internal/claude/testdata/mock_claude.sh
+++ b/internal/claude/testdata/mock_claude.sh
@@ -44,6 +44,14 @@ case "${MOCK_CLAUDE_MODE}" in
     signal_term)
         kill -TERM $$
         ;;
+    tool_events)
+        echo '{"type":"system","subtype":"init","session_id":"test123","tools":["Read","Bash"],"mcp_servers":[]}'
+        echo '{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"tu_1","name":"Read","input":{"file_path":"main.go"}}]}}'
+        echo '{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tu_1","content":"file content"}]}}'
+        echo '{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"tu_2","name":"Bash","input":{"command":"ls"}}]}}'
+        echo '{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tu_2","content":"main.go"}]}}'
+        echo '{"type":"result","subtype":"success","result":"Done.","structured_output":{},"total_cost_usd":0.02,"usage":{"input_tokens":50,"output_tokens":20},"num_turns":2,"duration_ms":1000}'
+        ;;
     *)
         echo "unknown mode: ${MOCK_CLAUDE_MODE}" >&2
         exit 1

--- a/internal/claude/testdata/stream_json_fake_result_midstream.jsonl
+++ b/internal/claude/testdata/stream_json_fake_result_midstream.jsonl
@@ -1,0 +1,6 @@
+{"type":"system","subtype":"init","session_id":"abc123","tools":["Read","Bash"]}
+{"type":"assistant","message":{"id":"msg_001","type":"message","role":"assistant","content":[{"type":"text","text":"Reading file..."}],"model":"claude-sonnet-4-20250514","stop_reason":"tool_use","usage":{"input_tokens":100,"output_tokens":20}}}
+{"type":"assistant","message":{"id":"msg_002","type":"message","role":"assistant","content":[{"type":"tool_use","id":"tu_001","name":"Read","input":{"file_path":"test.go"}}],"model":"claude-sonnet-4-20250514","stop_reason":"tool_use","usage":{"input_tokens":100,"output_tokens":30}}}
+{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tu_001","content":"// This file contains {\"type\":\"result\",\"subtype\":\"success\"} in a comment\npackage main"}]}}
+{"type":"assistant","message":{"id":"msg_003","type":"message","role":"assistant","content":[{"type":"text","text":"Done."}],"model":"claude-sonnet-4-20250514","stop_reason":"end_turn","usage":{"input_tokens":200,"output_tokens":10}}}
+{"type":"result","subtype":"success","result":"Complete.","structured_output":{"status":"ok"},"total_cost_usd":0.03,"usage":{"input_tokens":400,"output_tokens":60},"num_turns":2,"duration_ms":3000}

--- a/internal/claude/testdata/stream_json_success.jsonl
+++ b/internal/claude/testdata/stream_json_success.jsonl
@@ -1,0 +1,8 @@
+{"type":"system","subtype":"init","session_id":"abc123","tools":["Read","Write","Edit","Bash"],"mcp_servers":[]}
+{"type":"assistant","message":{"id":"msg_001","type":"message","role":"assistant","content":[{"type":"text","text":"I'll start by reading the relevant files."}],"model":"claude-sonnet-4-20250514","stop_reason":"tool_use","usage":{"input_tokens":100,"output_tokens":20}}}
+{"type":"assistant","message":{"id":"msg_002","type":"message","role":"assistant","content":[{"type":"tool_use","id":"tu_001","name":"Read","input":{"file_path":"src/main.go"}}],"model":"claude-sonnet-4-20250514","stop_reason":"tool_use","usage":{"input_tokens":100,"output_tokens":30}}}
+{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tu_001","content":"package main\nfunc main() {}"}]}}
+{"type":"assistant","message":{"id":"msg_003","type":"message","role":"assistant","content":[{"type":"tool_use","id":"tu_002","name":"Bash","input":{"command":"go test ./..."}}],"model":"claude-sonnet-4-20250514","stop_reason":"tool_use","usage":{"input_tokens":200,"output_tokens":40}}}
+{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tu_002","content":"PASS\nok  \tpkg\t0.5s"}]}}
+{"type":"assistant","message":{"id":"msg_004","type":"message","role":"assistant","content":[{"type":"text","text":"All tests pass. Implementation complete."}],"model":"claude-sonnet-4-20250514","stop_reason":"end_turn","usage":{"input_tokens":300,"output_tokens":50}}}
+{"type":"result","subtype":"success","result":"Done.","structured_output":{"key":"value"},"total_cost_usd":0.05,"usage":{"input_tokens":700,"output_tokens":140},"num_turns":3,"duration_ms":5000}

--- a/internal/claude/transcript.go
+++ b/internal/claude/transcript.go
@@ -1,0 +1,234 @@
+package claude
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"strings"
+)
+
+// TranscriptLevel controls which events are persisted in the transcript.
+type TranscriptLevel string
+
+const (
+	// TranscriptOff disables transcript capture entirely.
+	TranscriptOff TranscriptLevel = "off"
+	// TranscriptTools captures tool_use and tool_result events only.
+	TranscriptTools TranscriptLevel = "tools"
+	// TranscriptFull captures all assistant/user events including text blocks.
+	TranscriptFull TranscriptLevel = "full"
+)
+
+// TranscriptEntry is a single human-readable entry in a phase transcript.
+type TranscriptEntry struct {
+	Role    string `json:"role"`              // "assistant", "tool_use", "tool_result"
+	Content string `json:"content"`           // display text
+	Tool    string `json:"tool,omitempty"`    // tool name (tool_use/tool_result only)
+	ToolID  string `json:"tool_id,omitempty"` // correlating tool_use_id
+}
+
+// streamEvent is the minimal structure needed to classify a stream-json line.
+type streamEvent struct {
+	Type    string          `json:"type"`
+	Subtype string          `json:"subtype,omitempty"`
+	Message json.RawMessage `json:"message,omitempty"`
+}
+
+// messageEnvelope extracts message-level fields.
+type messageEnvelope struct {
+	Role    string         `json:"role"`
+	Content []contentBlock `json:"content"`
+}
+
+// contentBlock is a single content block inside an assistant or user message.
+type contentBlock struct {
+	Type      string          `json:"type"`                  // "text", "tool_use", "tool_result"
+	Text      string          `json:"text,omitempty"`        // for type=text
+	Name      string          `json:"name,omitempty"`        // for type=tool_use
+	ID        string          `json:"id,omitempty"`          // for type=tool_use
+	ToolUseID string          `json:"tool_use_id,omitempty"` // for type=tool_result
+	Input     json.RawMessage `json:"input,omitempty"`       // for type=tool_use
+	Content   json.RawMessage `json:"content,omitempty"`     // for type=tool_result (string or array)
+}
+
+// extractDisplayText returns a human-readable summary of a stream-json line
+// suitable for the TUI, or "" if the line has no displayable content
+// (system init, user tool_result, result envelope, etc.).
+func extractDisplayText(line []byte) string {
+	var evt streamEvent
+	if err := json.Unmarshal(line, &evt); err != nil {
+		return ""
+	}
+
+	switch evt.Type {
+	case "assistant":
+		var msg messageEnvelope
+		if err := json.Unmarshal(evt.Message, &msg); err != nil {
+			return ""
+		}
+		var parts []string
+		for _, block := range msg.Content {
+			switch block.Type {
+			case "text":
+				if text := strings.TrimSpace(block.Text); text != "" {
+					parts = append(parts, text)
+				}
+			case "tool_use":
+				parts = append(parts, "["+block.Name+"]")
+			}
+		}
+		return strings.Join(parts, " ")
+
+	default:
+		return ""
+	}
+}
+
+// shouldPersist returns true if the stream-json line should be included in the
+// transcript at the given level. At TranscriptTools, only tool_use and
+// tool_result events pass. At TranscriptFull, all assistant and user events
+// pass. System and result events are always excluded.
+func shouldPersist(line []byte, level TranscriptLevel) bool {
+	if level == TranscriptOff {
+		return false
+	}
+
+	var evt streamEvent
+	if err := json.Unmarshal(line, &evt); err != nil {
+		return false
+	}
+
+	switch evt.Type {
+	case "system", "result":
+		return false
+	case "assistant":
+		if level == TranscriptFull {
+			return true
+		}
+		// TranscriptTools: only if the message contains a tool_use block.
+		var msg messageEnvelope
+		if err := json.Unmarshal(evt.Message, &msg); err != nil {
+			return false
+		}
+		for _, block := range msg.Content {
+			if block.Type == "tool_use" {
+				return true
+			}
+		}
+		return false
+	case "user":
+		if level == TranscriptFull {
+			return true
+		}
+		// TranscriptTools: only if the message contains a tool_result block.
+		var msg messageEnvelope
+		if err := json.Unmarshal(evt.Message, &msg); err != nil {
+			return false
+		}
+		for _, block := range msg.Content {
+			if block.Type == "tool_result" {
+				return true
+			}
+		}
+		return false
+	default:
+		return false
+	}
+}
+
+// parseTranscriptEntry converts a stream-json line into transcript entries.
+// A single line may produce multiple entries (e.g., text + tool_use in one message).
+func parseTranscriptEntry(line []byte) []TranscriptEntry {
+	var evt streamEvent
+	if err := json.Unmarshal(line, &evt); err != nil {
+		return nil
+	}
+
+	var msg messageEnvelope
+	if err := json.Unmarshal(evt.Message, &msg); err != nil {
+		return nil
+	}
+
+	var entries []TranscriptEntry
+	for _, block := range msg.Content {
+		switch block.Type {
+		case "text":
+			if text := strings.TrimSpace(block.Text); text != "" {
+				entries = append(entries, TranscriptEntry{
+					Role:    "assistant",
+					Content: text,
+				})
+			}
+		case "tool_use":
+			inputStr := string(block.Input)
+			entries = append(entries, TranscriptEntry{
+				Role:    "tool_use",
+				Content: inputStr,
+				Tool:    block.Name,
+				ToolID:  block.ID,
+			})
+		case "tool_result":
+			content := extractToolResultContent(block.Content)
+			entries = append(entries, TranscriptEntry{
+				Role:    "tool_result",
+				Content: content,
+				ToolID:  block.ToolUseID,
+			})
+		}
+	}
+	return entries
+}
+
+// extractToolResultContent extracts a string from tool_result content,
+// which may be a JSON string or a JSON array of content blocks.
+func extractToolResultContent(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+
+	// Try as a plain string first.
+	var str string
+	if err := json.Unmarshal(raw, &str); err == nil {
+		return str
+	}
+
+	// Try as an array of content blocks (tool_result can wrap text blocks).
+	var blocks []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(raw, &blocks); err == nil {
+		var parts []string
+		for _, block := range blocks {
+			if block.Text != "" {
+				parts = append(parts, block.Text)
+			}
+		}
+		return strings.Join(parts, "\n")
+	}
+
+	// Fallback: return raw JSON string.
+	return string(raw)
+}
+
+// FilterTranscript scans buffered stream-json output (JSONL) and returns
+// transcript entries filtered by the given level. This is used by the sandbox
+// runner which buffers stdout and processes it after the subprocess exits.
+func FilterTranscript(output []byte, level TranscriptLevel) []TranscriptEntry {
+	if level == TranscriptOff {
+		return nil
+	}
+
+	var entries []TranscriptEntry
+	scanner := bufio.NewScanner(bytes.NewReader(output))
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if !shouldPersist(line, level) {
+			continue
+		}
+		entries = append(entries, parseTranscriptEntry(line)...)
+	}
+	return entries
+}

--- a/internal/claude/transcript.go
+++ b/internal/claude/transcript.go
@@ -5,27 +5,20 @@ import (
 	"bytes"
 	"encoding/json"
 	"strings"
+
+	"github.com/decko/soda/internal/transcript"
 )
 
-// TranscriptLevel controls which events are persisted in the transcript.
-type TranscriptLevel string
+// Re-export transcript types for backward compatibility within this package.
+// New code outside internal/claude should import internal/transcript directly.
+type TranscriptLevel = transcript.Level
+type TranscriptEntry = transcript.Entry
 
 const (
-	// TranscriptOff disables transcript capture entirely.
-	TranscriptOff TranscriptLevel = "off"
-	// TranscriptTools captures tool_use and tool_result events only.
-	TranscriptTools TranscriptLevel = "tools"
-	// TranscriptFull captures all assistant/user events including text blocks.
-	TranscriptFull TranscriptLevel = "full"
+	TranscriptOff   = transcript.Off
+	TranscriptTools = transcript.Tools
+	TranscriptFull  = transcript.Full
 )
-
-// TranscriptEntry is a single human-readable entry in a phase transcript.
-type TranscriptEntry struct {
-	Role    string `json:"role"`              // "assistant", "tool_use", "tool_result"
-	Content string `json:"content"`           // display text
-	Tool    string `json:"tool,omitempty"`    // tool name (tool_use/tool_result only)
-	ToolID  string `json:"tool_id,omitempty"` // correlating tool_use_id
-}
 
 // streamEvent is the minimal structure needed to classify a stream-json line.
 type streamEvent struct {

--- a/internal/claude/transcript.go
+++ b/internal/claude/transcript.go
@@ -89,7 +89,7 @@ func extractDisplayText(line []byte) string {
 // tool_result events pass. At TranscriptFull, all assistant and user events
 // pass. System and result events are always excluded.
 func shouldPersist(line []byte, level TranscriptLevel) bool {
-	if level == TranscriptOff {
+	if level == TranscriptOff || level == "" {
 		return false
 	}
 
@@ -215,7 +215,7 @@ func extractToolResultContent(raw json.RawMessage) string {
 // transcript entries filtered by the given level. This is used by the sandbox
 // runner which buffers stdout and processes it after the subprocess exits.
 func FilterTranscript(output []byte, level TranscriptLevel) []TranscriptEntry {
-	if level == TranscriptOff {
+	if level == TranscriptOff || level == "" {
 		return nil
 	}
 

--- a/internal/claude/transcript_test.go
+++ b/internal/claude/transcript_test.go
@@ -1,0 +1,286 @@
+package claude
+
+import (
+	"os"
+	"testing"
+)
+
+func TestExtractDisplayText(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want string
+	}{
+		{
+			name: "text_block",
+			line: `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"I'll read the file now."}]}}`,
+			want: "I'll read the file now.",
+		},
+		{
+			name: "tool_use_block",
+			line: `{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"tu_1","name":"Read","input":{"file_path":"main.go"}}]}}`,
+			want: "[Read]",
+		},
+		{
+			name: "text_and_tool_use",
+			line: `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Reading file."},{"type":"tool_use","id":"tu_1","name":"Bash","input":{"command":"ls"}}]}}`,
+			want: "Reading file. [Bash]",
+		},
+		{
+			name: "system_event",
+			line: `{"type":"system","subtype":"init","session_id":"abc"}`,
+			want: "",
+		},
+		{
+			name: "user_event",
+			line: `{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tu_1","content":"ok"}]}}`,
+			want: "",
+		},
+		{
+			name: "result_event",
+			line: `{"type":"result","subtype":"success","result":"Done."}`,
+			want: "",
+		},
+		{
+			name: "empty_text",
+			line: `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"  "}]}}`,
+			want: "",
+		},
+		{
+			name: "invalid_json",
+			line: `not json at all`,
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractDisplayText([]byte(tt.line))
+			if got != tt.want {
+				t.Errorf("extractDisplayText() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestShouldPersist(t *testing.T) {
+	assistantText := `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Thinking..."}]}}`
+	assistantTool := `{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"tu_1","name":"Read","input":{"file_path":"main.go"}}]}}`
+	userToolResult := `{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tu_1","content":"data"}]}}`
+	systemEvent := `{"type":"system","subtype":"init","session_id":"abc"}`
+	resultEvent := `{"type":"result","subtype":"success","result":"Done."}`
+
+	tests := []struct {
+		name  string
+		line  string
+		level TranscriptLevel
+		want  bool
+	}{
+		// TranscriptOff
+		{"off_assistant_text", assistantText, TranscriptOff, false},
+		{"off_assistant_tool", assistantTool, TranscriptOff, false},
+
+		// TranscriptTools
+		{"tools_assistant_text", assistantText, TranscriptTools, false},
+		{"tools_assistant_tool", assistantTool, TranscriptTools, true},
+		{"tools_user_tool_result", userToolResult, TranscriptTools, true},
+		{"tools_system", systemEvent, TranscriptTools, false},
+		{"tools_result", resultEvent, TranscriptTools, false},
+
+		// TranscriptFull
+		{"full_assistant_text", assistantText, TranscriptFull, true},
+		{"full_assistant_tool", assistantTool, TranscriptFull, true},
+		{"full_user_tool_result", userToolResult, TranscriptFull, true},
+		{"full_system", systemEvent, TranscriptFull, false},
+		{"full_result", resultEvent, TranscriptFull, false},
+
+		// Invalid JSON
+		{"invalid_json", "not json", TranscriptFull, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldPersist([]byte(tt.line), tt.level)
+			if got != tt.want {
+				t.Errorf("shouldPersist(%s) = %v, want %v", tt.level, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseTranscriptEntry(t *testing.T) {
+	t.Run("text_block", func(t *testing.T) {
+		line := `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Hello world"}]}}`
+		entries := parseTranscriptEntry([]byte(line))
+		if len(entries) != 1 {
+			t.Fatalf("expected 1 entry, got %d", len(entries))
+		}
+		if entries[0].Role != "assistant" {
+			t.Errorf("Role = %q, want %q", entries[0].Role, "assistant")
+		}
+		if entries[0].Content != "Hello world" {
+			t.Errorf("Content = %q, want %q", entries[0].Content, "Hello world")
+		}
+	})
+
+	t.Run("tool_use_block", func(t *testing.T) {
+		line := `{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"tu_1","name":"Read","input":{"file_path":"main.go"}}]}}`
+		entries := parseTranscriptEntry([]byte(line))
+		if len(entries) != 1 {
+			t.Fatalf("expected 1 entry, got %d", len(entries))
+		}
+		if entries[0].Role != "tool_use" {
+			t.Errorf("Role = %q, want %q", entries[0].Role, "tool_use")
+		}
+		if entries[0].Tool != "Read" {
+			t.Errorf("Tool = %q, want %q", entries[0].Tool, "Read")
+		}
+		if entries[0].ToolID != "tu_1" {
+			t.Errorf("ToolID = %q, want %q", entries[0].ToolID, "tu_1")
+		}
+	})
+
+	t.Run("tool_result_block", func(t *testing.T) {
+		line := `{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tu_1","content":"file content here"}]}}`
+		entries := parseTranscriptEntry([]byte(line))
+		if len(entries) != 1 {
+			t.Fatalf("expected 1 entry, got %d", len(entries))
+		}
+		if entries[0].Role != "tool_result" {
+			t.Errorf("Role = %q, want %q", entries[0].Role, "tool_result")
+		}
+		if entries[0].Content != "file content here" {
+			t.Errorf("Content = %q, want %q", entries[0].Content, "file content here")
+		}
+		if entries[0].ToolID != "tu_1" {
+			t.Errorf("ToolID = %q, want %q", entries[0].ToolID, "tu_1")
+		}
+	})
+
+	t.Run("multiple_blocks", func(t *testing.T) {
+		line := `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Reading file."},{"type":"tool_use","id":"tu_2","name":"Bash","input":{"command":"ls"}}]}}`
+		entries := parseTranscriptEntry([]byte(line))
+		if len(entries) != 2 {
+			t.Fatalf("expected 2 entries, got %d", len(entries))
+		}
+		if entries[0].Role != "assistant" {
+			t.Errorf("entries[0].Role = %q, want %q", entries[0].Role, "assistant")
+		}
+		if entries[1].Role != "tool_use" {
+			t.Errorf("entries[1].Role = %q, want %q", entries[1].Role, "tool_use")
+		}
+	})
+
+	t.Run("invalid_json", func(t *testing.T) {
+		entries := parseTranscriptEntry([]byte("not json"))
+		if len(entries) != 0 {
+			t.Errorf("expected 0 entries for invalid JSON, got %d", len(entries))
+		}
+	})
+}
+
+func TestExtractToolResultContent(t *testing.T) {
+	t.Run("string_content", func(t *testing.T) {
+		result := extractToolResultContent([]byte(`"hello world"`))
+		if result != "hello world" {
+			t.Errorf("got %q, want %q", result, "hello world")
+		}
+	})
+
+	t.Run("array_content", func(t *testing.T) {
+		result := extractToolResultContent([]byte(`[{"type":"text","text":"line1"},{"type":"text","text":"line2"}]`))
+		if result != "line1\nline2" {
+			t.Errorf("got %q, want %q", result, "line1\nline2")
+		}
+	})
+
+	t.Run("empty_content", func(t *testing.T) {
+		result := extractToolResultContent(nil)
+		if result != "" {
+			t.Errorf("got %q, want empty", result)
+		}
+	})
+}
+
+func TestFilterTranscript(t *testing.T) {
+	data, err := os.ReadFile("testdata/stream_json_success.jsonl")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	t.Run("off_returns_nil", func(t *testing.T) {
+		entries := FilterTranscript(data, TranscriptOff)
+		if entries != nil {
+			t.Errorf("expected nil, got %d entries", len(entries))
+		}
+	})
+
+	t.Run("tools_level", func(t *testing.T) {
+		entries := FilterTranscript(data, TranscriptTools)
+		if len(entries) == 0 {
+			t.Fatal("expected non-empty transcript at tools level")
+		}
+		// Should contain tool_use and tool_result entries but not plain text.
+		for _, entry := range entries {
+			if entry.Role == "assistant" {
+				t.Errorf("tools level should not contain plain assistant text, got: %+v", entry)
+			}
+		}
+		// Should have at least the Read and Bash tool uses and their results
+		toolNames := make(map[string]bool)
+		for _, entry := range entries {
+			if entry.Tool != "" {
+				toolNames[entry.Tool] = true
+			}
+		}
+		if !toolNames["Read"] {
+			t.Error("expected Read tool use in transcript")
+		}
+		if !toolNames["Bash"] {
+			t.Error("expected Bash tool use in transcript")
+		}
+	})
+
+	t.Run("full_level", func(t *testing.T) {
+		entries := FilterTranscript(data, TranscriptFull)
+		if len(entries) == 0 {
+			t.Fatal("expected non-empty transcript at full level")
+		}
+		// Full level should include assistant text entries too.
+		hasAssistantText := false
+		for _, entry := range entries {
+			if entry.Role == "assistant" {
+				hasAssistantText = true
+				break
+			}
+		}
+		if !hasAssistantText {
+			t.Error("full level should contain assistant text entries")
+		}
+		// Full should have more entries than tools.
+		toolEntries := FilterTranscript(data, TranscriptTools)
+		if len(entries) <= len(toolEntries) {
+			t.Errorf("full (%d entries) should have more than tools (%d entries)", len(entries), len(toolEntries))
+		}
+	})
+
+	t.Run("empty_input", func(t *testing.T) {
+		entries := FilterTranscript([]byte{}, TranscriptFull)
+		if len(entries) != 0 {
+			t.Errorf("expected 0 entries for empty input, got %d", len(entries))
+		}
+	})
+}
+
+func TestTranscriptLevel_Values(t *testing.T) {
+	// Verify the string constants match expected values.
+	if TranscriptOff != "off" {
+		t.Errorf("TranscriptOff = %q, want %q", TranscriptOff, "off")
+	}
+	if TranscriptTools != "tools" {
+		t.Errorf("TranscriptTools = %q, want %q", TranscriptTools, "tools")
+	}
+	if TranscriptFull != "full" {
+		t.Errorf("TranscriptFull = %q, want %q", TranscriptFull, "full")
+	}
+}

--- a/internal/claude/transcript_test.go
+++ b/internal/claude/transcript_test.go
@@ -94,6 +94,10 @@ func TestShouldPersist(t *testing.T) {
 		{"full_system", systemEvent, TranscriptFull, false},
 		{"full_result", resultEvent, TranscriptFull, false},
 
+		// Empty level (zero value) treated as off
+		{"empty_level_assistant", assistantText, "", false},
+		{"empty_level_tool", assistantTool, "", false},
+
 		// Invalid JSON
 		{"invalid_json", "not json", TranscriptFull, false},
 	}
@@ -268,6 +272,13 @@ func TestFilterTranscript(t *testing.T) {
 		entries := FilterTranscript([]byte{}, TranscriptFull)
 		if len(entries) != 0 {
 			t.Errorf("expected 0 entries for empty input, got %d", len(entries))
+		}
+	})
+
+	t.Run("empty_level_returns_nil", func(t *testing.T) {
+		entries := FilterTranscript(data, "")
+		if entries != nil {
+			t.Errorf("empty level should return nil, got %d entries", len(entries))
 		}
 	})
 }

--- a/internal/claude/types.go
+++ b/internal/claude/types.go
@@ -7,24 +7,26 @@ import (
 
 // RunOpts holds per-invocation configuration for a single phase run.
 type RunOpts struct {
-	SystemPromptPath string        // path to system prompt file
-	SettingsPath     string        // path to Claude Code settings JSON (--settings-path)
-	OutputSchema     string        // JSON schema string passed to --json-schema
-	AllowedTools     []string      // tool names for --allowed-tools
-	MaxBudgetUSD     *float64      // nil = omit flag; non-nil = emit value
-	Prompt           string        // rendered template piped via stdin
-	Model            string        // per-phase model override; empty uses runner-level default
-	Timeout          time.Duration // fallback timeout if caller's context has no deadline
+	SystemPromptPath string          // path to system prompt file
+	SettingsPath     string          // path to Claude Code settings JSON (--settings-path)
+	OutputSchema     string          // JSON schema string passed to --json-schema
+	AllowedTools     []string        // tool names for --allowed-tools
+	MaxBudgetUSD     *float64        // nil = omit flag; non-nil = emit value
+	Prompt           string          // rendered template piped via stdin
+	Model            string          // per-phase model override; empty uses runner-level default
+	Timeout          time.Duration   // fallback timeout if caller's context has no deadline
+	TranscriptLevel  TranscriptLevel // transcript capture level; empty/"off" disables
 }
 
 // RunResult holds the parsed response from a Claude Code CLI invocation.
 type RunResult struct {
-	Output   json.RawMessage // raw structured_output — caller unmarshals into phase schema
-	Result   string          // freeform text from "result" field
-	CostUSD  float64         // 0.0 if absent — per-invocation, not cumulative
-	Tokens   TokenUsage
-	Duration time.Duration // parsed from duration_ms
-	Turns    int           // 0 if absent
+	Output     json.RawMessage // raw structured_output — caller unmarshals into phase schema
+	Result     string          // freeform text from "result" field
+	CostUSD    float64         // 0.0 if absent — per-invocation, not cumulative
+	Tokens     TokenUsage
+	Duration   time.Duration     // parsed from duration_ms
+	Turns      int               // 0 if absent
+	Transcript []TranscriptEntry // filtered transcript entries; nil when capture is disabled
 }
 
 // TokenUsage holds token counts from the CLI response.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,6 +35,14 @@ type Config struct {
 	Repos               []RepoConfig        `yaml:"repos"`
 	Monitor             MonitorConfig       `yaml:"monitor"`
 	Notify              NotifyConfig        `yaml:"notify"`
+	Transcript          TranscriptConfig    `yaml:"transcript,omitempty"`
+}
+
+// TranscriptConfig controls agent transcript persistence.
+// When Level is "tools" or "full", the engine writes a JSON transcript
+// file alongside the phase result for retrieval quality analysis.
+type TranscriptConfig struct {
+	Level string `yaml:"level,omitempty"` // "off" (default), "tools", or "full"
 }
 
 // AuthConfig holds authentication settings for the Claude Code CLI.

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -12,10 +12,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/decko/soda/internal/claude"
 	"github.com/decko/soda/internal/git"
 	"github.com/decko/soda/internal/progress"
 	"github.com/decko/soda/internal/runner"
+	"github.com/decko/soda/internal/transcript"
 )
 
 // Mode controls whether the engine pauses between phases.
@@ -59,21 +59,21 @@ type EngineConfig struct {
 	PauseSignal             <-chan bool // receives true=pause, false=resume from TUI; nil disables
 	SleepFunc               func(time.Duration)
 	JitterFunc              func(max time.Duration) time.Duration
-	PRPoller                PRPoller               // for monitor phase polling; nil disables monitor
-	NowFunc                 func() time.Time       // for testability; defaults to time.Now
-	AuthorityResolver       AuthorityResolver      // for comment authority checks; nil → all authoritative
-	MonitorProfile          *MonitorProfile        // behavioral profile; nil → use polling config as-is
-	SelfUser                string                 // PR author username for self-comment filtering
-	BotUsers                []string               // known bot usernames to filter
-	Stderr                  io.Writer              // destination for warning messages; defaults to os.Stderr
-	TokenBudget             TokenBudgetConfig      // prompt token budget estimation; zero value disables checks
-	ContextBudget           int                    // global default context budget in tokens; 0 disables adaptive fitting
-	Notify                  NotifyConfig           // notification hooks fired on pipeline completion; zero value disables
-	ApiKeyHelper            string                 // path to script that prints an API key; wired into runner.RunOpts
-	MergeMethod             string                 // merge method: "merge", "squash", "rebase"; defaults to "squash"
-	MergeLabels             []string               // required PR labels before auto-merge proceeds
-	AutoMergeTimeout        time.Duration          // max wait after approval before giving up; defaults to 30m
-	TranscriptLevel         claude.TranscriptLevel // transcript capture level; empty/"off" disables
+	PRPoller                PRPoller          // for monitor phase polling; nil disables monitor
+	NowFunc                 func() time.Time  // for testability; defaults to time.Now
+	AuthorityResolver       AuthorityResolver // for comment authority checks; nil → all authoritative
+	MonitorProfile          *MonitorProfile   // behavioral profile; nil → use polling config as-is
+	SelfUser                string            // PR author username for self-comment filtering
+	BotUsers                []string          // known bot usernames to filter
+	Stderr                  io.Writer         // destination for warning messages; defaults to os.Stderr
+	TokenBudget             TokenBudgetConfig // prompt token budget estimation; zero value disables checks
+	ContextBudget           int               // global default context budget in tokens; 0 disables adaptive fitting
+	Notify                  NotifyConfig      // notification hooks fired on pipeline completion; zero value disables
+	ApiKeyHelper            string            // path to script that prints an API key; wired into runner.RunOpts
+	MergeMethod             string            // merge method: "merge", "squash", "rebase"; defaults to "squash"
+	MergeLabels             []string          // required PR labels before auto-merge proceeds
+	AutoMergeTimeout        time.Duration     // max wait after approval before giving up; defaults to 30m
+	TranscriptLevel         transcript.Level  // transcript capture level; empty/"off" disables
 }
 
 // TokenBudgetConfig configures the prompt-size estimation check.

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -11,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/decko/soda/internal/claude"
 	"github.com/decko/soda/internal/git"
 	"github.com/decko/soda/internal/progress"
 	"github.com/decko/soda/internal/runner"
@@ -57,20 +59,21 @@ type EngineConfig struct {
 	PauseSignal             <-chan bool // receives true=pause, false=resume from TUI; nil disables
 	SleepFunc               func(time.Duration)
 	JitterFunc              func(max time.Duration) time.Duration
-	PRPoller                PRPoller          // for monitor phase polling; nil disables monitor
-	NowFunc                 func() time.Time  // for testability; defaults to time.Now
-	AuthorityResolver       AuthorityResolver // for comment authority checks; nil → all authoritative
-	MonitorProfile          *MonitorProfile   // behavioral profile; nil → use polling config as-is
-	SelfUser                string            // PR author username for self-comment filtering
-	BotUsers                []string          // known bot usernames to filter
-	Stderr                  io.Writer         // destination for warning messages; defaults to os.Stderr
-	TokenBudget             TokenBudgetConfig // prompt token budget estimation; zero value disables checks
-	ContextBudget           int               // global default context budget in tokens; 0 disables adaptive fitting
-	Notify                  NotifyConfig      // notification hooks fired on pipeline completion; zero value disables
-	ApiKeyHelper            string            // path to script that prints an API key; wired into runner.RunOpts
-	MergeMethod             string            // merge method: "merge", "squash", "rebase"; defaults to "squash"
-	MergeLabels             []string          // required PR labels before auto-merge proceeds
-	AutoMergeTimeout        time.Duration     // max wait after approval before giving up; defaults to 30m
+	PRPoller                PRPoller               // for monitor phase polling; nil disables monitor
+	NowFunc                 func() time.Time       // for testability; defaults to time.Now
+	AuthorityResolver       AuthorityResolver      // for comment authority checks; nil → all authoritative
+	MonitorProfile          *MonitorProfile        // behavioral profile; nil → use polling config as-is
+	SelfUser                string                 // PR author username for self-comment filtering
+	BotUsers                []string               // known bot usernames to filter
+	Stderr                  io.Writer              // destination for warning messages; defaults to os.Stderr
+	TokenBudget             TokenBudgetConfig      // prompt token budget estimation; zero value disables checks
+	ContextBudget           int                    // global default context budget in tokens; 0 disables adaptive fitting
+	Notify                  NotifyConfig           // notification hooks fired on pipeline completion; zero value disables
+	ApiKeyHelper            string                 // path to script that prints an API key; wired into runner.RunOpts
+	MergeMethod             string                 // merge method: "merge", "squash", "rebase"; defaults to "squash"
+	MergeLabels             []string               // required PR labels before auto-merge proceeds
+	AutoMergeTimeout        time.Duration          // max wait after approval before giving up; defaults to 30m
+	TranscriptLevel         claude.TranscriptLevel // transcript capture level; empty/"off" disables
 }
 
 // TokenBudgetConfig configures the prompt-size estimation check.
@@ -760,17 +763,18 @@ func (e *Engine) runPhase(ctx context.Context, phase PhaseConfig) error {
 	// before falling back to the phase default.
 	resolvedTimeout := e.resolvePhaseTimeout(phase)
 	opts := runner.RunOpts{
-		Phase:        phase.Name,
-		SystemPrompt: rendered,
-		UserPrompt:   "Execute the task described in the system prompt.",
-		OutputSchema: phase.Schema,
-		AllowedTools: phase.Tools,
-		MaxBudgetUSD: remaining,
-		WorkDir:      e.workDir(phase),
-		Model:        model,
-		Timeout:      resolvedTimeout,
-		OnChunk:      e.makeOnChunk(ctx, phase.Name),
-		ApiKeyHelper: e.config.ApiKeyHelper,
+		Phase:           phase.Name,
+		SystemPrompt:    rendered,
+		UserPrompt:      "Execute the task described in the system prompt.",
+		OutputSchema:    phase.Schema,
+		AllowedTools:    phase.Tools,
+		MaxBudgetUSD:    remaining,
+		WorkDir:         e.workDir(phase),
+		Model:           model,
+		Timeout:         resolvedTimeout,
+		OnChunk:         e.makeOnChunk(ctx, phase.Name),
+		ApiKeyHelper:    e.config.ApiKeyHelper,
+		TranscriptLevel: e.config.TranscriptLevel,
 	}
 
 	// Run with retry.
@@ -797,6 +801,17 @@ func (e *Engine) runPhase(ctx context.Context, phase PhaseConfig) error {
 	}
 	if err := e.state.AccumulateTokens(phase.Name, result.TokensIn, result.TokensOut, result.CacheTokensIn); err != nil {
 		return fmt.Errorf("engine: accumulate tokens for %s: %w", phase.Name, err)
+	}
+
+	// Persist transcript if capture was enabled and entries were collected.
+	if len(result.Transcript) > 0 {
+		transcriptJSON, jsonErr := json.Marshal(result.Transcript)
+		if jsonErr != nil {
+			// Non-fatal: log warning but don't fail the phase.
+			fmt.Fprintf(e.config.Stderr, "engine: warning: failed to marshal transcript for %s: %v\n", phase.Name, jsonErr)
+		} else if writeErr := e.state.WriteTranscript(phase.Name, transcriptJSON); writeErr != nil {
+			fmt.Fprintf(e.config.Stderr, "engine: warning: failed to write transcript for %s: %v\n", phase.Name, writeErr)
+		}
 	}
 
 	// Token budget calibration: after the LLM returns actual token counts,

--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -17,8 +17,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/decko/soda/internal/claude"
 	"github.com/decko/soda/internal/runner"
+	"github.com/decko/soda/internal/transcript"
 )
 
 func TestEngine_HappyPathAllPhasesComplete(t *testing.T) {
@@ -6744,7 +6744,7 @@ func TestEngine_WriteTranscript(t *testing.T) {
 		},
 	}
 
-	transcriptEntries := []claude.TranscriptEntry{
+	transcriptEntries := []transcript.Entry{
 		{Role: "tool_use", Content: `{"file_path":"main.go"}`, Tool: "Read", ToolID: "tu_1"},
 		{Role: "tool_result", Content: "file content here", ToolID: "tu_1"},
 	}
@@ -6763,7 +6763,7 @@ func TestEngine_WriteTranscript(t *testing.T) {
 	}
 
 	engine, state := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
-		cfg.TranscriptLevel = claude.TranscriptTools
+		cfg.TranscriptLevel = transcript.Tools
 	})
 
 	if err := engine.Run(context.Background()); err != nil {
@@ -6776,7 +6776,7 @@ func TestEngine_WriteTranscript(t *testing.T) {
 		t.Fatalf("read transcript file: %v", err)
 	}
 
-	var got []claude.TranscriptEntry
+	var got []transcript.Entry
 	if err := json.Unmarshal(data, &got); err != nil {
 		t.Fatalf("unmarshal transcript: %v", err)
 	}
@@ -6821,7 +6821,7 @@ func TestEngine_WriteTranscript_SkippedWhenEmpty(t *testing.T) {
 	}
 
 	engine, state := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
-		cfg.TranscriptLevel = claude.TranscriptOff
+		cfg.TranscriptLevel = transcript.Off
 	})
 
 	if err := engine.Run(context.Background()); err != nil {

--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/decko/soda/internal/claude"
 	"github.com/decko/soda/internal/runner"
 )
 
@@ -6731,6 +6732,105 @@ func TestEngine_NotificationPartialStatus(t *testing.T) {
 	}
 	if result.Status != "partial" {
 		t.Errorf("Status = %q, want %q", result.Status, "partial")
+	}
+}
+
+func TestEngine_WriteTranscript(t *testing.T) {
+	phases := []PhaseConfig{
+		{
+			Name:   "triage",
+			Prompt: "triage.md",
+			Retry:  RetryConfig{Transient: 0, Parse: 0, Semantic: 0},
+		},
+	}
+
+	transcriptEntries := []claude.TranscriptEntry{
+		{Role: "tool_use", Content: `{"file_path":"main.go"}`, Tool: "Read", ToolID: "tu_1"},
+		{Role: "tool_result", Content: "file content here", ToolID: "tu_1"},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"triage": {{
+				result: &runner.RunResult{
+					Output:     json.RawMessage(`{"automatable":"yes"}`),
+					RawText:    "Triage complete",
+					CostUSD:    0.05,
+					Transcript: transcriptEntries,
+				},
+			}},
+		},
+	}
+
+	engine, state := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.TranscriptLevel = claude.TranscriptTools
+	})
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	transcriptPath := filepath.Join(state.Dir(), "logs", "triage_transcript.json")
+	data, err := os.ReadFile(transcriptPath)
+	if err != nil {
+		t.Fatalf("read transcript file: %v", err)
+	}
+
+	var got []claude.TranscriptEntry
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal transcript: %v", err)
+	}
+
+	if len(got) != len(transcriptEntries) {
+		t.Fatalf("transcript entry count = %d, want %d", len(got), len(transcriptEntries))
+	}
+	if got[0].Tool != "Read" {
+		t.Errorf("entries[0].Tool = %q, want %q", got[0].Tool, "Read")
+	}
+	if got[0].ToolID != "tu_1" {
+		t.Errorf("entries[0].ToolID = %q, want %q", got[0].ToolID, "tu_1")
+	}
+	if got[1].Role != "tool_result" {
+		t.Errorf("entries[1].Role = %q, want %q", got[1].Role, "tool_result")
+	}
+	if got[1].Content != "file content here" {
+		t.Errorf("entries[1].Content = %q, want %q", got[1].Content, "file content here")
+	}
+}
+
+func TestEngine_WriteTranscript_SkippedWhenEmpty(t *testing.T) {
+	phases := []PhaseConfig{
+		{
+			Name:   "triage",
+			Prompt: "triage.md",
+			Retry:  RetryConfig{Transient: 0, Parse: 0, Semantic: 0},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"triage": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"automatable":"yes"}`),
+					RawText: "Triage complete",
+					CostUSD: 0.05,
+					// Transcript is nil — transcript capture disabled
+				},
+			}},
+		},
+	}
+
+	engine, state := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.TranscriptLevel = claude.TranscriptOff
+	})
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	transcriptPath := filepath.Join(state.Dir(), "logs", "triage_transcript.json")
+	if _, err := os.Stat(transcriptPath); !os.IsNotExist(err) {
+		t.Errorf("transcript file should not exist when capture is disabled, but got: %v", err)
 	}
 }
 

--- a/internal/pipeline/state.go
+++ b/internal/pipeline/state.go
@@ -271,6 +271,20 @@ func (s *State) WriteLog(phase, suffix string, content []byte) error {
 	return nil
 }
 
+// WriteTranscript writes a phase transcript file (logs/<phase>_transcript.json).
+// The content is a JSON array of TranscriptEntry objects.
+func (s *State) WriteTranscript(phase string, data []byte) error {
+	logsDir := filepath.Join(s.dir, "logs")
+	if err := os.MkdirAll(logsDir, 0755); err != nil {
+		return fmt.Errorf("pipeline: create logs dir: %w", err)
+	}
+	path := filepath.Join(logsDir, phase+"_transcript.json")
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("pipeline: write transcript %s: %w", path, err)
+	}
+	return nil
+}
+
 // LogEvent appends a structured event to events.jsonl.
 func (s *State) LogEvent(event Event) error {
 	return logEvent(s.dir, event)

--- a/internal/pipeline/state_test.go
+++ b/internal/pipeline/state_test.go
@@ -626,6 +626,25 @@ func TestWriteLog(t *testing.T) {
 	}
 }
 
+func TestWriteTranscript(t *testing.T) {
+	dir := t.TempDir()
+	state, _ := LoadOrCreate(dir, "T-1")
+
+	transcript := []byte(`[{"role":"tool_use","content":"{\"file_path\":\"main.go\"}","tool":"Read","tool_id":"tu_1"}]`)
+	if err := state.WriteTranscript("implement", transcript); err != nil {
+		t.Fatalf("WriteTranscript: %v", err)
+	}
+
+	transcriptPath := filepath.Join(dir, "T-1", "logs", "implement_transcript.json")
+	got, err := os.ReadFile(transcriptPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != string(transcript) {
+		t.Errorf("transcript content = %q, want %q", got, transcript)
+	}
+}
+
 func TestStateAcquireReleaseLock(t *testing.T) {
 	dir := t.TempDir()
 	state, _ := LoadOrCreate(dir, "T-1")

--- a/internal/runner/claude.go
+++ b/internal/runner/claude.go
@@ -28,11 +28,12 @@ func NewClaudeRunner(binary, model, workDir string) (*ClaudeRunner, error) {
 // Run maps runner.RunOpts to claude.RunOpts, invokes the CLI, and maps the result back.
 func (r *ClaudeRunner) Run(ctx context.Context, opts RunOpts) (*RunResult, error) {
 	claudeOpts := claude.RunOpts{
-		OutputSchema: opts.OutputSchema,
-		AllowedTools: opts.AllowedTools,
-		Prompt:       opts.UserPrompt,
-		Model:        opts.Model,
-		Timeout:      opts.Timeout,
+		OutputSchema:    opts.OutputSchema,
+		AllowedTools:    opts.AllowedTools,
+		Prompt:          opts.UserPrompt,
+		Model:           opts.Model,
+		Timeout:         opts.Timeout,
+		TranscriptLevel: opts.TranscriptLevel,
 	}
 
 	if opts.MaxBudgetUSD > 0 {
@@ -77,6 +78,7 @@ func (r *ClaudeRunner) Run(ctx context.Context, opts RunOpts) (*RunResult, error
 		CacheTokensIn: result.Tokens.CacheCreationInputTokens + result.Tokens.CacheReadInputTokens,
 		DurationMs:    result.Duration.Milliseconds(),
 		Turns:         result.Turns,
+		Transcript:    result.Transcript,
 	}, nil
 }
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/decko/soda/internal/claude"
+	"github.com/decko/soda/internal/transcript"
 )
 
 // Runner executes a single pipeline phase in an isolated session.
@@ -16,18 +16,18 @@ type Runner interface {
 
 // RunOpts holds everything needed to execute one phase.
 type RunOpts struct {
-	Phase           string                 // phase name (e.g., "triage", "plan")
-	SystemPrompt    string                 // rendered system prompt content
-	UserPrompt      string                 // rendered user prompt (ticket + artifacts)
-	OutputSchema    string                 // JSON schema for structured output
-	AllowedTools    []string               // tool scoping per phase
-	MaxBudgetUSD    float64                // cost cap for this phase
-	WorkDir         string                 // working directory for the agent
-	Model           string                 // model to use
-	Timeout         time.Duration          // phase timeout
-	OnChunk         func(string)           // called for each streamed output line; may be nil
-	ApiKeyHelper    string                 // path to a script that prints an API key to stdout
-	TranscriptLevel claude.TranscriptLevel // transcript capture level; empty/"off" disables
+	Phase           string           // phase name (e.g., "triage", "plan")
+	SystemPrompt    string           // rendered system prompt content
+	UserPrompt      string           // rendered user prompt (ticket + artifacts)
+	OutputSchema    string           // JSON schema for structured output
+	AllowedTools    []string         // tool scoping per phase
+	MaxBudgetUSD    float64          // cost cap for this phase
+	WorkDir         string           // working directory for the agent
+	Model           string           // model to use
+	Timeout         time.Duration    // phase timeout
+	OnChunk         func(string)     // called for each streamed output line; may be nil
+	ApiKeyHelper    string           // path to a script that prints an API key to stdout
+	TranscriptLevel transcript.Level // transcript capture level; empty/"off" disables
 }
 
 // RunResult holds the parsed response from a phase execution.
@@ -40,5 +40,5 @@ type RunResult struct {
 	CacheTokensIn int64 // tokens served from prompt cache (0 if unsupported)
 	DurationMs    int64
 	Turns         int
-	Transcript    []claude.TranscriptEntry // filtered transcript entries; nil when capture is disabled
+	Transcript    []transcript.Entry // filtered transcript entries; nil when capture is disabled
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"time"
+
+	"github.com/decko/soda/internal/claude"
 )
 
 // Runner executes a single pipeline phase in an isolated session.
@@ -14,17 +16,18 @@ type Runner interface {
 
 // RunOpts holds everything needed to execute one phase.
 type RunOpts struct {
-	Phase        string        // phase name (e.g., "triage", "plan")
-	SystemPrompt string        // rendered system prompt content
-	UserPrompt   string        // rendered user prompt (ticket + artifacts)
-	OutputSchema string        // JSON schema for structured output
-	AllowedTools []string      // tool scoping per phase
-	MaxBudgetUSD float64       // cost cap for this phase
-	WorkDir      string        // working directory for the agent
-	Model        string        // model to use
-	Timeout      time.Duration // phase timeout
-	OnChunk      func(string)  // called for each streamed output line; may be nil
-	ApiKeyHelper string        // path to a script that prints an API key to stdout
+	Phase           string                 // phase name (e.g., "triage", "plan")
+	SystemPrompt    string                 // rendered system prompt content
+	UserPrompt      string                 // rendered user prompt (ticket + artifacts)
+	OutputSchema    string                 // JSON schema for structured output
+	AllowedTools    []string               // tool scoping per phase
+	MaxBudgetUSD    float64                // cost cap for this phase
+	WorkDir         string                 // working directory for the agent
+	Model           string                 // model to use
+	Timeout         time.Duration          // phase timeout
+	OnChunk         func(string)           // called for each streamed output line; may be nil
+	ApiKeyHelper    string                 // path to a script that prints an API key to stdout
+	TranscriptLevel claude.TranscriptLevel // transcript capture level; empty/"off" disables
 }
 
 // RunResult holds the parsed response from a phase execution.
@@ -37,4 +40,5 @@ type RunResult struct {
 	CacheTokensIn int64 // tokens served from prompt cache (0 if unsupported)
 	DurationMs    int64
 	Turns         int
+	Transcript    []claude.TranscriptEntry // filtered transcript entries; nil when capture is disabled
 }

--- a/internal/sandbox/runner.go
+++ b/internal/sandbox/runner.go
@@ -142,6 +142,7 @@ func (r *Runner) Run(ctx context.Context, opts runner.RunOpts) (*runner.RunResul
 		AllowedTools:     opts.AllowedTools,
 		MaxBudgetUSD:     budgetPtr,
 		Timeout:          opts.Timeout,
+		TranscriptLevel:  opts.TranscriptLevel,
 	}
 	args := claude.BuildArgs(claudeOpts, opts.Model)
 
@@ -353,7 +354,8 @@ func (r *Runner) Run(ctx context.Context, opts runner.RunOpts) (*runner.RunResul
 		if stdout.Len() > 0 {
 			result, parseErr := claude.ParseResponse(stdout.Bytes())
 			if parseErr == nil {
-				return mapResult(result), nil
+				transcript := claude.FilterTranscript(stdout.Bytes(), opts.TranscriptLevel)
+				return mapResult(result, transcript), nil
 			}
 		}
 		return nil, mapSandboxError(&ExitError{
@@ -368,11 +370,13 @@ func (r *Runner) Run(ctx context.Context, opts runner.RunOpts) (*runner.RunResul
 		return nil, mapClaudeParseError(err)
 	}
 
-	return mapResult(result), nil
+	transcript := claude.FilterTranscript(stdout.Bytes(), opts.TranscriptLevel)
+	return mapResult(result, transcript), nil
 }
 
 // mapResult converts a claude.RunResult to a runner.RunResult.
-func mapResult(cr *claude.RunResult) *runner.RunResult {
+// transcript is computed post-run by FilterTranscript on buffered stdout.
+func mapResult(cr *claude.RunResult, transcript []claude.TranscriptEntry) *runner.RunResult {
 	return &runner.RunResult{
 		Output:        cr.Output,
 		RawText:       cr.Result,
@@ -382,6 +386,7 @@ func mapResult(cr *claude.RunResult) *runner.RunResult {
 		CacheTokensIn: cr.Tokens.CacheCreationInputTokens + cr.Tokens.CacheReadInputTokens,
 		DurationMs:    cr.Duration.Milliseconds(),
 		Turns:         cr.Turns,
+		Transcript:    transcript,
 	}
 }
 

--- a/internal/transcript/transcript.go
+++ b/internal/transcript/transcript.go
@@ -1,0 +1,24 @@
+// Package transcript defines shared types for agent transcript capture.
+// These types are intentionally in a separate package from internal/claude
+// to keep the runner interface agent-agnostic.
+package transcript
+
+// Level controls which events are persisted in the transcript.
+type Level string
+
+const (
+	// Off disables transcript capture entirely.
+	Off Level = "off"
+	// Tools captures tool_use and tool_result events only.
+	Tools Level = "tools"
+	// Full captures all assistant/user events including text blocks.
+	Full Level = "full"
+)
+
+// Entry is a single human-readable entry in a phase transcript.
+type Entry struct {
+	Role    string `json:"role"`              // "assistant", "tool_use", "tool_result"
+	Content string `json:"content"`           // display text
+	Tool    string `json:"tool,omitempty"`    // tool name (tool_use/tool_result only)
+	ToolID  string `json:"tool_id,omitempty"` // correlating tool_use_id
+}


### PR DESCRIPTION
## Summary

Implements full agent transcript persistence to enable raki retrieval quality metrics. The feature captures every JSONL event emitted by Claude via `--output-format stream-json`, filters them by configurable level (`tools`, `full`, or off), and writes the result to `logs/<phase>_transcript.json` inside the ticket directory (covered by `--purge`).

## Changes

### Engine / Runner
- **`args.go`**: Adds `--output-format stream-json` to every Claude invocation so JSONL events are emitted per-event.
- **`runner.go`**: Accumulates JSONL lines during streaming; `shouldPersist()` filters by block type; `FilterTranscript()` provides post-hoc filtering for sandbox runs.
- **`stream.go`**: `extractDisplayText()` extracts display text from stream events for TUI chunks; cost/token tracking unchanged.
- **`parser.go`**: `extractJSON` Strategy 1 finds `result` on the last JSONL line (stream-json result envelope).

### State
- **`state.go`**: Adds `WriteTranscript(phase, events)` to persist `[]TranscriptEvent` as JSON.
- **`transcript.go`** (new): Defines `TranscriptLevel`, `TranscriptEvent`, `TranscriptOff/Tools/Full` constants, and `FilterTranscript()`.

### CLI / Config
- **`run.go`**: `--transcript` flag with `opts.transcriptChanged` precedence (CLI overrides config).
- **`validate.go`**: Stage 8 — `validateTranscript()` rejects unknown levels.
- **`config.go`**: Adds `Transcript` field to `Config`.

### Docs
- **`AGENTS.md`**, **skill docs**: Updated `--output-format` references from `json` → `stream-json`.

## Test Plan

- `args_test.go`: `TestBuildArgs` verifies `--output-format stream-json` is present.
- `parser_test.go`: `stream_json` case verifies last-line result extraction.
- `transcript_test.go`: `TestFilterTranscript` covers `tools`, `full`, `empty` (off) levels.
- `runner_test.go`: `TestStream_TranscriptCapture` verifies accumulation via `tool_events` mock mode.
- `state_test.go`: `TestWriteTranscript` verifies JSON file written under `logs/`.
- `validate_test.go`: 5 dedicated tests for `validateTranscript()` (valid values + unknown level rejection).
- `stream_test.go`: `TestStream_Success` verifies cost/token values unchanged.

## Acceptance Criteria

- [x] `--output-format stream-json` added to all Claude invocations
- [x] Parser handles JSONL stream (last line = result envelope)
- [x] `tools` level saves only tool events
- [x] `full` level saves all assistant/user events
- [x] Default is off (backward compatible)
- [x] `--transcript` CLI flag overrides config value
- [x] TUI streaming works (chunks via `extractDisplayText`)
- [x] Cost/token tracking unchanged
- [x] Works for sandbox and non-sandbox runs
- [x] Transcript files covered by `--purge` (inside `logs/` in ticket dir)
- [x] `soda validate` (Stage 8) checks transcript config value

Assisted-by: SODA