### PR TITLE
[495] Diff-scoped review with prior-finding exclusion and severity calibration

### DIFF
--- a/cmd/soda/embeds/prompts/review-go.md
+++ b/cmd/soda/embeds/prompts/review-go.md
@@ -36,6 +36,26 @@ Summary: {{.Ticket.Summary}}
 
 Worktree: {{.WorktreePath}}
 Branch: {{.Branch}}
+{{- if .Diff}}
+
+## Changed Files
+
+The following diff shows all changes introduced in this branch. Focus your review on lines that were added or modified. Do not report issues in unchanged code.
+
+```diff
+{{.Diff}}
+```
+{{- end}}
+{{- if .PriorFindings}}
+
+## Previously Addressed Findings
+
+The following issues were raised in a previous review and have been addressed. Do NOT re-report these or variations of the same issues.
+
+{{- range .PriorFindings}}
+- [{{.Severity}}] {{.File}}{{if .Line}}:{{.Line}}{{end}} — {{.Issue}}
+{{- end}}
+{{- end}}
 
 ## Your Task
 
@@ -71,7 +91,17 @@ Review the implementation as a Go specialist. Focus on:
 - Are boundary conditions handled?
 - Is input validation adequate?
 
+{{- if .Diff}}
+Focus your review on the changed files shown in the diff above. Only report findings in lines that were added or modified. Read the actual code in the worktree for full context.
+{{- else}}
 Read the actual code in the worktree. Do not rely solely on the implementation report.
+{{- end}}
+
+## Severity definitions
+
+- **critical**: Will cause runtime failures, data corruption, or security vulnerabilities in production
+- **major**: Functional bug that affects correctness under realistic usage, or a missing test for core acceptance criteria
+- **minor**: Style, naming, documentation, performance nits, or improvements that don't affect correctness
 
 For each issue found, provide:
 - severity: "critical", "major", or "minor"

--- a/cmd/soda/embeds/prompts/review-harness.md
+++ b/cmd/soda/embeds/prompts/review-harness.md
@@ -36,6 +36,26 @@ Summary: {{.Ticket.Summary}}
 
 Worktree: {{.WorktreePath}}
 Branch: {{.Branch}}
+{{- if .Diff}}
+
+## Changed Files
+
+The following diff shows all changes introduced in this branch. Focus your review on lines that were added or modified. Do not report issues in unchanged code.
+
+```diff
+{{.Diff}}
+```
+{{- end}}
+{{- if .PriorFindings}}
+
+## Previously Addressed Findings
+
+The following issues were raised in a previous review and have been addressed. Do NOT re-report these or variations of the same issues.
+
+{{- range .PriorFindings}}
+- [{{.Severity}}] {{.File}}{{if .Line}}:{{.Line}}{{end}} — {{.Issue}}
+{{- end}}
+{{- end}}
 
 ## Your Task
 
@@ -70,7 +90,17 @@ Review the implementation as an AI harness specialist. Focus on:
 - Could schema mismatches cause parse errors?
 {{- end}}
 
+{{- if .Diff}}
+Focus your review on the changed files shown in the diff above. Only report findings in lines that were added or modified. Read the actual code in the worktree for full context.
+{{- else}}
 Read the actual code in the worktree. Do not rely solely on the implementation report.
+{{- end}}
+
+## Severity definitions
+
+- **critical**: Will cause runtime failures, data corruption, or security vulnerabilities in production
+- **major**: Functional bug that affects correctness under realistic usage, or a missing test for core acceptance criteria
+- **minor**: Style, naming, documentation, performance nits, or improvements that don't affect correctness
 
 For each issue found, provide:
 - severity: "critical", "major", or "minor"

--- a/cmd/soda/embeds/prompts/review.md
+++ b/cmd/soda/embeds/prompts/review.md
@@ -36,6 +36,26 @@ Summary: {{.Ticket.Summary}}
 
 Worktree: {{.WorktreePath}}
 Branch: {{.Branch}}
+{{- if .Diff}}
+
+## Changed Files
+
+The following diff shows all changes introduced in this branch. Focus your review on lines that were added or modified. Do not report issues in unchanged code.
+
+```diff
+{{.Diff}}
+```
+{{- end}}
+{{- if .PriorFindings}}
+
+## Previously Addressed Findings
+
+The following issues were raised in a previous review and have been addressed. Do NOT re-report these or variations of the same issues.
+
+{{- range .PriorFindings}}
+- [{{.Severity}}] {{.File}}{{if .Line}}:{{.Line}}{{end}} — {{.Issue}}
+{{- end}}
+{{- end}}
 
 ## Your Task
 
@@ -73,7 +93,17 @@ Review the implementation thoroughly. Focus on:
 - Are there unnecessary allocations or expensive operations?
 - Are there potential bottlenecks?
 
+{{- if .Diff}}
+Focus your review on the changed files shown in the diff above. Only report findings in lines that were added or modified. Read the actual code in the worktree for full context.
+{{- else}}
 Read the actual code in the worktree. Do not rely solely on the implementation report.
+{{- end}}
+
+## Severity definitions
+
+- **critical**: Will cause runtime failures, data corruption, or security vulnerabilities in production
+- **major**: Functional bug that affects correctness under realistic usage, or a missing test for core acceptance criteria
+- **minor**: Style, naming, documentation, performance nits, or improvements that don't affect correctness
 
 For each issue found, provide:
 - severity: "critical", "major", or "minor"

--- a/internal/pipeline/budget.go
+++ b/internal/pipeline/budget.go
@@ -44,7 +44,7 @@ type reductionStep struct {
 //
 // The order is phase-specific:
 //   - implement: siblings → exemplars → projectContext → extras → review comments → diff → (rework) → (artifacts) → conventions
-//   - review:    siblings → exemplars → extras → diff → projectContext → (rework) → (artifacts) → conventions
+//   - review:    siblings → exemplars → extras → Diff → projectContext → (rework) → (artifacts) → conventions
 //   - verify:    siblings → exemplars → extras → projectContext → diff → (rework) → (artifacts)  (no conventions — verify.md never renders RepoConventions)
 //   - patch:     diff → siblings → exemplars → extras → projectContext → (rework) → (artifacts) → conventions
 //
@@ -178,6 +178,15 @@ func phaseReductionOrder(phase string) []reductionStep {
 	// Rework reduction group used when ReworkFeedback is present.
 	reworkSteps := []reductionStep{reworkSnippetsStep, reworkDiffStep, reworkCommandOutputStep, reworkPriorCyclesStep}
 
+	// reviewDiffStep reduces the review-phase Diff field (distinct from
+	// DiffContext which is used for corrective/monitor phases and is never
+	// set during review).
+	reviewDiffStep := reductionStep{
+		label:   "Diff",
+		reduce:  func(d *PromptData) { d.Diff = "" },
+		applies: func(d *PromptData) bool { return d.Diff != "" },
+	}
+
 	switch phase {
 	case "implement":
 		// Conventions are shed last — they are compact and high-value for implement.
@@ -187,7 +196,7 @@ func phaseReductionOrder(phase string) []reductionStep {
 		steps = append(steps, conventionsStep)
 		return steps
 	case "review":
-		steps := []reductionStep{siblingStep, exemplarStep, extrasStep, diffStep, projectContextStep}
+		steps := []reductionStep{siblingStep, exemplarStep, extrasStep, reviewDiffStep, projectContextStep}
 		steps = append(steps, reworkSteps...)
 		steps = append(steps, artifactSteps...)
 		steps = append(steps, conventionsStep)

--- a/internal/pipeline/prompt.go
+++ b/internal/pipeline/prompt.go
@@ -26,14 +26,14 @@ type PromptData struct {
 	BaseBranch       string
 	ReviewComments   string
 	ReworkFeedback   *ReworkFeedback
-	DiffContext      string // git diff of current branch vs base, injected for monitor and corrective phases
-	Diff             string // git diff of current branch vs base, injected for review phases (distinct from DiffContext which is used for corrective/monitor phases)
-	SiblingContext   string // function signatures from files referenced in the plan; helps implement see surrounding code
-	PackageExemplars string // function signatures from existing files in the same packages as new files being created
-	VerifyClean      bool   // true when the verify phase produced a "pass" verdict (no failures)
+	DiffContext      string                  // git diff of current branch vs base, injected for monitor and corrective phases
+	Diff             string                  // git diff of current branch vs base, injected for review phases (distinct from DiffContext which is used for corrective/monitor phases)
+	SiblingContext   string                  // function signatures from files referenced in the plan; helps implement see surrounding code
+	PackageExemplars string                  // function signatures from existing files in the same packages as new files being created
+	VerifyClean      bool                    // true when the verify phase produced a "pass" verdict (no failures)
 	PriorFindings    []schemas.ReviewFinding // findings from a prior review cycle, injected per-reviewer so the model avoids re-reporting addressed issues
-	ContextFitted    bool   // true when fitToBudget reduced the prompt to fit the context window
-	ManifestNote     string // injected note telling the model which sections were trimmed and to use tools for missing context
+	ContextFitted    bool                    // true when fitToBudget reduced the prompt to fit the context window
+	ManifestNote     string                  // injected note telling the model which sections were trimmed and to use tools for missing context
 }
 
 // DetectedStackData holds auto-detected project stack information from the

--- a/internal/pipeline/prompt.go
+++ b/internal/pipeline/prompt.go
@@ -27,9 +27,11 @@ type PromptData struct {
 	ReviewComments   string
 	ReworkFeedback   *ReworkFeedback
 	DiffContext      string // git diff of current branch vs base, injected for monitor and corrective phases
+	Diff             string // git diff of current branch vs base, injected for review phases (distinct from DiffContext which is used for corrective/monitor phases)
 	SiblingContext   string // function signatures from files referenced in the plan; helps implement see surrounding code
 	PackageExemplars string // function signatures from existing files in the same packages as new files being created
 	VerifyClean      bool   // true when the verify phase produced a "pass" verdict (no failures)
+	PriorFindings    []schemas.ReviewFinding // findings from a prior review cycle, injected per-reviewer so the model avoids re-reporting addressed issues
 	ContextFitted    bool   // true when fitToBudget reduced the prompt to fit the context window
 	ManifestNote     string // injected note telling the model which sections were trimmed and to use tools for missing context
 }

--- a/internal/pipeline/prompt_data_test.go
+++ b/internal/pipeline/prompt_data_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/decko/soda/internal/runner"
+	"github.com/decko/soda/schemas"
 )
 
 func TestBuildPromptData_VerifyClean(t *testing.T) {
@@ -185,6 +186,141 @@ func TestVerifyCleanTemplateGating(t *testing.T) {
 			}
 			if strings.Contains(rendered, tc.gatedPhrase) {
 				t.Errorf("VerifyClean=true: expected %q section to be absent", tc.gatedPhrase)
+			}
+		})
+	}
+}
+
+// reviewTemplateNames lists the three review templates for table-driven tests.
+var reviewTemplateNames = []string{"review.md", "review-go.md", "review-harness.md"}
+
+// loadReviewTemplate reads a review template from the embedded prompts directory.
+func loadReviewTemplate(t *testing.T, name string) string {
+	t.Helper()
+	_, thisFile, _, _ := runtime.Caller(0)
+	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..")
+	embedDir := filepath.Join(repoRoot, "cmd", "soda", "embeds", "prompts")
+	raw, err := os.ReadFile(filepath.Join(embedDir, name))
+	if err != nil {
+		t.Fatalf("read template %s: %v", name, err)
+	}
+	return string(raw)
+}
+
+// baseReviewData returns a PromptData with enough fields populated to render
+// review templates without errors.
+func baseReviewData() PromptData {
+	return PromptData{
+		Ticket: TicketData{Key: "TEST-1", Summary: "Test"},
+		Artifacts: ArtifactData{
+			Plan:      "plan content",
+			Implement: "impl content",
+			Verify:    "verify content",
+		},
+		WorktreePath: "/tmp/test",
+		Branch:       "test-branch",
+	}
+}
+
+func TestReviewTemplates_DiffSection(t *testing.T) {
+	for _, name := range reviewTemplateNames {
+		name := name
+		t.Run(name+"_present", func(t *testing.T) {
+			tmpl := loadReviewTemplate(t, name)
+			data := baseReviewData()
+			data.Diff = "--- a/foo.go\n+++ b/foo.go\n@@ -1 +1 @@\n-old\n+new"
+
+			rendered, err := RenderPrompt(tmpl, data)
+			if err != nil {
+				t.Fatalf("RenderPrompt: %v", err)
+			}
+			if !strings.Contains(rendered, "## Changed Files") {
+				t.Error("expected '## Changed Files' section when Diff is non-empty")
+			}
+			if !strings.Contains(rendered, "+new") {
+				t.Error("expected diff content to appear in rendered output")
+			}
+			if !strings.Contains(rendered, "Focus your review on the changed files") {
+				t.Error("expected diff-scoped instruction when Diff is set")
+			}
+		})
+		t.Run(name+"_absent", func(t *testing.T) {
+			tmpl := loadReviewTemplate(t, name)
+			data := baseReviewData()
+			data.Diff = ""
+
+			rendered, err := RenderPrompt(tmpl, data)
+			if err != nil {
+				t.Fatalf("RenderPrompt: %v", err)
+			}
+			if strings.Contains(rendered, "## Changed Files") {
+				t.Error("'## Changed Files' section should be absent when Diff is empty")
+			}
+			if !strings.Contains(rendered, "Read the actual code in the worktree") {
+				t.Error("expected fallback instruction when Diff is empty")
+			}
+		})
+	}
+}
+
+func TestReviewTemplates_PriorFindingsSection(t *testing.T) {
+	for _, name := range reviewTemplateNames {
+		name := name
+		t.Run(name+"_present", func(t *testing.T) {
+			tmpl := loadReviewTemplate(t, name)
+			data := baseReviewData()
+			data.PriorFindings = []schemas.ReviewFinding{
+				{Severity: "major", File: "handler.go", Line: 42, Issue: "nil pointer dereference"},
+			}
+
+			rendered, err := RenderPrompt(tmpl, data)
+			if err != nil {
+				t.Fatalf("RenderPrompt: %v", err)
+			}
+			if !strings.Contains(rendered, "## Previously Addressed Findings") {
+				t.Error("expected '## Previously Addressed Findings' section")
+			}
+			if !strings.Contains(rendered, "nil pointer dereference") {
+				t.Error("expected finding issue text in rendered output")
+			}
+			if !strings.Contains(rendered, "handler.go:42") {
+				t.Error("expected file:line in rendered output")
+			}
+		})
+		t.Run(name+"_absent", func(t *testing.T) {
+			tmpl := loadReviewTemplate(t, name)
+			data := baseReviewData()
+			data.PriorFindings = nil
+
+			rendered, err := RenderPrompt(tmpl, data)
+			if err != nil {
+				t.Fatalf("RenderPrompt: %v", err)
+			}
+			if strings.Contains(rendered, "## Previously Addressed Findings") {
+				t.Error("'## Previously Addressed Findings' should be absent when PriorFindings is nil")
+			}
+		})
+	}
+}
+
+func TestReviewTemplates_SeverityDefinitions(t *testing.T) {
+	for _, name := range reviewTemplateNames {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			tmpl := loadReviewTemplate(t, name)
+			data := baseReviewData()
+
+			rendered, err := RenderPrompt(tmpl, data)
+			if err != nil {
+				t.Fatalf("RenderPrompt: %v", err)
+			}
+			if !strings.Contains(rendered, "## Severity definitions") {
+				t.Error("expected '## Severity definitions' section")
+			}
+			for _, word := range []string{"critical", "major", "minor"} {
+				if !strings.Contains(rendered, word) {
+					t.Errorf("expected severity word %q in rendered output", word)
+				}
 			}
 		})
 	}

--- a/internal/pipeline/review.go
+++ b/internal/pipeline/review.go
@@ -216,6 +216,11 @@ func (e *Engine) runParallelReview(ctx context.Context, phase PhaseConfig) error
 		return fmt.Errorf("engine: build prompt data for %s: %w", phase.Name, err)
 	}
 
+	// Populate diff for review-scoped focus. Uses the same helper as
+	// corrective phases but writes to Diff (not DiffContext) so the
+	// review templates can render a dedicated "Changed Files" section.
+	promptData.Diff = e.computeDiffContext(ctx)
+
 	// Resolve timeout and model before launching goroutines — avoid concurrent Meta() reads.
 	resolvedTimeout := e.resolvePhaseTimeout(phase)
 	resolvedModel := e.resolvePhaseModel(phase)
@@ -310,11 +315,17 @@ func (e *Engine) runParallelReview(ctx context.Context, phase PhaseConfig) error
 			results[idx] = reviewerResult{Name: reviewer.Name, Findings: carried}
 			continue
 		}
+		// Clone promptData by value so each reviewer gets its own copy
+		// with per-reviewer PriorFindings. On the first run priorReview
+		// is nil so PriorFindings stays nil; on rework cycles it is
+		// populated with findings the reviewer raised in the prior cycle.
+		reviewerData := promptData
+		reviewerData.PriorFindings = priorFindingsForReviewer(priorReview, reviewer.Name)
 		wg.Add(1)
-		go func(idx int, reviewer ReviewerConfig) {
+		go func(idx int, reviewer ReviewerConfig, data PromptData) {
 			defer wg.Done()
-			e.runReviewer(ctx, phase, reviewer, promptData, budgetRemaining, resolvedTimeout, resolvedModel, idx, msgCh)
-		}(idx, reviewer)
+			e.runReviewer(ctx, phase, reviewer, data, budgetRemaining, resolvedTimeout, resolvedModel, idx, msgCh)
+		}(idx, reviewer, reviewerData)
 	}
 
 	// Close channel once all goroutines finish.

--- a/internal/pipeline/review_test.go
+++ b/internal/pipeline/review_test.go
@@ -3596,3 +3596,133 @@ func TestEngine_ParallelReview_ConditionSkipCarriesFindings(t *testing.T) {
 		t.Error("expected reviewer_skipped event with condition reason for ai-harness in rework cycle")
 	}
 }
+
+func TestParallelReview_PriorFindingsInjectedOnRework(t *testing.T) {
+	// When a reviewer produced critical/major findings in cycle 1, on cycle 2
+	// that reviewer should receive PriorFindings in its prompt data containing
+	// the findings from cycle 1.
+	phases := []PhaseConfig{
+		{
+			Name:         "implement",
+			Prompt:       "implement.md",
+			Retry:        RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			FeedbackFrom: []string{"review"},
+		},
+		{
+			Name:      "review",
+			Type:      "parallel-review",
+			DependsOn: []string{"implement"},
+			Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			Rework:    &ReworkConfig{Target: "implement"},
+			Reviewers: []ReviewerConfig{
+				{Name: "go-specialist", Prompt: "prompts/review-go.md", Focus: "Go idioms"},
+			},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"implement": {
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(`{"tests_passed":true,"commits":1}`),
+					RawText: "Impl v1",
+					CostUSD: 0.50,
+				}},
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(`{"tests_passed":true,"commits":2}`),
+					RawText: "Impl v2",
+					CostUSD: 0.50,
+				}},
+			},
+			// go-specialist: critical finding in cycle 1, clean in cycle 2.
+			"review/go-specialist": {
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(`{"findings":[{"severity":"critical","file":"handler.go","line":42,"issue":"nil pointer dereference on ctx","suggestion":"add nil check"}]}`),
+					RawText: "Critical issue",
+					CostUSD: 0.15,
+				}},
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(`{"findings":[]}`),
+					RawText: "All clear",
+					CostUSD: 0.10,
+				}},
+			},
+		},
+	}
+
+	stateDir := t.TempDir()
+	promptDir := t.TempDir()
+	workDir := t.TempDir()
+
+	// Write reviewer template that renders PriorFindings when present.
+	reviewerTmpl := `Reviewer: go-specialist
+Ticket: {{.Ticket.Key}}
+{{- if .PriorFindings}}
+PRIOR:{{range .PriorFindings}} {{.Issue}}{{end}}
+{{- end}}
+`
+	implTmpl := "Phase: implement\nTicket: {{.Ticket.Key}}\n"
+
+	for _, entry := range []struct {
+		name    string
+		content string
+	}{
+		{"implement.md", implTmpl},
+		{"prompts/review-go.md", reviewerTmpl},
+	} {
+		tmplPath := filepath.Join(promptDir, entry.name)
+		if err := os.MkdirAll(filepath.Dir(tmplPath), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(tmplPath, []byte(entry.content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	state, err := LoadOrCreate(stateDir, "PRIOR-1")
+	if err != nil {
+		t.Fatalf("LoadOrCreate: %v", err)
+	}
+
+	cfg := EngineConfig{
+		Pipeline:   &PhasePipeline{Phases: phases},
+		Loader:     NewPromptLoader(promptDir),
+		Ticket:     TicketData{Key: "PRIOR-1", Summary: "Prior findings test"},
+		Model:      "test-model",
+		WorkDir:    workDir,
+		MaxCostUSD: 0,
+		Mode:       Autonomous,
+		SleepFunc:  func(time.Duration) {},
+		JitterFunc: func(time.Duration) time.Duration { return 0 },
+	}
+
+	engine := NewEngine(mock, state, cfg)
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// Find the second review/go-specialist call (the rework cycle).
+	reviewCalls := 0
+	var reworkPrompt string
+	for _, call := range mock.calls {
+		if call.Phase == "review/go-specialist" {
+			reviewCalls++
+			if reviewCalls == 2 {
+				reworkPrompt = call.SystemPrompt
+			}
+		}
+	}
+
+	if reviewCalls != 2 {
+		t.Fatalf("review/go-specialist called %d times, want 2", reviewCalls)
+	}
+
+	// The rework prompt should contain the prior findings.
+	if !strings.Contains(reworkPrompt, "PRIOR:") {
+		t.Errorf("rework prompt should contain PRIOR: marker;\ngot: %s", reworkPrompt)
+	}
+	if !strings.Contains(reworkPrompt, "nil pointer dereference on ctx") {
+		t.Errorf("rework prompt should contain prior finding issue text;\ngot: %s", reworkPrompt)
+	}
+}


### PR DESCRIPTION
## Summary

Implements diff-scoped code review with per-reviewer prior-finding injection and severity calibration (ticket #495).

### Changes

** struct** ()
- Added  field (after ) populated with the diff for the current review cycle
- Added  field (after ) for per-reviewer prior findings injection

**Budget reduction** ()
- Replaced the dead `diffStep` in the review phase (which reduced `DiffContext`, never set for reviews) with `reviewDiffStep` that correctly reduces `Diff`
- Reduction order: siblings → exemplars → extras → **Diff** → projectContext → rework → artifacts → conventions

**`runParallelReview` wiring** ()
- Populates `promptData.Diff` via `e.computeDiffContext(ctx)` after `buildPromptData`
- Each reviewer goroutine receives a value-copy clone `reviewerData` with per-reviewer `PriorFindings` from `priorFindingsForReviewer(priorReview, reviewer.Name)`

**Template changes** (all three review templates)
- Added `## Changed Files` section (conditional on `.Diff`) with diff-scoped instruction
- Added `## Previously Addressed Findings` section (conditional on `.PriorFindings`) to exclude already-resolved issues on rework cycles
- Added `## Severity definitions` section (unconditional) for calibrated severity scoring

**Tests**
- `TestReviewTemplates_DiffSection` — verifies diff section renders across all three templates
- `TestReviewTemplates_PriorFindingsSection` — verifies prior findings section renders across all three templates
- `TestReviewTemplates_SeverityDefinitions` — verifies severity definitions render across all three templates
- `TestParallelReview_PriorFindingsInjectedOnRework` — full integration test driving a 2-cycle rework and asserting prior findings appear in the rework prompt

## Test Plan

- All existing tests pass (including with race detector)
- New unit tests cover each template section in isolation
- Integration test validates end-to-end prior-findings injection in rework cycles

## Acceptance Criteria

- [x]  has  and  fields
- [x] Budget reducer uses  (reduces , not ) in review phase
- [x]  populates  and injects per-reviewer 
- [x] All three review templates include  section (diff-scoped)
- [x] All three review templates include  section
- [x] All three review templates include  section
- [x] Tests cover template sections and rework prior-findings injection

---
Assisted-by: SODA