### PR TITLE
feat(metrics): cost-per-complexity-band tracking for model routing validation [490]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -357,6 +357,7 @@ Additional engine-level errors:
 Atomic writes: always write to `.tmp` then rename. Archive on re-run (`verify.json` → `verify.json.1`).
 
 `meta.json` key fields:
+- `complexity` — triage complexity band ("low", "medium", "high"); empty for sessions without triage
 - `rework_cycles` — review rework counter
 - `patch_cycles` — corrective patch counter
 - `escalated_from_patch` — one-shot escalation flag
@@ -451,6 +452,7 @@ Atomic writes: always write to `.tmp` then rename. Archive on re-run (`verify.js
 | `knowledge_retrieval_miss_rate` | Fraction of rework findings caused by missing context | 1.0 |
 | `phase_execution_time` | Mean wall-clock seconds per session | 847s (p50=801, p95=1309) |
 | `token_efficiency` | Mean tokens per phase | available (persisted in meta.json) |
+| `cost_by_complexity` | Mean/median/total USD per triage complexity band | n/a (new) |
 
 ### Interpretation
 
@@ -666,6 +668,7 @@ If yes, include a "Docs to update" section in the issue body listing the files t
 | `soda log <ticket> -f` | Tail events in real-time (poll-based follow) |
 | `soda validate` | Check config, phases, and prompts for errors without running |
 | `soda cost` | Show cumulative cost breakdown across all sessions |
+| `soda cost --by-complexity` | Show cost breakdown grouped by triage complexity band |
 | `soda plugin install [--global] [--force]` | Install the SODA Claude Code plugin |
 | `soda plugin uninstall [--global]` | Remove the SODA Claude Code plugin |
 | `soda spec <description>` | Generate a ticket specification from a short description |

--- a/cmd/soda/cost.go
+++ b/cmd/soda/cost.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 	"os"
+	"sort"
+	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -11,7 +13,9 @@ import (
 )
 
 func newCostCmd() *cobra.Command {
-	return &cobra.Command{
+	var byComplexity bool
+
+	cmd := &cobra.Command{
 		Use:   "cost",
 		Short: "Show cost breakdown from the persistent cost ledger",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -19,16 +23,22 @@ func newCostCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return runCost(cfg.StateDir)
+			entries, err := pipeline.ReadCostLedger(cfg.StateDir)
+			if err != nil {
+				return fmt.Errorf("cost: read ledger: %w", err)
+			}
+			if byComplexity {
+				return runCostByComplexity(entries)
+			}
+			return runCost(entries)
 		},
 	}
+
+	cmd.Flags().BoolVar(&byComplexity, "by-complexity", false, "Show cost breakdown grouped by triage complexity band")
+	return cmd
 }
 
-func runCost(stateDir string) error {
-	entries, err := pipeline.ReadCostLedger(stateDir)
-	if err != nil {
-		return fmt.Errorf("cost: read ledger: %w", err)
-	}
+func runCost(entries []pipeline.CostEntry) error {
 	if len(entries) == 0 {
 		fmt.Println("No cost entries found.")
 		return nil
@@ -57,5 +67,128 @@ func runCost(stateDir string) error {
 	}
 
 	fmt.Printf("\nTotal: $%.4f across %d run(s)\n", total, len(entries))
+	return nil
+}
+
+// complexityBandOrder defines the canonical sort order for complexity bands.
+// Bands not in this list are sorted alphabetically after the known ones.
+var complexityBandOrder = map[string]int{
+	"low":    0,
+	"medium": 1,
+	"high":   2,
+}
+
+// runCostByComplexity renders a cost breakdown grouped by triage complexity band.
+// Uses manual column-width computation (not tabwriter) to support future ANSI coloring.
+func runCostByComplexity(entries []pipeline.CostEntry) error {
+	if len(entries) == 0 {
+		fmt.Println("No cost entries found.")
+		return nil
+	}
+
+	byBand := pipeline.CostByComplexity(entries)
+
+	// Sort bands: low → medium → high → alphabetical rest (unknown last among unknowns).
+	bands := make([]string, 0, len(byBand))
+	for band := range byBand {
+		bands = append(bands, band)
+	}
+	sort.Slice(bands, func(i, j int) bool {
+		oi, oki := complexityBandOrder[bands[i]]
+		oj, okj := complexityBandOrder[bands[j]]
+		if oki && okj {
+			return oi < oj
+		}
+		if oki {
+			return true
+		}
+		if okj {
+			return false
+		}
+		return bands[i] < bands[j]
+	})
+
+	// Build rows for column-width computation.
+	type row struct {
+		complexity string
+		sessions   string
+		mean       string
+		median     string
+		total      string
+	}
+
+	header := row{"COMPLEXITY", "SESSIONS", "MEAN", "MEDIAN", "TOTAL"}
+	rows := make([]row, len(bands))
+	var totalSessions int
+	var totalCost float64
+	for idx, band := range bands {
+		stats := byBand[band]
+		rows[idx] = row{
+			complexity: strings.ToUpper(band),
+			sessions:   fmt.Sprintf("%d", stats.Sessions),
+			mean:       fmt.Sprintf("$%.2f", stats.Mean),
+			median:     fmt.Sprintf("$%.2f", stats.Median),
+			total:      fmt.Sprintf("$%.2f", stats.Total),
+		}
+		totalSessions += stats.Sessions
+		totalCost += stats.Total
+	}
+
+	// Compute column widths from all rows including header.
+	colW := [5]int{
+		len(header.complexity),
+		len(header.sessions),
+		len(header.mean),
+		len(header.median),
+		len(header.total),
+	}
+	for _, r := range rows {
+		if len(r.complexity) > colW[0] {
+			colW[0] = len(r.complexity)
+		}
+		if len(r.sessions) > colW[1] {
+			colW[1] = len(r.sessions)
+		}
+		if len(r.mean) > colW[2] {
+			colW[2] = len(r.mean)
+		}
+		if len(r.median) > colW[3] {
+			colW[3] = len(r.median)
+		}
+		if len(r.total) > colW[4] {
+			colW[4] = len(r.total)
+		}
+	}
+
+	// Also consider footer widths.
+	footerSessions := fmt.Sprintf("%d", totalSessions)
+	footerTotal := fmt.Sprintf("$%.2f", totalCost)
+	if len("TOTAL") > colW[0] {
+		colW[0] = len("TOTAL")
+	}
+	if len(footerSessions) > colW[1] {
+		colW[1] = len(footerSessions)
+	}
+	if len(footerTotal) > colW[4] {
+		colW[4] = len(footerTotal)
+	}
+
+	gap := 2
+	fmtRow := func(r row) string {
+		return fmt.Sprintf("%-*s%s%-*s%s%-*s%s%-*s%s%-*s",
+			colW[0], r.complexity, strings.Repeat(" ", gap),
+			colW[1], r.sessions, strings.Repeat(" ", gap),
+			colW[2], r.mean, strings.Repeat(" ", gap),
+			colW[3], r.median, strings.Repeat(" ", gap),
+			colW[4], r.total,
+		)
+	}
+
+	fmt.Println(fmtRow(header))
+	for _, r := range rows {
+		fmt.Println(fmtRow(r))
+	}
+
+	fmt.Printf("\nTotal: $%.2f across %d session(s)\n", totalCost, totalSessions)
 	return nil
 }

--- a/cmd/soda/cost_test.go
+++ b/cmd/soda/cost_test.go
@@ -10,8 +10,6 @@ import (
 )
 
 func TestRunCost_Empty(t *testing.T) {
-	dir := t.TempDir()
-
 	oldStdout := os.Stdout
 	r, w, err := os.Pipe()
 	if err != nil {
@@ -19,7 +17,7 @@ func TestRunCost_Empty(t *testing.T) {
 	}
 	os.Stdout = w
 
-	runErr := runCost(dir)
+	runErr := runCost(nil)
 
 	w.Close()
 	os.Stdout = oldStdout
@@ -46,24 +44,10 @@ func TestRunCost_Empty(t *testing.T) {
 }
 
 func TestRunCost_WithEntries(t *testing.T) {
-	dir := t.TempDir()
-
 	ts := time.Date(2026, 4, 19, 10, 0, 0, 0, time.UTC)
-	if err := pipeline.AppendCostEntry(dir, pipeline.CostEntry{
-		Ticket:    "PROJ-123",
-		Timestamp: ts,
-		Cost:      1.2345,
-		Success:   true,
-	}); err != nil {
-		t.Fatalf("AppendCostEntry: %v", err)
-	}
-	if err := pipeline.AppendCostEntry(dir, pipeline.CostEntry{
-		Ticket:    "PROJ-456",
-		Timestamp: ts,
-		Cost:      2.5000,
-		Success:   false,
-	}); err != nil {
-		t.Fatalf("AppendCostEntry: %v", err)
+	entries := []pipeline.CostEntry{
+		{Ticket: "PROJ-123", Timestamp: ts, Cost: 1.2345, Success: true},
+		{Ticket: "PROJ-456", Timestamp: ts, Cost: 2.5000, Success: false},
 	}
 
 	oldStdout := os.Stdout
@@ -73,7 +57,7 @@ func TestRunCost_WithEntries(t *testing.T) {
 	}
 	os.Stdout = w
 
-	runErr := runCost(dir)
+	runErr := runCost(entries)
 
 	w.Close()
 	os.Stdout = oldStdout
@@ -114,5 +98,152 @@ func TestRunCost_WithEntries(t *testing.T) {
 	}
 	if !strings.Contains(output, "2 run(s)") {
 		t.Errorf("output missing '2 run(s)':\n%s", output)
+	}
+}
+
+// captureStdout runs fn with os.Stdout redirected to a pipe and returns the captured output.
+func captureStdout(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+	oldStdout := os.Stdout
+	rd, wr, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = wr
+
+	fnErr := fn()
+
+	wr.Close()
+	os.Stdout = oldStdout
+
+	var buf strings.Builder
+	data := make([]byte, 4096)
+	for {
+		n, readErr := rd.Read(data)
+		if n > 0 {
+			buf.Write(data[:n])
+		}
+		if readErr != nil {
+			break
+		}
+	}
+	rd.Close()
+	return buf.String(), fnErr
+}
+
+func TestRunCostByComplexity_Empty(t *testing.T) {
+	output, err := captureStdout(t, func() error {
+		return runCostByComplexity(nil)
+	})
+	if err != nil {
+		t.Fatalf("runCostByComplexity error: %v", err)
+	}
+	if !strings.Contains(output, "No cost entries found") {
+		t.Errorf("expected 'No cost entries found', got: %s", output)
+	}
+}
+
+func TestRunCostByComplexity_WithEntries(t *testing.T) {
+	entries := []pipeline.CostEntry{
+		{Ticket: "T-1", Cost: 2.00, Complexity: "low"},
+		{Ticket: "T-2", Cost: 4.00, Complexity: "low"},
+		{Ticket: "T-3", Cost: 10.00, Complexity: "high"},
+		{Ticket: "T-4", Cost: 6.00, Complexity: "medium"},
+	}
+
+	output, err := captureStdout(t, func() error {
+		return runCostByComplexity(entries)
+	})
+	if err != nil {
+		t.Fatalf("runCostByComplexity error: %v", err)
+	}
+
+	// Check all bands are present.
+	if !strings.Contains(output, "LOW") {
+		t.Errorf("output missing LOW:\n%s", output)
+	}
+	if !strings.Contains(output, "MEDIUM") {
+		t.Errorf("output missing MEDIUM:\n%s", output)
+	}
+	if !strings.Contains(output, "HIGH") {
+		t.Errorf("output missing HIGH:\n%s", output)
+	}
+
+	// Check header.
+	if !strings.Contains(output, "COMPLEXITY") {
+		t.Errorf("output missing COMPLEXITY header:\n%s", output)
+	}
+	if !strings.Contains(output, "SESSIONS") {
+		t.Errorf("output missing SESSIONS header:\n%s", output)
+	}
+	if !strings.Contains(output, "MEAN") {
+		t.Errorf("output missing MEAN header:\n%s", output)
+	}
+	if !strings.Contains(output, "MEDIAN") {
+		t.Errorf("output missing MEDIAN header:\n%s", output)
+	}
+
+	// Check footer total.
+	if !strings.Contains(output, "4 session(s)") {
+		t.Errorf("output missing '4 session(s)':\n%s", output)
+	}
+	if !strings.Contains(output, "$22.00") {
+		t.Errorf("output missing total $22.00:\n%s", output)
+	}
+}
+
+func TestRunCostByComplexity_UnknownBand(t *testing.T) {
+	entries := []pipeline.CostEntry{
+		{Ticket: "T-1", Cost: 5.00}, // no complexity → UNKNOWN
+	}
+
+	output, err := captureStdout(t, func() error {
+		return runCostByComplexity(entries)
+	})
+	if err != nil {
+		t.Fatalf("runCostByComplexity error: %v", err)
+	}
+
+	if !strings.Contains(output, "UNKNOWN") {
+		t.Errorf("output missing UNKNOWN:\n%s", output)
+	}
+}
+
+func TestRunCostByComplexity_BandOrdering(t *testing.T) {
+	entries := []pipeline.CostEntry{
+		{Ticket: "T-1", Cost: 1.00, Complexity: "high"},
+		{Ticket: "T-2", Cost: 2.00, Complexity: "low"},
+		{Ticket: "T-3", Cost: 3.00, Complexity: "medium"},
+		{Ticket: "T-4", Cost: 4.00},                               // unknown
+		{Ticket: "T-5", Cost: 5.00, Complexity: "custom-special"}, // alphabetical
+	}
+
+	output, err := captureStdout(t, func() error {
+		return runCostByComplexity(entries)
+	})
+	if err != nil {
+		t.Fatalf("runCostByComplexity error: %v", err)
+	}
+
+	// Verify order: LOW before MEDIUM before HIGH before CUSTOM-SPECIAL before UNKNOWN.
+	lines := strings.Split(output, "\n")
+	var bandLines []string
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "COMPLEXITY") || strings.HasPrefix(trimmed, "Total:") {
+			continue
+		}
+		bandLines = append(bandLines, trimmed)
+	}
+
+	if len(bandLines) < 5 {
+		t.Fatalf("expected 5 band lines, got %d:\n%s", len(bandLines), output)
+	}
+
+	expectedOrder := []string{"LOW", "MEDIUM", "HIGH", "CUSTOM-SPECIAL", "UNKNOWN"}
+	for idx, expected := range expectedOrder {
+		if !strings.HasPrefix(bandLines[idx], expected) {
+			t.Errorf("band line %d: expected prefix %q, got %q", idx, expected, bandLines[idx])
+		}
 	}
 }

--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -481,10 +481,11 @@ func runPipeline(cfg *config.Config, opts pipelineOpts) error {
 	// Errors are non-fatal — a ledger write failure must not mask the pipeline result,
 	// but we emit a warning to stderr so users can diagnose issues (e.g. permission denied).
 	if ledgerErr := pipeline.AppendCostEntry(stateDir, pipeline.CostEntry{
-		Ticket:    ticketKey,
-		Timestamp: time.Now(),
-		Cost:      state.Meta().TotalCost - costBefore,
-		Success:   runErr == nil,
+		Ticket:     ticketKey,
+		Timestamp:  time.Now(),
+		Cost:       state.Meta().TotalCost - costBefore,
+		Success:    runErr == nil,
+		Complexity: state.Meta().Complexity,
 	}); ledgerErr != nil {
 		fmt.Fprintf(os.Stderr, "Warning: failed to record cost entry: %v\n", ledgerErr)
 	}

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -189,6 +189,32 @@ func (e *Engine) checkBinaryVersion() {
 	}
 }
 
+// populateTriageComplexity reads the triage result and sets meta.Complexity
+// from the triage output's complexity field. It is called at end-of-run so
+// that the cost ledger entry always includes the correct band, regardless
+// of success or failure. Returns the final complexity value.
+func (e *Engine) populateTriageComplexity() string {
+	if e.state.Meta().Complexity != "" {
+		return e.state.Meta().Complexity
+	}
+	raw, err := e.state.ReadResult("triage")
+	if err != nil {
+		return ""
+	}
+	var parsed struct {
+		Complexity string `json:"complexity"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return ""
+	}
+	if parsed.Complexity == "" {
+		return ""
+	}
+	e.state.Meta().Complexity = parsed.Complexity
+	_ = e.state.flushMeta() // non-fatal; best-effort persistence
+	return parsed.Complexity
+}
+
 // ensureWorktree creates a worktree if one hasn't been created yet and
 // WorktreeBase is configured. Called at the start of Run and Resume so
 // every phase executes inside the worktree.
@@ -277,6 +303,7 @@ func (e *Engine) Run(ctx context.Context) error {
 	}
 
 	if err := e.executePhases(ctx, e.config.Pipeline.Phases, false); err != nil {
+		e.populateTriageComplexity()
 		wrapped := e.wrapTimeoutError(ctx, err)
 		var pte *PipelineTimeoutError
 		if !errors.As(wrapped, &pte) {
@@ -286,7 +313,16 @@ func (e *Engine) Run(ctx context.Context) error {
 		return wrapped
 	}
 
-	e.emit(Event{Kind: EventEngineCompleted})
+	complexity := e.populateTriageComplexity()
+	completedData := map[string]any{}
+	if complexity != "" {
+		completedData["complexity"] = complexity
+	}
+	if len(completedData) > 0 {
+		e.emit(Event{Kind: EventEngineCompleted, Data: completedData})
+	} else {
+		e.emit(Event{Kind: EventEngineCompleted})
+	}
 	e.sendNotification(nil)
 	return nil
 }
@@ -355,6 +391,7 @@ func (e *Engine) Resume(ctx context.Context, fromPhase string) error {
 	// The fromPhase (first in slice) is always re-run, even if completed.
 	// Mark it with forceFirst=true so executePhases skips the shouldSkip check.
 	if err := e.executePhases(ctx, e.config.Pipeline.Phases[startIdx:], true); err != nil {
+		e.populateTriageComplexity()
 		wrapped := e.wrapTimeoutError(ctx, err)
 		var pte *PipelineTimeoutError
 		if !errors.As(wrapped, &pte) {
@@ -364,7 +401,16 @@ func (e *Engine) Resume(ctx context.Context, fromPhase string) error {
 		return wrapped
 	}
 
-	e.emit(Event{Kind: EventEngineCompleted})
+	complexity := e.populateTriageComplexity()
+	completedData := map[string]any{}
+	if complexity != "" {
+		completedData["complexity"] = complexity
+	}
+	if len(completedData) > 0 {
+		e.emit(Event{Kind: EventEngineCompleted, Data: completedData})
+	} else {
+		e.emit(Event{Kind: EventEngineCompleted})
+	}
 	e.sendNotification(nil)
 	return nil
 }

--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -6849,3 +6849,197 @@ func newTestWebhookServer(t *testing.T, onBody func([]byte)) *httpTestServer {
 type httpTestServer struct {
 	*httptest.Server
 }
+
+func TestEngine_ComplexityFromTriagePersistsInMeta(t *testing.T) {
+	phases := []PhaseConfig{
+		{
+			Name:   "triage",
+			Prompt: "triage.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+		{
+			Name:      "plan",
+			Prompt:    "plan.md",
+			DependsOn: []string{"triage"},
+			Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"triage": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"automatable":"yes","complexity":"high"}`),
+					RawText: "Triage result",
+					CostUSD: 0.10,
+				},
+			}},
+			"plan": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"tasks":["t1"]}`),
+					RawText: "Plan result",
+					CostUSD: 0.20,
+				},
+			}},
+		},
+	}
+
+	var events []Event
+	engine, state := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.OnEvent = func(ev Event) {
+			events = append(events, ev)
+		}
+	})
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// Complexity should be persisted in meta.
+	if state.Meta().Complexity != "high" {
+		t.Errorf("Meta.Complexity = %q, want %q", state.Meta().Complexity, "high")
+	}
+
+	// engine_completed event should carry complexity.
+	var foundComplexity bool
+	for _, ev := range events {
+		if ev.Kind == EventEngineCompleted {
+			if val, ok := ev.Data["complexity"]; ok {
+				if val != "high" {
+					t.Errorf("engine_completed complexity = %v, want %q", val, "high")
+				}
+				foundComplexity = true
+			}
+		}
+	}
+	if !foundComplexity {
+		t.Error("engine_completed event missing complexity data")
+	}
+}
+
+func TestEngine_ComplexityMissingWhenNoTriage(t *testing.T) {
+	phases := []PhaseConfig{
+		{
+			Name:   "plan",
+			Prompt: "plan.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"plan": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"tasks":["t1"]}`),
+					RawText: "Plan result",
+					CostUSD: 0.10,
+				},
+			}},
+		},
+	}
+
+	var events []Event
+	engine, state := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.OnEvent = func(ev Event) {
+			events = append(events, ev)
+		}
+	})
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// Complexity should remain empty when there's no triage phase.
+	if state.Meta().Complexity != "" {
+		t.Errorf("Meta.Complexity = %q, want empty", state.Meta().Complexity)
+	}
+
+	// engine_completed event should NOT carry complexity.
+	for _, ev := range events {
+		if ev.Kind == EventEngineCompleted {
+			if _, ok := ev.Data["complexity"]; ok {
+				t.Error("engine_completed should not carry complexity when triage is absent")
+			}
+		}
+	}
+}
+
+func TestEngine_ComplexityPreservedOnResume(t *testing.T) {
+	phases := []PhaseConfig{
+		{
+			Name:   "triage",
+			Prompt: "triage.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+		{
+			Name:      "plan",
+			Prompt:    "plan.md",
+			DependsOn: []string{"triage"},
+			Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"triage": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"automatable":"yes","complexity":"medium"}`),
+					RawText: "Triage result",
+					CostUSD: 0.10,
+				},
+			}},
+			"plan": {
+				// First call fails
+				{err: fmt.Errorf("simulated failure")},
+				// Second call succeeds (for resume)
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(`{"tasks":["t1"]}`),
+					RawText: "Plan result",
+					CostUSD: 0.20,
+				}},
+			},
+		},
+	}
+
+	var events []Event
+	engine, state := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.OnEvent = func(ev Event) {
+			events = append(events, ev)
+		}
+	})
+
+	// First run: triage succeeds, plan fails.
+	_ = engine.Run(context.Background())
+
+	// Complexity should be set from triage result even after failure.
+	if state.Meta().Complexity != "medium" {
+		t.Errorf("after failed Run: Meta.Complexity = %q, want %q", state.Meta().Complexity, "medium")
+	}
+
+	// Resume from plan.
+	events = nil
+	if err := engine.Resume(context.Background(), "plan"); err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+
+	// Complexity should still be present.
+	if state.Meta().Complexity != "medium" {
+		t.Errorf("after Resume: Meta.Complexity = %q, want %q", state.Meta().Complexity, "medium")
+	}
+
+	// engine_completed event should carry complexity on resume too.
+	var foundComplexity bool
+	for _, ev := range events {
+		if ev.Kind == EventEngineCompleted {
+			if val, ok := ev.Data["complexity"]; ok {
+				if val != "medium" {
+					t.Errorf("engine_completed complexity = %v, want %q", val, "medium")
+				}
+				foundComplexity = true
+			}
+		}
+	}
+	if !foundComplexity {
+		t.Error("engine_completed event missing complexity on resume")
+	}
+}

--- a/internal/pipeline/ledger.go
+++ b/internal/pipeline/ledger.go
@@ -5,16 +5,18 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"syscall"
 	"time"
 )
 
 // CostEntry records the cost of a single pipeline run in the persistent ledger.
 type CostEntry struct {
-	Ticket    string    `json:"ticket"`
-	Timestamp time.Time `json:"timestamp"`
-	Cost      float64   `json:"cost"`
-	Success   bool      `json:"success"`
+	Ticket     string    `json:"ticket"`
+	Timestamp  time.Time `json:"timestamp"`
+	Cost       float64   `json:"cost"`
+	Success    bool      `json:"success"`
+	Complexity string    `json:"complexity,omitempty"`
 }
 
 // costLedgerFile is the filename of the cost ledger within the state directory.
@@ -133,4 +135,55 @@ func AppendCostEntry(stateDir string, entry CostEntry) error {
 	}
 	data = append(data, '\n')
 	return atomicWrite(CostLedgerPath(stateDir), data)
+}
+
+// ComplexityStats holds aggregated cost statistics for a single complexity band.
+type ComplexityStats struct {
+	Sessions int
+	Mean     float64
+	Median   float64
+	Total    float64
+}
+
+// CostByComplexity groups cost entries by their complexity band and returns
+// aggregated statistics per band. Entries with an empty complexity value are
+// grouped under the key "unknown".
+func CostByComplexity(entries []CostEntry) map[string]ComplexityStats {
+	grouped := make(map[string][]float64)
+	for _, entry := range entries {
+		band := entry.Complexity
+		if band == "" {
+			band = "unknown"
+		}
+		grouped[band] = append(grouped[band], entry.Cost)
+	}
+
+	result := make(map[string]ComplexityStats, len(grouped))
+	for band, costs := range grouped {
+		var total float64
+		for _, cost := range costs {
+			total += cost
+		}
+		mean := total / float64(len(costs))
+
+		sorted := make([]float64, len(costs))
+		copy(sorted, costs)
+		sort.Float64s(sorted)
+
+		var median float64
+		n := len(sorted)
+		if n%2 == 0 {
+			median = (sorted[n/2-1] + sorted[n/2]) / 2.0
+		} else {
+			median = sorted[n/2]
+		}
+
+		result[band] = ComplexityStats{
+			Sessions: len(costs),
+			Mean:     mean,
+			Median:   median,
+			Total:    total,
+		}
+	}
+	return result
 }

--- a/internal/pipeline/ledger_test.go
+++ b/internal/pipeline/ledger_test.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -332,5 +333,153 @@ func TestCumulativeCost_NoDoubleCountingSlugifiedDir(t *testing.T) {
 	// The session should NOT be double-counted; only the ledger entry counts.
 	if cost != 3.00 {
 		t.Errorf("CumulativeCost = %f, want 3.00 (no double-count for slugified dir)", cost)
+	}
+}
+
+func TestCostByComplexity_Empty(t *testing.T) {
+	result := CostByComplexity(nil)
+	if len(result) != 0 {
+		t.Errorf("expected empty map, got %v", result)
+	}
+}
+
+func TestCostByComplexity_BandGrouping(t *testing.T) {
+	entries := []CostEntry{
+		{Ticket: "T-1", Cost: 2.00, Complexity: "low"},
+		{Ticket: "T-2", Cost: 4.00, Complexity: "low"},
+		{Ticket: "T-3", Cost: 10.00, Complexity: "high"},
+	}
+	result := CostByComplexity(entries)
+
+	low, ok := result["low"]
+	if !ok {
+		t.Fatal("missing 'low' band")
+	}
+	if low.Sessions != 2 {
+		t.Errorf("low.Sessions = %d, want 2", low.Sessions)
+	}
+	if low.Mean != 3.00 {
+		t.Errorf("low.Mean = %f, want 3.00", low.Mean)
+	}
+	if low.Median != 3.00 {
+		t.Errorf("low.Median = %f, want 3.00", low.Median)
+	}
+	if low.Total != 6.00 {
+		t.Errorf("low.Total = %f, want 6.00", low.Total)
+	}
+
+	high, ok := result["high"]
+	if !ok {
+		t.Fatal("missing 'high' band")
+	}
+	if high.Sessions != 1 {
+		t.Errorf("high.Sessions = %d, want 1", high.Sessions)
+	}
+	if high.Mean != 10.00 {
+		t.Errorf("high.Mean = %f, want 10.00", high.Mean)
+	}
+	if high.Median != 10.00 {
+		t.Errorf("high.Median = %f, want 10.00", high.Median)
+	}
+	if high.Total != 10.00 {
+		t.Errorf("high.Total = %f, want 10.00", high.Total)
+	}
+}
+
+func TestCostByComplexity_UnknownBand(t *testing.T) {
+	entries := []CostEntry{
+		{Ticket: "T-1", Cost: 5.00},
+		{Ticket: "T-2", Cost: 3.00, Complexity: ""},
+	}
+	result := CostByComplexity(entries)
+
+	unknown, ok := result["unknown"]
+	if !ok {
+		t.Fatal("missing 'unknown' band")
+	}
+	if unknown.Sessions != 2 {
+		t.Errorf("unknown.Sessions = %d, want 2", unknown.Sessions)
+	}
+	if unknown.Total != 8.00 {
+		t.Errorf("unknown.Total = %f, want 8.00", unknown.Total)
+	}
+}
+
+func TestCostByComplexity_EvenMedian(t *testing.T) {
+	entries := []CostEntry{
+		{Ticket: "T-1", Cost: 1.00, Complexity: "medium"},
+		{Ticket: "T-2", Cost: 3.00, Complexity: "medium"},
+		{Ticket: "T-3", Cost: 5.00, Complexity: "medium"},
+		{Ticket: "T-4", Cost: 7.00, Complexity: "medium"},
+	}
+	result := CostByComplexity(entries)
+
+	medium := result["medium"]
+	// Sorted: 1,3,5,7 → median = (3+5)/2 = 4
+	if medium.Median != 4.00 {
+		t.Errorf("medium.Median = %f, want 4.00", medium.Median)
+	}
+}
+
+func TestCostByComplexity_OddMedian(t *testing.T) {
+	entries := []CostEntry{
+		{Ticket: "T-1", Cost: 1.00, Complexity: "low"},
+		{Ticket: "T-2", Cost: 5.00, Complexity: "low"},
+		{Ticket: "T-3", Cost: 3.00, Complexity: "low"},
+	}
+	result := CostByComplexity(entries)
+
+	low := result["low"]
+	// Sorted: 1,3,5 → median = 3
+	if low.Median != 3.00 {
+		t.Errorf("low.Median = %f, want 3.00", low.Median)
+	}
+}
+
+func TestCostEntryComplexityRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+
+	entry := CostEntry{
+		Ticket:     "T-1",
+		Timestamp:  time.Now().Truncate(time.Second),
+		Cost:       5.00,
+		Success:    true,
+		Complexity: "high",
+	}
+	if err := AppendCostEntry(dir, entry); err != nil {
+		t.Fatalf("AppendCostEntry: %v", err)
+	}
+
+	entries, err := ReadCostLedger(dir)
+	if err != nil {
+		t.Fatalf("ReadCostLedger: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("len(entries) = %d, want 1", len(entries))
+	}
+	if entries[0].Complexity != "high" {
+		t.Errorf("Complexity = %q, want %q", entries[0].Complexity, "high")
+	}
+}
+
+func TestCostEntryComplexityOmitEmpty(t *testing.T) {
+	dir := t.TempDir()
+
+	entry := CostEntry{
+		Ticket:    "T-1",
+		Timestamp: time.Now().Truncate(time.Second),
+		Cost:      5.00,
+		Success:   true,
+	}
+	if err := AppendCostEntry(dir, entry); err != nil {
+		t.Fatalf("AppendCostEntry: %v", err)
+	}
+
+	data, err := os.ReadFile(CostLedgerPath(dir))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if strings.Contains(string(data), "complexity") {
+		t.Errorf("cost.json should omit complexity when empty, got:\n%s", data)
 	}
 }

--- a/internal/pipeline/meta.go
+++ b/internal/pipeline/meta.go
@@ -52,6 +52,7 @@ type PipelineMeta struct {
 	PatchCycles        int                    `json:"patch_cycles,omitempty"`
 	EscalatedFromPatch bool                   `json:"escalated_from_patch,omitempty"`
 	PatchRetryUsed     bool                   `json:"patch_retry_used,omitempty"`
+	Complexity         string                 `json:"complexity,omitempty"`
 	PreviousFailures   []string               `json:"previous_failures,omitempty"`
 	Phases             map[string]*PhaseState `json:"phases"`
 }

--- a/internal/pipeline/meta_test.go
+++ b/internal/pipeline/meta_test.go
@@ -523,6 +523,55 @@ func TestMetaPromptHashOmitEmpty(t *testing.T) {
 	}
 }
 
+func TestMetaComplexityRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "meta.json")
+
+	original := &PipelineMeta{
+		Ticket:     "PROJ-490",
+		Complexity: "high",
+		StartedAt:  time.Now().Truncate(time.Second),
+		Phases:     map[string]*PhaseState{},
+	}
+
+	if err := WriteMeta(path, original); err != nil {
+		t.Fatalf("writeMeta: %v", err)
+	}
+
+	loaded, err := ReadMeta(path)
+	if err != nil {
+		t.Fatalf("ReadMeta: %v", err)
+	}
+
+	if loaded.Complexity != "high" {
+		t.Errorf("Complexity = %q, want %q", loaded.Complexity, "high")
+	}
+}
+
+func TestMetaComplexityOmitEmpty(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "meta.json")
+
+	original := &PipelineMeta{
+		Ticket:    "PROJ-490",
+		StartedAt: time.Now().Truncate(time.Second),
+		Phases:    map[string]*PhaseState{},
+	}
+
+	if err := WriteMeta(path, original); err != nil {
+		t.Fatalf("writeMeta: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+
+	if strings.Contains(string(data), "complexity") {
+		t.Errorf("meta.json should omit complexity when empty, got:\n%s", data)
+	}
+}
+
 func TestPhaseStatusConstants(t *testing.T) {
 	// Verify JSON serialization matches expected strings
 	tests := []struct {


### PR DESCRIPTION
## Summary

Implements cost-per-complexity-band tracking to validate model routing decisions. This feature closes ticket #490.

### Changes

****
- Added  field to 

****
- Added  — reads `triage.json`, sets `meta.Complexity`, and flushes meta (best-effort, both success and failure paths)
- Both `Run()` and `Resume()` include `data["complexity"]` in the `engine_completed` event when non-empty

****
- Added `Complexity` field to `CostEntry` (persisted to `cost.json`)
- Added `ComplexityStats{Sessions, Mean, Median, Total}` struct
- Added `CostByComplexity()` aggregation method on the ledger

****
- Forwards `state.Meta().Complexity` to the ledger entry on cost append

****
- Registered `--by-complexity` flag routing to `runCostByComplexity()`
- Band ordering: low → medium → high → alphabetical → unknown
- Manual column-width padding (no tabwriter, ANSI-compatible)

****
- Documents `complexity` field in meta.json key fields
- Documents `cost_by_complexity` in Raki metrics table
- Documents `soda cost --by-complexity` in CLI commands table

---

## Test Plan

All tests run in  (558 tests pass, no regressions):

| Test | Covers |
|---|---|
|  | AC1 — complexity persists in meta.json |
|  | AC1 — omitempty when not set |
|  | AC2 — engine_completed includes complexity |
|  | AC2 — no spurious key when absent |
|  | AC2 — value survives failure+resume cycle |
|  (5 tests) | AC4 — ledger aggregation |
|  (4 tests) | AC3 — CLI --by-complexity output |

---

## Acceptance Criteria

- [x] **AC1** — Triage complexity is persisted in `meta.json` (`PipelineMeta.Complexity`, populated via `populateTriageComplexity()`)
- [x] **AC2** — `engine_completed` event includes `complexity` field when non-empty (both `Run()` and `Resume()` paths)
- [x] **AC3** — `soda cost --by-complexity` CLI command outputs cost breakdown by band with correct ordering (low → medium → high → alpha → unknown)
- [x] **AC4** — `CostByComplexity()` in ledger computes sessions, mean, median, and total per band; `CostEntry.Complexity` persisted to `cost.json`

---

Assisted-by: SODA