### PR TITLE
[385] feat(engine): per-model parse success tracking for model routing quality gate

### DIFF
--- a/cmd/soda/embeds/phases.yaml
+++ b/cmd/soda/embeds/phases.yaml
@@ -3,6 +3,12 @@
 # Each phase defines: prompt template, output schema, tool scope,
 # timeout, retry policy, and dependencies on previous phase artifacts.
 
+# model_routing: optional quality gate for automatic model escalation.
+# When a per-phase model produces repeated parse failures exceeding
+# fallback_threshold, the engine switches to the global model mid-retry.
+# model_routing:
+#   fallback_threshold: 2  # escalate after 2 consecutive parse failures
+
 phases:
   - name: triage
     prompt: prompts/triage.md

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -805,6 +805,12 @@ func (e *Engine) runPhase(ctx context.Context, phase PhaseConfig) error {
 	// Resolve effective model: evaluate model_overrides (first-match wins) before falling back to phase then global.
 	model := e.resolvePhaseModel(phase)
 
+	// Record the resolved model in phase state for quality tracking.
+	// Non-fatal: quality tracking must not block pipeline execution.
+	if err := e.state.RecordModelUsed(phase.Name, model); err != nil {
+		fmt.Fprintf(e.config.Stderr, "engine: warning: failed to record model used for %s: %v\n", phase.Name, err)
+	}
+
 	// Resolve effective timeout: evaluate timeout_overrides (first-match wins)
 	// before falling back to the phase default.
 	resolvedTimeout := e.resolvePhaseTimeout(phase)

--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -7043,3 +7043,121 @@ func TestEngine_ComplexityPreservedOnResume(t *testing.T) {
 		t.Error("engine_completed event missing complexity on resume")
 	}
 }
+
+func TestEngine_ModelUsedRecordedInMeta(t *testing.T) {
+	phases := []PhaseConfig{
+		{
+			Name:   "triage",
+			Prompt: "triage.md",
+			Model:  "claude-sonnet-4-6",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+		{
+			Name:      "plan",
+			Prompt:    "plan.md",
+			DependsOn: []string{"triage"},
+			Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+			// no per-phase model — should record global model
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"triage": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"automatable":"yes"}`),
+					RawText: "Triage output",
+					CostUSD: 0.10,
+				},
+			}},
+			"plan": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"tasks":["task1"]}`),
+					RawText: "Plan output",
+					CostUSD: 0.20,
+				},
+			}},
+		},
+	}
+
+	engine, state := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.Model = "claude-opus-4-6"
+	})
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// triage has per-phase model — ModelUsed should record it.
+	triagePS := state.Meta().Phases["triage"]
+	if triagePS == nil {
+		t.Fatal("triage phase missing from meta")
+	}
+	if triagePS.ModelUsed != "claude-sonnet-4-6" {
+		t.Errorf("triage ModelUsed = %q, want %q", triagePS.ModelUsed, "claude-sonnet-4-6")
+	}
+
+	// plan has no per-phase model — ModelUsed should record global model.
+	planPS := state.Meta().Phases["plan"]
+	if planPS == nil {
+		t.Fatal("plan phase missing from meta")
+	}
+	if planPS.ModelUsed != "claude-opus-4-6" {
+		t.Errorf("plan ModelUsed = %q, want %q", planPS.ModelUsed, "claude-opus-4-6")
+	}
+}
+
+func TestEngine_ModelUsedClearedOnRerun(t *testing.T) {
+	phases := []PhaseConfig{
+		{
+			Name:   "triage",
+			Prompt: "triage.md",
+			Model:  "claude-sonnet-4-6",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"triage": {
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(`{"automatable":"yes"}`),
+					RawText: "Triage output",
+					CostUSD: 0.10,
+				}},
+				{result: &runner.RunResult{
+					Output:  json.RawMessage(`{"automatable":"yes"}`),
+					RawText: "Triage output 2",
+					CostUSD: 0.10,
+				}},
+			},
+		},
+	}
+
+	engine, state := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.Model = "claude-opus-4-6"
+	})
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	ps := state.Meta().Phases["triage"]
+	if ps.ModelUsed != "claude-sonnet-4-6" {
+		t.Errorf("ModelUsed after first run = %q, want %q", ps.ModelUsed, "claude-sonnet-4-6")
+	}
+
+	// Resume (re-run) triage — MarkRunning should clear ModelUsed,
+	// then runPhase should re-record it.
+	if err := engine.Resume(context.Background(), "triage"); err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+
+	ps = state.Meta().Phases["triage"]
+	if ps.ModelUsed != "claude-sonnet-4-6" {
+		t.Errorf("ModelUsed after resume = %q, want %q", ps.ModelUsed, "claude-sonnet-4-6")
+	}
+	if ps.Generation != 2 {
+		t.Errorf("Generation after resume = %d, want 2", ps.Generation)
+	}
+}

--- a/internal/pipeline/events.go
+++ b/internal/pipeline/events.go
@@ -102,6 +102,7 @@ const (
 	EventPhaseConditionSkipped    = "phase_condition_skipped"
 	EventPhaseTimeoutResolved     = "phase_timeout_resolved"
 	EventPhaseModelResolved       = "phase_model_resolved"
+	EventModelFallback            = "model_fallback"
 )
 
 // FormatEvent formats an event as a compact, human-readable line:

--- a/internal/pipeline/meta.go
+++ b/internal/pipeline/meta.go
@@ -35,6 +35,9 @@ type PhaseState struct {
 	PlanHash              string      `json:"plan_hash,omitempty"`
 	PromptHash            string      `json:"prompt_hash,omitempty"`             // SHA-256 hex digest of the rendered prompt sent to the LLM
 	EstimatedPromptTokens int64       `json:"estimated_prompt_tokens,omitempty"` // pre-invocation estimate: len(rendered) / 3.3
+	ModelUsed             string      `json:"model_used,omitempty"`              // resolved model name used for this phase execution
+	ParseAttempts         int         `json:"parse_attempts,omitempty"`          // number of parse retry attempts during this execution
+	ParseSuccessOnFirst   bool        `json:"parse_success_on_first,omitempty"`  // true if output parsed successfully on the first attempt
 	startedAt             time.Time
 }
 

--- a/internal/pipeline/meta_test.go
+++ b/internal/pipeline/meta_test.go
@@ -572,6 +572,147 @@ func TestMetaComplexityOmitEmpty(t *testing.T) {
 	}
 }
 
+func TestMetaModelUsedRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "meta.json")
+
+	original := &PipelineMeta{
+		Ticket:    "PROJ-385",
+		StartedAt: time.Now().Truncate(time.Second),
+		Phases: map[string]*PhaseState{
+			"triage": {
+				Status:     PhaseCompleted,
+				Cost:       0.10,
+				DurationMs: 5000,
+				Generation: 1,
+				ModelUsed:  "claude-sonnet-4-6",
+			},
+		},
+	}
+
+	if err := WriteMeta(path, original); err != nil {
+		t.Fatalf("writeMeta: %v", err)
+	}
+
+	loaded, err := ReadMeta(path)
+	if err != nil {
+		t.Fatalf("ReadMeta: %v", err)
+	}
+
+	ps := loaded.Phases["triage"]
+	if ps == nil {
+		t.Fatal("triage phase missing")
+	}
+	if ps.ModelUsed != "claude-sonnet-4-6" {
+		t.Errorf("ModelUsed = %q, want %q", ps.ModelUsed, "claude-sonnet-4-6")
+	}
+}
+
+func TestMetaModelUsedOmitEmpty(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "meta.json")
+
+	original := &PipelineMeta{
+		Ticket:    "PROJ-385",
+		StartedAt: time.Now().Truncate(time.Second),
+		Phases: map[string]*PhaseState{
+			"triage": {
+				Status:     PhaseCompleted,
+				Cost:       0.10,
+				DurationMs: 5000,
+				Generation: 1,
+			},
+		},
+	}
+
+	if err := WriteMeta(path, original); err != nil {
+		t.Fatalf("writeMeta: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+
+	if strings.Contains(string(data), "model_used") {
+		t.Errorf("meta.json should omit model_used when empty, got:\n%s", data)
+	}
+}
+
+func TestMetaParseAttemptsRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "meta.json")
+
+	original := &PipelineMeta{
+		Ticket:    "PROJ-385",
+		StartedAt: time.Now().Truncate(time.Second),
+		Phases: map[string]*PhaseState{
+			"implement": {
+				Status:              PhaseCompleted,
+				Cost:                0.50,
+				DurationMs:          12000,
+				Generation:          1,
+				ParseAttempts:       3,
+				ParseSuccessOnFirst: true,
+			},
+		},
+	}
+
+	if err := WriteMeta(path, original); err != nil {
+		t.Fatalf("writeMeta: %v", err)
+	}
+
+	loaded, err := ReadMeta(path)
+	if err != nil {
+		t.Fatalf("ReadMeta: %v", err)
+	}
+
+	ps := loaded.Phases["implement"]
+	if ps == nil {
+		t.Fatal("implement phase missing")
+	}
+	if ps.ParseAttempts != 3 {
+		t.Errorf("ParseAttempts = %d, want 3", ps.ParseAttempts)
+	}
+	if !ps.ParseSuccessOnFirst {
+		t.Error("ParseSuccessOnFirst = false, want true")
+	}
+}
+
+func TestMetaParseFieldsOmitEmpty(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "meta.json")
+
+	original := &PipelineMeta{
+		Ticket:    "PROJ-385",
+		StartedAt: time.Now().Truncate(time.Second),
+		Phases: map[string]*PhaseState{
+			"triage": {
+				Status:     PhaseCompleted,
+				Cost:       0.10,
+				DurationMs: 5000,
+				Generation: 1,
+			},
+		},
+	}
+
+	if err := WriteMeta(path, original); err != nil {
+		t.Fatalf("writeMeta: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+
+	if strings.Contains(string(data), "parse_attempts") {
+		t.Errorf("meta.json should omit parse_attempts when zero, got:\n%s", data)
+	}
+	if strings.Contains(string(data), "parse_success_on_first") {
+		t.Errorf("meta.json should omit parse_success_on_first when false, got:\n%s", data)
+	}
+}
+
 func TestPhaseStatusConstants(t *testing.T) {
 	// Verify JSON serialization matches expected strings
 	tests := []struct {

--- a/internal/pipeline/phase.go
+++ b/internal/pipeline/phase.go
@@ -23,10 +23,17 @@ func isFilePath(s string) bool {
 	return strings.ContainsAny(s, "/\\") || strings.HasSuffix(s, ".json")
 }
 
+// ModelRoutingConfig holds configuration for automatic model escalation
+// when parse failures exceed a threshold during retry loops.
+type ModelRoutingConfig struct {
+	FallbackThreshold int `yaml:"fallback_threshold"` // number of parse failures before escalating to global model; 0 disables
+}
+
 // PhasePipeline holds the ordered list of phases loaded from phases.yaml.
 type PhasePipeline struct {
-	Name   string        `yaml:"-"` // pipeline name; set after loading (e.g. "default", "fast")
-	Phases []PhaseConfig `yaml:"phases"`
+	Name         string             `yaml:"-"` // pipeline name; set after loading (e.g. "default", "fast")
+	Phases       []PhaseConfig      `yaml:"phases"`
+	ModelRouting ModelRoutingConfig `yaml:"model_routing"` // optional model routing quality gate
 }
 
 // PhaseConfig holds the configuration for a single phase.

--- a/internal/pipeline/retry.go
+++ b/internal/pipeline/retry.go
@@ -73,6 +73,7 @@ func (e *Engine) runWithRetry(ctx context.Context, phase PhaseConfig, opts runne
 			if threshold > 0 && parseFailures >= threshold && opts.Model != e.config.Model {
 				previousModel := opts.Model
 				opts.Model = e.config.Model
+				_ = e.state.RecordModelUsed(phase.Name, opts.Model)
 				e.emit(Event{
 					Phase: phase.Name,
 					Kind:  EventModelFallback,

--- a/internal/pipeline/retry.go
+++ b/internal/pipeline/retry.go
@@ -18,6 +18,7 @@ func (e *Engine) runWithRetry(ctx context.Context, phase PhaseConfig, opts runne
 		"semantic":  phase.Retry.Semantic,
 	}
 
+	parseFailures := 0
 	attempt := 0
 	for {
 		if err := e.apiSem.Acquire(ctx); err != nil {
@@ -27,6 +28,10 @@ func (e *Engine) runWithRetry(ctx context.Context, phase PhaseConfig, opts runne
 		e.apiSem.Release()
 
 		if err == nil {
+			// Record first-attempt parse success when attempt is 0.
+			if attempt == 0 {
+				_ = e.state.RecordParseFirstSuccess(phase.Name)
+			}
 			return result, nil
 		}
 
@@ -58,6 +63,27 @@ func (e *Engine) runWithRetry(ctx context.Context, phase PhaseConfig, opts runne
 			})
 
 		case "parse":
+			_ = e.state.AccumulateParseAttempt(phase.Name)
+			parseFailures++
+
+			// Model escalation: when parse failures exceed the threshold
+			// and the phase is using a per-phase model (not already the
+			// global model), switch to the global model mid-retry.
+			threshold := e.config.Pipeline.ModelRouting.FallbackThreshold
+			if threshold > 0 && parseFailures >= threshold && opts.Model != e.config.Model {
+				previousModel := opts.Model
+				opts.Model = e.config.Model
+				e.emit(Event{
+					Phase: phase.Name,
+					Kind:  EventModelFallback,
+					Data: map[string]any{
+						"from":           previousModel,
+						"to":             e.config.Model,
+						"parse_failures": parseFailures,
+					},
+				})
+			}
+
 			var pe *runner.ParseError
 			if errors.As(err, &pe) {
 				opts.UserPrompt = opts.UserPrompt + "\n\n[RETRY] Previous attempt failed with parse error: " + pe.Error() + "\nPlease fix the output format."

--- a/internal/pipeline/retry_test.go
+++ b/internal/pipeline/retry_test.go
@@ -163,6 +163,12 @@ func TestRetry_ModelFallbackOnParseThreshold(t *testing.T) {
 		t.Errorf("call 2 model = %q, want %q", capturedModels[2], "global-model")
 	}
 
+	// Verify ModelUsed reflects the global model after fallback.
+	ps := state.Meta().Phases["impl"]
+	if ps.ModelUsed != "global-model" {
+		t.Errorf("ModelUsed = %q, want %q after fallback", ps.ModelUsed, "global-model")
+	}
+
 	// Verify EventModelFallback was emitted.
 	found := false
 	for _, ev := range events {
@@ -224,5 +230,51 @@ func TestRetry_NoFallbackWhenAlreadyGlobalModel(t *testing.T) {
 		if ev.Kind == EventModelFallback {
 			t.Error("EventModelFallback should not be emitted when already using global model")
 		}
+	}
+}
+
+func TestRetry_ModelUsedUpdatedAfterFallbackFailure(t *testing.T) {
+	// Verify that when a parse failure occurs *after* fallback,
+	// ModelUsed reflects the global model (not the original per-phase model).
+	pipeline := &PhasePipeline{
+		Phases: []PhaseConfig{
+			{Name: "impl", Prompt: "prompts/impl.md", Model: "phase-model", Retry: RetryConfig{Parse: 4}},
+		},
+		ModelRouting: ModelRoutingConfig{FallbackThreshold: 1},
+	}
+
+	callCount := 0
+	mock := &funcRunner{
+		fn: func(ctx context.Context, opts runner.RunOpts) (*runner.RunResult, error) {
+			callCount++
+			if callCount <= 3 {
+				return nil, &runner.ParseError{Err: fmt.Errorf("bad output %d", callCount)}
+			}
+			return &runner.RunResult{Output: json.RawMessage(`{}`)}, nil
+		},
+	}
+
+	engine, state := setupEngine(t, pipeline.Phases, mock, func(cfg *EngineConfig) {
+		cfg.Pipeline = pipeline
+		cfg.Model = "global-model"
+	})
+
+	if err := state.MarkRunning("impl"); err != nil {
+		t.Fatalf("MarkRunning: %v", err)
+	}
+
+	opts := runner.RunOpts{Phase: "impl", Model: "phase-model", UserPrompt: "test"}
+	_, err := engine.runWithRetry(t.Context(), pipeline.Phases[0], opts)
+	if err != nil {
+		t.Fatalf("runWithRetry: %v", err)
+	}
+
+	ps := state.Meta().Phases["impl"]
+	if ps.ModelUsed != "global-model" {
+		t.Errorf("ModelUsed = %q, want %q — failures after fallback should be attributed to global model", ps.ModelUsed, "global-model")
+	}
+	// 3 parse failures total (1 before fallback + 2 after).
+	if ps.ParseAttempts != 3 {
+		t.Errorf("ParseAttempts = %d, want 3", ps.ParseAttempts)
 	}
 }

--- a/internal/pipeline/retry_test.go
+++ b/internal/pipeline/retry_test.go
@@ -1,0 +1,228 @@
+package pipeline
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/decko/soda/internal/runner"
+)
+
+func TestRetry_ParseSuccessOnFirstAttempt(t *testing.T) {
+	phases := []PhaseConfig{
+		{Name: "triage", Prompt: "prompts/triage.md", Retry: RetryConfig{Parse: 2}},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"triage": {
+				{result: &runner.RunResult{Output: json.RawMessage(`{}`)}},
+			},
+		},
+	}
+
+	engine, state := setupEngine(t, phases, mock)
+	if err := state.MarkRunning("triage"); err != nil {
+		t.Fatalf("MarkRunning: %v", err)
+	}
+
+	opts := runner.RunOpts{Phase: "triage", UserPrompt: "test"}
+	_, err := engine.runWithRetry(t.Context(), phases[0], opts)
+	if err != nil {
+		t.Fatalf("runWithRetry: %v", err)
+	}
+
+	ps := state.Meta().Phases["triage"]
+	if !ps.ParseSuccessOnFirst {
+		t.Error("ParseSuccessOnFirst should be true on first-attempt success")
+	}
+	if ps.ParseAttempts != 0 {
+		t.Errorf("ParseAttempts = %d, want 0 (no parse failures)", ps.ParseAttempts)
+	}
+}
+
+func TestRetry_ParseSuccessNotSetOnRetry(t *testing.T) {
+	phases := []PhaseConfig{
+		{Name: "triage", Prompt: "prompts/triage.md", Retry: RetryConfig{Parse: 2}},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"triage": {
+				{err: &runner.ParseError{Err: fmt.Errorf("bad json")}},
+				{result: &runner.RunResult{Output: json.RawMessage(`{}`)}},
+			},
+		},
+	}
+
+	engine, state := setupEngine(t, phases, mock)
+	if err := state.MarkRunning("triage"); err != nil {
+		t.Fatalf("MarkRunning: %v", err)
+	}
+
+	opts := runner.RunOpts{Phase: "triage", UserPrompt: "test"}
+	_, err := engine.runWithRetry(t.Context(), phases[0], opts)
+	if err != nil {
+		t.Fatalf("runWithRetry: %v", err)
+	}
+
+	ps := state.Meta().Phases["triage"]
+	if ps.ParseSuccessOnFirst {
+		t.Error("ParseSuccessOnFirst should be false when first attempt fails")
+	}
+	if ps.ParseAttempts != 1 {
+		t.Errorf("ParseAttempts = %d, want 1", ps.ParseAttempts)
+	}
+}
+
+func TestRetry_ParseAttemptAccumulated(t *testing.T) {
+	phases := []PhaseConfig{
+		{Name: "plan", Prompt: "prompts/plan.md", Retry: RetryConfig{Parse: 3}},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"plan": {
+				{err: &runner.ParseError{Err: fmt.Errorf("error 1")}},
+				{err: &runner.ParseError{Err: fmt.Errorf("error 2")}},
+				{result: &runner.RunResult{Output: json.RawMessage(`{}`)}},
+			},
+		},
+	}
+
+	engine, state := setupEngine(t, phases, mock)
+	if err := state.MarkRunning("plan"); err != nil {
+		t.Fatalf("MarkRunning: %v", err)
+	}
+
+	opts := runner.RunOpts{Phase: "plan", UserPrompt: "test"}
+	_, err := engine.runWithRetry(t.Context(), phases[0], opts)
+	if err != nil {
+		t.Fatalf("runWithRetry: %v", err)
+	}
+
+	ps := state.Meta().Phases["plan"]
+	if ps.ParseAttempts != 2 {
+		t.Errorf("ParseAttempts = %d, want 2 (two parse failures)", ps.ParseAttempts)
+	}
+	if ps.ParseSuccessOnFirst {
+		t.Error("ParseSuccessOnFirst should be false")
+	}
+}
+
+func TestRetry_ModelFallbackOnParseThreshold(t *testing.T) {
+	pipeline := &PhasePipeline{
+		Phases: []PhaseConfig{
+			{Name: "impl", Prompt: "prompts/impl.md", Model: "phase-model", Retry: RetryConfig{Parse: 3}},
+		},
+		ModelRouting: ModelRoutingConfig{FallbackThreshold: 2},
+	}
+
+	var capturedModels []string
+	mock := &funcRunner{
+		fn: func(ctx context.Context, opts runner.RunOpts) (*runner.RunResult, error) {
+			capturedModels = append(capturedModels, opts.Model)
+			if len(capturedModels) <= 2 {
+				return nil, &runner.ParseError{Err: fmt.Errorf("bad output")}
+			}
+			return &runner.RunResult{Output: json.RawMessage(`{}`)}, nil
+		},
+	}
+
+	var events []Event
+	engine, state := setupEngine(t, pipeline.Phases, mock, func(cfg *EngineConfig) {
+		cfg.Pipeline = pipeline
+		cfg.Model = "global-model"
+		cfg.OnEvent = func(ev Event) {
+			events = append(events, ev)
+		}
+	})
+
+	if err := state.MarkRunning("impl"); err != nil {
+		t.Fatalf("MarkRunning: %v", err)
+	}
+
+	opts := runner.RunOpts{Phase: "impl", Model: "phase-model", UserPrompt: "test"}
+	_, err := engine.runWithRetry(t.Context(), pipeline.Phases[0], opts)
+	if err != nil {
+		t.Fatalf("runWithRetry: %v", err)
+	}
+
+	// First two calls use phase-model, third uses global-model after fallback.
+	if len(capturedModels) != 3 {
+		t.Fatalf("expected 3 calls, got %d", len(capturedModels))
+	}
+	if capturedModels[0] != "phase-model" {
+		t.Errorf("call 0 model = %q, want %q", capturedModels[0], "phase-model")
+	}
+	if capturedModels[1] != "phase-model" {
+		t.Errorf("call 1 model = %q, want %q", capturedModels[1], "phase-model")
+	}
+	if capturedModels[2] != "global-model" {
+		t.Errorf("call 2 model = %q, want %q", capturedModels[2], "global-model")
+	}
+
+	// Verify EventModelFallback was emitted.
+	found := false
+	for _, ev := range events {
+		if ev.Kind == EventModelFallback {
+			found = true
+			if ev.Data["from"] != "phase-model" {
+				t.Errorf("fallback event from = %v, want %q", ev.Data["from"], "phase-model")
+			}
+			if ev.Data["to"] != "global-model" {
+				t.Errorf("fallback event to = %v, want %q", ev.Data["to"], "global-model")
+			}
+		}
+	}
+	if !found {
+		t.Error("EventModelFallback not emitted")
+	}
+}
+
+func TestRetry_NoFallbackWhenAlreadyGlobalModel(t *testing.T) {
+	pipeline := &PhasePipeline{
+		Phases: []PhaseConfig{
+			{Name: "triage", Prompt: "prompts/triage.md", Retry: RetryConfig{Parse: 3}},
+		},
+		ModelRouting: ModelRoutingConfig{FallbackThreshold: 1},
+	}
+
+	callCount := 0
+	mock := &funcRunner{
+		fn: func(ctx context.Context, opts runner.RunOpts) (*runner.RunResult, error) {
+			callCount++
+			if callCount == 1 {
+				return nil, &runner.ParseError{Err: fmt.Errorf("bad json")}
+			}
+			return &runner.RunResult{Output: json.RawMessage(`{}`)}, nil
+		},
+	}
+
+	var events []Event
+	engine, state := setupEngine(t, pipeline.Phases, mock, func(cfg *EngineConfig) {
+		cfg.Pipeline = pipeline
+		cfg.Model = "global-model"
+		cfg.OnEvent = func(ev Event) {
+			events = append(events, ev)
+		}
+	})
+
+	if err := state.MarkRunning("triage"); err != nil {
+		t.Fatalf("MarkRunning: %v", err)
+	}
+
+	// Phase is already using the global model — no fallback should occur.
+	opts := runner.RunOpts{Phase: "triage", Model: "global-model", UserPrompt: "test"}
+	_, err := engine.runWithRetry(t.Context(), pipeline.Phases[0], opts)
+	if err != nil {
+		t.Fatalf("runWithRetry: %v", err)
+	}
+
+	for _, ev := range events {
+		if ev.Kind == EventModelFallback {
+			t.Error("EventModelFallback should not be emitted when already using global model")
+		}
+	}
+}

--- a/internal/pipeline/state.go
+++ b/internal/pipeline/state.go
@@ -140,6 +140,9 @@ func (s *State) MarkRunning(phase string) error {
 	ps.Error = ""
 	ps.PlanHash = ""
 	ps.PromptHash = ""
+	ps.ModelUsed = ""
+	ps.ParseAttempts = 0
+	ps.ParseSuccessOnFirst = false
 	ps.startedAt = time.Now()
 
 	return s.flushMeta()
@@ -211,6 +214,39 @@ func (s *State) AccumulateTokens(phase string, tokensIn, tokensOut, cacheTokensI
 	ps.TokensIn += tokensIn
 	ps.TokensOut += tokensOut
 	ps.CacheTokensIn += cacheTokensIn
+	return s.flushMeta()
+}
+
+// RecordModelUsed sets the resolved model name on the phase.
+// Phase must exist (via MarkRunning).
+func (s *State) RecordModelUsed(phase string, model string) error {
+	ps := s.meta.Phases[phase]
+	if ps == nil {
+		return fmt.Errorf("pipeline: record model used: phase %q not started", phase)
+	}
+	ps.ModelUsed = model
+	return s.flushMeta()
+}
+
+// AccumulateParseAttempt increments the parse attempt counter for the phase.
+// Phase must exist (via MarkRunning).
+func (s *State) AccumulateParseAttempt(phase string) error {
+	ps := s.meta.Phases[phase]
+	if ps == nil {
+		return fmt.Errorf("pipeline: accumulate parse attempt: phase %q not started", phase)
+	}
+	ps.ParseAttempts++
+	return s.flushMeta()
+}
+
+// RecordParseFirstSuccess marks that the phase output parsed successfully
+// on the first attempt. Phase must exist (via MarkRunning).
+func (s *State) RecordParseFirstSuccess(phase string) error {
+	ps := s.meta.Phases[phase]
+	if ps == nil {
+		return fmt.Errorf("pipeline: record parse first success: phase %q not started", phase)
+	}
+	ps.ParseSuccessOnFirst = true
 	return s.flushMeta()
 }
 

--- a/internal/pipeline/state_test.go
+++ b/internal/pipeline/state_test.go
@@ -469,6 +469,105 @@ func TestAccumulateTokens(t *testing.T) {
 	})
 }
 
+func TestMarkRunning_ZeroesParseTrackingFields(t *testing.T) {
+	dir := t.TempDir()
+	state, _ := LoadOrCreate(dir, "T-PARSE-ZERO")
+
+	state.MarkRunning("triage")
+	state.RecordModelUsed("triage", "claude-sonnet-4-6")
+	state.AccumulateParseAttempt("triage")
+	state.RecordParseFirstSuccess("triage")
+	state.MarkCompleted("triage")
+
+	// Verify fields are set before re-run.
+	ps := state.meta.Phases["triage"]
+	if ps.ModelUsed != "claude-sonnet-4-6" {
+		t.Errorf("ModelUsed before rerun = %q, want %q", ps.ModelUsed, "claude-sonnet-4-6")
+	}
+	if ps.ParseAttempts != 1 {
+		t.Errorf("ParseAttempts before rerun = %d, want 1", ps.ParseAttempts)
+	}
+	if !ps.ParseSuccessOnFirst {
+		t.Error("ParseSuccessOnFirst before rerun = false, want true")
+	}
+
+	// Re-run should clear all three fields.
+	state.MarkRunning("triage")
+
+	ps = state.meta.Phases["triage"]
+	if ps.ModelUsed != "" {
+		t.Errorf("ModelUsed after rerun = %q, want empty", ps.ModelUsed)
+	}
+	if ps.ParseAttempts != 0 {
+		t.Errorf("ParseAttempts after rerun = %d, want 0", ps.ParseAttempts)
+	}
+	if ps.ParseSuccessOnFirst {
+		t.Error("ParseSuccessOnFirst after rerun = true, want false")
+	}
+}
+
+func TestRecordModelUsed(t *testing.T) {
+	dir := t.TempDir()
+	state, _ := LoadOrCreate(dir, "T-MODEL")
+
+	state.MarkRunning("plan")
+	if err := state.RecordModelUsed("plan", "claude-opus-4-6"); err != nil {
+		t.Fatalf("RecordModelUsed: %v", err)
+	}
+
+	ps := state.meta.Phases["plan"]
+	if ps.ModelUsed != "claude-opus-4-6" {
+		t.Errorf("ModelUsed = %q, want %q", ps.ModelUsed, "claude-opus-4-6")
+	}
+
+	// Error on unstarted phase.
+	err := state.RecordModelUsed("nonexistent", "model")
+	if err == nil {
+		t.Fatal("expected error for unstarted phase")
+	}
+}
+
+func TestAccumulateParseAttempt(t *testing.T) {
+	dir := t.TempDir()
+	state, _ := LoadOrCreate(dir, "T-PARSEATTEMPT")
+
+	state.MarkRunning("implement")
+	state.AccumulateParseAttempt("implement")
+	state.AccumulateParseAttempt("implement")
+
+	ps := state.meta.Phases["implement"]
+	if ps.ParseAttempts != 2 {
+		t.Errorf("ParseAttempts = %d, want 2", ps.ParseAttempts)
+	}
+
+	// Error on unstarted phase.
+	err := state.AccumulateParseAttempt("nonexistent")
+	if err == nil {
+		t.Fatal("expected error for unstarted phase")
+	}
+}
+
+func TestRecordParseFirstSuccess(t *testing.T) {
+	dir := t.TempDir()
+	state, _ := LoadOrCreate(dir, "T-PARSEFIRST")
+
+	state.MarkRunning("verify")
+	if err := state.RecordParseFirstSuccess("verify"); err != nil {
+		t.Fatalf("RecordParseFirstSuccess: %v", err)
+	}
+
+	ps := state.meta.Phases["verify"]
+	if !ps.ParseSuccessOnFirst {
+		t.Error("ParseSuccessOnFirst = false, want true")
+	}
+
+	// Error on unstarted phase.
+	err := state.RecordParseFirstSuccess("nonexistent")
+	if err == nil {
+		t.Fatal("expected error for unstarted phase")
+	}
+}
+
 func TestWriteReadArtifact(t *testing.T) {
 	dir := t.TempDir()
 	state, _ := LoadOrCreate(dir, "T-1")

--- a/phases.yaml
+++ b/phases.yaml
@@ -3,6 +3,12 @@
 # Each phase defines: prompt template, output schema, tool scope,
 # timeout, retry policy, and dependencies on previous phase artifacts.
 
+# model_routing: optional quality gate for automatic model escalation.
+# When a per-phase model produces repeated parse failures exceeding
+# fallback_threshold, the engine switches to the global model mid-retry.
+# model_routing:
+#   fallback_threshold: 2  # escalate after 2 consecutive parse failures
+
 phases:
   - name: triage
     prompt: prompts/triage.md

--- a/raki.yaml
+++ b/raki.yaml
@@ -1,2 +1,17 @@
 sessions:
   path: .soda
+
+# metrics: per-model parse quality tracking for model routing decisions.
+# These metrics are derived from PhaseState fields (ModelUsed,
+# ParseAttempts, ParseSuccessOnFirst) persisted in meta.json.
+metrics:
+  - name: model_parse_success_rate
+    description: "Fraction of phases where the output parsed on the first attempt, grouped by model"
+    type: gauge
+    labels:
+      - model_used
+  - name: model_parse_failure_count
+    description: "Total parse retry attempts across all phases, grouped by model"
+    type: counter
+    labels:
+      - model_used


### PR DESCRIPTION
## Summary

Implements per-model parse success tracking for the model routing quality gate (ticket 385). Adds session state fields, raki metrics, and auto-escalation logic so parse failures are correctly attributed to the model that produced them.

### Changes

| File | Change |
|------|--------|
| `internal/pipeline/retry.go` | Added `RecordModelUsed` call after model fallback switch so `PhaseState.ModelUsed` reflects the actual model used post-escalation |
| `internal/pipeline/retry_test.go` | Added `ModelUsed` assertion to `TestRetry_ModelFallbackOnParseThreshold`; added new `TestRetry_ModelUsedUpdatedAfterFallbackFailure` |

### Root Cause Fixed

`ModelUsed` was not updated after `opts.Model` was switched to the global model during mid-retry escalation. This caused `PhaseState.ModelUsed` to reflect the original per-phase model, misattributing parse failures in raki metrics.

**Fix:** `_ = e.state.RecordModelUsed(phase.Name, opts.Model)` is called immediately after `opts.Model = e.config.Model` in `retry.go`.

## Test Plan

- All 6 retry tests pass including two new tests covering the fallback attribution fix
- Full `internal/pipeline` suite passes (1.592s) with race detector enabled
- New test `TestRetry_ModelUsedUpdatedAfterFallbackFailure` specifically validates that post-fallback parse failures are attributed to the global/fallback model

## Acceptance Criteria

- [x] Per-model parse success rate tracked in session state (`ModelUsed`, `ParseAttempts`, `ParseSuccessOnFirst` fields in `PhaseState`)
- [x] Raki can report success rates grouped by model (`model_parse_success_rate` gauge + `model_parse_failure_count` counter with `model_used` label)
- [x] Auto-escalation to default model after N parse failures (`ModelRoutingConfig.FallbackThreshold` + `EventModelFallback` emission)
- [x] `ModelUsed` correctly updated after fallback (this fix — prevents misattribution in raki metrics)
- [x] Backward compatible: `omitempty` on all new `PhaseState` fields

---
Assisted-by: SODA