### PR TITLE
fix(claude): add --verbose flag required for stream-json with --print

### DIFF
--- a/internal/claude/args.go
+++ b/internal/claude/args.go
@@ -25,6 +25,7 @@ func BuildArgs(opts RunOpts, model string) []string {
 	args := []string{
 		"--print",
 		"--bare",
+		"--verbose",
 		"--output-format", "stream-json",
 		"--permission-mode", "bypassPermissions",
 	}


### PR DESCRIPTION
## Summary

Claude CLI 2.1.128 requires `--verbose` when using `--print` with `--output-format stream-json`. Without it, the CLI exits with:

```
Error: When using --print, --output-format=stream-json requires --verbose
```

This caused sandbox pipeline failures (exit code 1, $0 cost) after the #483 stream-json migration.

## Test plan

- [x] `go test ./internal/claude/... -run TestBuildArgs` passes
- [x] `claude --bare --print --verbose --output-format stream-json -p "ok"` works
- [x] Pipeline run with sandbox (#385) succeeds end-to-end