### PR TITLE
[#493] feat(engine): resume-from-phase dependency validation after schema changes

### DIFF
--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -46,6 +46,7 @@ type pipelineOpts struct {
 	useTUI            bool
 	transcript        string // CLI override: "tools", "full", or "off"
 	transcriptChanged bool   // true when --transcript was explicitly passed
+	force             bool   // override schema version mismatch checks
 }
 
 // pipelineOptsFromCmd extracts pipelineOpts from Cobra flags registered on the
@@ -59,6 +60,7 @@ func pipelineOptsFromCmd(cmd *cobra.Command, ticketKey string) pipelineOpts {
 	useMock, _ := cmd.Flags().GetBool("mock")
 	useTUI, _ := cmd.Flags().GetBool("tui")
 	transcript, _ := cmd.Flags().GetString("transcript")
+	force, _ := cmd.Flags().GetBool("force")
 
 	return pipelineOpts{
 		ticketKey:         ticketKey,
@@ -73,6 +75,7 @@ func pipelineOptsFromCmd(cmd *cobra.Command, ticketKey string) pipelineOpts {
 		useTUI:            useTUI,
 		transcript:        transcript,
 		transcriptChanged: cmd.Flags().Changed("transcript"),
+		force:             force,
 	}
 }
 
@@ -102,6 +105,7 @@ func newRunCmd() *cobra.Command {
 	cmd.Flags().Bool("tui", false, "use interactive TUI display")
 	cmd.Flags().String("query", "", "search filter for listing tickets (picker mode)")
 	cmd.Flags().String("transcript", "", "transcript capture level: tools, full, or off (overrides config)")
+	cmd.Flags().Bool("force", false, "override schema version mismatch checks on resume")
 
 	return cmd
 }
@@ -426,6 +430,7 @@ func runPipeline(cfg *config.Config, opts pipelineOpts) error {
 		MonitorProfile:    monitorProfile,
 		AuthorityResolver: authorityResolver,
 		TranscriptLevel:   transcriptLevel,
+		Force:             opts.force,
 		OnEvent: func(event pipeline.Event) {
 			if event.Kind == pipeline.EventPhaseSkipped || event.Kind == pipeline.EventMonitorSkipped {
 				skippedPhases[event.Phase] = true
@@ -881,6 +886,22 @@ func handleEvent(ctx context.Context, cancel context.CancelFunc, engine *pipelin
 			current = c
 		}
 		prog.Message(fmt.Sprintf("Warning: binary version changed since pipeline started (was %s, now %s)", stored, current))
+
+	case pipeline.EventSchemaVersionMismatch:
+		phase := event.Phase
+		var storedVer string
+		if s, ok := event.Data["stored_version"].(string); ok {
+			storedVer = s
+		}
+		var currentVer string
+		if c, ok := event.Data["current_version"].(string); ok {
+			currentVer = c
+		}
+		if storedVer == "" {
+			prog.Message(fmt.Sprintf("Warning: phase %s artifact has no schema version (current: %s)", phase, currentVer))
+		} else {
+			prog.Message(fmt.Sprintf("Warning: phase %s schema version mismatch (stored: %s, current: %s)", phase, storedVer, currentVer))
+		}
 
 	case pipeline.EventNotifySuccess:
 		prog.Message("  📬 Notification sent")

--- a/cmd/soda/run_test.go
+++ b/cmd/soda/run_test.go
@@ -1102,6 +1102,66 @@ func TestHandleEvent_NotifyFailed(t *testing.T) {
 	}
 }
 
+func TestNewRunCmd_ForceFlag(t *testing.T) {
+	cmd := newRunCmd()
+	flag := cmd.Flags().Lookup("force")
+	if flag == nil {
+		t.Fatal("--force flag should be registered on run command")
+	}
+	if flag.DefValue != "false" {
+		t.Errorf("--force default = %q, want %q", flag.DefValue, "false")
+	}
+}
+
+func TestHandleEvent_SchemaVersionMismatch(t *testing.T) {
+	dir := t.TempDir()
+	state, _ := pipeline.LoadOrCreate(dir, "T-1")
+
+	var buf bytes.Buffer
+	prog := progress.New(&buf, false)
+
+	event := pipeline.Event{
+		Phase: "triage",
+		Kind:  pipeline.EventSchemaVersionMismatch,
+		Data: map[string]any{
+			"stored_version":  "aaaa1111bbbb2222",
+			"current_version": "cccc3333dddd4444",
+		},
+	}
+	handleEvent(context.Background(), nil, nil, state, prog, event)
+
+	output := buf.String()
+	if !strings.Contains(output, "triage") {
+		t.Errorf("expected phase name in output, got %q", output)
+	}
+	if !strings.Contains(output, "mismatch") {
+		t.Errorf("expected 'mismatch' in output, got %q", output)
+	}
+}
+
+func TestHandleEvent_SchemaVersionMismatchMissingVersion(t *testing.T) {
+	dir := t.TempDir()
+	state, _ := pipeline.LoadOrCreate(dir, "T-1")
+
+	var buf bytes.Buffer
+	prog := progress.New(&buf, false)
+
+	event := pipeline.Event{
+		Phase: "triage",
+		Kind:  pipeline.EventSchemaVersionMismatch,
+		Data: map[string]any{
+			"stored_version":  "",
+			"current_version": "cccc3333dddd4444",
+		},
+	}
+	handleEvent(context.Background(), nil, nil, state, prog, event)
+
+	output := buf.String()
+	if !strings.Contains(output, "no schema version") {
+		t.Errorf("expected 'no schema version' in output, got %q", output)
+	}
+}
+
 func TestFormatTokenCount(t *testing.T) {
 	tests := []struct {
 		name string

--- a/cmd/soda/validate.go
+++ b/cmd/soda/validate.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -20,19 +21,27 @@ func newValidateCmd() *cobra.Command {
 		Short: "Check config and phases without running",
 		Long: `Validate configuration, phases, prompts, schemas, and context files
 without executing the pipeline. Exits 0 if everything is valid
-(warnings are OK), exits 1 if any validation error is found.`,
+(warnings are OK), exits 1 if any validation error is found.
+
+Use --session <ticket> to check schema version compatibility of stored
+phase artifacts for a specific session.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := loadConfig(cmd)
 			if err != nil {
 				return err
 			}
+			session, _ := cmd.Flags().GetString("session")
 			pipelineName, _ := cmd.Flags().GetString("pipeline")
+			if session != "" {
+				return runValidateSession(cmd.OutOrStdout(), cfg, session, pipelineName)
+			}
 			return runValidate(cmd.OutOrStdout(), cmd.ErrOrStderr(), cfg, pipelineName)
 		},
 	}
 
 	cmd.Flags().String("pipeline", "", "pipeline name (default: phases.yaml)")
+	cmd.Flags().String("session", "", "ticket key to check schema version compatibility")
 
 	return cmd
 }
@@ -311,6 +320,105 @@ func validateNotifyScript(result *validationResult, prefix string, sc *config.Sc
 	if _, err := exec.LookPath(binary); err != nil {
 		result.addWarning("%s: script binary %q not found in PATH: %v", prefix, binary, err)
 	}
+}
+
+// runValidateSession checks schema version compatibility for a stored session.
+// It loads the pipeline, reads each completed phase's artifact, extracts the
+// _schema_version field, and compares it against the current schema hash.
+func runValidateSession(w io.Writer, cfg *config.Config, ticketKey string, pipelineName string) error {
+	// Load pipeline.
+	phasesPath, cleanup, err := resolvePhasesPath(pipelineName, cfg.PhasesPath)
+	if err != nil {
+		return fmt.Errorf("validate session: %w", err)
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	pl, err := pipeline.LoadPipeline(phasesPath)
+	if err != nil {
+		return fmt.Errorf("validate session: %w", err)
+	}
+
+	// Resolve state directory.
+	stateDir := cfg.StateDir
+	sessionDir := filepath.Join(stateDir, ticketKey)
+	if _, err := os.Stat(sessionDir); err != nil {
+		return fmt.Errorf("validate session: state directory not found for %q: %w", ticketKey, err)
+	}
+
+	state, err := pipeline.LoadOrCreate(stateDir, ticketKey)
+	if err != nil {
+		return fmt.Errorf("validate session: %w", err)
+	}
+
+	fmt.Fprintf(w, "Session: %s\n\n", ticketKey)
+
+	hasIssues := false
+	for _, phase := range pl.Phases {
+		currentVersion := schemas.SchemaVersionFor(phase.Name)
+
+		if !state.IsCompleted(phase.Name) {
+			fmt.Fprintf(w, "  %-15s  ⏭  not completed\n", phase.Name)
+			continue
+		}
+
+		if currentVersion == "" {
+			fmt.Fprintf(w, "  %-15s  ⏭  no schema defined\n", phase.Name)
+			continue
+		}
+
+		storedVersion, err := extractSessionSchemaVersion(state, phase.Name)
+		if err != nil {
+			fmt.Fprintf(w, "  %-15s  ⚠  cannot read artifact: %v\n", phase.Name, err)
+			hasIssues = true
+			continue
+		}
+
+		if storedVersion == "" {
+			fmt.Fprintf(w, "  %-15s  ⚠  no _schema_version (old artifact)\n", phase.Name)
+			hasIssues = true
+			continue
+		}
+
+		if storedVersion == currentVersion {
+			fmt.Fprintf(w, "  %-15s  ✓  current (%s)\n", phase.Name, storedVersion[:8])
+		} else {
+			fmt.Fprintf(w, "  %-15s  ✗  outdated (stored: %s, current: %s)\n", phase.Name, storedVersion[:8], currentVersion[:8])
+			hasIssues = true
+		}
+	}
+
+	fmt.Fprintln(w)
+	if hasIssues {
+		fmt.Fprintln(w, "Some phases have schema compatibility issues. Use --force on resume to override.")
+		return fmt.Errorf("session %s has schema compatibility issues", ticketKey)
+	}
+	fmt.Fprintln(w, "All phase schemas are current.")
+	return nil
+}
+
+// extractSessionSchemaVersion reads the _schema_version from a phase result file.
+func extractSessionSchemaVersion(state *pipeline.State, phase string) (string, error) {
+	data, err := state.ReadResult(phase)
+	if err != nil {
+		return "", err
+	}
+
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return "", fmt.Errorf("unmarshal: %w", err)
+	}
+
+	versionRaw, ok := obj["_schema_version"]
+	if !ok {
+		return "", nil
+	}
+
+	var version string
+	if err := json.Unmarshal(versionRaw, &version); err != nil {
+		return "", fmt.Errorf("unmarshal _schema_version: %w", err)
+	}
+	return version, nil
 }
 
 // validateTranscript checks that the transcript level is a recognized value.

--- a/cmd/soda/validate.go
+++ b/cmd/soda/validate.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -10,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/decko/soda/internal/config"
+	"github.com/decko/soda/internal/git"
 	"github.com/decko/soda/internal/pipeline"
 	"github.com/decko/soda/schemas"
 	"github.com/spf13/cobra"
@@ -339,8 +341,15 @@ func runValidateSession(w io.Writer, cfg *config.Config, ticketKey string, pipel
 		return fmt.Errorf("validate session: %w", err)
 	}
 
-	// Resolve state directory.
+	// Resolve state directory relative to repo root, matching runPipeline.
 	stateDir := cfg.StateDir
+	if !filepath.IsAbs(stateDir) {
+		repoRoot, rootErr := git.RepoRoot(context.Background(), ".")
+		if rootErr != nil {
+			return fmt.Errorf("validate session: resolve repo root: %w", rootErr)
+		}
+		stateDir = filepath.Join(repoRoot, stateDir)
+	}
 	sessionDir := filepath.Join(stateDir, ticketKey)
 	if _, err := os.Stat(sessionDir); err != nil {
 		return fmt.Errorf("validate session: state directory not found for %q: %w", ticketKey, err)

--- a/cmd/soda/validate.go
+++ b/cmd/soda/validate.go
@@ -381,9 +381,9 @@ func runValidateSession(w io.Writer, cfg *config.Config, ticketKey string, pipel
 		}
 
 		if storedVersion == currentVersion {
-			fmt.Fprintf(w, "  %-15s  ✓  current (%s)\n", phase.Name, storedVersion[:8])
+			fmt.Fprintf(w, "  %-15s  ✓  current (%s)\n", phase.Name, truncateVersion(storedVersion, 8))
 		} else {
-			fmt.Fprintf(w, "  %-15s  ✗  outdated (stored: %s, current: %s)\n", phase.Name, storedVersion[:8], currentVersion[:8])
+			fmt.Fprintf(w, "  %-15s  ✗  outdated (stored: %s, current: %s)\n", phase.Name, truncateVersion(storedVersion, 8), truncateVersion(currentVersion, 8))
 			hasIssues = true
 		}
 	}
@@ -419,6 +419,16 @@ func extractSessionSchemaVersion(state *pipeline.State, phase string) (string, e
 		return "", fmt.Errorf("unmarshal _schema_version: %w", err)
 	}
 	return version, nil
+}
+
+// truncateVersion returns the first n characters of version, or the full
+// string when it is shorter than n. This guards against panics on corrupted
+// or manually edited _schema_version values.
+func truncateVersion(version string, maxLen int) string {
+	if len(version) <= maxLen {
+		return version
+	}
+	return version[:maxLen]
 }
 
 // validateTranscript checks that the transcript level is a recognized value.

--- a/cmd/soda/validate_test.go
+++ b/cmd/soda/validate_test.go
@@ -674,6 +674,111 @@ func TestValidateTranscript_InvalidLevel(t *testing.T) {
 	}
 }
 
+func TestRunValidateSession_Current(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{StateDir: dir}
+
+	// Create state with current schema version (via WriteResult injection).
+	state, err := pipeline.LoadOrCreate(dir, "T-1")
+	if err != nil {
+		t.Fatalf("LoadOrCreate: %v", err)
+	}
+	_ = state.MarkRunning("triage")
+	_ = state.WriteResult("triage", []byte(`{"ticket_key":"T-1","complexity":"low"}`))
+	_ = state.MarkCompleted("triage")
+
+	var buf bytes.Buffer
+	err = runValidateSession(&buf, cfg, "T-1", "")
+	if err != nil {
+		t.Fatalf("runValidateSession: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "current") {
+		t.Errorf("expected 'current' in output, got %q", output)
+	}
+	if !strings.Contains(output, "✓") {
+		t.Errorf("expected ✓ in output, got %q", output)
+	}
+}
+
+func TestRunValidateSession_Outdated(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{StateDir: dir}
+
+	state, err := pipeline.LoadOrCreate(dir, "T-2")
+	if err != nil {
+		t.Fatalf("LoadOrCreate: %v", err)
+	}
+	_ = state.MarkRunning("triage")
+	// Write with fake old schema version.
+	resultPath := state.Dir() + "/triage.json"
+	_ = os.WriteFile(resultPath, []byte(`{"ticket_key":"T-2","_schema_version":"deadbeef12345678"}`), 0644)
+	_ = state.MarkCompleted("triage")
+
+	var buf bytes.Buffer
+	err = runValidateSession(&buf, cfg, "T-2", "")
+	if err == nil {
+		t.Fatal("expected error for outdated schema version")
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "outdated") {
+		t.Errorf("expected 'outdated' in output, got %q", output)
+	}
+	if !strings.Contains(output, "✗") {
+		t.Errorf("expected ✗ in output, got %q", output)
+	}
+}
+
+func TestRunValidateSession_NoVersion(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{StateDir: dir}
+
+	state, err := pipeline.LoadOrCreate(dir, "T-3")
+	if err != nil {
+		t.Fatalf("LoadOrCreate: %v", err)
+	}
+	_ = state.MarkRunning("triage")
+	// Write without _schema_version.
+	resultPath := state.Dir() + "/triage.json"
+	_ = os.WriteFile(resultPath, []byte(`{"ticket_key":"T-3"}`), 0644)
+	_ = state.MarkCompleted("triage")
+
+	var buf bytes.Buffer
+	err = runValidateSession(&buf, cfg, "T-3", "")
+	if err == nil {
+		t.Fatal("expected error for missing schema version")
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "no _schema_version") {
+		t.Errorf("expected 'no _schema_version' in output, got %q", output)
+	}
+}
+
+func TestRunValidateSession_MissingDir(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{StateDir: dir}
+
+	var buf bytes.Buffer
+	err := runValidateSession(&buf, cfg, "NONEXISTENT-999", "")
+	if err == nil {
+		t.Fatal("expected error for missing session directory")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' in error, got %q", err.Error())
+	}
+}
+
+func TestNewValidateCmd_SessionFlag(t *testing.T) {
+	cmd := newValidateCmd()
+	flag := cmd.Flags().Lookup("session")
+	if flag == nil {
+		t.Fatal("--session flag should be registered on validate command")
+	}
+}
+
 func TestRunValidate_WithTranscriptConfig(t *testing.T) {
 	cfg := &config.Config{
 		TicketSource: "github",

--- a/cmd/soda/validate_test.go
+++ b/cmd/soda/validate_test.go
@@ -771,6 +771,56 @@ func TestRunValidateSession_MissingDir(t *testing.T) {
 	}
 }
 
+func TestTruncateVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		maxLen  int
+		want    string
+	}{
+		{"full 16-char", "abcdef1234567890", 8, "abcdef12"},
+		{"exact length", "abcdef12", 8, "abcdef12"},
+		{"short value", "abc", 8, "abc"},
+		{"empty string", "", 8, ""},
+		{"single char", "x", 8, "x"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := truncateVersion(tt.version, tt.maxLen)
+			if got != tt.want {
+				t.Errorf("truncateVersion(%q, %d) = %q, want %q", tt.version, tt.maxLen, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunValidateSession_ShortVersion(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{StateDir: dir}
+
+	state, err := pipeline.LoadOrCreate(dir, "T-SHORT")
+	if err != nil {
+		t.Fatalf("LoadOrCreate: %v", err)
+	}
+	_ = state.MarkRunning("triage")
+	// Write with a very short _schema_version to test no panic.
+	resultPath := state.Dir() + "/triage.json"
+	_ = os.WriteFile(resultPath, []byte(`{"ticket_key":"T-SHORT","_schema_version":"abc"}`), 0644)
+	_ = state.MarkCompleted("triage")
+
+	var buf bytes.Buffer
+	// Should not panic, even though stored version is shorter than 8 chars.
+	err = runValidateSession(&buf, cfg, "T-SHORT", "")
+	if err == nil {
+		t.Fatal("expected error for mismatched schema version")
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "outdated") {
+		t.Errorf("expected 'outdated' in output, got %q", output)
+	}
+}
+
 func TestNewValidateCmd_SessionFlag(t *testing.T) {
 	cmd := newValidateCmd()
 	flag := cmd.Flags().Lookup("session")

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -361,6 +361,11 @@ func (e *Engine) Resume(ctx context.Context, fromPhase string) error {
 	// Check binary version for staleness detection on resume.
 	e.checkBinaryVersion()
 
+	// Validate schema versions of completed upstream phases.
+	if err := e.checkSchemaVersions(fromPhase); err != nil {
+		return err
+	}
+
 	// Cache ticket summary in meta for soda sessions/history display.
 	if e.state.Meta().Summary == "" && e.config.Ticket.Summary != "" {
 		e.state.Meta().Summary = e.config.Ticket.Summary

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -74,6 +74,7 @@ type EngineConfig struct {
 	MergeLabels             []string          // required PR labels before auto-merge proceeds
 	AutoMergeTimeout        time.Duration     // max wait after approval before giving up; defaults to 30m
 	TranscriptLevel         transcript.Level  // transcript capture level; empty/"off" disables
+	Force                   bool              // when true, schema version mismatches warn instead of blocking resume
 }
 
 // TokenBudgetConfig configures the prompt-size estimation check.

--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -1039,6 +1039,109 @@ func TestEngine_ResumeInvalidPhase(t *testing.T) {
 	}
 }
 
+func TestEngine_ResumeBlocksOnStaleSchemaVersion(t *testing.T) {
+	phases := []PhaseConfig{
+		{
+			Name:   "triage",
+			Prompt: "triage.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+		{
+			Name:      "plan",
+			Prompt:    "plan.md",
+			DependsOn: []string{"triage"},
+			Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"plan": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"tasks":["t1"]}`),
+					RawText: "Plan done",
+					CostUSD: 0.10,
+				},
+			}},
+		},
+	}
+
+	engine, state := setupEngine(t, phases, mock)
+
+	// Pre-complete triage with a stale schema version.
+	if err := state.MarkRunning("triage"); err != nil {
+		t.Fatal(err)
+	}
+	writeResultRaw(state, "triage", json.RawMessage(`{"ticket_key":"TEST-1","_schema_version":"deadbeef12345678"}`))
+	if err := state.MarkCompleted("triage"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Resume from plan — should be blocked by schema mismatch.
+	err := engine.Resume(context.Background(), "plan")
+	if err == nil {
+		t.Fatal("expected Resume to fail due to schema version mismatch")
+	}
+
+	var svErr *SchemaVersionMismatchError
+	if !errors.As(err, &svErr) {
+		t.Fatalf("expected SchemaVersionMismatchError, got: %T: %v", err, err)
+	}
+	if svErr.Phase != "triage" {
+		t.Errorf("Phase = %q, want %q", svErr.Phase, "triage")
+	}
+}
+
+func TestEngine_ResumeForceOverridesStaleSchemaVersion(t *testing.T) {
+	phases := []PhaseConfig{
+		{
+			Name:   "triage",
+			Prompt: "triage.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+		{
+			Name:      "plan",
+			Prompt:    "plan.md",
+			DependsOn: []string{"triage"},
+			Retry:     RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"plan": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"tasks":["t1"]}`),
+					RawText: "Plan done",
+					CostUSD: 0.10,
+				},
+			}},
+		},
+	}
+
+	engine, state := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.Force = true
+	})
+
+	// Pre-complete triage with a stale schema version.
+	if err := state.MarkRunning("triage"); err != nil {
+		t.Fatal(err)
+	}
+	writeResultRaw(state, "triage", json.RawMessage(`{"ticket_key":"TEST-1","_schema_version":"deadbeef12345678"}`))
+	if err := state.MarkCompleted("triage"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Resume from plan with Force — should proceed.
+	if err := engine.Resume(context.Background(), "plan"); err != nil {
+		t.Fatalf("Resume with Force should succeed: %v", err)
+	}
+
+	if !state.IsCompleted("plan") {
+		t.Error("plan should be completed")
+	}
+}
+
 func TestEngine_SkipPlanRouting_SkipsPlanPhaseWhenTriageSetSkipPlan(t *testing.T) {
 	// When triage sets skip_plan=true and the ticket has an ExistingPlan,
 	// the engine should skip the plan LLM call, write the ExistingPlan as

--- a/internal/pipeline/errors.go
+++ b/internal/pipeline/errors.go
@@ -192,6 +192,24 @@ func transientSuggestion(err error) string {
 	return transientSuggestionCatalog[te.Reason]
 }
 
+// SchemaVersionMismatchError is returned when a stored phase artifact has a
+// _schema_version that differs from the current schema version, indicating
+// the artifact was produced with an older (or newer) schema definition.
+type SchemaVersionMismatchError struct {
+	Phase          string
+	StoredVersion  string // empty when old artifact lacks _schema_version
+	CurrentVersion string
+}
+
+func (e *SchemaVersionMismatchError) Error() string {
+	if e.StoredVersion == "" {
+		return fmt.Sprintf("engine: phase %s artifact has no schema version (current: %s)",
+			e.Phase, e.CurrentVersion)
+	}
+	return fmt.Sprintf("engine: phase %s schema version mismatch: stored %s, current %s",
+		e.Phase, e.StoredVersion, e.CurrentVersion)
+}
+
 // reworkFinding is a minimal finding type used by reworkSignal for error
 // message context. It carries only the fields needed to describe rework
 // issues (severity + issue text), decoupled from schemas.ReviewFinding

--- a/internal/pipeline/errors_test.go
+++ b/internal/pipeline/errors_test.go
@@ -455,6 +455,61 @@ func TestTransientSuggestionCatalog(t *testing.T) {
 	}
 }
 
+func TestSchemaVersionMismatchError(t *testing.T) {
+	tests := []struct {
+		name        string
+		err         *SchemaVersionMismatchError
+		wantContain []string
+	}{
+		{
+			name: "missing_version",
+			err: &SchemaVersionMismatchError{
+				Phase:          "triage",
+				StoredVersion:  "",
+				CurrentVersion: "abc123def4567890",
+			},
+			wantContain: []string{"triage", "no schema version", "abc123def4567890"},
+		},
+		{
+			name: "hash_mismatch",
+			err: &SchemaVersionMismatchError{
+				Phase:          "plan",
+				StoredVersion:  "aaaa1111bbbb2222",
+				CurrentVersion: "cccc3333dddd4444",
+			},
+			wantContain: []string{"plan", "mismatch", "aaaa1111bbbb2222", "cccc3333dddd4444"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := tt.err.Error()
+			if msg == "" {
+				t.Fatal("Error() should return non-empty string")
+			}
+			for _, want := range tt.wantContain {
+				if !strings.Contains(msg, want) {
+					t.Errorf("Error() = %q, should contain %q", msg, want)
+				}
+			}
+
+			var target *SchemaVersionMismatchError
+			if !errors.As(tt.err, &target) {
+				t.Error("errors.As should match SchemaVersionMismatchError")
+			}
+			if target.Phase != tt.err.Phase {
+				t.Errorf("Phase = %q, want %q", target.Phase, tt.err.Phase)
+			}
+			if target.StoredVersion != tt.err.StoredVersion {
+				t.Errorf("StoredVersion = %q, want %q", target.StoredVersion, tt.err.StoredVersion)
+			}
+			if target.CurrentVersion != tt.err.CurrentVersion {
+				t.Errorf("CurrentVersion = %q, want %q", target.CurrentVersion, tt.err.CurrentVersion)
+			}
+		})
+	}
+}
+
 func TestEmitPhaseFailedEnrichment(t *testing.T) {
 	t.Run("retries_exhausted_with_suggestion", func(t *testing.T) {
 		var captured []Event

--- a/internal/pipeline/events.go
+++ b/internal/pipeline/events.go
@@ -87,6 +87,7 @@ const (
 	EventPipelineTimeout          = "pipeline_timeout"
 	EventPhaseCostsReset          = "phase_costs_reset"
 	EventBinaryVersionMismatch    = "binary_version_mismatch"
+	EventSchemaVersionMismatch    = "schema_version_mismatch"
 	EventAPISemaphoreWait         = "api_semaphore_wait"
 	EventImplementNoChanges       = "implement_no_changes"
 	EventTokenBudgetWarning       = "token_budget_warning"

--- a/internal/pipeline/schema_version.go
+++ b/internal/pipeline/schema_version.go
@@ -1,0 +1,108 @@
+package pipeline
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/decko/soda/schemas"
+)
+
+// checkSchemaVersions validates that completed phases preceding fromPhase
+// have artifacts whose _schema_version matches the current schema hash.
+//
+// Phases with missing _schema_version (old artifacts) emit a warning event
+// but do not block. Phases with a mismatched hash emit an error event and
+// return a SchemaVersionMismatchError — unless Force is true, in which case
+// only a warning event is emitted.
+func (e *Engine) checkSchemaVersions(fromPhase string) error {
+	phases := e.config.Pipeline.Phases
+
+	for _, phase := range phases {
+		if phase.Name == fromPhase {
+			break
+		}
+
+		if !e.state.IsCompleted(phase.Name) {
+			continue
+		}
+
+		currentVersion := schemas.SchemaVersionFor(phase.Name)
+		if currentVersion == "" {
+			// Phase has no known schema — nothing to validate.
+			continue
+		}
+
+		storedVersion, err := extractSchemaVersion(e.state, phase.Name)
+		if err != nil {
+			// Result file missing or unreadable — skip silently.
+			continue
+		}
+
+		if storedVersion == "" {
+			// Old artifact without _schema_version — warn but don't block.
+			e.emit(Event{
+				Phase: phase.Name,
+				Kind:  EventSchemaVersionMismatch,
+				Data: map[string]any{
+					"stored_version":  "",
+					"current_version": currentVersion,
+					"warning":         "artifact has no schema version (old format)",
+				},
+			})
+			continue
+		}
+
+		if storedVersion != currentVersion {
+			e.emit(Event{
+				Phase: phase.Name,
+				Kind:  EventSchemaVersionMismatch,
+				Data: map[string]any{
+					"stored_version":  storedVersion,
+					"current_version": currentVersion,
+				},
+			})
+
+			if !e.config.Force {
+				return &SchemaVersionMismatchError{
+					Phase:          phase.Name,
+					StoredVersion:  storedVersion,
+					CurrentVersion: currentVersion,
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// extractSchemaVersion reads the _schema_version field from a phase's
+// stored result JSON. Returns ("", nil) if the field is absent. Returns
+// an error if the result cannot be read or is not a JSON object.
+func extractSchemaVersion(state *State, phase string) (string, error) {
+	data, err := state.ReadResult(phase)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf("result not found")
+		}
+		return "", fmt.Errorf("read result: %w", err)
+	}
+
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return "", fmt.Errorf("unmarshal result: %w", err)
+	}
+
+	versionRaw, ok := obj["_schema_version"]
+	if !ok {
+		return "", nil
+	}
+
+	var version string
+	if err := json.Unmarshal(versionRaw, &version); err != nil {
+		return "", fmt.Errorf("unmarshal _schema_version: %w", err)
+	}
+
+	return version, nil
+}

--- a/internal/pipeline/schema_version_test.go
+++ b/internal/pipeline/schema_version_test.go
@@ -1,0 +1,223 @@
+package pipeline
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/decko/soda/schemas"
+)
+
+func TestCheckSchemaVersions(t *testing.T) {
+	tests := []struct {
+		name       string
+		phases     []PhaseConfig
+		fromPhase  string
+		setup      func(*State) // prepare state before check
+		force      bool
+		wantErr    bool
+		wantEvents int // expected EventSchemaVersionMismatch events
+	}{
+		{
+			name: "matching_versions_no_error",
+			phases: []PhaseConfig{
+				{Name: "triage", Prompt: "triage.md"},
+				{Name: "plan", Prompt: "plan.md"},
+			},
+			fromPhase: "plan",
+			setup: func(state *State) {
+				state.MarkRunning("triage")
+				// Write with current schema version (injected by WriteResult).
+				state.WriteResult("triage", json.RawMessage(`{"ticket_key":"TEST-1","complexity":"low"}`))
+				state.MarkCompleted("triage")
+			},
+			wantErr:    false,
+			wantEvents: 0,
+		},
+		{
+			name: "missing_version_warns_but_no_error",
+			phases: []PhaseConfig{
+				{Name: "triage", Prompt: "triage.md"},
+				{Name: "plan", Prompt: "plan.md"},
+			},
+			fromPhase: "plan",
+			setup: func(state *State) {
+				state.MarkRunning("triage")
+				// Write directly to bypass _schema_version injection.
+				writeResultRaw(state, "triage", json.RawMessage(`{"ticket_key":"TEST-1","complexity":"low"}`))
+				state.MarkCompleted("triage")
+			},
+			wantErr:    false,
+			wantEvents: 1,
+		},
+		{
+			name: "mismatched_version_blocks",
+			phases: []PhaseConfig{
+				{Name: "triage", Prompt: "triage.md"},
+				{Name: "plan", Prompt: "plan.md"},
+			},
+			fromPhase: "plan",
+			setup: func(state *State) {
+				state.MarkRunning("triage")
+				// Write with a fake old schema version.
+				writeResultRaw(state, "triage", json.RawMessage(`{"ticket_key":"TEST-1","_schema_version":"deadbeef12345678"}`))
+				state.MarkCompleted("triage")
+			},
+			wantErr:    true,
+			wantEvents: 1,
+		},
+		{
+			name: "mismatched_version_force_overrides",
+			phases: []PhaseConfig{
+				{Name: "triage", Prompt: "triage.md"},
+				{Name: "plan", Prompt: "plan.md"},
+			},
+			fromPhase: "plan",
+			force:     true,
+			setup: func(state *State) {
+				state.MarkRunning("triage")
+				writeResultRaw(state, "triage", json.RawMessage(`{"ticket_key":"TEST-1","_schema_version":"deadbeef12345678"}`))
+				state.MarkCompleted("triage")
+			},
+			wantErr:    false,
+			wantEvents: 1,
+		},
+		{
+			name: "uncompleted_phase_skipped",
+			phases: []PhaseConfig{
+				{Name: "triage", Prompt: "triage.md"},
+				{Name: "plan", Prompt: "plan.md"},
+			},
+			fromPhase: "plan",
+			setup: func(state *State) {
+				// triage not completed — should be skipped.
+			},
+			wantErr:    false,
+			wantEvents: 0,
+		},
+		{
+			name: "unknown_schema_phase_skipped",
+			phases: []PhaseConfig{
+				{Name: "custom_phase", Prompt: "custom.md"},
+				{Name: "plan", Prompt: "plan.md"},
+			},
+			fromPhase: "plan",
+			setup: func(state *State) {
+				state.MarkRunning("custom_phase")
+				state.WriteResult("custom_phase", json.RawMessage(`{"key":"value"}`))
+				state.MarkCompleted("custom_phase")
+			},
+			wantErr:    false,
+			wantEvents: 0,
+		},
+		{
+			name: "multiple_phases_checks_all",
+			phases: []PhaseConfig{
+				{Name: "triage", Prompt: "triage.md"},
+				{Name: "plan", Prompt: "plan.md"},
+				{Name: "implement", Prompt: "implement.md"},
+			},
+			fromPhase: "implement",
+			setup: func(state *State) {
+				// triage: matching version
+				state.MarkRunning("triage")
+				state.WriteResult("triage", json.RawMessage(`{"ticket_key":"TEST-1","complexity":"low"}`))
+				state.MarkCompleted("triage")
+
+				// plan: mismatched version → blocks
+				state.MarkRunning("plan")
+				writeResultRaw(state, "plan", json.RawMessage(`{"ticket_key":"TEST-1","_schema_version":"deadbeef12345678"}`))
+				state.MarkCompleted("plan")
+			},
+			wantErr:    true,
+			wantEvents: 1, // only the mismatch event
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var events []Event
+			engine, _ := setupEngine(t, tt.phases, &flexMockRunner{}, func(cfg *EngineConfig) {
+				cfg.Force = tt.force
+				cfg.OnEvent = func(e Event) { events = append(events, e) }
+			})
+
+			if tt.setup != nil {
+				tt.setup(engine.state)
+			}
+
+			err := engine.checkSchemaVersions(tt.fromPhase)
+
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error but got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tt.wantErr {
+				var svErr *SchemaVersionMismatchError
+				if !errors.As(err, &svErr) {
+					t.Errorf("error should be SchemaVersionMismatchError, got %T: %v", err, err)
+				}
+			}
+
+			// Count schema version mismatch events.
+			mismatchEvents := 0
+			for _, ev := range events {
+				if ev.Kind == EventSchemaVersionMismatch {
+					mismatchEvents++
+				}
+			}
+			if mismatchEvents != tt.wantEvents {
+				t.Errorf("schema_version_mismatch events = %d, want %d", mismatchEvents, tt.wantEvents)
+			}
+		})
+	}
+}
+
+func TestExtractSchemaVersion(t *testing.T) {
+	dir := t.TempDir()
+	state, _ := LoadOrCreate(dir, "T-ESV")
+
+	t.Run("present", func(t *testing.T) {
+		state.MarkRunning("triage")
+		// Use WriteResult which injects _schema_version.
+		state.WriteResult("triage", json.RawMessage(`{"ticket_key":"TEST"}`))
+
+		version, err := extractSchemaVersion(state, "triage")
+		if err != nil {
+			t.Fatalf("extractSchemaVersion: %v", err)
+		}
+		expected := schemas.SchemaVersionFor("triage")
+		if version != expected {
+			t.Errorf("version = %q, want %q", version, expected)
+		}
+	})
+
+	t.Run("missing_field", func(t *testing.T) {
+		state.MarkRunning("plan")
+		writeResultRaw(state, "plan", json.RawMessage(`{"ticket_key":"TEST"}`))
+
+		version, err := extractSchemaVersion(state, "plan")
+		if err != nil {
+			t.Fatalf("extractSchemaVersion: %v", err)
+		}
+		if version != "" {
+			t.Errorf("version = %q, want empty", version)
+		}
+	})
+
+	t.Run("missing_file", func(t *testing.T) {
+		_, err := extractSchemaVersion(state, "nonexistent")
+		if err == nil {
+			t.Fatal("expected error for missing file")
+		}
+	})
+}
+
+// writeResultRaw writes a result without _schema_version injection,
+// bypassing the normal WriteResult path for testing purposes.
+func writeResultRaw(state *State, phase string, data json.RawMessage) error {
+	return atomicWrite(state.Dir()+"/"+phase+".json", data)
+}

--- a/internal/pipeline/state.go
+++ b/internal/pipeline/state.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -8,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/decko/soda/schemas"
 )
 
 // State manages the disk state for a single ticket's pipeline run.
@@ -265,12 +268,48 @@ func (s *State) ReadArtifact(phase string) ([]byte, error) {
 }
 
 // WriteResult writes structured output (<phase>.json) atomically.
+// If the phase has a known schema, a _schema_version field is injected
+// into JSON-object payloads for later compatibility checks on resume.
 func (s *State) WriteResult(phase string, result json.RawMessage) error {
+	result = injectSchemaVersion(phase, result)
 	path := filepath.Join(s.dir, phase+".json")
 	if err := atomicWrite(path, result); err != nil {
 		return fmt.Errorf("pipeline: write result %s: %w", path, err)
 	}
 	return nil
+}
+
+// injectSchemaVersion adds a _schema_version field to a JSON-object payload
+// if the phase has a known schema. Non-object payloads and unknown phases
+// are returned unmodified.
+func injectSchemaVersion(phase string, data json.RawMessage) json.RawMessage {
+	version := schemas.SchemaVersionFor(phase)
+	if version == "" {
+		return data
+	}
+
+	// Only inject into JSON objects.
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || trimmed[0] != '{' {
+		return data
+	}
+
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return data
+	}
+
+	versionJSON, err := json.Marshal(version)
+	if err != nil {
+		return data
+	}
+	obj["_schema_version"] = versionJSON
+
+	out, err := json.Marshal(obj)
+	if err != nil {
+		return data
+	}
+	return out
 }
 
 // ReadResult reads structured output (<phase>.json).

--- a/internal/pipeline/state_test.go
+++ b/internal/pipeline/state_test.go
@@ -609,8 +609,99 @@ func TestWriteReadResult(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadResult: %v", err)
 	}
-	if string(got) != string(result) {
-		t.Errorf("result = %q, want %q", got, result)
+
+	// Verify result is valid JSON and contains original fields.
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(got, &parsed); err != nil {
+		t.Fatalf("result is not valid JSON: %v", err)
+	}
+	if parsed["verdict"] != "pass" {
+		t.Errorf("verdict = %v, want pass", parsed["verdict"])
+	}
+}
+
+func TestWriteResult_InjectsSchemaVersion(t *testing.T) {
+	dir := t.TempDir()
+	state, _ := LoadOrCreate(dir, "T-SV-1")
+
+	// "triage" is a known phase with a schema.
+	result := json.RawMessage(`{"ticket_key":"TEST-1","complexity":"low"}`)
+	if err := state.WriteResult("triage", result); err != nil {
+		t.Fatalf("WriteResult: %v", err)
+	}
+
+	got, err := state.ReadResult("triage")
+	if err != nil {
+		t.Fatalf("ReadResult: %v", err)
+	}
+
+	var parsed map[string]json.RawMessage
+	if err := json.Unmarshal(got, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	versionRaw, ok := parsed["_schema_version"]
+	if !ok {
+		t.Fatal("_schema_version not found in result")
+	}
+
+	var version string
+	if err := json.Unmarshal(versionRaw, &version); err != nil {
+		t.Fatalf("unmarshal _schema_version: %v", err)
+	}
+	if len(version) != 16 {
+		t.Errorf("_schema_version length = %d, want 16", len(version))
+	}
+
+	// Original fields should still be present.
+	if _, ok := parsed["ticket_key"]; !ok {
+		t.Error("ticket_key field missing after injection")
+	}
+	if _, ok := parsed["complexity"]; !ok {
+		t.Error("complexity field missing after injection")
+	}
+}
+
+func TestWriteResult_NonObjectPassesThrough(t *testing.T) {
+	dir := t.TempDir()
+	state, _ := LoadOrCreate(dir, "T-SV-2")
+
+	// Array payload should pass through unmodified.
+	result := json.RawMessage(`[1,2,3]`)
+	if err := state.WriteResult("triage", result); err != nil {
+		t.Fatalf("WriteResult: %v", err)
+	}
+
+	got, err := state.ReadResult("triage")
+	if err != nil {
+		t.Fatalf("ReadResult: %v", err)
+	}
+	if string(got) != `[1,2,3]` {
+		t.Errorf("result = %q, want [1,2,3]", got)
+	}
+}
+
+func TestWriteResult_UnknownPhasePassesThrough(t *testing.T) {
+	dir := t.TempDir()
+	state, _ := LoadOrCreate(dir, "T-SV-3")
+
+	// "unknown_phase" has no schema, so _schema_version should not be injected.
+	result := json.RawMessage(`{"key":"value"}`)
+	if err := state.WriteResult("unknown_phase", result); err != nil {
+		t.Fatalf("WriteResult: %v", err)
+	}
+
+	got, err := state.ReadResult("unknown_phase")
+	if err != nil {
+		t.Fatalf("ReadResult: %v", err)
+	}
+
+	var parsed map[string]json.RawMessage
+	if err := json.Unmarshal(got, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := parsed["_schema_version"]; ok {
+		t.Error("_schema_version should not be present for unknown phase")
 	}
 }
 

--- a/internal/pipeline/state_test.go
+++ b/internal/pipeline/state_test.go
@@ -170,8 +170,13 @@ func TestMarkRunning(t *testing.T) {
 		if err != nil {
 			t.Fatalf("archived .json: %v", err)
 		}
-		if string(archived) != `{"verdict":"pass"}` {
-			t.Errorf("archived content = %q", archived)
+		// Archived content includes injected _schema_version; verify original field.
+		var archivedObj map[string]interface{}
+		if err := json.Unmarshal(archived, &archivedObj); err != nil {
+			t.Fatalf("unmarshal archived: %v", err)
+		}
+		if archivedObj["verdict"] != "pass" {
+			t.Errorf("archived verdict = %v, want pass", archivedObj["verdict"])
 		}
 
 		archivedMd, err := os.ReadFile(filepath.Join(stateDir, "verify.md.1"))
@@ -967,8 +972,13 @@ func TestFullLifecycle(t *testing.T) {
 		t.Errorf("triage artifact = %q", triageArtifact)
 	}
 	triageResult, _ := state2.ReadResult("triage")
-	if string(triageResult) != `{"complexity":"medium"}` {
-		t.Errorf("triage result = %q", triageResult)
+	// Result includes injected _schema_version; verify original field is present.
+	var triageObj map[string]interface{}
+	if err := json.Unmarshal(triageResult, &triageObj); err != nil {
+		t.Fatalf("unmarshal triage result: %v", err)
+	}
+	if triageObj["complexity"] != "medium" {
+		t.Errorf("triage result complexity = %v, want medium", triageObj["complexity"])
 	}
 
 	// Re-run implement (generation 2)

--- a/schemas/lookup.go
+++ b/schemas/lookup.go
@@ -1,5 +1,10 @@
 package schemas
 
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
 // SchemaFor returns the generated JSON Schema string for the named phase.
 // Returns an empty string if the phase is not recognized.
 func SchemaFor(phase string) string {
@@ -8,6 +13,19 @@ func SchemaFor(phase string) string {
 		return ""
 	}
 	return schema
+}
+
+// SchemaVersionFor returns a content-addressed version hash for the named
+// phase's schema. The hash is the first 8 bytes (16 hex characters) of the
+// SHA-256 digest of the schema content. Returns an empty string if the phase
+// is not recognized.
+func SchemaVersionFor(phase string) string {
+	schema := SchemaFor(phase)
+	if schema == "" {
+		return ""
+	}
+	digest := sha256.Sum256([]byte(schema))
+	return hex.EncodeToString(digest[:8])
 }
 
 // phaseSchemas maps phase names to their generated JSON Schema constants.

--- a/schemas/schemas_test.go
+++ b/schemas/schemas_test.go
@@ -5,6 +5,45 @@ import (
 	"testing"
 )
 
+func TestSchemaVersionFor_KnownPhase(t *testing.T) {
+	version := SchemaVersionFor("triage")
+	if version == "" {
+		t.Fatal("SchemaVersionFor(triage) returned empty string")
+	}
+	if len(version) != 16 {
+		t.Errorf("SchemaVersionFor(triage) length = %d, want 16", len(version))
+	}
+	// Must be valid hex characters.
+	for _, ch := range version {
+		if !((ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f')) {
+			t.Errorf("SchemaVersionFor(triage) contains non-hex char %q", ch)
+		}
+	}
+}
+
+func TestSchemaVersionFor_StableAcrossCalls(t *testing.T) {
+	first := SchemaVersionFor("plan")
+	second := SchemaVersionFor("plan")
+	if first != second {
+		t.Errorf("SchemaVersionFor not stable: %q != %q", first, second)
+	}
+}
+
+func TestSchemaVersionFor_DifferentPhasesDiffer(t *testing.T) {
+	triageVersion := SchemaVersionFor("triage")
+	planVersion := SchemaVersionFor("plan")
+	if triageVersion == planVersion {
+		t.Errorf("triage and plan should have different schema versions, both = %q", triageVersion)
+	}
+}
+
+func TestSchemaVersionFor_UnknownPhase(t *testing.T) {
+	version := SchemaVersionFor("nonexistent")
+	if version != "" {
+		t.Errorf("SchemaVersionFor(nonexistent) = %q, want empty", version)
+	}
+}
+
 func TestSchemaFor_KnownPhases(t *testing.T) {
 	phases := []struct {
 		name    string


### PR DESCRIPTION
## Summary

Implements resume-from-phase schema version validation so that `soda run --resume-from` detects stale artifacts produced by a different schema version before execution continues.

### Changes

**Schema version injection into phase results**
- `WriteResult()` injects `_schema_version` (SHA-256 hash, first 16 hex chars) into every phase output artifact via `injectSchemaVersion()`

**Resume validation**
- `checkSchemaVersions(fromPhase)` is called from `Resume()` after `checkBinaryVersion()`
- Checks all completed phases before `fromPhase` and returns `SchemaVersionMismatchError` on mismatch when `Force=false`
- `EngineConfig.Force bool` wired to `--force` CLI flag in `run.go`

**`soda validate --session` command**
- New `--session` flag on the validate command renders a per-phase compatibility report (`✓ / ✗ / ⚠`)
- Relative `StateDir` is resolved via `git.RepoRoot()`, matching the pattern in `runPipeline`

**Safety fixes (specialist review)**
- `truncateVersion(version string, maxLen int) string` helper prevents panic on short `_schema_version` strings
- Short-version test cases added (`TestTruncateVersion`, `TestRunValidateSession_ShortVersion`)

### Test Plan

All packages pass with `CGO_ENABLED=0`:

```
go test ./cmd/soda/... ./internal/pipeline/... ./schemas/...
```

Key new tests:
- `TestWriteResult_InjectsSchemaVersion`
- `TestCheckSchemaVersions` (7 table-driven cases)
- `TestEngine_ResumeBlocksOnStaleSchemaVersion`
- `TestEngine_ResumeForceOverridesStaleSchemaVersion`
- `TestRunValidateSession` (4 cases)
- `TestTruncateVersion` (5 cases)
- `TestRunValidateSession_ShortVersion`

## Acceptance Criteria

- [x] Schema version hash written to phase result artifacts (`_schema_version`)
- [x] Resume validates upstream schema versions for all completed phases before `fromPhase`
- [x] Schema mismatch blocks by default; `--force` overrides
- [x] `soda validate --session` checks artifact compatibility with a per-phase report
- [x] Warning events emitted for mismatches (`EventSchemaVersionMismatch`)

---
Assisted-by: SODA