### PR TITLE
test(ticket): Jira ticket source smoke tests [492]

### DIFF
--- a/internal/ticket/jira_test.go
+++ b/internal/ticket/jira_test.go
@@ -3,6 +3,7 @@ package ticket
 import (
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -381,6 +382,84 @@ func TestJiraSource_Fetch_ADFDescription(t *testing.T) {
 		if !strings.Contains(ticket.Description, want) {
 			t.Errorf("Description missing %q: got %q", want, ticket.Description)
 		}
+	}
+}
+
+func TestJiraSource_Fetch_InvalidJSON(t *testing.T) {
+	t.Setenv("MOCK_MCP_FIXTURE", "jira_invalid.json")
+
+	source, err := NewJiraSource(JiraConfig{Command: mockBinary(t)})
+	if err != nil {
+		t.Fatalf("NewJiraSource: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_, err = source.Fetch(ctx, "PROJ-BAD")
+	if err == nil {
+		t.Fatal("Fetch should fail for invalid JSON response")
+	}
+	if !strings.Contains(err.Error(), "parse") {
+		t.Errorf("error = %q, want it to contain %q", err.Error(), "parse")
+	}
+}
+
+func TestJiraSource_Fetch_NullFields(t *testing.T) {
+	t.Setenv("MOCK_MCP_FIXTURE", "jira_fetch_null_fields.json")
+
+	source, err := NewJiraSource(JiraConfig{Command: mockBinary(t)})
+	if err != nil {
+		t.Fatalf("NewJiraSource: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	ticket, err := source.Fetch(ctx, "PROJ-99")
+	if err != nil {
+		t.Fatalf("Fetch should not fail for null fields: %v", err)
+	}
+
+	if ticket.Key != "PROJ-99" {
+		t.Errorf("Key = %q, want %q", ticket.Key, "PROJ-99")
+	}
+	if ticket.Summary != "" {
+		t.Errorf("Summary = %q, want empty", ticket.Summary)
+	}
+	if ticket.RawFields != nil {
+		t.Errorf("RawFields = %v, want nil", ticket.RawFields)
+	}
+}
+
+func TestJiraSource_Integration(t *testing.T) {
+	jiraURL := os.Getenv("JIRA_TEST_URL")
+	if jiraURL == "" {
+		t.Skip("JIRA_TEST_URL not set; skipping integration test")
+	}
+
+	if _, lookErr := exec.LookPath("wtmcp"); lookErr != nil {
+		t.Skip("wtmcp binary not found; skipping integration test")
+	}
+
+	source, err := NewJiraSource(JiraConfig{Command: "wtmcp"})
+	if err != nil {
+		t.Fatalf("NewJiraSource: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	ticket, err := source.Fetch(ctx, jiraURL)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+
+	if ticket.Key == "" {
+		t.Error("Key is empty")
+	}
+	if ticket.Summary == "" {
+		t.Error("Summary is empty")
 	}
 }
 

--- a/internal/ticket/jira_test.go
+++ b/internal/ticket/jira_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 )
@@ -201,6 +202,185 @@ func TestJiraSource_Fetch_BadBinary(t *testing.T) {
 	_, err = source.Fetch(ctx, "PROJ-1")
 	if err == nil {
 		t.Fatal("Fetch should fail with bad binary")
+	}
+}
+
+func TestJiraSource_Fetch_WithCustomFields(t *testing.T) {
+	t.Setenv("MOCK_MCP_FIXTURE", "jira_fetch_with_spec.json")
+
+	source, err := NewJiraSource(JiraConfig{Command: mockBinary(t)})
+	if err != nil {
+		t.Fatalf("NewJiraSource: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	ticket, err := source.Fetch(ctx, "PROJ-50")
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+
+	if ticket.Key != "PROJ-50" {
+		t.Errorf("Key = %q, want %q", ticket.Key, "PROJ-50")
+	}
+	if ticket.RawFields == nil {
+		t.Fatal("RawFields is nil")
+	}
+
+	// Verify custom fields survive in RawFields
+	specVal, ok := ticket.RawFields["customfield_10050"]
+	if !ok {
+		t.Fatal("RawFields missing customfield_10050")
+	}
+	planVal, ok := ticket.RawFields["customfield_10051"]
+	if !ok {
+		t.Fatal("RawFields missing customfield_10051")
+	}
+
+	// FieldExtractor should populate ExistingSpec/ExistingPlan from custom fields
+	extractor := &FieldExtractor{
+		SpecField: "customfield_10050",
+		PlanField: "customfield_10051",
+	}
+	extractor.Extract(ticket)
+
+	if ticket.ExistingSpec != "Spec from custom field." {
+		t.Errorf("ExistingSpec = %q, want %q", ticket.ExistingSpec, "Spec from custom field.")
+	}
+	if ticket.ExistingPlan != "Plan from custom field." {
+		t.Errorf("ExistingPlan = %q, want %q", ticket.ExistingPlan, "Plan from custom field.")
+	}
+
+	// Sanity-check the raw values match
+	if specStr, ok := specVal.(string); !ok || specStr != "Spec from custom field." {
+		t.Errorf("RawFields[customfield_10050] = %v, want %q", specVal, "Spec from custom field.")
+	}
+	if planStr, ok := planVal.(string); !ok || planStr != "Plan from custom field." {
+		t.Errorf("RawFields[customfield_10051] = %v, want %q", planVal, "Plan from custom field.")
+	}
+}
+
+func TestJiraSource_Fetch_DescriptionMarkers(t *testing.T) {
+	t.Setenv("MOCK_MCP_FIXTURE", "jira_fetch_with_spec.json")
+
+	source, err := NewJiraSource(JiraConfig{Command: mockBinary(t)})
+	if err != nil {
+		t.Fatalf("NewJiraSource: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	ticket, err := source.Fetch(ctx, "PROJ-50")
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+
+	// String description should survive fetch intact
+	if !strings.Contains(ticket.Description, "<!-- spec:start -->") {
+		t.Fatalf("Description missing spec markers: %q", ticket.Description)
+	}
+
+	// DescriptionMarkerExtractor should extract spec/plan from description
+	extractor := &DescriptionMarkerExtractor{
+		Spec: MarkerPair{
+			StartMarker: "<!-- spec:start -->",
+			EndMarker:   "<!-- spec:end -->",
+		},
+		Plan: MarkerPair{
+			StartMarker: "<!-- plan:start -->",
+			EndMarker:   "<!-- plan:end -->",
+		},
+	}
+	extractor.Extract(ticket)
+
+	if ticket.ExistingSpec != "Spec from description markers." {
+		t.Errorf("ExistingSpec = %q, want %q", ticket.ExistingSpec, "Spec from description markers.")
+	}
+	if ticket.ExistingPlan != "Plan from description markers." {
+		t.Errorf("ExistingPlan = %q, want %q", ticket.ExistingPlan, "Plan from description markers.")
+	}
+}
+
+func TestJiraSource_Fetch_WithSubtasks(t *testing.T) {
+	t.Setenv("MOCK_MCP_FIXTURE", "jira_subtasks.json")
+
+	source, err := NewJiraSource(JiraConfig{Command: mockBinary(t)})
+	if err != nil {
+		t.Fatalf("NewJiraSource: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	ticket, err := source.Fetch(ctx, "EPIC-20")
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+
+	if ticket.Key != "EPIC-20" {
+		t.Errorf("Key = %q, want %q", ticket.Key, "EPIC-20")
+	}
+	if ticket.RawFields == nil {
+		t.Fatal("RawFields is nil")
+	}
+
+	// RawFields should carry subtasks as []any
+	subtasksRaw, ok := ticket.RawFields["subtasks"]
+	if !ok {
+		t.Fatal("RawFields missing 'subtasks'")
+	}
+	subtasks, ok := subtasksRaw.([]any)
+	if !ok {
+		t.Fatalf("subtasks is %T, want []any", subtasksRaw)
+	}
+	if len(subtasks) != 3 {
+		t.Fatalf("subtasks len = %d, want 3", len(subtasks))
+	}
+
+	// SubtaskExtractor should format ExistingPlan
+	extractor := &SubtaskExtractor{}
+	extractor.Extract(ticket)
+
+	wantPlan := "- [PROJ-21] Design authentication flow (Done)\n" +
+		"- [PROJ-22] Implement login endpoint (In Progress)\n" +
+		"- [PROJ-23] Add session expiry logic (To Do)"
+	if ticket.ExistingPlan != wantPlan {
+		t.Errorf("ExistingPlan =\n%s\nwant:\n%s", ticket.ExistingPlan, wantPlan)
+	}
+}
+
+func TestJiraSource_Fetch_ADFDescription(t *testing.T) {
+	t.Setenv("MOCK_MCP_FIXTURE", "jira_fetch_adf.json")
+
+	source, err := NewJiraSource(JiraConfig{Command: mockBinary(t)})
+	if err != nil {
+		t.Fatalf("NewJiraSource: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	ticket, err := source.Fetch(ctx, "PROJ-55")
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+
+	if ticket.Key != "PROJ-55" {
+		t.Errorf("Key = %q, want %q", ticket.Key, "PROJ-55")
+	}
+
+	// Description should be plain text extracted from ADF, not raw JSON
+	if strings.HasPrefix(ticket.Description, "{") {
+		t.Errorf("Description starts with '{', expected plain text from ADF extraction")
+	}
+
+	// All three ADF text nodes should appear in the extracted description
+	for _, want := range []string{"First paragraph text.", "Section Heading", "Second paragraph text."} {
+		if !strings.Contains(ticket.Description, want) {
+			t.Errorf("Description missing %q: got %q", want, ticket.Description)
+		}
 	}
 }
 

--- a/internal/ticket/testdata/jira_fetch_adf.json
+++ b/internal/ticket/testdata/jira_fetch_adf.json
@@ -1,0 +1,41 @@
+{
+  "issues": [
+    {
+      "key": "PROJ-55",
+      "id": "10055",
+      "fields": {
+        "summary": "Ticket with ADF description",
+        "description": {
+          "version": 1,
+          "type": "doc",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [
+                {"type": "text", "text": "First paragraph text."}
+              ]
+            },
+            {
+              "type": "heading",
+              "attrs": {"level": 2},
+              "content": [
+                {"type": "text", "text": "Section Heading"}
+              ]
+            },
+            {
+              "type": "paragraph",
+              "content": [
+                {"type": "text", "text": "Second paragraph text."}
+              ]
+            }
+          ]
+        },
+        "issuetype": {"name": "Task", "id": "10002"},
+        "priority": {"name": "Low", "id": "4"},
+        "status": {"name": "Open", "id": "1"},
+        "labels": ["cloud"]
+      }
+    }
+  ],
+  "count": 1
+}

--- a/internal/ticket/testdata/jira_fetch_null_fields.json
+++ b/internal/ticket/testdata/jira_fetch_null_fields.json
@@ -1,0 +1,10 @@
+{
+  "issues": [
+    {
+      "key": "PROJ-99",
+      "id": "10099",
+      "fields": null
+    }
+  ],
+  "count": 1
+}

--- a/internal/ticket/testdata/jira_fetch_with_spec.json
+++ b/internal/ticket/testdata/jira_fetch_with_spec.json
@@ -1,0 +1,19 @@
+{
+  "issues": [
+    {
+      "key": "PROJ-50",
+      "id": "10050",
+      "fields": {
+        "summary": "Epic with custom spec and plan fields",
+        "description": "Overview of the epic.\n\n<!-- spec:start -->\nSpec from description markers.\n<!-- spec:end -->\n\nMore text.\n\n<!-- plan:start -->\nPlan from description markers.\n<!-- plan:end -->",
+        "issuetype": {"name": "Epic", "id": "10000"},
+        "priority": {"name": "Medium", "id": "3"},
+        "status": {"name": "Open", "id": "1"},
+        "labels": ["epic", "planning"],
+        "customfield_10050": "Spec from custom field.",
+        "customfield_10051": "Plan from custom field."
+      }
+    }
+  ],
+  "count": 1
+}

--- a/internal/ticket/testdata/jira_invalid.json
+++ b/internal/ticket/testdata/jira_invalid.json
@@ -1,0 +1,1 @@
+not valid json {{{

--- a/internal/ticket/testdata/jira_subtasks.json
+++ b/internal/ticket/testdata/jira_subtasks.json
@@ -1,0 +1,40 @@
+{
+  "issues": [
+    {
+      "key": "EPIC-20",
+      "id": "10020",
+      "fields": {
+        "summary": "Epic with subtasks",
+        "description": "Parent epic for authentication work.",
+        "issuetype": {"name": "Epic", "id": "10000"},
+        "priority": {"name": "High", "id": "2"},
+        "status": {"name": "In Progress", "id": "3"},
+        "labels": ["epic"],
+        "subtasks": [
+          {
+            "key": "PROJ-21",
+            "fields": {
+              "summary": "Design authentication flow",
+              "status": {"name": "Done"}
+            }
+          },
+          {
+            "key": "PROJ-22",
+            "fields": {
+              "summary": "Implement login endpoint",
+              "status": {"name": "In Progress"}
+            }
+          },
+          {
+            "key": "PROJ-23",
+            "fields": {
+              "summary": "Add session expiry logic",
+              "status": {"name": "To Do"}
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "count": 1
+}


### PR DESCRIPTION
## Summary

Adds smoke tests for the Jira ticket source, covering fixture-based fetch scenarios, extractor integration, and error-recovery paths.

## Changes

### Fixtures (5 new)
- `jira_fetch_with_spec.json` — PROJ-50 with custom fields + description markers (serves double duty)
- `jira_subtasks.json` — EPIC-20 with 3 nested subtasks
- `jira_fetch_adf.json` — PROJ-55 with ADF object description
- `jira_invalid.json` — `not valid json {{{`
- `jira_fetch_null_fields.json` — PROJ-99 with `"fields": null`

### Tests (7 new)
| Test | Description |
|---|---|
| `TestJiraSource_Fetch_WithCustomFields` | Custom fields piped through `FieldExtractor` |
| `TestJiraSource_Fetch_DescriptionMarkers` | Description markers through `DescriptionMarkerExtractor` |
| `TestJiraSource_Fetch_WithSubtasks` | Subtask array through `SubtaskExtractor` |
| `TestJiraSource_Fetch_ADFDescription` | ADF description extracted to plain text |
| `TestJiraSource_Fetch_InvalidJSON` | Error returned on malformed JSON |
| `TestJiraSource_Fetch_NullFields` | Error-recovery with `"fields": null` |
| `TestJiraSource_Integration` | Env-gated real Jira test (skips when `JIRA_TEST_URL` unset) |

## Test Plan

All 7 tests pass, `go vet` is clean, no regressions:

```
=== RUN   TestJiraSource_Fetch_WithCustomFields     PASS
=== RUN   TestJiraSource_Fetch_DescriptionMarkers   PASS
=== RUN   TestJiraSource_Fetch_WithSubtasks         PASS
=== RUN   TestJiraSource_Fetch_ADFDescription       PASS
=== RUN   TestJiraSource_Fetch_InvalidJSON          PASS
=== RUN   TestJiraSource_Fetch_NullFields           PASS
=== RUN   TestJiraSource_Integration                SKIP (JIRA_TEST_URL unset)
```

## Acceptance Criteria

- [x] 5 Jira JSON fixtures added under testdata/
- [x] 4 extractor-integration smoke tests pass
- [x] 2 error-path tests (invalid JSON, null fields) pass
- [x] Integration test is correctly gated on `JIRA_TEST_URL` env var
- [x] `go vet` reports no issues
- [x] No regressions in existing test suite

Assisted-by: SODA