### PR TITLE
[512] feat(cli): pin Claude CLI version range in soda doctor

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,3 +63,17 @@ Three ways to skip the pre-commit checks:
 - Build with `go build -o soda ./cmd/soda`.
 
 See [AGENTS.md](AGENTS.md) for the full list of conventions.
+
+## Release checklist
+
+When upgrading the supported Claude Code CLI version range:
+
+1. **Install** the target CLI version locally.
+2. **Run** the full test suite: `CGO_ENABLED=0 go test ./... -count=1`.
+3. **Run** `soda doctor` against a real project to confirm no regressions.
+4. **Bump** `MaxTestedCLIVersion` in `internal/claude/args.go` to the newly
+   validated version.
+5. **If** the new CLI introduces flags SODA depends on, bump
+   `MinCLIVersion` as well and update the flag timeline comment.
+6. **Commit** with a message like
+   `chore(claude): bump MaxTestedCLIVersion to X.Y.Z`.

--- a/cmd/soda/doctor.go
+++ b/cmd/soda/doctor.go
@@ -248,6 +248,14 @@ func checkClaudeVersion(env *doctorEnv) checkResult {
 		}
 	}
 
+	if compareSemver(ver, claude.MaxTestedCLIVersion) > 0 {
+		return checkResult{
+			name:   "claude-version",
+			passed: true,
+			detail: fmt.Sprintf("%s ⚠ newer than tested range (%s–%s)", out, claude.MinCLIVersion, claude.MaxTestedCLIVersion),
+		}
+	}
+
 	return checkResult{
 		name:     "claude-version",
 		passed:   true,

--- a/cmd/soda/doctor.go
+++ b/cmd/soda/doctor.go
@@ -252,7 +252,7 @@ func checkClaudeVersion(env *doctorEnv) checkResult {
 		return checkResult{
 			name:   "claude-version",
 			passed: true,
-			detail: fmt.Sprintf("%s ⚠ newer than tested range (%s–%s)", out, claude.MinCLIVersion, claude.MaxTestedCLIVersion),
+			detail: fmt.Sprintf("%s ⚠ newer than tested range (%s–%s); to pin: npm install -g @anthropic-ai/claude-code@%s", out, claude.MinCLIVersion, claude.MaxTestedCLIVersion, claude.MaxTestedCLIVersion),
 		}
 	}
 

--- a/cmd/soda/doctor_test.go
+++ b/cmd/soda/doctor_test.go
@@ -335,6 +335,9 @@ func TestCheckClaudeVersion_AboveMax(t *testing.T) {
 	if !strings.Contains(r.detail, claude.MaxTestedCLIVersion) {
 		t.Errorf("expected detail to mention MaxTestedCLIVersion, got: %q", r.detail)
 	}
+	if !strings.Contains(r.detail, "@anthropic-ai/claude-code@"+claude.MaxTestedCLIVersion) {
+		t.Errorf("expected pin command in detail, got: %q", r.detail)
+	}
 }
 
 func TestCheckClaudeVersion_AtMax(t *testing.T) {

--- a/cmd/soda/doctor_test.go
+++ b/cmd/soda/doctor_test.go
@@ -314,6 +314,64 @@ func TestCheckClaudeVersion_BelowMinimum(t *testing.T) {
 	}
 }
 
+func TestCheckClaudeVersion_AboveMax(t *testing.T) {
+	env := allPassEnv()
+	env.RunCmd = func(name string, args ...string) (string, error) {
+		if name == "claude" && len(args) > 0 && args[0] == "--version" {
+			return "claude 99.0.0", nil
+		}
+		return ".git", nil
+	}
+	r := checkClaudeVersion(env)
+	if !r.passed {
+		t.Error("expected claude-version check to pass (warning only) for version above max")
+	}
+	if r.required {
+		t.Error("expected claude-version check to be non-required for version above max")
+	}
+	if !strings.Contains(r.detail, "⚠") {
+		t.Errorf("expected ⚠ in detail for untested version, got: %q", r.detail)
+	}
+	if !strings.Contains(r.detail, claude.MaxTestedCLIVersion) {
+		t.Errorf("expected detail to mention MaxTestedCLIVersion, got: %q", r.detail)
+	}
+}
+
+func TestCheckClaudeVersion_AtMax(t *testing.T) {
+	env := allPassEnv()
+	env.RunCmd = func(name string, args ...string) (string, error) {
+		if name == "claude" && len(args) > 0 && args[0] == "--version" {
+			return fmt.Sprintf("claude %s", claude.MaxTestedCLIVersion), nil
+		}
+		return ".git", nil
+	}
+	r := checkClaudeVersion(env)
+	if !r.passed {
+		t.Error("expected claude-version check to pass at MaxTestedCLIVersion")
+	}
+	if strings.Contains(r.detail, "⚠") {
+		t.Errorf("expected no warning at MaxTestedCLIVersion, got: %q", r.detail)
+	}
+}
+
+func TestCheckClaudeVersion_BelowMax(t *testing.T) {
+	env := allPassEnv()
+	// MinCLIVersion is below MaxTestedCLIVersion, so no warning expected.
+	env.RunCmd = func(name string, args ...string) (string, error) {
+		if name == "claude" && len(args) > 0 && args[0] == "--version" {
+			return fmt.Sprintf("claude %s", claude.MinCLIVersion), nil
+		}
+		return ".git", nil
+	}
+	r := checkClaudeVersion(env)
+	if !r.passed {
+		t.Error("expected claude-version check to pass at MinCLIVersion")
+	}
+	if strings.Contains(r.detail, "⚠") {
+		t.Errorf("expected no warning at MinCLIVersion, got: %q", r.detail)
+	}
+}
+
 func TestCheckClaudeVersion_UnparseableVersion(t *testing.T) {
 	env := allPassEnv()
 	env.RunCmd = func(name string, args ...string) (string, error) {

--- a/internal/claude/args.go
+++ b/internal/claude/args.go
@@ -1,6 +1,10 @@
 package claude
 
-import "strconv"
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
 
 // MinCLIVersion is the minimum Claude Code CLI version that supports all
 // flags used by SODA. The bottleneck is --bare, introduced in v2.1.81.
@@ -17,6 +21,49 @@ import "strconv"
 //	--json-schema                      ≤ v2.1.21 (fix in v2.1.22)
 //	--bare                             v2.1.81 ← bottleneck
 const MinCLIVersion = "2.1.81"
+
+// MaxTestedCLIVersion is the highest Claude Code CLI version that SODA has
+// been tested against. Versions above this will still work but produce a
+// warning in `soda doctor` so operators know the pairing is unverified.
+//
+// Bump this constant after validating SODA against a newer CLI release.
+// See CONTRIBUTING.md § "Release checklist" for the full procedure.
+const MaxTestedCLIVersion = "2.2.0"
+
+func init() {
+	if compareCLIVersions(MinCLIVersion, MaxTestedCLIVersion) >= 0 {
+		panic(fmt.Sprintf(
+			"claude: MinCLIVersion (%s) must be less than MaxTestedCLIVersion (%s)",
+			MinCLIVersion, MaxTestedCLIVersion,
+		))
+	}
+}
+
+// compareCLIVersions compares two semver strings (X.Y.Z).
+// Returns -1 if a < b, 0 if a == b, +1 if a > b.
+// This is intentionally duplicated from cmd/soda/doctor.go's compareSemver
+// because internal/claude cannot import cmd/soda.
+func compareCLIVersions(a, b string) int {
+	aParts := strings.SplitN(a, ".", 3)
+	bParts := strings.SplitN(b, ".", 3)
+
+	for idx := 0; idx < 3; idx++ {
+		ai, bi := 0, 0
+		if idx < len(aParts) {
+			ai, _ = strconv.Atoi(aParts[idx])
+		}
+		if idx < len(bParts) {
+			bi, _ = strconv.Atoi(bParts[idx])
+		}
+		if ai < bi {
+			return -1
+		}
+		if ai > bi {
+			return 1
+		}
+	}
+	return 0
+}
 
 // BuildArgs constructs the CLI argument list from RunOpts and model.
 // When opts.Model is non-empty it takes precedence over the runner-level


### PR DESCRIPTION
## Summary

Adds an upper-bound version check to `soda doctor` for the Claude CLI. When the installed Claude CLI version exceeds the tested range, the check passes (exit 0) but emits a warning with a pin command so the user can roll back to the last verified version.

## Changes

### `internal/claude/args.go`
- Added `MaxTestedCLIVersion = "2.2.0"` constant
- Added `init()` guard that panics if `MinCLIVersion >= MaxTestedCLIVersion` (catches misconfiguration at startup)
- Added `compareCLIVersions` helper (intentional duplicate of `compareSemver` to avoid import cycle)

### `cmd/soda/doctor.go`
- Extended `checkClaudeVersion` with a new branch: when the installed version exceeds `MaxTestedCLIVersion`, returns `passed: true` with a `⚠` warning detail that includes the tested range and the exact `npm install -g` pin command

### `cmd/soda/doctor_test.go`
- `TestCheckClaudeVersion_BelowMax` — no warning when version is within range
- `TestCheckClaudeVersion_AboveMax` — warning + pin command when version exceeds max
- `TestCheckClaudeVersion_AtMax` — no warning when version equals max exactly

### `CONTRIBUTING.md`
- Added `## Release checklist` section with 6-step procedure for bumping `MaxTestedCLIVersion` on new Claude CLI releases

## Test Plan

```
CGO_ENABLED=0 go test ./... -count=1
```

All tests pass with no regressions.

## Acceptance Criteria

- [x] `MaxTestedCLIVersion` constant defined in `internal/claude/args.go`
- [x] `init()` guard panics on misconfigured version bounds
- [x] `checkClaudeVersion` warns (but passes) when CLI version exceeds max tested
- [x] Warning detail includes the tested version range and pin command
- [x] `soda doctor` exits 0 when CLI is above max (non-blocking warning)
- [x] `runPreflight` is unaffected (still uses `passed: true` path)
- [x] Three new unit tests cover below-max, at-max, and above-max cases
- [x] `CONTRIBUTING.md` documents the release checklist for version bumps

Assisted-by: SODA