### PR TITLE
[504] feat: inject triage relevant_files into implement prompt

### DIFF
--- a/cmd/soda/embeds/prompts/implement.md
+++ b/cmd/soda/embeds/prompts/implement.md
@@ -45,6 +45,15 @@ Use these as a guide to the package API surface, naming conventions, and structu
 
 {{.PackageExemplars}}
 {{- end}}
+{{- if .TriageFiles}}
+
+## Priority Files
+
+Read these files first — triage identified them as most relevant to this ticket:
+{{range .TriageFiles}}
+- `{{.}}`
+{{- end}}
+{{- end}}
 
 {{- if .ReworkFeedback}}
 {{- if .ReworkFeedback.ImplementDiff}}

--- a/cmd/soda/embeds/prompts/patch.md
+++ b/cmd/soda/embeds/prompts/patch.md
@@ -28,6 +28,15 @@ The following diff shows what was implemented (base...HEAD):
 {{.DiffContext}}
 ```
 {{- end}}
+{{- if .TriageFiles}}
+
+## Priority Files
+
+Read these files first — triage identified them as most relevant to this ticket:
+{{range .TriageFiles}}
+- `{{.}}`
+{{- end}}
+{{- end}}
 
 {{- if .ReworkFeedback}}
 {{- if .ReworkFeedback.PriorCycles}}

--- a/cmd/soda/render.go
+++ b/cmd/soda/render.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -9,6 +10,7 @@ import (
 	"github.com/decko/soda/internal/config"
 	"github.com/decko/soda/internal/pipeline"
 	"github.com/decko/soda/internal/ticket"
+	"github.com/decko/soda/schemas"
 	"github.com/spf13/cobra"
 )
 
@@ -268,6 +270,13 @@ func loadArtifacts(state *pipeline.State, data *pipeline.PromptData, pl *pipelin
 
 	if artifact, err := state.ReadArtifact("triage"); err == nil {
 		data.Artifacts.Triage = string(artifact)
+	}
+	// Parse triage files for structured injection into downstream phases.
+	if data.Artifacts.Triage != "" {
+		var triageResult schemas.TriageOutput
+		if json.Unmarshal([]byte(data.Artifacts.Triage), &triageResult) == nil {
+			data.TriageFiles = triageResult.Files
+		}
 	}
 	if artifact, err := state.ReadArtifact("plan"); err == nil {
 		data.Artifacts.Plan = string(artifact)

--- a/internal/pipeline/budget.go
+++ b/internal/pipeline/budget.go
@@ -76,6 +76,11 @@ func phaseReductionOrder(phase string) []reductionStep {
 		reduce:  func(d *PromptData) { d.Context.RepoConventions = "" },
 		applies: func(d *PromptData) bool { return d.Context.RepoConventions != "" },
 	}
+	triageFilesStep := reductionStep{
+		label:   "TriageFiles",
+		reduce:  func(d *PromptData) { d.TriageFiles = nil },
+		applies: func(d *PromptData) bool { return len(d.TriageFiles) > 0 },
+	}
 	extrasStep := reductionStep{
 		label:   "Artifacts.Extras",
 		reduce:  func(d *PromptData) { d.Artifacts.Extras = nil },
@@ -190,7 +195,7 @@ func phaseReductionOrder(phase string) []reductionStep {
 	switch phase {
 	case "implement":
 		// Conventions are shed last — they are compact and high-value for implement.
-		steps := []reductionStep{siblingStep, exemplarStep, projectContextStep, extrasStep, reviewCommentsStep, diffStep}
+		steps := []reductionStep{siblingStep, exemplarStep, triageFilesStep, projectContextStep, extrasStep, reviewCommentsStep, diffStep}
 		steps = append(steps, reworkSteps...)
 		steps = append(steps, artifactSteps...)
 		steps = append(steps, conventionsStep)
@@ -211,7 +216,7 @@ func phaseReductionOrder(phase string) []reductionStep {
 		steps = append(steps, artifactSteps...)
 		return steps
 	case "patch":
-		steps := []reductionStep{diffStep, siblingStep, exemplarStep, extrasStep, projectContextStep}
+		steps := []reductionStep{diffStep, siblingStep, exemplarStep, triageFilesStep, extrasStep, projectContextStep}
 		steps = append(steps, reworkSteps...)
 		steps = append(steps, artifactSteps...)
 		steps = append(steps, conventionsStep)

--- a/internal/pipeline/budget_test.go
+++ b/internal/pipeline/budget_test.go
@@ -19,6 +19,9 @@ Siblings: {{.SiblingContext}}
 {{- if .PackageExemplars}}
 Exemplars: {{.PackageExemplars}}
 {{- end}}
+{{- if .TriageFiles}}
+TriageFiles: {{range .TriageFiles}}{{.}} {{end}}
+{{- end}}
 {{- if .DiffContext}}
 Diff: {{.DiffContext}}
 {{- end}}
@@ -680,6 +683,88 @@ func TestFitToBudget_ReducesExemplarsBeforeProjectContext_Implement(t *testing.T
 	}
 	if projectIdx != -1 {
 		t.Error("ProjectContext should NOT be in reduced list when budget is met without it")
+	}
+}
+
+func TestPhaseReductionOrder_TriageFilesStep_Implement(t *testing.T) {
+	steps := phaseReductionOrder("implement")
+	exemplarIdx := -1
+	triageFilesIdx := -1
+	projectIdx := -1
+	for idx, step := range steps {
+		switch step.label {
+		case "PackageExemplars":
+			exemplarIdx = idx
+		case "TriageFiles":
+			triageFilesIdx = idx
+		case "ProjectContext":
+			projectIdx = idx
+		}
+	}
+	if triageFilesIdx == -1 {
+		t.Fatal("TriageFiles step not found in implement reduction order")
+	}
+	if exemplarIdx == -1 {
+		t.Fatal("PackageExemplars step not found")
+	}
+	if projectIdx == -1 {
+		t.Fatal("ProjectContext step not found")
+	}
+	if triageFilesIdx <= exemplarIdx {
+		t.Errorf("TriageFiles (idx=%d) should be after PackageExemplars (idx=%d)", triageFilesIdx, exemplarIdx)
+	}
+	if triageFilesIdx >= projectIdx {
+		t.Errorf("TriageFiles (idx=%d) should be before ProjectContext (idx=%d)", triageFilesIdx, projectIdx)
+	}
+}
+
+func TestPhaseReductionOrder_TriageFilesStep_Patch(t *testing.T) {
+	steps := phaseReductionOrder("patch")
+	exemplarIdx := -1
+	triageFilesIdx := -1
+	extrasIdx := -1
+	for idx, step := range steps {
+		switch step.label {
+		case "PackageExemplars":
+			exemplarIdx = idx
+		case "TriageFiles":
+			triageFilesIdx = idx
+		case "Artifacts.Extras":
+			extrasIdx = idx
+		}
+	}
+	if triageFilesIdx == -1 {
+		t.Fatal("TriageFiles step not found in patch reduction order")
+	}
+	if exemplarIdx == -1 {
+		t.Fatal("PackageExemplars step not found")
+	}
+	if extrasIdx == -1 {
+		t.Fatal("Artifacts.Extras step not found")
+	}
+	if triageFilesIdx <= exemplarIdx {
+		t.Errorf("TriageFiles (idx=%d) should be after PackageExemplars (idx=%d)", triageFilesIdx, exemplarIdx)
+	}
+	if triageFilesIdx >= extrasIdx {
+		t.Errorf("TriageFiles (idx=%d) should be before Artifacts.Extras (idx=%d)", triageFilesIdx, extrasIdx)
+	}
+}
+
+func TestPhaseReductionOrder_TriageFilesAbsent_Review(t *testing.T) {
+	steps := phaseReductionOrder("review")
+	for _, step := range steps {
+		if step.label == "TriageFiles" {
+			t.Fatal("review phase should not include TriageFiles reduction step — review.md never renders it")
+		}
+	}
+}
+
+func TestPhaseReductionOrder_TriageFilesAbsent_Verify(t *testing.T) {
+	steps := phaseReductionOrder("verify")
+	for _, step := range steps {
+		if step.label == "TriageFiles" {
+			t.Fatal("verify phase should not include TriageFiles reduction step — verify.md never renders it")
+		}
 	}
 }
 

--- a/internal/pipeline/prompt.go
+++ b/internal/pipeline/prompt.go
@@ -30,6 +30,7 @@ type PromptData struct {
 	Diff             string                  // git diff of current branch vs base, injected for review phases (distinct from DiffContext which is used for corrective/monitor phases)
 	SiblingContext   string                  // function signatures from files referenced in the plan; helps implement see surrounding code
 	PackageExemplars string                  // function signatures from existing files in the same packages as new files being created
+	TriageFiles      []string                // files identified by triage as most relevant; injected into implement/patch prompts as priority reads
 	VerifyClean      bool                    // true when the verify phase produced a "pass" verdict (no failures)
 	PriorFindings    []schemas.ReviewFinding // findings from a prior review cycle, injected per-reviewer so the model avoids re-reporting addressed issues
 	ContextFitted    bool                    // true when fitToBudget reduced the prompt to fit the context window

--- a/internal/pipeline/prompt_data.go
+++ b/internal/pipeline/prompt_data.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/decko/soda/internal/git"
+	"github.com/decko/soda/schemas"
 )
 
 // defaultMaxDiffBytes is the default byte limit for git diffs injected into
@@ -56,6 +57,14 @@ func (e *Engine) buildPromptData(ctx context.Context, phase PhaseConfig) (Prompt
 			// Custom/user-defined phase: store in Extras map so
 			// templates can access via {{index .Artifacts.Extras "name"}}.
 			data.Artifacts.Extras[dep] = content
+		}
+	}
+
+	// Parse triage files for structured injection into downstream phases.
+	if data.Artifacts.Triage != "" {
+		var triageResult schemas.TriageOutput
+		if json.Unmarshal([]byte(data.Artifacts.Triage), &triageResult) == nil {
+			data.TriageFiles = triageResult.Files
 		}
 	}
 

--- a/internal/pipeline/prompt_data_test.go
+++ b/internal/pipeline/prompt_data_test.go
@@ -360,3 +360,216 @@ func TestBuildPromptData_Smoke(t *testing.T) {
 	// Run context (to silence unused import warnings).
 	_ = context.Background()
 }
+
+func TestBuildPromptData_TriageFiles_Populated(t *testing.T) {
+	phases := []PhaseConfig{
+		{
+			Name:   "implement",
+			Prompt: "prompts/implement.md",
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"implement": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"ticket_key":"TEST-1"}`),
+					RawText: "done",
+				},
+			}},
+		},
+	}
+
+	engine, state := setupEngine(t, phases, mock)
+
+	// Write a triage artifact with files.
+	triageJSON := `{"ticket_key":"TEST-1","repo":"test","code_area":"pipeline","files":["internal/pipeline/prompt.go","schemas/triage.go"],"complexity":"low","approach":"add field","risks":[],"automatable":"yes"}`
+	if err := state.WriteArtifact("triage", []byte(triageJSON)); err != nil {
+		t.Fatalf("WriteArtifact triage: %v", err)
+	}
+
+	phase := PhaseConfig{Name: "implement", DependsOn: []string{"triage"}}
+	data, err := engine.buildPromptData(context.Background(), phase)
+	if err != nil {
+		t.Fatalf("buildPromptData: %v", err)
+	}
+
+	want := []string{"internal/pipeline/prompt.go", "schemas/triage.go"}
+	if len(data.TriageFiles) != len(want) {
+		t.Fatalf("TriageFiles = %v, want %v", data.TriageFiles, want)
+	}
+	for idx, got := range data.TriageFiles {
+		if got != want[idx] {
+			t.Errorf("TriageFiles[%d] = %q, want %q", idx, got, want[idx])
+		}
+	}
+}
+
+func TestBuildPromptData_TriageFiles_EmptyWhenNoTriage(t *testing.T) {
+	phases := []PhaseConfig{
+		{
+			Name:   "implement",
+			Prompt: "prompts/implement.md",
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"implement": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"ticket_key":"TEST-1"}`),
+					RawText: "done",
+				},
+			}},
+		},
+	}
+
+	engine, _ := setupEngine(t, phases, mock)
+
+	// Phase without triage dependency.
+	phase := PhaseConfig{Name: "implement", DependsOn: []string{}}
+	data, err := engine.buildPromptData(context.Background(), phase)
+	if err != nil {
+		t.Fatalf("buildPromptData: %v", err)
+	}
+
+	if data.TriageFiles != nil {
+		t.Errorf("TriageFiles should be nil when no triage dep, got %v", data.TriageFiles)
+	}
+}
+
+func TestBuildPromptData_TriageFiles_EmptyWhenMalformedJSON(t *testing.T) {
+	phases := []PhaseConfig{
+		{
+			Name:   "implement",
+			Prompt: "prompts/implement.md",
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"implement": {{
+				result: &runner.RunResult{
+					Output:  json.RawMessage(`{"ticket_key":"TEST-1"}`),
+					RawText: "done",
+				},
+			}},
+		},
+	}
+
+	engine, state := setupEngine(t, phases, mock)
+
+	// Write malformed triage artifact.
+	if err := state.WriteArtifact("triage", []byte("not-json")); err != nil {
+		t.Fatalf("WriteArtifact triage: %v", err)
+	}
+
+	phase := PhaseConfig{Name: "implement", DependsOn: []string{"triage"}}
+	data, err := engine.buildPromptData(context.Background(), phase)
+	if err != nil {
+		t.Fatalf("buildPromptData: %v", err)
+	}
+
+	if data.TriageFiles != nil {
+		t.Errorf("TriageFiles should be nil on malformed JSON, got %v", data.TriageFiles)
+	}
+}
+
+func TestImplementTemplateTriageFiles(t *testing.T) {
+	_, thisFile, _, _ := runtime.Caller(0)
+	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..")
+	embedDir := filepath.Join(repoRoot, "cmd", "soda", "embeds", "prompts")
+	raw, err := os.ReadFile(filepath.Join(embedDir, "implement.md"))
+	if err != nil {
+		t.Fatalf("read implement.md: %v", err)
+	}
+	tmpl := string(raw)
+
+	baseData := PromptData{
+		Ticket:       TicketData{Key: "TEST-1", Summary: "Test"},
+		Artifacts:    ArtifactData{Plan: "plan content"},
+		WorktreePath: "/tmp/test",
+		Branch:       "test-branch",
+		BaseBranch:   "main",
+	}
+
+	t.Run("present", func(t *testing.T) {
+		data := baseData
+		data.TriageFiles = []string{"foo.go", "bar.go"}
+		rendered, err := RenderPrompt(tmpl, data)
+		if err != nil {
+			t.Fatalf("RenderPrompt: %v", err)
+		}
+		if !strings.Contains(rendered, "## Priority Files") {
+			t.Error("expected '## Priority Files' section when TriageFiles is set")
+		}
+		if !strings.Contains(rendered, "- `foo.go`") {
+			t.Error("expected foo.go in rendered output")
+		}
+		if !strings.Contains(rendered, "- `bar.go`") {
+			t.Error("expected bar.go in rendered output")
+		}
+	})
+
+	t.Run("absent", func(t *testing.T) {
+		data := baseData
+		data.TriageFiles = nil
+		rendered, err := RenderPrompt(tmpl, data)
+		if err != nil {
+			t.Fatalf("RenderPrompt: %v", err)
+		}
+		if strings.Contains(rendered, "## Priority Files") {
+			t.Error("'## Priority Files' should be absent when TriageFiles is nil")
+		}
+	})
+}
+
+func TestPatchTemplateTriageFiles(t *testing.T) {
+	_, thisFile, _, _ := runtime.Caller(0)
+	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..")
+	embedDir := filepath.Join(repoRoot, "cmd", "soda", "embeds", "prompts")
+	raw, err := os.ReadFile(filepath.Join(embedDir, "patch.md"))
+	if err != nil {
+		t.Fatalf("read patch.md: %v", err)
+	}
+	tmpl := string(raw)
+
+	baseData := PromptData{
+		Ticket:       TicketData{Key: "TEST-1", Summary: "Test"},
+		WorktreePath: "/tmp/test",
+		Branch:       "test-branch",
+		BaseBranch:   "main",
+		ReworkFeedback: &ReworkFeedback{
+			Source:        "verify",
+			Verdict:       "fail",
+			FixesRequired: []string{"fix something"},
+		},
+	}
+
+	t.Run("present", func(t *testing.T) {
+		data := baseData
+		data.TriageFiles = []string{"internal/handler.go"}
+		rendered, err := RenderPrompt(tmpl, data)
+		if err != nil {
+			t.Fatalf("RenderPrompt: %v", err)
+		}
+		if !strings.Contains(rendered, "## Priority Files") {
+			t.Error("expected '## Priority Files' section when TriageFiles is set")
+		}
+		if !strings.Contains(rendered, "- `internal/handler.go`") {
+			t.Error("expected internal/handler.go in rendered output")
+		}
+	})
+
+	t.Run("absent", func(t *testing.T) {
+		data := baseData
+		data.TriageFiles = nil
+		rendered, err := RenderPrompt(tmpl, data)
+		if err != nil {
+			t.Fatalf("RenderPrompt: %v", err)
+		}
+		if strings.Contains(rendered, "## Priority Files") {
+			t.Error("'## Priority Files' should be absent when TriageFiles is nil")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Injects triage `relevant_files` data into the implement and patch prompts so that Claude receives structured file-priority hints derived from the triage phase.

### Changes

| Component | Change |
|-----------|--------|
| `prompt.go` | Added `TriageFiles []string` field to `PromptData` |
| `prompt_data.go` | `buildPromptData` populates `TriageFiles` from triage artifact JSON (silent on missing/malformed) |
| `budget.go` | `triageFilesStep` wired into implement (after exemplar, before projectContext) and patch (after exemplar, before extras) |
| `prompts/implement.md` | Added guarded `## Priority Files` section (`{{- if .TriageFiles}}`) |
| `prompts/patch.md` | Added guarded `## Priority Files` section (`{{- if .TriageFiles}}`) |
| `render.go` | `loadArtifacts` now also parses triage JSON into `TriageFiles` (supports `soda render-prompt`) |
| `prompt_data_test.go` | New unit tests for `TriageFiles` population |
| `budget_test.go` | New unit tests for `triageFilesStep` budget reduction |

### How it works

1. When triage runs, it writes a JSON artifact containing `files` (a ranked list of relevant file paths).
2. During implement/patch prompt construction, `buildPromptData` reads that artifact and unmarshals `files` into `TriageFiles`.
3. If no triage artifact exists or it is malformed, `TriageFiles` is nil and the template section is silently omitted.
4. The `## Priority Files` section in both templates renders a bullet list, helping Claude focus on the most relevant files first.

## Test Plan

- 7 new unit tests across `prompt_data_test.go` and `budget_test.go`
- All existing pipeline tests pass (1,571ms, no regressions)
- Template guards verified: section absent when `TriageFiles` is nil

## Acceptance Criteria

- [x] `TriageFiles []string` field added to `PromptData`
- [x] `buildPromptData` populates `TriageFiles` from triage JSON artifact (silently ignores missing/malformed)
- [x] `triageFilesStep` wired into implement phase budget reduction
- [x] `triageFilesStep` wired into patch phase budget reduction
- [x] `implement.md` has guarded `## Priority Files` section
- [x] `patch.md` has guarded `## Priority Files` section
- [x] Unit tests cover all new paths
- [x] `render.go` `loadArtifacts` populates `TriageFiles` (bonus: supports CLI `soda render-prompt`)

Assisted-by: SODA