### PR TITLE
fix(sandbox): respect CLOUD_ML_REGION=global for Vertex endpoint

### DIFF
--- a/internal/sandbox/resolve.go
+++ b/internal/sandbox/resolve.go
@@ -136,13 +136,12 @@ func claudeEnv(tmpDir string, opts runner.RunOpts, claudeBin, proxyURL string) [
 			)
 			// Resolve the Vertex region. Claude Code validates model
 			// availability directly (bypassing the proxy) using
-			// CLOUD_ML_REGION. The "global" region doesn't host models,
-			// so we fall back to the proxy's upstream region.
+			// CLOUD_ML_REGION.
 			region := os.Getenv("CLOUD_ML_REGION")
-			if region == "" || region == "global" {
+			if region == "" {
 				region = os.Getenv("VERTEXAI_LOCATION")
 			}
-			if region == "" || region == "global" {
+			if region == "" {
 				region = "us-east5"
 			}
 			for _, key := range []string{"VERTEXAI_PROJECT", "ANTHROPIC_VERTEX_PROJECT_ID"} {

--- a/internal/sandbox/runner.go
+++ b/internal/sandbox/runner.go
@@ -192,16 +192,18 @@ func (r *Runner) Run(ctx context.Context, opts runner.RunOpts) (*runner.RunResul
 
 		if os.Getenv("CLAUDE_CODE_USE_VERTEX") != "" {
 			// Vertex mode: resolve upstream URL and token source from ADC.
-			// The "global" region is used for billing/routing but doesn't
-			// host model endpoints. Fall back to a real region.
 			region := os.Getenv("CLOUD_ML_REGION")
-			if region == "" || region == "global" {
+			if region == "" {
 				region = os.Getenv("VERTEXAI_LOCATION")
 			}
-			if region == "" || region == "global" {
+			if region == "" {
 				region = "us-east5"
 			}
-			proxyCfg.UpstreamURL = fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1", region)
+			if region == "global" {
+				proxyCfg.UpstreamURL = "https://aiplatform.googleapis.com/v1"
+			} else {
+				proxyCfg.UpstreamURL = fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1", region)
+			}
 
 			tokenFunc, tokenErr := proxy.VertexTokenSource("")
 			if tokenErr != nil {


### PR DESCRIPTION
## Summary

- Stop overriding `CLOUD_ML_REGION=global` to `us-east5` in the sandbox proxy and claudeEnv
- Use the region-less URL format (`https://aiplatform.googleapis.com/v1`) when region is `global`
- Fall back to `us-east5` only when no region is set at all

## Context

The original fix (#471) treated `global` as invalid because the `global-aiplatform.googleapis.com` hostname didn't host model endpoints. Now that Vertex supports the global endpoint at `aiplatform.googleapis.com` (no region prefix), we should respect the user's `CLOUD_ML_REGION=global` setting instead of silently overriding it.

Without this fix, the proxy constructs `https://global-aiplatform.googleapis.com/v1` which either fails DNS resolution inside the sandbox or returns empty responses.

## Test plan

- [x] `go test ./internal/sandbox/... -short` passes
- [x] Verified end-to-end: `soda run 504` completed successfully with `CLOUD_ML_REGION=global`