### PR TITLE
507: feat(observability): error classification telemetry

### DIFF
--- a/cmd/soda/history.go
+++ b/cmd/soda/history.go
@@ -88,6 +88,13 @@ func renderEventsHistory(meta *pipeline.PipelineMeta, events []pipeline.Event, s
 			h.Entries[i].TransientRetries = ps.TransientRetries
 			h.Entries[i].ParseRetries = ps.ParseRetries
 			h.Entries[i].SemanticRetries = ps.SemanticRetries
+			// Fallback: use PhaseState's FailureCategory when the event-sourced
+			// value is empty. This covers gate errors (no EventPhaseFailed emitted)
+			// and timeout errors (state overwrites "context" → "timeout" after the
+			// event is emitted).
+			if h.Entries[i].FailureCategory == "" {
+				h.Entries[i].FailureCategory = ps.FailureCategory
+			}
 		}
 	}
 

--- a/cmd/soda/history.go
+++ b/cmd/soda/history.go
@@ -85,6 +85,9 @@ func renderEventsHistory(meta *pipeline.PipelineMeta, events []pipeline.Event, s
 		if ps, ok := meta.Phases[h.Entries[i].Phase]; ok {
 			h.Entries[i].PromptHash = ps.PromptHash
 			h.Entries[i].EstimatedPromptTokens = ps.EstimatedPromptTokens
+			h.Entries[i].TransientRetries = ps.TransientRetries
+			h.Entries[i].ParseRetries = ps.ParseRetries
+			h.Entries[i].SemanticRetries = ps.SemanticRetries
 		}
 	}
 
@@ -121,6 +124,10 @@ func renderEventsHistory(meta *pipeline.PipelineMeta, events []pipeline.Event, s
 		generation            int
 		promptHash            string
 		estimatedPromptTokens int64
+		failureCategory       string
+		transientRetries      int
+		parseRetries          int
+		semanticRetries       int
 		data                  json.RawMessage
 	}
 	var outputs []outputBlock
@@ -148,12 +155,18 @@ func renderEventsHistory(meta *pipeline.PipelineMeta, events []pipeline.Event, s
 		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
 			entry.Phase, gen, sym, dur, cost, details)
 
-		if (detail || phaseFilter != "") && (len(entry.FullOutput) > 0 || entry.PromptHash != "" || entry.EstimatedPromptTokens > 0) {
+		hasRetries := entry.TransientRetries > 0 || entry.ParseRetries > 0 || entry.SemanticRetries > 0
+		hasDetailData := len(entry.FullOutput) > 0 || entry.PromptHash != "" || entry.EstimatedPromptTokens > 0 || entry.FailureCategory != "" || hasRetries
+		if (detail || phaseFilter != "") && hasDetailData {
 			outputs = append(outputs, outputBlock{
 				phase:                 entry.Phase,
 				generation:            entry.Generation,
 				promptHash:            entry.PromptHash,
 				estimatedPromptTokens: entry.EstimatedPromptTokens,
+				failureCategory:       entry.FailureCategory,
+				transientRetries:      entry.TransientRetries,
+				parseRetries:          entry.ParseRetries,
+				semanticRetries:       entry.SemanticRetries,
 				data:                  entry.FullOutput,
 			})
 		}
@@ -188,6 +201,13 @@ func renderEventsHistory(meta *pipeline.PipelineMeta, events []pipeline.Event, s
 		}
 		if ob.estimatedPromptTokens > 0 {
 			fmt.Printf("Estimated Prompt Tokens: %d\n", ob.estimatedPromptTokens)
+		}
+		if ob.failureCategory != "" {
+			fmt.Printf("Failure Category: %s\n", ob.failureCategory)
+		}
+		if ob.transientRetries > 0 || ob.parseRetries > 0 || ob.semanticRetries > 0 {
+			fmt.Printf("Retries: transient=%d parse=%d semantic=%d\n",
+				ob.transientRetries, ob.parseRetries, ob.semanticRetries)
 		}
 		if len(ob.data) > 0 {
 			fmt.Println(prettyJSON(ob.data))

--- a/cmd/soda/history_test.go
+++ b/cmd/soda/history_test.go
@@ -321,3 +321,169 @@ func TestRenderEventsHistory_PromptHashNoDetail(t *testing.T) {
 		t.Errorf("non-detail output should not contain prompt hash %q\ngot:\n%s", wantHash, output)
 	}
 }
+
+// TestRenderEventsHistory_FailureCategoryFallbackFromMeta verifies that when
+// a phase's FailureCategory is set in PhaseState but not in events (e.g., gate
+// errors where no EventPhaseFailed carries failure_category), the enrichment
+// loop fills it from meta.Phases.
+func TestRenderEventsHistory_FailureCategoryFallbackFromMeta(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write a result file so the phase has output.
+	result := map[string]any{"verdict": "PASS"}
+	data, _ := json.Marshal(result)
+	if err := os.WriteFile(filepath.Join(dir, "verify.json"), data, 0644); err != nil {
+		t.Fatalf("WriteFile verify.json: %v", err)
+	}
+
+	meta := &pipeline.PipelineMeta{
+		Ticket:    "TEST-GATE",
+		TotalCost: 0.50,
+		Phases: map[string]*pipeline.PhaseState{
+			"verify": {
+				Status:          pipeline.PhaseCompleted,
+				Cost:            0.50,
+				FailureCategory: "gate", // set by SetFailureCategory, no event carries it
+			},
+		},
+	}
+
+	// Gate errors don't emit EventPhaseFailed with failure_category — only
+	// EventPhaseCompleted is emitted before the gate check.
+	events := []pipeline.Event{
+		{Phase: "verify", Kind: pipeline.EventPhaseStarted, Data: map[string]any{"generation": float64(1)}},
+		{Phase: "verify", Kind: pipeline.EventPhaseCompleted, Data: map[string]any{"cost": 0.50, "duration_ms": float64(3000)}},
+	}
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := renderEventsHistory(meta, events, dir, true /* detail */, "" /* phaseFilter */)
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	output := buf.String()
+
+	if err != nil {
+		t.Fatalf("renderEventsHistory error: %v", err)
+	}
+
+	if !strings.Contains(output, "Failure Category: gate") {
+		t.Errorf("detail output should contain 'Failure Category: gate' from meta fallback\ngot:\n%s", output)
+	}
+}
+
+// TestRenderEventsHistory_FailureCategoryTimeoutOverride verifies that for
+// timeout errors, the PhaseState value ("timeout") takes precedence over
+// the event-sourced value ("context") when the event has no failure_category.
+func TestRenderEventsHistory_FailureCategoryTimeoutOverride(t *testing.T) {
+	dir := t.TempDir()
+
+	meta := &pipeline.PipelineMeta{
+		Ticket:    "TEST-TIMEOUT",
+		TotalCost: 1.00,
+		Phases: map[string]*pipeline.PhaseState{
+			"implement": {
+				Status:          pipeline.PhaseFailed,
+				Cost:            1.00,
+				FailureCategory: "timeout", // set by wrapTimeoutError after event emission
+			},
+		},
+	}
+
+	// The EventPhaseFailed event was emitted with failure_category="context"
+	// by emitPhaseFailed, but wrapTimeoutError later overwrites the state to
+	// "timeout". When the event carries "context", the fallback should NOT
+	// overwrite it (event-sourced value wins). But if the event doesn't carry
+	// failure_category at all, the meta fallback should fill it.
+	events := []pipeline.Event{
+		{Phase: "implement", Kind: pipeline.EventPhaseStarted, Data: map[string]any{"generation": float64(1)}},
+		{Phase: "implement", Kind: pipeline.EventPhaseFailed, Data: map[string]any{
+			"error":       "context deadline exceeded",
+			"duration_ms": float64(60000),
+			"cost":        1.00,
+			// No failure_category in event — meta fallback should fill "timeout"
+		}},
+	}
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := renderEventsHistory(meta, events, dir, true /* detail */, "" /* phaseFilter */)
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	output := buf.String()
+
+	if err != nil {
+		t.Fatalf("renderEventsHistory error: %v", err)
+	}
+
+	if !strings.Contains(output, "Failure Category: timeout") {
+		t.Errorf("detail output should contain 'Failure Category: timeout' from meta fallback\ngot:\n%s", output)
+	}
+}
+
+// TestRenderEventsHistory_FailureCategoryEventPreserved verifies that when
+// an EventPhaseFailed carries a failure_category, the event-sourced value
+// is NOT overwritten by the meta fallback.
+func TestRenderEventsHistory_FailureCategoryEventPreserved(t *testing.T) {
+	dir := t.TempDir()
+
+	meta := &pipeline.PipelineMeta{
+		Ticket:    "TEST-PRESERVE",
+		TotalCost: 0.30,
+		Phases: map[string]*pipeline.PhaseState{
+			"implement": {
+				Status:          pipeline.PhaseFailed,
+				Cost:            0.30,
+				FailureCategory: "transient", // same as event — no conflict
+			},
+		},
+	}
+
+	events := []pipeline.Event{
+		{Phase: "implement", Kind: pipeline.EventPhaseStarted, Data: map[string]any{"generation": float64(1)}},
+		{Phase: "implement", Kind: pipeline.EventPhaseFailed, Data: map[string]any{
+			"error":            "retries exhausted",
+			"duration_ms":      float64(5000),
+			"cost":             0.30,
+			"failure_category": "transient", // event carries the value
+		}},
+	}
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := renderEventsHistory(meta, events, dir, true /* detail */, "" /* phaseFilter */)
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	output := buf.String()
+
+	if err != nil {
+		t.Fatalf("renderEventsHistory error: %v", err)
+	}
+
+	if !strings.Contains(output, "Failure Category: transient") {
+		t.Errorf("detail output should preserve event-sourced 'Failure Category: transient'\ngot:\n%s", output)
+	}
+
+	// Should appear exactly once — not duplicated.
+	count := strings.Count(output, "Failure Category:")
+	if count != 1 {
+		t.Errorf("'Failure Category:' should appear exactly once, appeared %d times\ngot:\n%s", count, output)
+	}
+}

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -478,6 +478,10 @@ func (e *Engine) executePhases(ctx context.Context, phases []PhaseConfig, forceF
 						rework = true
 						break
 					}
+					var gateErr *PhaseGateError
+					if errors.As(err, &gateErr) {
+						_ = e.state.SetFailureCategory(phase.Name, "gate")
+					}
 					return err
 				}
 				e.emit(Event{Phase: phase.Name, Kind: EventPhaseSkipped})
@@ -926,7 +930,14 @@ func (e *Engine) runPhase(ctx context.Context, phase PhaseConfig) error {
 	})
 
 	// Domain gating.
-	return e.gatePhase(phase)
+	if err := e.gatePhase(phase); err != nil {
+		var gateErr *PhaseGateError
+		if errors.As(err, &gateErr) {
+			_ = e.state.SetFailureCategory(phase.Name, "gate")
+		}
+		return err
+	}
+	return nil
 }
 
 // sleepWithContext runs SleepFunc(d) but returns early if ctx is cancelled.

--- a/internal/pipeline/history.go
+++ b/internal/pipeline/history.go
@@ -26,6 +26,10 @@ type PhaseGeneration struct {
 	Superseded            bool            // true if a later generation exists
 	PromptHash            string          // SHA-256 hex digest of the rendered prompt (from PhaseState)
 	EstimatedPromptTokens int64           // pre-invocation token estimate (from PhaseState)
+	FailureCategory       string          // error classification (e.g. "transient", "gate", "timeout")
+	TransientRetries      int             // number of transient-error retries
+	ParseRetries          int             // number of parse-error retries
+	SemanticRetries       int             // number of semantic-error retries
 }
 
 // History holds the reconstructed multi-generation history for a ticket.
@@ -121,6 +125,11 @@ func BuildHistory(events []Event, stateDir string) History {
 			}
 			if v, ok := ev.Data["cost"]; ok {
 				h.Entries[idx].Cost = toFloat64(v)
+			}
+			if v, ok := ev.Data["failure_category"]; ok {
+				if s, ok := v.(string); ok {
+					h.Entries[idx].FailureCategory = s
+				}
 			}
 			// Load details from result JSON (may exist even for failed phases,
 			// e.g. verify with verdict=FAIL); fall back to event-embedded summary.

--- a/internal/pipeline/meta.go
+++ b/internal/pipeline/meta.go
@@ -38,6 +38,10 @@ type PhaseState struct {
 	ModelUsed             string      `json:"model_used,omitempty"`              // resolved model name used for this phase execution
 	ParseAttempts         int         `json:"parse_attempts,omitempty"`          // number of parse retry attempts during this execution
 	ParseSuccessOnFirst   bool        `json:"parse_success_on_first,omitempty"`  // true if output parsed successfully on the first attempt
+	TransientRetries      int         `json:"transient_retries,omitempty"`       // number of transient-error retries during this execution
+	ParseRetries          int         `json:"parse_retries,omitempty"`           // number of parse-error retries during this execution
+	SemanticRetries       int         `json:"semantic_retries,omitempty"`        // number of semantic-error retries during this execution
+	FailureCategory       string      `json:"failure_category,omitempty"`        // error classification on terminal failure (e.g. "transient", "gate", "timeout")
 	startedAt             time.Time
 }
 

--- a/internal/pipeline/recovery.go
+++ b/internal/pipeline/recovery.go
@@ -26,12 +26,16 @@ func (e *Engine) emitPhaseFailed(phase string, phaseErr error) {
 	var pbe *PhaseBudgetExceededError
 	var gbe *GenerationBudgetExceededError
 	var dne *DependencyNotMetError
+	var cbe *ContextBudgetError
+
+	var failureCategory string
 
 	switch {
 	case errors.As(phaseErr, &re):
 		data["error_type"] = "retries_exhausted"
 		data["category"] = re.Category
 		data["attempts"] = re.Attempts
+		failureCategory = re.Category
 		if re.Reviewer != "" {
 			data["reviewer"] = re.Reviewer
 		}
@@ -42,6 +46,7 @@ func (e *Engine) emitPhaseFailed(phase string, phaseErr error) {
 	case errors.As(phaseErr, &pe):
 		data["error_type"] = "prompt_error"
 		data["operation"] = pe.Operation
+		failureCategory = "prompt"
 		if pe.Reviewer != "" {
 			data["reviewer"] = pe.Reviewer
 		}
@@ -49,17 +54,32 @@ func (e *Engine) emitPhaseFailed(phase string, phaseErr error) {
 		data["error_type"] = "budget_exceeded"
 		data["limit"] = be.Limit
 		data["actual"] = be.Actual
+		failureCategory = "budget"
 	case errors.As(phaseErr, &pbe):
 		data["error_type"] = "phase_budget_exceeded"
 		data["limit"] = pbe.Limit
 		data["actual"] = pbe.Actual
+		failureCategory = "budget"
 	case errors.As(phaseErr, &gbe):
 		data["error_type"] = "generation_budget_exceeded"
 		data["limit"] = gbe.Limit
 		data["actual"] = gbe.Actual
+		failureCategory = "budget"
 	case errors.As(phaseErr, &dne):
 		data["error_type"] = "dependency_not_met"
 		data["dependency"] = dne.Dependency
+		failureCategory = "dependency"
+	case errors.As(phaseErr, &cbe):
+		data["error_type"] = "context_budget_exceeded"
+		data["budget_tokens"] = cbe.BudgetTokens
+		data["current_tokens"] = cbe.CurrentTokens
+		failureCategory = "context"
+	}
+
+	// Persist and emit failure_category for downstream consumers.
+	if failureCategory != "" {
+		data["failure_category"] = failureCategory
+		_ = e.state.SetFailureCategory(phase, failureCategory)
 	}
 
 	e.emit(Event{Phase: phase, Kind: EventPhaseFailed, Data: data})

--- a/internal/pipeline/recovery_test.go
+++ b/internal/pipeline/recovery_test.go
@@ -1,0 +1,293 @@
+package pipeline
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/decko/soda/internal/runner"
+)
+
+func TestEmitPhaseFailed_RetriesExhausted_SetsFailureCategory(t *testing.T) {
+	phases := []PhaseConfig{
+		{Name: "triage", Prompt: "prompts/triage.md"},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"triage": {{result: &runner.RunResult{Output: json.RawMessage(`{}`)}}},
+		},
+	}
+
+	var events []Event
+	engine, state := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.OnEvent = func(ev Event) {
+			events = append(events, ev)
+		}
+	})
+
+	if err := state.MarkRunning("triage"); err != nil {
+		t.Fatalf("MarkRunning: %v", err)
+	}
+
+	phaseErr := &RetriesExhaustedError{
+		Phase:    "triage",
+		Category: "transient",
+		Attempts: 3,
+		Err:      &runner.TransientError{Err: fmt.Errorf("503")},
+	}
+	engine.emitPhaseFailed("triage", phaseErr)
+
+	// Verify failure_category is set in phase state.
+	ps := state.Meta().Phases["triage"]
+	if ps.FailureCategory != "transient" {
+		t.Errorf("FailureCategory = %q, want %q", ps.FailureCategory, "transient")
+	}
+
+	// Verify failure_category is in the emitted event.
+	var failedEvent *Event
+	for idx := range events {
+		if events[idx].Kind == EventPhaseFailed {
+			failedEvent = &events[idx]
+			break
+		}
+	}
+	if failedEvent == nil {
+		t.Fatal("no phase_failed event emitted")
+	}
+	if failedEvent.Data["failure_category"] != "transient" {
+		t.Errorf("event failure_category = %v, want %q", failedEvent.Data["failure_category"], "transient")
+	}
+	if failedEvent.Data["category"] != "transient" {
+		t.Errorf("event category = %v, want %q (backward compat)", failedEvent.Data["category"], "transient")
+	}
+}
+
+func TestEmitPhaseFailed_BudgetExceeded_SetsFailureCategory(t *testing.T) {
+	phases := []PhaseConfig{
+		{Name: "plan", Prompt: "prompts/plan.md"},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"plan": {{result: &runner.RunResult{Output: json.RawMessage(`{}`)}}},
+		},
+	}
+
+	var events []Event
+	engine, state := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.OnEvent = func(ev Event) {
+			events = append(events, ev)
+		}
+	})
+
+	if err := state.MarkRunning("plan"); err != nil {
+		t.Fatalf("MarkRunning: %v", err)
+	}
+
+	phaseErr := &BudgetExceededError{Phase: "plan", Limit: 5.0, Actual: 5.5}
+	engine.emitPhaseFailed("plan", phaseErr)
+
+	ps := state.Meta().Phases["plan"]
+	if ps.FailureCategory != "budget" {
+		t.Errorf("FailureCategory = %q, want %q", ps.FailureCategory, "budget")
+	}
+
+	var failedEvent *Event
+	for idx := range events {
+		if events[idx].Kind == EventPhaseFailed {
+			failedEvent = &events[idx]
+			break
+		}
+	}
+	if failedEvent == nil {
+		t.Fatal("no phase_failed event emitted")
+	}
+	if failedEvent.Data["failure_category"] != "budget" {
+		t.Errorf("event failure_category = %v, want %q", failedEvent.Data["failure_category"], "budget")
+	}
+}
+
+func TestEmitPhaseFailed_PromptError_SetsFailureCategory(t *testing.T) {
+	phases := []PhaseConfig{
+		{Name: "impl", Prompt: "prompts/impl.md"},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"impl": {{result: &runner.RunResult{Output: json.RawMessage(`{}`)}}},
+		},
+	}
+
+	var events []Event
+	engine, state := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.OnEvent = func(ev Event) {
+			events = append(events, ev)
+		}
+	})
+
+	if err := state.MarkRunning("impl"); err != nil {
+		t.Fatalf("MarkRunning: %v", err)
+	}
+
+	phaseErr := &PromptError{Phase: "impl", Operation: "render", Err: fmt.Errorf("bad template")}
+	engine.emitPhaseFailed("impl", phaseErr)
+
+	ps := state.Meta().Phases["impl"]
+	if ps.FailureCategory != "prompt" {
+		t.Errorf("FailureCategory = %q, want %q", ps.FailureCategory, "prompt")
+	}
+
+	var failedEvent *Event
+	for idx := range events {
+		if events[idx].Kind == EventPhaseFailed {
+			failedEvent = &events[idx]
+			break
+		}
+	}
+	if failedEvent == nil {
+		t.Fatal("no phase_failed event emitted")
+	}
+	if failedEvent.Data["failure_category"] != "prompt" {
+		t.Errorf("event failure_category = %v, want %q", failedEvent.Data["failure_category"], "prompt")
+	}
+}
+
+func TestEmitPhaseFailed_ContextBudgetError_SetsFailureCategory(t *testing.T) {
+	phases := []PhaseConfig{
+		{Name: "impl", Prompt: "prompts/impl.md"},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"impl": {{result: &runner.RunResult{Output: json.RawMessage(`{}`)}}},
+		},
+	}
+
+	var events []Event
+	engine, state := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.OnEvent = func(ev Event) {
+			events = append(events, ev)
+		}
+	})
+
+	if err := state.MarkRunning("impl"); err != nil {
+		t.Fatalf("MarkRunning: %v", err)
+	}
+
+	phaseErr := &ContextBudgetError{Phase: "impl", BudgetTokens: 10000, CurrentTokens: 25000}
+	engine.emitPhaseFailed("impl", phaseErr)
+
+	ps := state.Meta().Phases["impl"]
+	if ps.FailureCategory != "context" {
+		t.Errorf("FailureCategory = %q, want %q", ps.FailureCategory, "context")
+	}
+
+	var failedEvent *Event
+	for idx := range events {
+		if events[idx].Kind == EventPhaseFailed {
+			failedEvent = &events[idx]
+			break
+		}
+	}
+	if failedEvent == nil {
+		t.Fatal("no phase_failed event emitted")
+	}
+	if failedEvent.Data["failure_category"] != "context" {
+		t.Errorf("event failure_category = %v, want %q", failedEvent.Data["failure_category"], "context")
+	}
+	if failedEvent.Data["error_type"] != "context_budget_exceeded" {
+		t.Errorf("event error_type = %v, want %q", failedEvent.Data["error_type"], "context_budget_exceeded")
+	}
+}
+
+func TestEmitPhaseFailed_UnstructuredError_NoFailureCategory(t *testing.T) {
+	phases := []PhaseConfig{
+		{Name: "triage", Prompt: "prompts/triage.md"},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"triage": {{result: &runner.RunResult{Output: json.RawMessage(`{}`)}}},
+		},
+	}
+
+	var events []Event
+	engine, state := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.OnEvent = func(ev Event) {
+			events = append(events, ev)
+		}
+	})
+
+	if err := state.MarkRunning("triage"); err != nil {
+		t.Fatalf("MarkRunning: %v", err)
+	}
+
+	// Plain error — should not set failure_category.
+	phaseErr := fmt.Errorf("some generic error")
+	engine.emitPhaseFailed("triage", phaseErr)
+
+	ps := state.Meta().Phases["triage"]
+	if ps.FailureCategory != "" {
+		t.Errorf("FailureCategory = %q, want empty for unstructured error", ps.FailureCategory)
+	}
+
+	var failedEvent *Event
+	for idx := range events {
+		if events[idx].Kind == EventPhaseFailed {
+			failedEvent = &events[idx]
+			break
+		}
+	}
+	if failedEvent == nil {
+		t.Fatal("no phase_failed event emitted")
+	}
+	if _, ok := failedEvent.Data["failure_category"]; ok {
+		t.Errorf("failure_category should not be present for unstructured errors, got %v", failedEvent.Data["failure_category"])
+	}
+}
+
+func TestEmitPhaseFailed_DependencyNotMet_SetsFailureCategory(t *testing.T) {
+	phases := []PhaseConfig{
+		{Name: "impl", Prompt: "prompts/impl.md"},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"impl": {{result: &runner.RunResult{Output: json.RawMessage(`{}`)}}},
+		},
+	}
+
+	var events []Event
+	engine, state := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.OnEvent = func(ev Event) {
+			events = append(events, ev)
+		}
+	})
+
+	if err := state.MarkRunning("impl"); err != nil {
+		t.Fatalf("MarkRunning: %v", err)
+	}
+
+	phaseErr := &DependencyNotMetError{Phase: "impl", Dependency: "plan"}
+	engine.emitPhaseFailed("impl", phaseErr)
+
+	ps := state.Meta().Phases["impl"]
+	if ps.FailureCategory != "dependency" {
+		t.Errorf("FailureCategory = %q, want %q", ps.FailureCategory, "dependency")
+	}
+
+	var failedEvent *Event
+	for idx := range events {
+		if events[idx].Kind == EventPhaseFailed {
+			failedEvent = &events[idx]
+			break
+		}
+	}
+	if failedEvent == nil {
+		t.Fatal("no phase_failed event emitted")
+	}
+	if failedEvent.Data["failure_category"] != "dependency" {
+		t.Errorf("event failure_category = %v, want %q", failedEvent.Data["failure_category"], "dependency")
+	}
+}

--- a/internal/pipeline/retry.go
+++ b/internal/pipeline/retry.go
@@ -39,6 +39,7 @@ func (e *Engine) runWithRetry(ctx context.Context, phase PhaseConfig, opts runne
 
 		left, tracked := remaining[category]
 		if !tracked || left <= 0 {
+			_ = e.state.SetFailureCategory(phase.Name, category)
 			return nil, &RetriesExhaustedError{
 				Phase:    phase.Name,
 				Category: category,
@@ -47,6 +48,9 @@ func (e *Engine) runWithRetry(ctx context.Context, phase PhaseConfig, opts runne
 			}
 		}
 		remaining[category]--
+
+		// Increment the per-category retry counter in phase state.
+		_ = e.state.IncrementRetryCounter(phase.Name, category)
 
 		switch category {
 		case "transient":

--- a/internal/pipeline/retry_test.go
+++ b/internal/pipeline/retry_test.go
@@ -233,6 +233,241 @@ func TestRetry_NoFallbackWhenAlreadyGlobalModel(t *testing.T) {
 	}
 }
 
+func TestRetry_TransientRetryCounterIncremented(t *testing.T) {
+	phases := []PhaseConfig{
+		{Name: "triage", Prompt: "prompts/triage.md", Retry: RetryConfig{Transient: 2, Parse: 1}},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"triage": {
+				{err: &runner.TransientError{Err: fmt.Errorf("503")}},
+				{result: &runner.RunResult{Output: json.RawMessage(`{}`)}},
+			},
+		},
+	}
+
+	engine, state := setupEngine(t, phases, mock)
+	if err := state.MarkRunning("triage"); err != nil {
+		t.Fatalf("MarkRunning: %v", err)
+	}
+
+	opts := runner.RunOpts{Phase: "triage", UserPrompt: "test"}
+	_, err := engine.runWithRetry(t.Context(), phases[0], opts)
+	if err != nil {
+		t.Fatalf("runWithRetry: %v", err)
+	}
+
+	ps := state.Meta().Phases["triage"]
+	if ps.TransientRetries != 1 {
+		t.Errorf("TransientRetries = %d, want 1", ps.TransientRetries)
+	}
+	if ps.ParseRetries != 0 {
+		t.Errorf("ParseRetries = %d, want 0 (no parse failures)", ps.ParseRetries)
+	}
+	if ps.SemanticRetries != 0 {
+		t.Errorf("SemanticRetries = %d, want 0", ps.SemanticRetries)
+	}
+}
+
+func TestRetry_ParseRetryCounterIncremented(t *testing.T) {
+	phases := []PhaseConfig{
+		{Name: "plan", Prompt: "prompts/plan.md", Retry: RetryConfig{Parse: 3}},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"plan": {
+				{err: &runner.ParseError{Err: fmt.Errorf("error 1")}},
+				{err: &runner.ParseError{Err: fmt.Errorf("error 2")}},
+				{result: &runner.RunResult{Output: json.RawMessage(`{}`)}},
+			},
+		},
+	}
+
+	engine, state := setupEngine(t, phases, mock)
+	if err := state.MarkRunning("plan"); err != nil {
+		t.Fatalf("MarkRunning: %v", err)
+	}
+
+	opts := runner.RunOpts{Phase: "plan", UserPrompt: "test"}
+	_, err := engine.runWithRetry(t.Context(), phases[0], opts)
+	if err != nil {
+		t.Fatalf("runWithRetry: %v", err)
+	}
+
+	ps := state.Meta().Phases["plan"]
+	if ps.ParseRetries != 2 {
+		t.Errorf("ParseRetries = %d, want 2", ps.ParseRetries)
+	}
+	if ps.TransientRetries != 0 {
+		t.Errorf("TransientRetries = %d, want 0", ps.TransientRetries)
+	}
+}
+
+func TestRetry_SemanticRetryCounterIncremented(t *testing.T) {
+	phases := []PhaseConfig{
+		{Name: "verify", Prompt: "prompts/verify.md", Retry: RetryConfig{Semantic: 2}},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"verify": {
+				{err: &runner.SemanticError{Message: "bad"}},
+				{result: &runner.RunResult{Output: json.RawMessage(`{}`)}},
+			},
+		},
+	}
+
+	engine, state := setupEngine(t, phases, mock)
+	if err := state.MarkRunning("verify"); err != nil {
+		t.Fatalf("MarkRunning: %v", err)
+	}
+
+	opts := runner.RunOpts{Phase: "verify", UserPrompt: "test"}
+	_, err := engine.runWithRetry(t.Context(), phases[0], opts)
+	if err != nil {
+		t.Fatalf("runWithRetry: %v", err)
+	}
+
+	ps := state.Meta().Phases["verify"]
+	if ps.SemanticRetries != 1 {
+		t.Errorf("SemanticRetries = %d, want 1", ps.SemanticRetries)
+	}
+	if ps.TransientRetries != 0 {
+		t.Errorf("TransientRetries = %d, want 0", ps.TransientRetries)
+	}
+	if ps.ParseRetries != 0 {
+		t.Errorf("ParseRetries = %d, want 0", ps.ParseRetries)
+	}
+}
+
+func TestRetry_FailureCategoryOnExhaustion(t *testing.T) {
+	phases := []PhaseConfig{
+		{Name: "triage", Prompt: "prompts/triage.md", Retry: RetryConfig{Transient: 1}},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"triage": {
+				{err: &runner.TransientError{Err: fmt.Errorf("503")}},
+				{err: &runner.TransientError{Err: fmt.Errorf("503 again")}},
+			},
+		},
+	}
+
+	engine, state := setupEngine(t, phases, mock)
+	if err := state.MarkRunning("triage"); err != nil {
+		t.Fatalf("MarkRunning: %v", err)
+	}
+
+	opts := runner.RunOpts{Phase: "triage", UserPrompt: "test"}
+	_, err := engine.runWithRetry(t.Context(), phases[0], opts)
+	if err == nil {
+		t.Fatal("expected error from exhausted retries")
+	}
+
+	ps := state.Meta().Phases["triage"]
+	if ps.FailureCategory != "transient" {
+		t.Errorf("FailureCategory = %q, want %q", ps.FailureCategory, "transient")
+	}
+	if ps.TransientRetries != 1 {
+		t.Errorf("TransientRetries = %d, want 1 (one successful retry before exhaustion)", ps.TransientRetries)
+	}
+}
+
+func TestRetry_MixedRetryCounters(t *testing.T) {
+	phases := []PhaseConfig{
+		{Name: "impl", Prompt: "prompts/impl.md", Retry: RetryConfig{Transient: 2, Parse: 2, Semantic: 2}},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"impl": {
+				{err: &runner.TransientError{Err: fmt.Errorf("503")}},
+				{err: &runner.ParseError{Err: fmt.Errorf("bad json")}},
+				{err: &runner.SemanticError{Message: "bad logic"}},
+				{result: &runner.RunResult{Output: json.RawMessage(`{}`)}},
+			},
+		},
+	}
+
+	engine, state := setupEngine(t, phases, mock)
+	if err := state.MarkRunning("impl"); err != nil {
+		t.Fatalf("MarkRunning: %v", err)
+	}
+
+	opts := runner.RunOpts{Phase: "impl", UserPrompt: "test"}
+	_, err := engine.runWithRetry(t.Context(), phases[0], opts)
+	if err != nil {
+		t.Fatalf("runWithRetry: %v", err)
+	}
+
+	ps := state.Meta().Phases["impl"]
+	if ps.TransientRetries != 1 {
+		t.Errorf("TransientRetries = %d, want 1", ps.TransientRetries)
+	}
+	if ps.ParseRetries != 1 {
+		t.Errorf("ParseRetries = %d, want 1", ps.ParseRetries)
+	}
+	if ps.SemanticRetries != 1 {
+		t.Errorf("SemanticRetries = %d, want 1", ps.SemanticRetries)
+	}
+	if ps.FailureCategory != "" {
+		t.Errorf("FailureCategory = %q, want empty (no exhaustion)", ps.FailureCategory)
+	}
+}
+
+func TestRetry_CountersResetOnRerun(t *testing.T) {
+	phases := []PhaseConfig{
+		{Name: "triage", Prompt: "prompts/triage.md", Retry: RetryConfig{Transient: 2, Parse: 2}},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"triage": {
+				{err: &runner.TransientError{Err: fmt.Errorf("503")}},
+				{result: &runner.RunResult{Output: json.RawMessage(`{}`)}},
+			},
+		},
+	}
+
+	engine, state := setupEngine(t, phases, mock)
+	if err := state.MarkRunning("triage"); err != nil {
+		t.Fatalf("MarkRunning: %v", err)
+	}
+
+	opts := runner.RunOpts{Phase: "triage", UserPrompt: "test"}
+	_, err := engine.runWithRetry(t.Context(), phases[0], opts)
+	if err != nil {
+		t.Fatalf("runWithRetry: %v", err)
+	}
+
+	ps := state.Meta().Phases["triage"]
+	if ps.TransientRetries != 1 {
+		t.Errorf("TransientRetries after first run = %d, want 1", ps.TransientRetries)
+	}
+
+	// Simulate a resume --from by marking running again; counters should reset.
+	if err := state.MarkRunning("triage"); err != nil {
+		t.Fatalf("MarkRunning (rerun): %v", err)
+	}
+
+	ps = state.Meta().Phases["triage"]
+	if ps.TransientRetries != 0 {
+		t.Errorf("TransientRetries after rerun = %d, want 0", ps.TransientRetries)
+	}
+	if ps.ParseRetries != 0 {
+		t.Errorf("ParseRetries after rerun = %d, want 0", ps.ParseRetries)
+	}
+	if ps.SemanticRetries != 0 {
+		t.Errorf("SemanticRetries after rerun = %d, want 0", ps.SemanticRetries)
+	}
+	if ps.FailureCategory != "" {
+		t.Errorf("FailureCategory after rerun = %q, want empty", ps.FailureCategory)
+	}
+}
+
 func TestRetry_ModelUsedUpdatedAfterFallbackFailure(t *testing.T) {
 	// Verify that when a parse failure occurs *after* fallback,
 	// ModelUsed reflects the global model (not the original per-phase model).

--- a/internal/pipeline/state.go
+++ b/internal/pipeline/state.go
@@ -146,6 +146,10 @@ func (s *State) MarkRunning(phase string) error {
 	ps.ModelUsed = ""
 	ps.ParseAttempts = 0
 	ps.ParseSuccessOnFirst = false
+	ps.TransientRetries = 0
+	ps.ParseRetries = 0
+	ps.SemanticRetries = 0
+	ps.FailureCategory = ""
 	ps.startedAt = time.Now()
 
 	return s.flushMeta()
@@ -159,6 +163,7 @@ func (s *State) MarkCompleted(phase string) error {
 	}
 
 	ps.Status = PhaseCompleted
+	ps.FailureCategory = ""
 	if !ps.startedAt.IsZero() {
 		ps.DurationMs = time.Since(ps.startedAt).Milliseconds()
 	}
@@ -250,6 +255,37 @@ func (s *State) RecordParseFirstSuccess(phase string) error {
 		return fmt.Errorf("pipeline: record parse first success: phase %q not started", phase)
 	}
 	ps.ParseSuccessOnFirst = true
+	return s.flushMeta()
+}
+
+// IncrementRetryCounter increments the retry counter for the given category
+// ("transient", "parse", or "semantic"). Phase must exist (via MarkRunning).
+func (s *State) IncrementRetryCounter(phase string, category string) error {
+	ps := s.meta.Phases[phase]
+	if ps == nil {
+		return fmt.Errorf("pipeline: increment retry counter: phase %q not started", phase)
+	}
+	switch category {
+	case "transient":
+		ps.TransientRetries++
+	case "parse":
+		ps.ParseRetries++
+	case "semantic":
+		ps.SemanticRetries++
+	default:
+		return fmt.Errorf("pipeline: increment retry counter: unknown category %q", category)
+	}
+	return s.flushMeta()
+}
+
+// SetFailureCategory records the terminal failure classification on the phase.
+// Phase must exist (via MarkRunning).
+func (s *State) SetFailureCategory(phase string, category string) error {
+	ps := s.meta.Phases[phase]
+	if ps == nil {
+		return fmt.Errorf("pipeline: set failure category: phase %q not started", phase)
+	}
+	ps.FailureCategory = category
 	return s.flushMeta()
 }
 

--- a/internal/pipeline/state_test.go
+++ b/internal/pipeline/state_test.go
@@ -573,6 +573,213 @@ func TestRecordParseFirstSuccess(t *testing.T) {
 	}
 }
 
+func TestIncrementRetryCounter(t *testing.T) {
+	t.Run("increments_transient", func(t *testing.T) {
+		dir := t.TempDir()
+		state, _ := LoadOrCreate(dir, "T-RETRY-1")
+
+		state.MarkRunning("triage")
+		state.IncrementRetryCounter("triage", "transient")
+		state.IncrementRetryCounter("triage", "transient")
+
+		ps := state.meta.Phases["triage"]
+		if ps.TransientRetries != 2 {
+			t.Errorf("TransientRetries = %d, want 2", ps.TransientRetries)
+		}
+		if ps.ParseRetries != 0 {
+			t.Errorf("ParseRetries = %d, want 0", ps.ParseRetries)
+		}
+		if ps.SemanticRetries != 0 {
+			t.Errorf("SemanticRetries = %d, want 0", ps.SemanticRetries)
+		}
+	})
+
+	t.Run("increments_parse", func(t *testing.T) {
+		dir := t.TempDir()
+		state, _ := LoadOrCreate(dir, "T-RETRY-2")
+
+		state.MarkRunning("plan")
+		state.IncrementRetryCounter("plan", "parse")
+
+		ps := state.meta.Phases["plan"]
+		if ps.ParseRetries != 1 {
+			t.Errorf("ParseRetries = %d, want 1", ps.ParseRetries)
+		}
+	})
+
+	t.Run("increments_semantic", func(t *testing.T) {
+		dir := t.TempDir()
+		state, _ := LoadOrCreate(dir, "T-RETRY-3")
+
+		state.MarkRunning("verify")
+		state.IncrementRetryCounter("verify", "semantic")
+
+		ps := state.meta.Phases["verify"]
+		if ps.SemanticRetries != 1 {
+			t.Errorf("SemanticRetries = %d, want 1", ps.SemanticRetries)
+		}
+	})
+
+	t.Run("error_on_unknown_category", func(t *testing.T) {
+		dir := t.TempDir()
+		state, _ := LoadOrCreate(dir, "T-RETRY-4")
+
+		state.MarkRunning("triage")
+		err := state.IncrementRetryCounter("triage", "unknown_cat")
+		if err == nil {
+			t.Fatal("expected error for unknown category")
+		}
+	})
+
+	t.Run("error_on_unstarted_phase", func(t *testing.T) {
+		dir := t.TempDir()
+		state, _ := LoadOrCreate(dir, "T-RETRY-5")
+
+		err := state.IncrementRetryCounter("nonexistent", "transient")
+		if err == nil {
+			t.Fatal("expected error for unstarted phase")
+		}
+	})
+}
+
+func TestSetFailureCategory(t *testing.T) {
+	t.Run("sets_category", func(t *testing.T) {
+		dir := t.TempDir()
+		state, _ := LoadOrCreate(dir, "T-FAIL-1")
+
+		state.MarkRunning("triage")
+		if err := state.SetFailureCategory("triage", "transient"); err != nil {
+			t.Fatalf("SetFailureCategory: %v", err)
+		}
+
+		ps := state.meta.Phases["triage"]
+		if ps.FailureCategory != "transient" {
+			t.Errorf("FailureCategory = %q, want %q", ps.FailureCategory, "transient")
+		}
+	})
+
+	t.Run("overwrites_category", func(t *testing.T) {
+		dir := t.TempDir()
+		state, _ := LoadOrCreate(dir, "T-FAIL-2")
+
+		state.MarkRunning("plan")
+		state.SetFailureCategory("plan", "parse")
+		state.SetFailureCategory("plan", "budget")
+
+		ps := state.meta.Phases["plan"]
+		if ps.FailureCategory != "budget" {
+			t.Errorf("FailureCategory = %q, want %q", ps.FailureCategory, "budget")
+		}
+	})
+
+	t.Run("cleared_by_mark_completed", func(t *testing.T) {
+		dir := t.TempDir()
+		state, _ := LoadOrCreate(dir, "T-FAIL-3")
+
+		state.MarkRunning("verify")
+		state.SetFailureCategory("verify", "transient")
+		state.MarkCompleted("verify")
+
+		ps := state.meta.Phases["verify"]
+		if ps.FailureCategory != "" {
+			t.Errorf("FailureCategory = %q, want empty after MarkCompleted", ps.FailureCategory)
+		}
+	})
+
+	t.Run("cleared_by_mark_running", func(t *testing.T) {
+		dir := t.TempDir()
+		state, _ := LoadOrCreate(dir, "T-FAIL-4")
+
+		state.MarkRunning("impl")
+		state.SetFailureCategory("impl", "transient")
+		state.MarkFailed("impl", fmt.Errorf("fail"))
+
+		// Re-run should clear FailureCategory.
+		state.MarkRunning("impl")
+
+		ps := state.meta.Phases["impl"]
+		if ps.FailureCategory != "" {
+			t.Errorf("FailureCategory = %q, want empty after MarkRunning", ps.FailureCategory)
+		}
+	})
+
+	t.Run("error_on_unstarted_phase", func(t *testing.T) {
+		dir := t.TempDir()
+		state, _ := LoadOrCreate(dir, "T-FAIL-5")
+
+		err := state.SetFailureCategory("nonexistent", "parse")
+		if err == nil {
+			t.Fatal("expected error for unstarted phase")
+		}
+	})
+
+	t.Run("persists_to_disk", func(t *testing.T) {
+		dir := t.TempDir()
+		state, _ := LoadOrCreate(dir, "T-FAIL-6")
+
+		state.MarkRunning("triage")
+		state.SetFailureCategory("triage", "gate")
+		state.MarkFailed("triage", fmt.Errorf("gated"))
+
+		// Reload from disk.
+		state2, err := LoadOrCreate(dir, "T-FAIL-6")
+		if err != nil {
+			t.Fatalf("reload: %v", err)
+		}
+		ps := state2.Meta().Phases["triage"]
+		if ps == nil {
+			t.Fatal("triage phase not found after reload")
+		}
+		if ps.FailureCategory != "gate" {
+			t.Errorf("FailureCategory after reload = %q, want %q", ps.FailureCategory, "gate")
+		}
+	})
+}
+
+func TestMarkRunning_ZeroesRetryCounters(t *testing.T) {
+	dir := t.TempDir()
+	state, _ := LoadOrCreate(dir, "T-RETRY-ZERO")
+
+	state.MarkRunning("triage")
+	state.IncrementRetryCounter("triage", "transient")
+	state.IncrementRetryCounter("triage", "parse")
+	state.IncrementRetryCounter("triage", "semantic")
+	state.SetFailureCategory("triage", "transient")
+	state.MarkFailed("triage", fmt.Errorf("fail"))
+
+	// Verify fields are set before re-run.
+	ps := state.meta.Phases["triage"]
+	if ps.TransientRetries != 1 {
+		t.Errorf("TransientRetries before rerun = %d, want 1", ps.TransientRetries)
+	}
+	if ps.ParseRetries != 1 {
+		t.Errorf("ParseRetries before rerun = %d, want 1", ps.ParseRetries)
+	}
+	if ps.SemanticRetries != 1 {
+		t.Errorf("SemanticRetries before rerun = %d, want 1", ps.SemanticRetries)
+	}
+	if ps.FailureCategory != "transient" {
+		t.Errorf("FailureCategory before rerun = %q, want %q", ps.FailureCategory, "transient")
+	}
+
+	// Re-run should clear all retry counters and failure category.
+	state.MarkRunning("triage")
+
+	ps = state.meta.Phases["triage"]
+	if ps.TransientRetries != 0 {
+		t.Errorf("TransientRetries after rerun = %d, want 0", ps.TransientRetries)
+	}
+	if ps.ParseRetries != 0 {
+		t.Errorf("ParseRetries after rerun = %d, want 0", ps.ParseRetries)
+	}
+	if ps.SemanticRetries != 0 {
+		t.Errorf("SemanticRetries after rerun = %d, want 0", ps.SemanticRetries)
+	}
+	if ps.FailureCategory != "" {
+		t.Errorf("FailureCategory after rerun = %q, want empty", ps.FailureCategory)
+	}
+}
+
 func TestWriteReadArtifact(t *testing.T) {
 	dir := t.TempDir()
 	state, _ := LoadOrCreate(dir, "T-1")

--- a/internal/pipeline/timeout.go
+++ b/internal/pipeline/timeout.go
@@ -65,6 +65,11 @@ func (e *Engine) wrapTimeoutError(ctx context.Context, err error) error {
 	// Find the phase that was running when the timeout fired.
 	phase := e.lastRunningPhase()
 
+	// Persist failure category as "timeout" on the phase that was running.
+	if phase != "unknown" {
+		_ = e.state.SetFailureCategory(phase, "timeout")
+	}
+
 	e.emit(Event{
 		Kind: EventPipelineTimeout,
 		Data: map[string]any{


### PR DESCRIPTION
## Summary

Implements error classification telemetry for phase execution (#507). Propagates `FailureCategory` from `PhaseState` through the history enrichment loop so that `soda history <ticket> --detail` correctly shows gate/timeout error categories alongside retry counters.

### Root Cause

The enrichment loop in `cmd/soda/history.go` copied `TransientRetries`, `ParseRetries`, and `SemanticRetries` from `meta.Phases` but omitted `FailureCategory`. This caused two gaps:

- **Gate errors**: `SetFailureCategory(phase, "gate")` is called in `engine.go` but no `EventPhaseFailed` event carries `failure_category`, so history never showed `FailureCategory=gate`.
- **Timeout errors**: `wrapTimeoutError` overwrites state to `"timeout"` *after* `emitPhaseFailed` already emitted `"context"` in the event; without a fallback the corrected value was never surfaced.

### Fix

Added a fallback copy in the enrichment loop after the retry counter assignments:

```go
if h.Entries[i].FailureCategory == "" {
    h.Entries[i].FailureCategory = ps.FailureCategory
}
```

The fallback only fills when the event-sourced value is empty, so it never overwrites a value already populated from `EventPhaseFailed`.

## Changes

- `cmd/soda/history.go`: add `FailureCategory` fallback in enrichment loop
- `cmd/soda/history_test.go`: add 3 new tests for gate/timeout fallback and event-source preservation

## Test Plan

Three new unit tests in `cmd/soda/history_test.go`:

| Test | Scenario |
|---|---|
| `TestRenderEventsHistory_FailureCategoryFallbackFromMeta` | Gate error — fallback copies category from `PhaseState` |
| `TestRenderEventsHistory_FailureCategoryTimeoutOverride` | Timeout error — fallback fills when event has no `failure_category` |
| `TestRenderEventsHistory_FailureCategoryEventPreserved` | Event-sourced value is preserved (not overwritten) |

## Acceptance Criteria

- [x] `FailureCategory` added to `PhaseState` and zeroed in `MarkRunning`
- [x] All 8 required `FailureCategory` values set at correct call sites (`transient`/`parse`/`semantic`/`context`/`unknown` via `classifyError`; `gate` via `engine.go`; `budget` via `recovery.go`; `timeout` via `timeout.go`)
- [x] `EventPhaseRetrying` carries `"category"` in all three retry branches
- [x] `EventPhaseFailed` carries `"failure_category"` when set
- [x] `soda history <ticket> --detail` renders `Failure Category:` and `Retries: transient=N parse=N semantic=N`
- [x] Retry counters reset in `MarkRunning`
- [x] `FailureCategory` cleared in `MarkCompleted`
- [x] Per-category increment tests + mixed counter test
- [x] `TestRetry_FailureCategoryOnExhaustion` exercises `retry.go:42-48`
- [x] `TestRetry_CountersResetOnRerun` simulates `--from` resume via second `MarkRunning` call

---
Assisted-by: SODA
