### PR TITLE
[514] docs: README and docs overhaul — pipeline flexibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,30 +2,94 @@
 
 [![CI](https://github.com/decko/soda/actions/workflows/ci.yaml/badge.svg)](https://github.com/decko/soda/actions/workflows/ci.yaml) [![Go 1.25](https://img.shields.io/badge/go-1.25-blue.svg)](https://go.dev) [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 
-Give it a ticket, get a PR. SODA is a Go CLI/TUI that orchestrates AI coding
-sessions through a structured pipeline to implement GitHub Issues end-to-end.
-Each pipeline phase runs in a fresh, sandboxed Claude Code session with
-structured output — no shared context, no prompt bleed. A typical run costs
-**$5–11 USD** in Claude API usage and produces a reviewed, tested pull request.
+A programmable pipeline that turns tickets into PRs — one phase at a time. SODA
+is a Go CLI/TUI that orchestrates AI coding sessions through configurable
+pipelines to implement GitHub Issues end-to-end. Each phase runs in a fresh,
+sandboxed Claude Code session with structured output — no shared context, no
+prompt bleed. Use the default 9-phase pipeline out of the box, or compose your
+own from scratch.
 
-## Pipeline
+## Build Your Pipeline
+
+SODA ships three built-in pipelines. Pick one, or compose your own.
+
+| Want to… | Use |
+|----------|-----|
+| Run everything end-to-end | `soda run 42` (default pipeline) |
+| Skip triage and planning | `soda run 42 --pipeline quick-fix` |
+| Update docs only (Sonnet) | `soda run 42 --pipeline docs-only` |
+| Build a custom pipeline | `soda pipelines new my-pipeline` |
+| Design phases interactively | Ask the `pipeline-architect` agent |
+
+### Minimal custom pipeline (3 phases)
+
+Create `phases-my-pipeline.yaml` in your project root:
+
+```yaml
+phases:
+  - name: implement
+    tools: [Read, Write, Edit, Glob, Grep, Bash]
+    timeout: 25m
+
+  - name: verify
+    tools: [Read, Glob, Grep, Bash]
+    timeout: 8m
+
+  - name: submit
+    tools: ["Bash(git:*)", "Bash(gh:*)"]
+    timeout: 3m
+```
+
+Then run it:
+
+```bash
+soda run 42 --pipeline my-pipeline
+```
+
+See [docs/pipelines.md](docs/pipelines.md) for the full tutorial, conditional
+phases, and model routing cookbooks.
+
+## Default Pipeline
 
 ```
 Ticket → Triage → Plan → Implement → Verify → Review → Submit → Monitor → PR
 ```
 
-| Phase | What it does |
-|-------|-------------|
-| **Triage** | Classifies the ticket, identifies relevant files, routes the pipeline |
-| **Plan** | Designs the approach, breaks work into atomic tasks |
-| **Implement** | Writes code, runs tests, commits |
-| **Verify** | Runs tests, checks acceptance criteria, reviews code quality |
-| **Review** | Parallel specialist review (Go, AI harness, SRE) |
-| **Submit** | Pushes branch, opens pull request |
-| **Monitor** | Polls PR for comments and CI, responds and fixes |
+| Phase | What it does | Tools | Timeout | Model |
+|-------|-------------|-------|---------|-------|
+| **Triage** | Classifies the ticket, identifies relevant files, routes the default pipeline | Read-only | 3m | global |
+| **Plan** | Designs the approach, breaks work into atomic tasks | Read-only | 8m | global |
+| **Implement** | Writes code, runs tests, commits | Full | 25m | global |
+| **Verify** | Runs tests, checks acceptance criteria, reviews code quality | Read + Bash | 8m | global |
+| **Review** | Parallel specialist review (Go, AI harness, SRE) | Read + Bash | 12m | global |
+| **Submit** | Pushes branch, opens pull request | git + gh/glab | 3m | global |
+| **Monitor** | Polls PR for comments and CI, responds and fixes | Full | 10m/round | global |
 
-Conditional phases: **Patch** runs when verify fails (targeted fixes);
-**Follow-up** runs when review passes with minor findings (creates follow-up tickets).
+Conditional phases: **Patch** runs when verify fails (targeted fixes, Sonnet);
+**Follow-up** runs when review passes with minor findings (creates follow-up
+tickets). All phases, tools, timeouts, and models are configurable in
+`phases.yaml`.
+
+## Per-Phase Control
+
+Every knob in the default pipeline is configurable per phase in `phases.yaml`:
+
+| Knob | Scope | Example |
+|------|-------|---------|
+| Model | Per phase | Sonnet for triage, Opus for implement |
+| Tools | Per phase | Read-only for triage, full write for implement |
+| Timeout | Per phase | 3m for triage, 25m for implement |
+| Skip condition | Per phase | `{{ ne .Complexity "low" }}` |
+| Retry policy | Per phase, per error type | 2 transient, 1 parse, 0 semantic |
+
+See [docs/pipelines.md](docs/pipelines.md) and
+[docs/configuration.md](docs/configuration.md) for the full reference.
+
+## Status
+
+**Status (v0.5.0):** 185+ default pipeline runs across 6 releases. 67%
+first-pass success rate on medium-complexity tickets. Average cost $5–11 per
+session. SODA is used to develop itself.
 
 ## Cost
 
@@ -33,10 +97,24 @@ Conditional phases: **Patch** runs when verify fails (targeted fixes);
 |-------------|-------------|
 | Simple fix (1–3 tasks) | $2–6 |
 | Medium feature (4–8 tasks) | $8–15 |
-| Full 9-phase pipeline | $5–11 average |
+| Full default pipeline | $5–11 average |
 
 Set `max_cost_per_ticket` in `soda.yaml` as a hard safety net. Per-phase
 and per-generation limits are also available.
+
+## Quick Start
+
+```bash
+soda init                    # generate soda.yaml for this project
+soda doctor                  # verify prerequisites are installed
+soda run <issue-number>      # run the default pipeline for a GitHub issue
+soda run <issue-number> --pipeline quick-fix   # or choose a named pipeline
+soda status                  # check active and recent pipelines
+soda history <issue-number>  # inspect phase-by-phase results
+```
+
+See [docs/quickstart.md](docs/quickstart.md) for a step-by-step walkthrough
+including pipeline selection.
 
 ## Prerequisites
 
@@ -80,18 +158,6 @@ builds, and checksum verification.
 > `-sandbox` binary (Linux amd64 only). All other binaries work without
 > sandbox — it's optional.
 
-## Quick Start
-
-```bash
-soda init                    # generate soda.yaml for this project
-soda doctor                  # verify prerequisites are installed
-soda run <issue-number>      # run the full pipeline for a GitHub issue
-soda status                  # check active and recent pipelines
-soda history <issue-number>  # inspect phase-by-phase results
-```
-
-See [docs/quickstart.md](docs/quickstart.md) for a step-by-step walkthrough.
-
 ## Configuration
 
 SODA uses three config layers:
@@ -99,7 +165,7 @@ SODA uses three config layers:
 | Layer | File | Purpose |
 |-------|------|---------|
 | Project config | `soda.yaml` | Ticket source, model, budget limits, repo settings |
-| Pipeline config | `phases.yaml` | Add, remove, or reorder phases; set tools and timeouts |
+| Pipeline config | `phases.yaml` | Add, remove, or reorder phases; set tools, timeouts, and models |
 | Prompt overrides | `~/.config/soda/prompts/<phase>.md` | Customize phase prompts without forking |
 
 Run `soda init` to generate a `soda.yaml` auto-detected from your project.
@@ -110,8 +176,8 @@ and [docs/configuration.md](docs/configuration.md) for the full guide.
 
 | Command | Purpose |
 |---------|---------|
-| `soda run <ticket>` | Run pipeline for a ticket |
-| `soda run <ticket> --pipeline docs-only` | Use a named pipeline |
+| `soda run <ticket>` | Run the default pipeline for a ticket |
+| `soda run <ticket> --pipeline quick-fix` | Use a named pipeline |
 | `soda run <ticket> --from last` | Resume from last failed phase |
 | `soda run <ticket> --mode checkpoint` | Pause after each phase for confirmation |
 | `soda status` | Show active and recent pipelines |
@@ -125,81 +191,34 @@ and [docs/configuration.md](docs/configuration.md) for the full guide.
 | `soda spec "description"` | Generate a ticket specification |
 | `soda pick` | Interactive ticket picker |
 | `soda pipelines` | List available named pipelines |
+| `soda pipelines new <name>` | Scaffold a custom pipeline |
 | `soda init` | Generate `soda.yaml` config |
-
-## Named Pipelines
-
-| Pipeline | Phases | Use case |
-|----------|--------|----------|
-| `default` | Full 9-phase pipeline | New features, bug fixes |
-| `quick-fix` | implement → verify → submit | Small, well-understood fixes |
-| `docs-only` | plan → implement → submit | Documentation changes (Sonnet) |
-
-```bash
-soda run 42 --pipeline quick-fix
-soda run 42 --pipeline docs-only
-soda pipelines new my-pipeline   # create a custom pipeline
-```
 
 ## How It Works
 
-SODA creates a Git worktree before any phase runs — all phases execute inside
-the worktree, never in the main checkout. For each phase, SODA renders a prompt
-template with handoff artifacts from upstream phases, spawns a Claude Code
-session with `--bare --json-schema` (structured output, no auto-discovery),
-streams output to the TUI, parses the JSON response, and writes the artifact
-to `.soda/<ticket>/`. Context resets between phases: each session starts fresh.
-A rework loop triggers when review flags critical or major findings (max 2
-cycles). A corrective loop triggers when verify fails (patch phase, then
-re-verify).
+- **Worktree isolation** — a Git worktree is created before any phase runs; all
+  phases execute inside it, never in the main checkout
+- **Fresh context per phase** — each phase starts a new Claude Code session;
+  context resets between phases, no prompt bleed
+- **Structured JSON artifact handoff** — each phase writes a validated JSON
+  artifact to `.soda/<ticket>/`; the next phase reads it as structured input
+- **Rework loop** — when Review flags critical or major findings, the default
+  pipeline routes back to Implement (max 2 cycles); prior findings are injected
+  to prevent the whack-a-mole pattern
+- **Corrective loop** — when Verify fails, a targeted Patch phase runs before
+  re-verification; on exhaustion, the policy escalates or stops
 
 ## Sandbox
 
-When built with `CGO_ENABLED=1`, SODA uses
-[go-arapuca](https://github.com/sergio-correia/go-arapuca) for OS-level
-isolation around each Claude Code session:
+OS-level isolation for each Claude Code session (Landlock, seccomp, cgroups).
+See [docs/sandbox.md](docs/sandbox.md) for setup, configuration, and platform
+requirements.
 
-- **Landlock** — filesystem access restricted to the worktree
-- **seccomp** — syscall allowlist enforced at the kernel level
-- **cgroups** — memory, CPU, and PID limits
+## Plugin
 
-Sandbox is **optional**. Builds with `CGO_ENABLED=0` run without isolation —
-useful for environments where CGO is unavailable. Configure via the `sandbox:`
-block in `soda.yaml`.
-
-## Claude Code Plugin
-
-SODA ships an embedded plugin that gives Claude Code knowledge of SODA
-pipelines and quick access to soda commands. The plugin is auto-discovered
-from the `.claude/` directory.
-
-### Install
-
-```bash
-soda plugin install              # project-local: .claude/plugins/soda/
-soda plugin install --global     # global: ~/.claude/plugins/soda/
-```
-
-### Uninstall
-
-```bash
-soda plugin uninstall            # remove project-local plugin
-soda plugin uninstall --global   # remove global plugin
-```
-
-### What the plugin provides
-
-| Component | Description |
-|-----------|-------------|
-| **Skill: `soda-pipeline`** | Pipeline architecture, phase lifecycle, state management, troubleshooting |
-| **Skill: `orchestrate`** | Milestone-level coordination: dependency ordering, label lifecycle, SODA dispatch, cost tracking, progress reporting |
-| **`/soda:run <ticket>`** | Run the pipeline for a ticket |
-| **`/soda:status`** | Show current pipeline status |
-| **`/soda:sessions`** | List previous pipeline sessions |
-| **Agent: `pipeline-architect`** | Design-only agent that proposes a `phases.yaml` |
-
-Plugin files are embedded in the soda binary and version-matched — updates
-arrive with `go install`.
+Embedded plugin that gives Claude Code knowledge of SODA pipelines and quick
+access to `soda` commands. See [docs/plugin.md](docs/plugin.md) for install
+instructions and what the plugin provides.
 
 ## Contributing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,8 +15,9 @@ Guides for people running SODA against their own projects.
 | [install.md](install.md) | All installation methods (binary, Go install, source) | available |
 | [configuration.md](configuration.md) | `soda.yaml` and `phases.yaml` reference | available |
 | [cli-reference.md](cli-reference.md) | Full CLI command reference | planned |
-| [pipelines.md](pipelines.md) | Named pipelines, custom pipelines, phase customization | planned |
-| [plugin.md](plugin.md) | Claude Code plugin: install, commands, agent | planned |
+| [pipelines.md](pipelines.md) | Named pipelines, custom pipelines, conditional phases, model routing | available |
+| [sandbox.md](sandbox.md) | OS-level isolation: setup, configuration, platform support | available |
+| [plugin.md](plugin.md) | Claude Code plugin: install, commands, pipeline-architect agent | available |
 | [troubleshooting.md](troubleshooting.md) | Top failure modes and fixes | available |
 
 ## Contributor docs

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -259,9 +259,30 @@ phases:
                               # (e.g. "prompts/implement.md")
     schema: string            # structured output schema: inline JSON, file path, or empty to use
                               # the auto-generated schema for the phase name
-    model: string             # per-phase model override; empty uses the global model from soda.yaml
+
+    # Per-phase model override — use this to balance cost and capability across phases.
+    # For example: Sonnet for cheap classification phases (triage, plan, submit) and Opus for
+    # complex reasoning phases (implement, review). Omit to use the global model from soda.yaml.
+    model: string
+
     tools: [string]           # allowed tools list (see Tool scoping below)
-    timeout: duration         # phase timeout as a Go duration string (e.g. "25m", "3m")
+
+    # Per-phase timeout — set tighter limits for fast phases (triage: 3m, submit: 3m) and
+    # longer limits for phases that run tests or write code (implement: 25m, review: 12m).
+    # Catching runaway sessions early saves both time and cost.
+    timeout: duration         # Go duration string (e.g. "25m", "3m")
+
+    # Skip condition — a Go template expression evaluated against pipeline state.
+    # The phase is skipped when the expression evaluates to the string "false".
+    # Use this to build adaptive pipelines: skip planning for low-complexity tickets,
+    # skip review for docs-only changes, or skip monitor for quick-fix pipelines.
+    # Template variables: .Complexity, .TicketType, and all PromptData fields.
+    # Example: '{{ ne .Complexity "low" }}'  — skips the phase for low-complexity tickets
+    condition: string
+
+    # Per-phase retry policy — tune separately from other phases.
+    # implement often benefits from fewer semantic retries (fail fast and rework instead);
+    # verify benefits from more transient retries to handle flaky tests.
     retry:
       transient: int          # retries for transient API errors (rate limits, timeouts) (default: 2)
       parse: int              # retries when output fails JSON schema validation (default: 1)
@@ -282,6 +303,12 @@ phases:
 
 ### Rework routing
 
+Use rework routing to close the review → implement loop. When a phase returns a
+`rework` verdict (e.g. review finds critical or major issues), the engine routes
+back to the target phase and re-runs from there. Prior findings are injected
+into the rework prompt so the agent knows what to fix without re-reading the
+whole diff.
+
 To route back to an earlier phase on a bad verdict, add a `rework` block to the phase that produces the verdict:
 
 ```yaml
@@ -292,6 +319,14 @@ To route back to an earlier phase on a bad verdict, add a `rework` block to the 
 Example: the review phase routes back to implement on a `rework` verdict.
 
 ### Corrective routing
+
+Use corrective routing to close the verify → patch loop. When a phase fails
+(e.g. verify finds test failures), the engine triggers a lightweight corrective
+phase (patch) to attempt targeted fixes, then re-runs verify. This avoids
+routing all failures back through a full implement session. Configure
+`on_exhausted` to decide what happens when the corrective phase runs out of
+attempts: stop the pipeline, escalate to a full implement session, or allow one
+extra attempt.
 
 To trigger a corrective phase on failure, add a `corrective` block to the triggering phase:
 
@@ -307,7 +342,14 @@ Example: the verify phase triggers the patch corrective phase on a FAIL verdict.
 
 ### Parallel review
 
-For `type: parallel-review`, configure individual reviewers and quorum requirements:
+For `type: parallel-review`, configure individual reviewers and quorum requirements.
+
+Configure multiple reviewers when you need specialist perspectives on the same
+diff — for example, a Go specialist for correctness, an AI harness reviewer for
+prompt quality, and an SRE reviewer for operational concerns. Reviewers run in
+parallel and their findings are merged before a final verdict is determined.
+Use per-reviewer model overrides to run cheaper reviewers on Sonnet while
+reserving Opus for the most critical specialist.
 
 ```yaml
     min_reviewers: int         # minimum number of reviewers that must succeed; 0 means all must succeed
@@ -316,10 +358,18 @@ For `type: parallel-review`, configure individual reviewers and quorum requireme
       - name: string           # reviewer identifier (used in log filenames and output)
         prompt: string         # reviewer-specific prompt template path
         focus: string          # short description of the reviewer's focus area (injected into the prompt)
-        model: string          # per-reviewer model override (optional)
+        model: string          # per-reviewer model override (optional; empty = global model)
+        condition: string      # skip this reviewer when expression evaluates to "false" (optional)
+                               # useful for running expensive reviewers only on high-complexity tickets
 ```
 
 ### Polling (monitor)
+
+The polling phase type is used for the monitor phase — a long-running loop that
+watches the PR for review comments and CI status, then responds or fixes as
+needed. Configure `max_response_rounds` to limit how many Claude sessions can
+run during monitoring (each fix or reply counts as one round). Set
+`max_duration` to cap the total wall-clock time the monitor phase can consume.
 
 For `type: polling`, add a `polling` block:
 
@@ -336,7 +386,14 @@ For `type: polling`, add a `polling` block:
 
 ### Tool scoping
 
-The `tools` list in each phase is passed to Claude Code as `--allowed-tools`. This is advisory — use sandbox isolation for enforcement in unattended runs.
+Restrict what each phase can do by limiting its tools. Read-only phases
+(triage, plan) don't need write access — scoping them to `Read`, `Glob`,
+`Grep`, and `Bash(git:*)` reduces the blast radius if anything goes wrong.
+Submit phases only need forge CLI access and never need to read source files.
+
+The `tools` list in each phase is passed to Claude Code as `--allowed-tools`.
+This is advisory — use sandbox isolation for enforcement in unattended runs
+(see [docs/sandbox.md](sandbox.md)).
 
 Supported tool names and patterns:
 
@@ -425,6 +482,9 @@ soda pipelines new <name> --global     # write to ~/.config/soda/phases-<name>.y
 This scaffolds a new pipeline definition file named `phases-<name>.yaml`. Edit the generated file to add, remove, or reorder phases.
 
 Custom pipelines follow the same file format as the default `phases.yaml`. The pipeline file is self-contained: it references prompt templates and the schema is either inline JSON or resolved automatically from the phase name.
+
+For a step-by-step tutorial with conditional phases and model routing cookbooks,
+see [docs/pipelines.md](pipelines.md).
 
 ### Running with a named pipeline
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -1,0 +1,382 @@
+# Pipelines
+
+SODA's pipeline is fully configurable. You can add, remove, or reorder phases;
+swap models per phase; scope tools per phase; and add conditional logic to skip
+phases based on ticket metadata. This guide walks you through building a custom
+pipeline from scratch.
+
+---
+
+## Built-in pipelines
+
+| Name | Phases | Use case |
+|------|--------|----------|
+| `default` | triage → plan → implement → verify → review → submit → monitor | Full pipeline for standard tickets |
+| `quick-fix` | implement → verify → submit | Small, well-understood fixes |
+| `docs-only` | plan → implement → submit | Documentation changes (Sonnet) |
+
+```bash
+soda pipelines                       # list all available pipelines
+soda run 42                          # use the default pipeline
+soda run 42 --pipeline quick-fix
+soda run 42 --pipeline docs-only
+```
+
+---
+
+## Design your pipeline
+
+### Step 1 — Scaffold a pipeline file
+
+```bash
+soda pipelines new my-pipeline              # creates phases-my-pipeline.yaml in the current directory
+soda pipelines new my-pipeline --global     # creates ~/.config/soda/phases-my-pipeline.yaml
+```
+
+### Step 2 — Edit the generated file
+
+A pipeline file is a list of phase definitions. Each phase specifies its tools,
+timeout, model, and (optionally) conditional logic.
+
+**Minimal pipeline (3 phases):**
+
+```yaml
+phases:
+  - name: implement
+    tools: [Read, Write, Edit, Glob, Grep, Bash]
+    timeout: 25m
+
+  - name: verify
+    tools: [Read, Glob, Grep, Bash]
+    timeout: 8m
+
+  - name: submit
+    tools: ["Bash(git:*)", "Bash(gh:*)"]
+    timeout: 3m
+```
+
+### Step 3 — Run it
+
+```bash
+soda run 42 --pipeline my-pipeline
+```
+
+SODA resolves `phases-my-pipeline.yaml` from the current directory first,
+then `~/.config/soda/phases-my-pipeline.yaml`, then embedded defaults.
+
+---
+
+## Phase field reference
+
+```yaml
+phases:
+  - name: string            # phase identifier; used in logs, state files, and artifacts
+    type: string            # "corrective", "post-submit", "parallel-review", "polling"
+                            # omit for a normal forward phase
+    prompt: string          # prompt template path (e.g. "prompts/implement.md")
+                            # omit to use the auto-resolved embedded default for this phase name
+    model: string           # per-phase model override
+                            # omit to use the global model from soda.yaml
+    tools: [string]         # allowed tools list passed to Claude Code as --allowed-tools
+    timeout: duration       # phase timeout (e.g. "25m", "3m")
+    condition: string       # Go template expression; phase is skipped when it evaluates to "false"
+                            # (see Conditional phases cookbook below)
+    depends_on: [string]    # phase names that must complete before this phase runs
+    feedback_from: [string] # upstream phases whose output is injected as rework feedback
+    retry:
+      transient: int        # retries for transient API errors (default: 2)
+      parse: int            # retries when output fails JSON schema validation (default: 1)
+      semantic: int         # retries when output is valid but semantically wrong (default: 1)
+```
+
+### Tool reference
+
+| Tool | What it allows |
+|------|---------------|
+| `Read` | Read files |
+| `Write` | Write files |
+| `Edit` | In-place edits |
+| `Glob` | File pattern matching |
+| `Grep` | Content search |
+| `Bash` | Unrestricted shell |
+| `Bash(git:*)` | Git subcommands only |
+| `Bash(gh:*)` | GitHub CLI only |
+| `Bash(glab:*)` | GitLab CLI only |
+| `Bash(ls:*)` | Directory listing only |
+| `Bash(go test:*)` | Go test invocations only |
+
+---
+
+## Conditional phases cookbook
+
+Use the `condition` field to skip a phase based on ticket metadata. The
+condition is a Go template expression evaluated against pipeline state; the
+phase is skipped when the expression evaluates to the string `"false"`.
+
+Available template variables mirror the `PromptData` struct — see
+[docs/configuration.md](configuration.md#prompt-overrides) for the full list.
+The most useful ones for conditions are:
+
+| Variable | Type | Example values |
+|----------|------|---------------|
+| `{{.Complexity}}` | string | `"low"`, `"medium"`, `"high"` |
+| `{{.TicketType}}` | string | `"bug"`, `"feature"`, `"docs"` |
+| `{{.Artifacts.Triage}}` | JSON string | triage output (parsed by template funcs) |
+
+### Skip plan for low-complexity tickets
+
+When triage classifies a ticket as `low` complexity, skip the planning phase —
+the implementation is straightforward enough to go straight to code.
+
+```yaml
+  - name: plan
+    condition: '{{ ne .Complexity "low" }}'
+    tools: [Read, Glob, Grep, "Bash(git:*)"]
+    timeout: 8m
+```
+
+### Skip review for docs-only changes
+
+Documentation changes rarely need code review from specialist agents. Skip the
+review phase when the ticket type is `docs`.
+
+```yaml
+  - name: review
+    condition: '{{ ne .TicketType "docs" }}'
+    type: parallel-review
+    timeout: 12m
+    reviewers:
+      - name: go-specialist
+        prompt: prompts/review-go.md
+```
+
+### Only run AI harness reviewer for high-complexity tickets
+
+Specialist AI harness review is expensive. Reserve it for complex tickets where
+prompt engineering is most likely to be the failure mode.
+
+```yaml
+  - name: review
+    type: parallel-review
+    reviewers:
+      - name: go-specialist
+        prompt: prompts/review-go.md
+      - name: ai-harness
+        prompt: prompts/review-ai-harness.md
+        condition: '{{ eq .Complexity "high" }}'
+```
+
+### Skip monitor for a quick-fix pipeline
+
+Quick fixes don't need continuous PR monitoring — just submit and move on.
+Omit the monitor phase entirely from the pipeline definition.
+
+```yaml
+phases:
+  - name: implement
+    tools: [Read, Write, Edit, Glob, Grep, Bash]
+    timeout: 25m
+
+  - name: verify
+    tools: [Read, Glob, Grep, Bash]
+    timeout: 8m
+
+  - name: submit
+    tools: ["Bash(git:*)", "Bash(gh:*)"]
+    timeout: 3m
+
+  # monitor phase omitted — pipeline ends after submit
+```
+
+---
+
+## Model routing cookbook
+
+### Cheap phases with Sonnet, expensive phases with Opus
+
+Use fast, cheap models for triage and submit; reserve the most capable model
+for implement and review.
+
+```yaml
+phases:
+  - name: triage
+    model: claude-sonnet-4-20250514   # fast and cheap for classification
+    tools: [Read, Glob, Grep, "Bash(git:*)", "Bash(ls:*)"]
+    timeout: 3m
+
+  - name: plan
+    model: claude-sonnet-4-20250514
+    tools: [Read, Glob, Grep, "Bash(git:*)"]
+    timeout: 8m
+
+  - name: implement
+    # no model override — uses global model (e.g. Opus) from soda.yaml
+    tools: [Read, Write, Edit, Glob, Grep, Bash]
+    timeout: 25m
+
+  - name: verify
+    # no model override
+    tools: [Read, Glob, Grep, Bash]
+    timeout: 8m
+
+  - name: submit
+    model: claude-sonnet-4-20250514   # no heavy reasoning needed for submission
+    tools: ["Bash(git:*)", "Bash(gh:*)"]
+    timeout: 3m
+```
+
+Set the global model in `soda.yaml`:
+
+```yaml
+model: claude-opus-4-20251101   # used for phases with no per-phase override
+```
+
+### Corrective patch phase with Sonnet
+
+The corrective patch phase can use a cheaper model for targeted fixes, falling
+back to the global model for full implement escalation.
+
+```yaml
+  - name: patch
+    type: corrective
+    model: claude-sonnet-4-20250514   # fast targeted fixes
+    tools: [Read, Write, Edit, Glob, Grep, Bash]
+    timeout: 8m
+```
+
+This is the default pipeline's approach — Sonnet for quick targeted fixes,
+Opus reserved for full implement sessions.
+
+### Per-reviewer model selection
+
+Different reviewers can use different models:
+
+```yaml
+  - name: review
+    type: parallel-review
+    reviewers:
+      - name: go-specialist
+        prompt: prompts/review-go.md
+        # no model override — uses global model
+      - name: ai-harness
+        prompt: prompts/review-ai-harness.md
+        model: claude-sonnet-4-20250514   # cheaper for harness review
+      - name: sre
+        prompt: prompts/review-sre.md
+        model: claude-sonnet-4-20250514
+```
+
+---
+
+## Annotated walkthroughs
+
+### `quick-fix` pipeline
+
+Skips triage, plan, review, and monitor. Assumes you know what to fix.
+Use when you've diagnosed the problem and want to automate the mechanical work.
+
+```yaml
+phases:
+  - name: implement
+    tools: [Read, Write, Edit, Glob, Grep, Bash]
+    timeout: 15m
+    retry:
+      transient: 2
+      parse: 1
+      semantic: 0   # fail fast — no semantic retry on implement
+
+  - name: verify
+    tools: [Read, Glob, Grep, Bash]
+    timeout: 8m
+    corrective:
+      phase: patch
+      max_attempts: 1
+      on_exhausted: stop
+
+  - name: patch
+    type: corrective
+    model: claude-sonnet-4-20250514
+    tools: [Read, Write, Edit, Glob, Grep, Bash]
+    timeout: 8m
+
+  - name: submit
+    tools: ["Bash(git:*)", "Bash(gh:*)"]
+    timeout: 3m
+```
+
+**When to use:** Bug fixes where you've already diagnosed the problem. API
+changes with obvious call-site updates. Dependency upgrades with known
+migration paths.
+
+### `docs-only` pipeline
+
+Uses Sonnet throughout (docs don't need Opus). Skips triage and all
+testing/review phases.
+
+```yaml
+phases:
+  - name: plan
+    model: claude-sonnet-4-20250514
+    tools: [Read, Glob, Grep, "Bash(git:*)"]
+    timeout: 5m
+
+  - name: implement
+    model: claude-sonnet-4-20250514
+    tools: [Read, Write, Edit, Glob, Grep, Bash]
+    timeout: 10m
+
+  - name: submit
+    model: claude-sonnet-4-20250514
+    tools: ["Bash(git:*)", "Bash(gh:*)"]
+    timeout: 3m
+```
+
+**When to use:** README updates, changelog entries, docstring improvements,
+configuration reference updates. Any change where the test suite doesn't cover
+correctness of the output.
+
+---
+
+## Using the pipeline-architect agent
+
+The `pipeline-architect` agent is a design-only Claude Code agent that proposes
+a custom pipeline configuration based on your project and requirements. It
+analyzes your tech stack and suggests phases, reviewers, timeouts, and model
+selection calibrated to your codebase.
+
+Install the SODA plugin first:
+
+```bash
+soda plugin install
+```
+
+Then, in a Claude Code session:
+
+```
+@pipeline-architect I need a pipeline for reviewing and merging dependency
+updates. Run tests, check for breaking changes, and submit without full review.
+```
+
+The agent outputs a complete `phases-<name>.yaml` you can copy into your
+project and run immediately with `soda run <ticket> --pipeline <name>`.
+
+> **Note:** The pipeline-architect agent only *designs* pipelines — it does not
+> execute them. It will not write any files.
+
+---
+
+## Discovery order
+
+SODA resolves named pipelines (`phases-<name>.yaml`) in this order (first found
+wins):
+
+1. Current working directory (`./phases-<name>.yaml`)
+2. User config directory (`~/.config/soda/phases-<name>.yaml`)
+3. Embedded defaults (compiled into the binary)
+
+The default pipeline (`phases.yaml`) also checks `phases_path` in `soda.yaml`
+before the current working directory.
+
+For the full `phases.yaml` field reference including rework routing, corrective
+routing, parallel review, and polling configuration, see
+[docs/configuration.md](configuration.md#phasesyaml-reference).

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -1,0 +1,71 @@
+# Claude Code Plugin
+
+SODA ships an embedded plugin that gives Claude Code knowledge of SODA
+pipelines and quick access to `soda` commands. Install it once; updates arrive
+with `go install` or a new binary download.
+
+## Install
+
+```bash
+soda plugin install              # project-local: .claude/plugins/soda/
+soda plugin install --global     # global: ~/.claude/plugins/soda/
+```
+
+Project-local installs apply only when Claude Code is opened from that project
+directory. Global installs apply everywhere.
+
+## Uninstall
+
+```bash
+soda plugin uninstall            # remove project-local plugin
+soda plugin uninstall --global   # remove global plugin
+```
+
+## What the plugin provides
+
+| Component | Description |
+|-----------|-------------|
+| **Skill: `soda-pipeline`** | Pipeline architecture, phase lifecycle, state management, troubleshooting |
+| **Skill: `orchestrate`** | Milestone-level coordination: dependency ordering, label lifecycle, SODA dispatch, cost tracking, progress reporting |
+| **`/soda:run <ticket>`** | Run the default pipeline for a ticket |
+| **`/soda:status`** | Show current pipeline status |
+| **`/soda:sessions`** | List previous pipeline sessions |
+| **Agent: `pipeline-architect`** | Design-only agent that proposes a custom `phases.yaml` based on your project and requirements |
+
+## The pipeline-architect agent
+
+The `pipeline-architect` agent is available after installing the plugin. Invoke
+it in a Claude Code session:
+
+```
+@pipeline-architect I want a pipeline that skips triage for small tickets
+and uses Sonnet for everything except implement.
+```
+
+The agent analyzes your project structure and outputs a ready-to-use
+`phases-<name>.yaml`. It does not execute the pipeline or write any files —
+it only designs and proposes.
+
+See [docs/pipelines.md](pipelines.md#using-the-pipeline-architect-agent) for
+more detail.
+
+## Plugin files
+
+Plugin files are embedded in the soda binary at build time. The plugin
+directory structure after install:
+
+```
+.claude/plugins/soda/
+├── skills/
+│   ├── soda-pipeline/
+│   │   ├── SKILL.md
+│   │   └── RUNBOOK.md
+│   └── orchestrate/
+│       └── SKILL.md
+├── commands/
+│   ├── soda-run.md
+│   ├── soda-status.md
+│   └── soda-sessions.md
+└── agents/
+    └── pipeline-architect.md
+```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -222,7 +222,40 @@ gh issue create \
 
 ---
 
-## Step 6 — Run `soda run <issue-number>`
+## Step 6 — Choose your pipeline
+
+SODA ships three built-in pipelines. For your first run, the default pipeline
+is a good choice — it handles triage, planning, implementation, verification,
+review, and submission end-to-end.
+
+| Pipeline | Phases | Use case |
+|----------|--------|----------|
+| `default` | triage → plan → implement → verify → review → submit → monitor | New features, bug fixes |
+| `quick-fix` | implement → verify → submit | Small, well-understood fixes |
+| `docs-only` | plan → implement → submit | Documentation changes (Sonnet) |
+
+```bash
+soda pipelines     # see all available pipelines
+```
+
+To use a specific pipeline, pass `--pipeline` to `soda run`:
+
+```bash
+soda run 42 --pipeline quick-fix
+```
+
+You can also build a custom pipeline tailored to your project:
+
+```bash
+soda pipelines new my-pipeline   # scaffolds phases-my-pipeline.yaml
+```
+
+See [docs/pipelines.md](pipelines.md) for the full tutorial, conditional
+phases, and model routing cookbooks.
+
+---
+
+## Step 7 — Run `soda run <issue-number>`
 
 ```bash
 soda run 42
@@ -268,7 +301,7 @@ SODA — myorg/my-service — issue #42
 
 ---
 
-## Step 7 — Find your pull request
+## Step 8 — Find your pull request
 
 When Submit completes, SODA prints the PR URL:
 

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -1,0 +1,101 @@
+# Sandbox
+
+When built with `CGO_ENABLED=1`, SODA uses
+[go-arapuca](https://github.com/sergio-correia/go-arapuca) for OS-level
+isolation around each Claude Code session.
+
+## What the sandbox enforces
+
+- **Landlock** — filesystem access restricted to the worktree; the agent cannot
+  read or write outside the working directory
+- **seccomp** — syscall allowlist enforced at the kernel level; blocks syscalls
+  the agent has no business making
+- **cgroups** — memory, CPU, and PID limits per session; prevents runaway
+  resource consumption
+- **Network namespace** — Unix sockets only; the agent cannot make outbound
+  network calls from inside the sandbox (API calls are proxied through the host)
+
+## Why sandbox?
+
+The `--allowed-tools` flag passed to Claude Code is **advisory** — the model
+can choose to ignore it. Landlock, seccomp, and cgroups are kernel-enforced and
+cannot be bypassed by the agent. For unattended autonomous execution,
+enforcement beats advisory.
+
+## Enabling the sandbox
+
+The sandbox is **optional**. Builds with `CGO_ENABLED=0` run without isolation,
+which is appropriate for environments where CGO is unavailable (macOS, Linux
+ARM64). The agent is still bounded by `--allowed-tools` and
+`--permission-mode bypassPermissions`.
+
+### Download the sandbox binary
+
+Download the `-sandbox` binary (Linux amd64 only) from the
+[releases page](https://github.com/decko/soda/releases):
+
+```bash
+curl -L https://github.com/decko/soda/releases/latest/download/soda-linux-amd64-sandbox -o soda
+chmod +x soda
+sudo mv soda /usr/local/bin/
+```
+
+### Enable in soda.yaml
+
+```yaml
+sandbox:
+  enabled: true
+  limits:
+    memory_mb: 2048      # cgroup memory limit in MiB
+    cpu_percent: 200     # cgroup CPU quota as a percentage of one core
+    max_pids: 256        # cgroup PID limit
+```
+
+### Verify
+
+```bash
+soda doctor
+```
+
+Look for the `sandbox` check in the output. If it shows `✓`, the sandbox is
+active.
+
+## Proxy mode
+
+Enable the proxy to route API calls through a host-side bridge for credential
+isolation and token metering. Requires `sandbox.enabled: true`.
+
+```yaml
+sandbox:
+  enabled: true
+  proxy:
+    enabled: true
+    upstream_url: https://api.anthropic.com   # default; set ANTHROPIC_BASE_URL to override
+    max_input_tokens: 0                        # 0 = unlimited per session
+    max_output_tokens: 0
+    log_dir: ""                                # set to a directory path to enable request/response audit logging
+```
+
+When the proxy is enabled, API calls are bridged through a Unix socket. The
+host-side proxy injects credentials, so no API key is needed inside the
+sandbox.
+
+## Platform support
+
+| Platform | Sandbox available |
+|----------|-------------------|
+| Linux amd64 | ✅ full isolation (Landlock + seccomp + cgroups) |
+| Linux arm64 | ❌ no sandbox (CGO cross-compilation not available) |
+| macOS (any) | ❌ no sandbox |
+
+Sandbox requires unprivileged user namespaces. Verify with:
+
+```bash
+unshare --user --net --map-current-user -- /bin/true
+```
+
+If this fails, the sandbox falls back to seccomp-only mode.
+
+## Full configuration reference
+
+See [docs/configuration.md](configuration.md#sandbox) for all sandbox options.


### PR DESCRIPTION
## Summary

Overhauls README.md and all affected docs to lead with SODA's configurable pipeline story instead of black-box framing.

### Changes

**README.md** — Full rewrite:
- New tagline leads with "configurable pipelines" / "programmable pipeline"
- New "Build Your Pipeline" section: want-to table + minimal 3-phase YAML example
- Rename "Pipeline" → "Default Pipeline"; expand phase table with Tools, Timeout, Model columns
- Add "Per-Phase Control" table (model, tools, timeout, skip condition, retry policy)
- Status/Results line: 185+ runs, 67% first-pass rate, $5–11 avg
- "How It Works" reformatted from wall-of-text into 5 bullets
- Sandbox and Plugin sections collapsed to 2 lines each + links to new docs
- Section order restructured per ticket spec

**docs/quickstart.md** — Added Step 6 "Choose your pipeline" (with `--pipeline` flag) between issue selection and run; renumbered subsequent steps 7 and 8.

**docs/configuration.md** — Documented the previously-undocumented `condition` field; added "why" context before model, timeout, condition, retry, rework routing, corrective routing, reviewers, polling, and tool scoping; added link to pipelines.md tutorial.

**docs/README.md** — Marked pipelines.md and plugin.md as available; added sandbox.md to the index.

**docs/pipelines.md** *(new)* — Full tutorial: scaffold → edit → run, phase field reference with examples, 4 conditional-phase recipes, 3 model-routing recipes, annotated quick-fix and docs-only walkthroughs, pipeline-architect agent guide, discovery order.

**docs/sandbox.md** *(new)* — What the sandbox enforces, why it matters, enable instructions, proxy mode, platform support table.

**docs/plugin.md** *(new)* — Install/uninstall, component table, pipeline-architect agent guide, plugin file structure.

Also fixes the broken quickstart → pipelines.md link (file now exists).

## Test Plan

- [ ] Read README.md from top to bottom and verify the flow matches the ticket spec
- [ ] Follow docs/quickstart.md Step 6 and confirm the `--pipeline` flag is described correctly
- [ ] Open docs/pipelines.md and verify all internal links resolve
- [ ] Open docs/sandbox.md and docs/plugin.md and verify no broken links
- [ ] Verify docs/configuration.md `condition` field example is accurate against the schema

## Acceptance Criteria

- [x] README leads with "configurable pipelines" / "programmable pipeline" tagline
- [x] "Build Your Pipeline" section exists before "Default Pipeline"
- [x] Default pipeline phase table includes Tools, Timeout, Model columns
- [x] Per-Phase Control table present
- [x] docs/pipelines.md created with tutorial, cookbook, and agent guide
- [x] docs/sandbox.md created
- [x] docs/plugin.md created
- [x] docs/quickstart.md has pipeline step
- [x] docs/configuration.md documents `condition` field
- [x] docs/README.md index updated
- [x] No broken internal links introduced

Fixes: #514

Assisted-by: SODA