### PR TITLE
[511] feat(cli): soda cost --outcomes — phase cost by pipeline outcome

### DIFF
--- a/cmd/soda/cost.go
+++ b/cmd/soda/cost.go
@@ -202,7 +202,7 @@ func runCostByComplexity(entries []pipeline.CostEntry) error {
 }
 
 // outcomeOrder defines the canonical display order for pipeline outcome buckets.
-var outcomeOrder = []string{"clean", "patched", "rework_1", "rework_2+", "failed"}
+var outcomeOrder = []string{"first_pass", "patched", "rework_1", "rework_2+", "failed"}
 
 // runCostByOutcome renders a cost breakdown grouped by pipeline outcome.
 func runCostByOutcome(entries []pipeline.CostEntry) error {
@@ -307,7 +307,7 @@ func runCostByOutcome(entries []pipeline.CostEntry) error {
 	fmt.Printf("\nTotal: $%.2f across %d session(s)\n", totalCost, totalSessions)
 
 	// Rework-tax line: weighted mean of rework_1 + rework_2+ vs clean mean.
-	cleanStats, hasClean := byOutcome["clean"]
+	cleanStats, hasClean := byOutcome["first_pass"]
 	rework1Stats, hasR1 := byOutcome["rework_1"]
 	rework2Stats, hasR2 := byOutcome["rework_2+"]
 	if hasClean && (hasR1 || hasR2) {
@@ -324,7 +324,7 @@ func runCostByOutcome(entries []pipeline.CostEntry) error {
 		reworkMean := reworkTotal / float64(reworkSessions)
 		if cleanStats.Mean > 0 {
 			tax := ((reworkMean - cleanStats.Mean) / cleanStats.Mean) * 100
-			fmt.Printf("Rework tax: %.0f%% (rework mean $%.2f vs clean mean $%.2f)\n", tax, reworkMean, cleanStats.Mean)
+			fmt.Printf("Rework tax: %.0f%% (rework mean $%.2f vs first_pass mean $%.2f)\n", tax, reworkMean, cleanStats.Mean)
 		}
 	}
 

--- a/cmd/soda/cost.go
+++ b/cmd/soda/cost.go
@@ -14,6 +14,7 @@ import (
 
 func newCostCmd() *cobra.Command {
 	var byComplexity bool
+	var byOutcomes bool
 
 	cmd := &cobra.Command{
 		Use:   "cost",
@@ -27,6 +28,12 @@ func newCostCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("cost: read ledger: %w", err)
 			}
+			if byOutcomes && byComplexity {
+				return runCostByOutcomeAndComplexity(entries)
+			}
+			if byOutcomes {
+				return runCostByOutcome(entries)
+			}
 			if byComplexity {
 				return runCostByComplexity(entries)
 			}
@@ -35,6 +42,7 @@ func newCostCmd() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&byComplexity, "by-complexity", false, "Show cost breakdown grouped by triage complexity band")
+	cmd.Flags().BoolVar(&byOutcomes, "outcomes", false, "Show cost breakdown grouped by pipeline outcome")
 	return cmd
 }
 
@@ -190,5 +198,257 @@ func runCostByComplexity(entries []pipeline.CostEntry) error {
 	}
 
 	fmt.Printf("\nTotal: $%.2f across %d session(s)\n", totalCost, totalSessions)
+	return nil
+}
+
+// outcomeOrder defines the canonical display order for pipeline outcome buckets.
+var outcomeOrder = []string{"clean", "patched", "rework_1", "rework_2+", "failed"}
+
+// runCostByOutcome renders a cost breakdown grouped by pipeline outcome.
+func runCostByOutcome(entries []pipeline.CostEntry) error {
+	if len(entries) == 0 {
+		fmt.Println("No cost entries found.")
+		return nil
+	}
+
+	byOutcome := pipeline.CostByOutcome(entries)
+
+	// Build rows in canonical outcome order, skipping absent outcomes.
+	type row struct {
+		outcome  string
+		sessions string
+		mean     string
+		median   string
+		meanDur  string
+		total    string
+	}
+
+	header := row{"OUTCOME", "SESSIONS", "MEAN", "MEDIAN", "MEAN DUR", "TOTAL"}
+	var rows []row
+	var totalSessions int
+	var totalCost float64
+	for _, outcome := range outcomeOrder {
+		stats, ok := byOutcome[outcome]
+		if !ok {
+			continue
+		}
+		rows = append(rows, row{
+			outcome:  strings.ToUpper(outcome),
+			sessions: fmt.Sprintf("%d", stats.Sessions),
+			mean:     fmt.Sprintf("$%.2f", stats.Mean),
+			median:   fmt.Sprintf("$%.2f", stats.Median),
+			meanDur:  formatDuration(stats.MeanDurMs),
+			total:    fmt.Sprintf("$%.2f", stats.Total),
+		})
+		totalSessions += stats.Sessions
+		totalCost += stats.Total
+	}
+
+	// Compute column widths from all rows including header.
+	colW := [6]int{
+		len(header.outcome),
+		len(header.sessions),
+		len(header.mean),
+		len(header.median),
+		len(header.meanDur),
+		len(header.total),
+	}
+	for _, r := range rows {
+		if len(r.outcome) > colW[0] {
+			colW[0] = len(r.outcome)
+		}
+		if len(r.sessions) > colW[1] {
+			colW[1] = len(r.sessions)
+		}
+		if len(r.mean) > colW[2] {
+			colW[2] = len(r.mean)
+		}
+		if len(r.median) > colW[3] {
+			colW[3] = len(r.median)
+		}
+		if len(r.meanDur) > colW[4] {
+			colW[4] = len(r.meanDur)
+		}
+		if len(r.total) > colW[5] {
+			colW[5] = len(r.total)
+		}
+	}
+
+	// Consider footer widths.
+	footerSessions := fmt.Sprintf("%d", totalSessions)
+	footerTotal := fmt.Sprintf("$%.2f", totalCost)
+	if len("TOTAL") > colW[0] {
+		colW[0] = len("TOTAL")
+	}
+	if len(footerSessions) > colW[1] {
+		colW[1] = len(footerSessions)
+	}
+	if len(footerTotal) > colW[5] {
+		colW[5] = len(footerTotal)
+	}
+
+	gap := 2
+	fmtRow := func(r row) string {
+		return fmt.Sprintf("%-*s%s%-*s%s%-*s%s%-*s%s%-*s%s%-*s",
+			colW[0], r.outcome, strings.Repeat(" ", gap),
+			colW[1], r.sessions, strings.Repeat(" ", gap),
+			colW[2], r.mean, strings.Repeat(" ", gap),
+			colW[3], r.median, strings.Repeat(" ", gap),
+			colW[4], r.meanDur, strings.Repeat(" ", gap),
+			colW[5], r.total,
+		)
+	}
+
+	fmt.Println(fmtRow(header))
+	for _, r := range rows {
+		fmt.Println(fmtRow(r))
+	}
+
+	fmt.Printf("\nTotal: $%.2f across %d session(s)\n", totalCost, totalSessions)
+
+	// Rework-tax line: weighted mean of rework_1 + rework_2+ vs clean mean.
+	cleanStats, hasClean := byOutcome["clean"]
+	rework1Stats, hasR1 := byOutcome["rework_1"]
+	rework2Stats, hasR2 := byOutcome["rework_2+"]
+	if hasClean && (hasR1 || hasR2) {
+		var reworkTotal float64
+		var reworkSessions int
+		if hasR1 {
+			reworkTotal += rework1Stats.Total
+			reworkSessions += rework1Stats.Sessions
+		}
+		if hasR2 {
+			reworkTotal += rework2Stats.Total
+			reworkSessions += rework2Stats.Sessions
+		}
+		reworkMean := reworkTotal / float64(reworkSessions)
+		if cleanStats.Mean > 0 {
+			tax := ((reworkMean - cleanStats.Mean) / cleanStats.Mean) * 100
+			fmt.Printf("Rework tax: %.0f%% (rework mean $%.2f vs clean mean $%.2f)\n", tax, reworkMean, cleanStats.Mean)
+		}
+	}
+
+	return nil
+}
+
+// runCostByOutcomeAndComplexity renders a 2D matrix of cost (mean) broken
+// down by outcome (rows) and complexity (columns).
+func runCostByOutcomeAndComplexity(entries []pipeline.CostEntry) error {
+	if len(entries) == 0 {
+		fmt.Println("No cost entries found.")
+		return nil
+	}
+
+	// Group entries by (outcome, complexity).
+	type cellKey struct {
+		outcome    string
+		complexity string
+	}
+	cells := make(map[cellKey][]float64)
+	complexitySet := make(map[string]bool)
+	outcomeSet := make(map[string]bool)
+	for _, entry := range entries {
+		outcome := pipeline.ClassifyOutcome(entry)
+		complexity := entry.Complexity
+		if complexity == "" {
+			complexity = "unknown"
+		}
+		key := cellKey{outcome, complexity}
+		cells[key] = append(cells[key], entry.Cost)
+		complexitySet[complexity] = true
+		outcomeSet[outcome] = true
+	}
+
+	// Sort complexity columns using the same band ordering as runCostByComplexity.
+	complexities := make([]string, 0, len(complexitySet))
+	for comp := range complexitySet {
+		complexities = append(complexities, comp)
+	}
+	sort.Slice(complexities, func(i, j int) bool {
+		oi, oki := complexityBandOrder[complexities[i]]
+		oj, okj := complexityBandOrder[complexities[j]]
+		if oki && okj {
+			return oi < oj
+		}
+		if oki {
+			return true
+		}
+		if okj {
+			return false
+		}
+		return complexities[i] < complexities[j]
+	})
+
+	// Build header row.
+	numCols := 1 + len(complexities) // outcome + one per complexity
+	colW := make([]int, numCols)
+	colW[0] = len("OUTCOME")
+	headerCells := []string{"OUTCOME"}
+	for idx, comp := range complexities {
+		label := strings.ToUpper(comp)
+		headerCells = append(headerCells, label)
+		if len(label) > colW[idx+1] {
+			colW[idx+1] = len(label)
+		}
+	}
+
+	// Build data rows in canonical outcome order.
+	type matrixRow struct {
+		cells []string
+	}
+	var dataRows []matrixRow
+	for _, outcome := range outcomeOrder {
+		if !outcomeSet[outcome] {
+			continue
+		}
+		rowCells := []string{strings.ToUpper(outcome)}
+		if len(rowCells[0]) > colW[0] {
+			colW[0] = len(rowCells[0])
+		}
+		for idx, comp := range complexities {
+			key := cellKey{outcome, comp}
+			costs, ok := cells[key]
+			if !ok {
+				rowCells = append(rowCells, "—")
+			} else {
+				var total float64
+				for _, cost := range costs {
+					total += cost
+				}
+				mean := total / float64(len(costs))
+				cell := fmt.Sprintf("$%.2f (%d)", mean, len(costs))
+				rowCells = append(rowCells, cell)
+				if len(cell) > colW[idx+1] {
+					colW[idx+1] = len(cell)
+				}
+			}
+		}
+		dataRows = append(dataRows, matrixRow{cells: rowCells})
+	}
+
+	// Ensure header label widths are respected.
+	for idx, label := range headerCells {
+		if len(label) > colW[idx] {
+			colW[idx] = len(label)
+		}
+	}
+
+	gap := 2
+	printRow := func(cells []string) {
+		var sb strings.Builder
+		for idx, cell := range cells {
+			if idx > 0 {
+				sb.WriteString(strings.Repeat(" ", gap))
+			}
+			sb.WriteString(fmt.Sprintf("%-*s", colW[idx], cell))
+		}
+		fmt.Println(sb.String())
+	}
+
+	printRow(headerCells)
+	for _, dr := range dataRows {
+		printRow(dr.cells)
+	}
+
 	return nil
 }

--- a/cmd/soda/cost_test.go
+++ b/cmd/soda/cost_test.go
@@ -267,7 +267,7 @@ func TestRunCostByOutcome_RowOrder(t *testing.T) {
 		dataLines = append(dataLines, trimmed)
 	}
 
-	expectedOrder := []string{"CLEAN", "PATCHED", "REWORK_1", "REWORK_2+", "FAILED"}
+	expectedOrder := []string{"FIRST_PASS", "PATCHED", "REWORK_1", "REWORK_2+", "FAILED"}
 	if len(dataLines) != len(expectedOrder) {
 		t.Fatalf("expected %d data lines, got %d:\n%s", len(expectedOrder), len(dataLines), output)
 	}
@@ -358,8 +358,8 @@ func TestRunCostByOutcomeAndComplexity_MixedEntries(t *testing.T) {
 	}
 
 	// Check outcome rows.
-	if !strings.Contains(output, "CLEAN") {
-		t.Errorf("output missing CLEAN row:\n%s", output)
+	if !strings.Contains(output, "FIRST_PASS") {
+		t.Errorf("output missing FIRST_PASS row:\n%s", output)
 	}
 	if !strings.Contains(output, "REWORK_1") {
 		t.Errorf("output missing REWORK_1 row:\n%s", output)

--- a/cmd/soda/cost_test.go
+++ b/cmd/soda/cost_test.go
@@ -209,6 +209,171 @@ func TestRunCostByComplexity_UnknownBand(t *testing.T) {
 	}
 }
 
+func TestRunCostByOutcome_Empty(t *testing.T) {
+	output, err := captureStdout(t, func() error {
+		return runCostByOutcome(nil)
+	})
+	if err != nil {
+		t.Fatalf("runCostByOutcome error: %v", err)
+	}
+	if !strings.Contains(output, "No cost entries found") {
+		t.Errorf("expected 'No cost entries found', got: %s", output)
+	}
+}
+
+func TestRunCostByOutcome_Headers(t *testing.T) {
+	entries := []pipeline.CostEntry{
+		{Ticket: "T-1", Cost: 1.00, Success: true, DurationMs: 5000},
+	}
+
+	output, err := captureStdout(t, func() error {
+		return runCostByOutcome(entries)
+	})
+	if err != nil {
+		t.Fatalf("runCostByOutcome error: %v", err)
+	}
+
+	for _, header := range []string{"OUTCOME", "SESSIONS", "MEAN", "MEDIAN", "MEAN DUR", "TOTAL"} {
+		if !strings.Contains(output, header) {
+			t.Errorf("output missing %q header:\n%s", header, output)
+		}
+	}
+}
+
+func TestRunCostByOutcome_RowOrder(t *testing.T) {
+	entries := []pipeline.CostEntry{
+		{Ticket: "T-1", Cost: 1.00, Success: false},                                  // failed
+		{Ticket: "T-2", Cost: 2.00, Success: true},                                   // clean
+		{Ticket: "T-3", Cost: 3.00, Success: true, ReworkCycles: 1},                  // rework_1
+		{Ticket: "T-4", Cost: 4.00, Success: true, PatchCycles: 1},                   // patched
+		{Ticket: "T-5", Cost: 5.00, Success: true, ReworkCycles: 3, Escalated: true}, // rework_2+
+	}
+
+	output, err := captureStdout(t, func() error {
+		return runCostByOutcome(entries)
+	})
+	if err != nil {
+		t.Fatalf("runCostByOutcome error: %v", err)
+	}
+
+	// Extract non-header, non-footer data lines.
+	lines := strings.Split(output, "\n")
+	var dataLines []string
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "OUTCOME") || strings.HasPrefix(trimmed, "Total:") || strings.HasPrefix(trimmed, "Rework tax:") {
+			continue
+		}
+		dataLines = append(dataLines, trimmed)
+	}
+
+	expectedOrder := []string{"CLEAN", "PATCHED", "REWORK_1", "REWORK_2+", "FAILED"}
+	if len(dataLines) != len(expectedOrder) {
+		t.Fatalf("expected %d data lines, got %d:\n%s", len(expectedOrder), len(dataLines), output)
+	}
+	for idx, expected := range expectedOrder {
+		if !strings.HasPrefix(dataLines[idx], expected) {
+			t.Errorf("data line %d: expected prefix %q, got %q", idx, expected, dataLines[idx])
+		}
+	}
+}
+
+func TestRunCostByOutcome_ReworkTaxPresent(t *testing.T) {
+	entries := []pipeline.CostEntry{
+		{Ticket: "T-1", Cost: 2.00, Success: true},                  // clean
+		{Ticket: "T-2", Cost: 4.00, Success: true},                  // clean
+		{Ticket: "T-3", Cost: 6.00, Success: true, ReworkCycles: 1}, // rework_1
+	}
+
+	output, err := captureStdout(t, func() error {
+		return runCostByOutcome(entries)
+	})
+	if err != nil {
+		t.Fatalf("runCostByOutcome error: %v", err)
+	}
+
+	if !strings.Contains(output, "Rework tax:") {
+		t.Errorf("expected 'Rework tax:' line in output:\n%s", output)
+	}
+	// Clean mean = 3.00, rework mean = 6.00, tax = 100%
+	if !strings.Contains(output, "100%") {
+		t.Errorf("expected 100%% rework tax, got:\n%s", output)
+	}
+}
+
+func TestRunCostByOutcome_ReworkTaxAbsent(t *testing.T) {
+	entries := []pipeline.CostEntry{
+		{Ticket: "T-1", Cost: 2.00, Success: true}, // clean only
+		{Ticket: "T-2", Cost: 4.00, Success: true}, // clean only
+	}
+
+	output, err := captureStdout(t, func() error {
+		return runCostByOutcome(entries)
+	})
+	if err != nil {
+		t.Fatalf("runCostByOutcome error: %v", err)
+	}
+
+	if strings.Contains(output, "Rework tax:") {
+		t.Errorf("should not show rework tax when no rework entries exist:\n%s", output)
+	}
+}
+
+func TestRunCostByOutcomeAndComplexity_Empty(t *testing.T) {
+	output, err := captureStdout(t, func() error {
+		return runCostByOutcomeAndComplexity(nil)
+	})
+	if err != nil {
+		t.Fatalf("runCostByOutcomeAndComplexity error: %v", err)
+	}
+	if !strings.Contains(output, "No cost entries found") {
+		t.Errorf("expected 'No cost entries found', got: %s", output)
+	}
+}
+
+func TestRunCostByOutcomeAndComplexity_MixedEntries(t *testing.T) {
+	entries := []pipeline.CostEntry{
+		{Ticket: "T-1", Cost: 2.00, Success: true, Complexity: "low"},
+		{Ticket: "T-2", Cost: 4.00, Success: true, Complexity: "high"},
+		{Ticket: "T-3", Cost: 6.00, Success: true, ReworkCycles: 1, Complexity: "low"},
+		{Ticket: "T-4", Cost: 8.00, Success: false, Complexity: "high"},
+	}
+
+	output, err := captureStdout(t, func() error {
+		return runCostByOutcomeAndComplexity(entries)
+	})
+	if err != nil {
+		t.Fatalf("runCostByOutcomeAndComplexity error: %v", err)
+	}
+
+	// Check header has OUTCOME and complexity columns.
+	if !strings.Contains(output, "OUTCOME") {
+		t.Errorf("output missing OUTCOME header:\n%s", output)
+	}
+	if !strings.Contains(output, "LOW") {
+		t.Errorf("output missing LOW column:\n%s", output)
+	}
+	if !strings.Contains(output, "HIGH") {
+		t.Errorf("output missing HIGH column:\n%s", output)
+	}
+
+	// Check outcome rows.
+	if !strings.Contains(output, "CLEAN") {
+		t.Errorf("output missing CLEAN row:\n%s", output)
+	}
+	if !strings.Contains(output, "REWORK_1") {
+		t.Errorf("output missing REWORK_1 row:\n%s", output)
+	}
+	if !strings.Contains(output, "FAILED") {
+		t.Errorf("output missing FAILED row:\n%s", output)
+	}
+
+	// Absent cells should have "—".
+	if !strings.Contains(output, "—") {
+		t.Errorf("expected dash (—) for absent cells:\n%s", output)
+	}
+}
+
 func TestRunCostByComplexity_BandOrdering(t *testing.T) {
 	entries := []pipeline.CostEntry{
 		{Ticket: "T-1", Cost: 1.00, Complexity: "high"},

--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -486,11 +486,15 @@ func runPipeline(cfg *config.Config, opts pipelineOpts) error {
 	// Errors are non-fatal — a ledger write failure must not mask the pipeline result,
 	// but we emit a warning to stderr so users can diagnose issues (e.g. permission denied).
 	if ledgerErr := pipeline.AppendCostEntry(stateDir, pipeline.CostEntry{
-		Ticket:     ticketKey,
-		Timestamp:  time.Now(),
-		Cost:       state.Meta().TotalCost - costBefore,
-		Success:    runErr == nil,
-		Complexity: state.Meta().Complexity,
+		Ticket:       ticketKey,
+		Timestamp:    time.Now(),
+		Cost:         state.Meta().TotalCost - costBefore,
+		Success:      runErr == nil,
+		Complexity:   state.Meta().Complexity,
+		ReworkCycles: state.Meta().ReworkCycles,
+		PatchCycles:  state.Meta().PatchCycles,
+		Escalated:    state.Meta().EscalatedFromPatch,
+		DurationMs:   time.Since(startTime).Milliseconds(),
 	}); ledgerErr != nil {
 		fmt.Fprintf(os.Stderr, "Warning: failed to record cost entry: %v\n", ledgerErr)
 	}

--- a/internal/pipeline/ledger.go
+++ b/internal/pipeline/ledger.go
@@ -12,11 +12,15 @@ import (
 
 // CostEntry records the cost of a single pipeline run in the persistent ledger.
 type CostEntry struct {
-	Ticket     string    `json:"ticket"`
-	Timestamp  time.Time `json:"timestamp"`
-	Cost       float64   `json:"cost"`
-	Success    bool      `json:"success"`
-	Complexity string    `json:"complexity,omitempty"`
+	Ticket       string    `json:"ticket"`
+	Timestamp    time.Time `json:"timestamp"`
+	Cost         float64   `json:"cost"`
+	Success      bool      `json:"success"`
+	Complexity   string    `json:"complexity,omitempty"`
+	ReworkCycles int       `json:"rework_cycles,omitempty"`
+	PatchCycles  int       `json:"patch_cycles,omitempty"`
+	Escalated    bool      `json:"escalated,omitempty"`
+	DurationMs   int64     `json:"duration_ms,omitempty"`
 }
 
 // costLedgerFile is the filename of the cost ledger within the state directory.
@@ -183,6 +187,105 @@ func CostByComplexity(entries []CostEntry) map[string]ComplexityStats {
 			Mean:     mean,
 			Median:   median,
 			Total:    total,
+		}
+	}
+	return result
+}
+
+// OutcomeStats holds aggregated cost and duration statistics for a single
+// pipeline outcome bucket (e.g. "clean", "patched", "rework_1").
+type OutcomeStats struct {
+	Sessions  int
+	Mean      float64
+	Median    float64
+	Total     float64
+	MeanDurMs int64
+}
+
+// ClassifyOutcome assigns a pipeline outcome label using a 5-level precedence:
+//
+//  1. !Success              → "failed"
+//  2. ReworkCycles ≥ 2      → "rework_2+"
+//  3. ReworkCycles == 1 OR Escalated with ReworkCycles == 0 → "rework_1"
+//  4. PatchCycles > 0       → "patched"
+//  5. otherwise             → "clean"
+//
+// Escalation with zero rework cycles is treated as a minimum of one rework
+// cycle because the patch-to-rework escalation itself constitutes a rework.
+func ClassifyOutcome(entry CostEntry) string {
+	if !entry.Success {
+		return "failed"
+	}
+	rework := entry.ReworkCycles
+	if entry.Escalated && rework == 0 {
+		rework = 1
+	}
+	switch {
+	case rework >= 2:
+		return "rework_2+"
+	case rework == 1:
+		return "rework_1"
+	case entry.PatchCycles > 0:
+		return "patched"
+	default:
+		return "clean"
+	}
+}
+
+// CostByOutcome groups cost entries by their classified outcome and returns
+// aggregated statistics per outcome bucket. The median uses "lower-median"
+// semantics: sorted[n/2-1] for even n, sorted[n/2] for odd n. This is
+// intentionally different from CostByComplexity's interpolated median.
+func CostByOutcome(entries []CostEntry) map[string]OutcomeStats {
+	type bucket struct {
+		costs       []float64
+		durationsMs []int64
+	}
+	grouped := make(map[string]*bucket)
+	for _, entry := range entries {
+		outcome := ClassifyOutcome(entry)
+		bkt, ok := grouped[outcome]
+		if !ok {
+			bkt = &bucket{}
+			grouped[outcome] = bkt
+		}
+		bkt.costs = append(bkt.costs, entry.Cost)
+		bkt.durationsMs = append(bkt.durationsMs, entry.DurationMs)
+	}
+
+	result := make(map[string]OutcomeStats, len(grouped))
+	for outcome, bkt := range grouped {
+		var totalCost float64
+		for _, cost := range bkt.costs {
+			totalCost += cost
+		}
+		mean := totalCost / float64(len(bkt.costs))
+
+		sorted := make([]float64, len(bkt.costs))
+		copy(sorted, bkt.costs)
+		sort.Float64s(sorted)
+
+		// Lower-median: sorted[n/2-1] for even n, sorted[n/2] for odd n.
+		var median float64
+		n := len(sorted)
+		if n%2 == 0 {
+			median = sorted[n/2-1]
+		} else {
+			median = sorted[n/2]
+		}
+
+		var totalDurMs int64
+		for _, dur := range bkt.durationsMs {
+			totalDurMs += dur
+		}
+		meanDurMs := totalDurMs / int64(len(bkt.durationsMs))
+
+		result[outcome] = OutcomeStats{
+			Sessions:  len(bkt.costs),
+			Mean:      mean,
+			Median:    median,
+			Total:     totalCost,
+			MeanDurMs: meanDurMs,
 		}
 	}
 	return result

--- a/internal/pipeline/ledger.go
+++ b/internal/pipeline/ledger.go
@@ -193,7 +193,7 @@ func CostByComplexity(entries []CostEntry) map[string]ComplexityStats {
 }
 
 // OutcomeStats holds aggregated cost and duration statistics for a single
-// pipeline outcome bucket (e.g. "clean", "patched", "rework_1").
+// pipeline outcome bucket (e.g. "first_pass", "patched", "rework_1").
 type OutcomeStats struct {
 	Sessions  int
 	Mean      float64
@@ -208,7 +208,7 @@ type OutcomeStats struct {
 //  2. ReworkCycles ≥ 2      → "rework_2+"
 //  3. ReworkCycles == 1 OR Escalated with ReworkCycles == 0 → "rework_1"
 //  4. PatchCycles > 0       → "patched"
-//  5. otherwise             → "clean"
+//  5. otherwise             → "first_pass"
 //
 // Escalation with zero rework cycles is treated as a minimum of one rework
 // cycle because the patch-to-rework escalation itself constitutes a rework.
@@ -228,7 +228,7 @@ func ClassifyOutcome(entry CostEntry) string {
 	case entry.PatchCycles > 0:
 		return "patched"
 	default:
-		return "clean"
+		return "first_pass"
 	}
 }
 

--- a/internal/pipeline/ledger_test.go
+++ b/internal/pipeline/ledger_test.go
@@ -471,7 +471,7 @@ func TestClassifyOutcome(t *testing.T) {
 		{
 			name:     "clean run",
 			entry:    CostEntry{Success: true},
-			expected: "clean",
+			expected: "first_pass",
 		},
 		{
 			name:     "patched only",
@@ -541,9 +541,9 @@ func TestCostByOutcome_Grouping(t *testing.T) {
 	}
 	result := CostByOutcome(entries)
 
-	clean, ok := result["clean"]
+	clean, ok := result["first_pass"]
 	if !ok {
-		t.Fatal("missing 'clean' outcome")
+		t.Fatal("missing 'first_pass' outcome")
 	}
 	if clean.Sessions != 2 {
 		t.Errorf("clean.Sessions = %d, want 2", clean.Sessions)
@@ -584,7 +584,7 @@ func TestCostByOutcome_LowerMedianEven(t *testing.T) {
 		{Ticket: "T-4", Cost: 7.00, Success: true},
 	}
 	result := CostByOutcome(entries)
-	clean := result["clean"]
+	clean := result["first_pass"]
 	// Sorted: 1,3,5,7 → lower-median = sorted[4/2-1] = sorted[1] = 3
 	if clean.Median != 3.00 {
 		t.Errorf("clean.Median = %f, want 3.00 (lower-median)", clean.Median)
@@ -599,7 +599,7 @@ func TestCostByOutcome_LowerMedianOdd(t *testing.T) {
 		{Ticket: "T-3", Cost: 3.00, Success: true},
 	}
 	result := CostByOutcome(entries)
-	clean := result["clean"]
+	clean := result["first_pass"]
 	// Sorted: 1,3,5 → lower-median = sorted[3/2] = sorted[1] = 3
 	if clean.Median != 3.00 {
 		t.Errorf("clean.Median = %f, want 3.00 (lower-median)", clean.Median)
@@ -613,7 +613,7 @@ func TestCostByOutcome_MeanDuration(t *testing.T) {
 		{Ticket: "T-3", Cost: 3.00, Success: true, DurationMs: 5000},
 	}
 	result := CostByOutcome(entries)
-	clean := result["clean"]
+	clean := result["first_pass"]
 	// Mean duration: (1000 + 3000 + 5000) / 3 = 3000
 	if clean.MeanDurMs != 3000 {
 		t.Errorf("clean.MeanDurMs = %d, want 3000", clean.MeanDurMs)

--- a/internal/pipeline/ledger_test.go
+++ b/internal/pipeline/ledger_test.go
@@ -462,6 +462,228 @@ func TestCostEntryComplexityRoundTrip(t *testing.T) {
 	}
 }
 
+func TestClassifyOutcome(t *testing.T) {
+	tests := []struct {
+		name     string
+		entry    CostEntry
+		expected string
+	}{
+		{
+			name:     "clean run",
+			entry:    CostEntry{Success: true},
+			expected: "clean",
+		},
+		{
+			name:     "patched only",
+			entry:    CostEntry{Success: true, PatchCycles: 2},
+			expected: "patched",
+		},
+		{
+			name:     "single rework cycle",
+			entry:    CostEntry{Success: true, ReworkCycles: 1},
+			expected: "rework_1",
+		},
+		{
+			name:     "multiple rework cycles",
+			entry:    CostEntry{Success: true, ReworkCycles: 3},
+			expected: "rework_2+",
+		},
+		{
+			name:     "failed run overrides everything",
+			entry:    CostEntry{Success: false, ReworkCycles: 5, PatchCycles: 3, Escalated: true},
+			expected: "failed",
+		},
+		{
+			name:     "escalated with zero rework becomes rework_1",
+			entry:    CostEntry{Success: true, Escalated: true, ReworkCycles: 0},
+			expected: "rework_1",
+		},
+		{
+			name:     "escalated with rework>=2 becomes rework_2+",
+			entry:    CostEntry{Success: true, Escalated: true, ReworkCycles: 2},
+			expected: "rework_2+",
+		},
+		{
+			name:     "rework overrides patch",
+			entry:    CostEntry{Success: true, ReworkCycles: 1, PatchCycles: 3},
+			expected: "rework_1",
+		},
+		{
+			name:     "failed with zero cycles",
+			entry:    CostEntry{Success: false},
+			expected: "failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ClassifyOutcome(tt.entry)
+			if got != tt.expected {
+				t.Errorf("ClassifyOutcome(%+v) = %q, want %q", tt.entry, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCostByOutcome_Empty(t *testing.T) {
+	result := CostByOutcome(nil)
+	if len(result) != 0 {
+		t.Errorf("expected empty map, got %v", result)
+	}
+}
+
+func TestCostByOutcome_Grouping(t *testing.T) {
+	entries := []CostEntry{
+		{Ticket: "T-1", Cost: 2.00, Success: true, DurationMs: 1000},
+		{Ticket: "T-2", Cost: 4.00, Success: true, DurationMs: 3000},
+		{Ticket: "T-3", Cost: 10.00, Success: true, ReworkCycles: 1, DurationMs: 5000},
+		{Ticket: "T-4", Cost: 6.00, Success: false, DurationMs: 2000},
+	}
+	result := CostByOutcome(entries)
+
+	clean, ok := result["clean"]
+	if !ok {
+		t.Fatal("missing 'clean' outcome")
+	}
+	if clean.Sessions != 2 {
+		t.Errorf("clean.Sessions = %d, want 2", clean.Sessions)
+	}
+	if clean.Mean != 3.00 {
+		t.Errorf("clean.Mean = %f, want 3.00", clean.Mean)
+	}
+	if clean.Total != 6.00 {
+		t.Errorf("clean.Total = %f, want 6.00", clean.Total)
+	}
+	if clean.MeanDurMs != 2000 {
+		t.Errorf("clean.MeanDurMs = %d, want 2000", clean.MeanDurMs)
+	}
+
+	rework1, ok := result["rework_1"]
+	if !ok {
+		t.Fatal("missing 'rework_1' outcome")
+	}
+	if rework1.Sessions != 1 {
+		t.Errorf("rework_1.Sessions = %d, want 1", rework1.Sessions)
+	}
+
+	failed, ok := result["failed"]
+	if !ok {
+		t.Fatal("missing 'failed' outcome")
+	}
+	if failed.Sessions != 1 {
+		t.Errorf("failed.Sessions = %d, want 1", failed.Sessions)
+	}
+}
+
+func TestCostByOutcome_LowerMedianEven(t *testing.T) {
+	// Even number of entries: lower-median = sorted[n/2-1]
+	entries := []CostEntry{
+		{Ticket: "T-1", Cost: 1.00, Success: true},
+		{Ticket: "T-2", Cost: 3.00, Success: true},
+		{Ticket: "T-3", Cost: 5.00, Success: true},
+		{Ticket: "T-4", Cost: 7.00, Success: true},
+	}
+	result := CostByOutcome(entries)
+	clean := result["clean"]
+	// Sorted: 1,3,5,7 → lower-median = sorted[4/2-1] = sorted[1] = 3
+	if clean.Median != 3.00 {
+		t.Errorf("clean.Median = %f, want 3.00 (lower-median)", clean.Median)
+	}
+}
+
+func TestCostByOutcome_LowerMedianOdd(t *testing.T) {
+	// Odd number of entries: lower-median = sorted[n/2]
+	entries := []CostEntry{
+		{Ticket: "T-1", Cost: 1.00, Success: true},
+		{Ticket: "T-2", Cost: 5.00, Success: true},
+		{Ticket: "T-3", Cost: 3.00, Success: true},
+	}
+	result := CostByOutcome(entries)
+	clean := result["clean"]
+	// Sorted: 1,3,5 → lower-median = sorted[3/2] = sorted[1] = 3
+	if clean.Median != 3.00 {
+		t.Errorf("clean.Median = %f, want 3.00 (lower-median)", clean.Median)
+	}
+}
+
+func TestCostByOutcome_MeanDuration(t *testing.T) {
+	entries := []CostEntry{
+		{Ticket: "T-1", Cost: 1.00, Success: true, DurationMs: 1000},
+		{Ticket: "T-2", Cost: 2.00, Success: true, DurationMs: 3000},
+		{Ticket: "T-3", Cost: 3.00, Success: true, DurationMs: 5000},
+	}
+	result := CostByOutcome(entries)
+	clean := result["clean"]
+	// Mean duration: (1000 + 3000 + 5000) / 3 = 3000
+	if clean.MeanDurMs != 3000 {
+		t.Errorf("clean.MeanDurMs = %d, want 3000", clean.MeanDurMs)
+	}
+}
+
+func TestCostEntryOutcomeFieldsRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+
+	entry := CostEntry{
+		Ticket:       "T-1",
+		Timestamp:    time.Now().Truncate(time.Second),
+		Cost:         5.00,
+		Success:      true,
+		ReworkCycles: 2,
+		PatchCycles:  1,
+		Escalated:    true,
+		DurationMs:   45000,
+	}
+	if err := AppendCostEntry(dir, entry); err != nil {
+		t.Fatalf("AppendCostEntry: %v", err)
+	}
+
+	entries, err := ReadCostLedger(dir)
+	if err != nil {
+		t.Fatalf("ReadCostLedger: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("len(entries) = %d, want 1", len(entries))
+	}
+	got := entries[0]
+	if got.ReworkCycles != 2 {
+		t.Errorf("ReworkCycles = %d, want 2", got.ReworkCycles)
+	}
+	if got.PatchCycles != 1 {
+		t.Errorf("PatchCycles = %d, want 1", got.PatchCycles)
+	}
+	if !got.Escalated {
+		t.Error("Escalated = false, want true")
+	}
+	if got.DurationMs != 45000 {
+		t.Errorf("DurationMs = %d, want 45000", got.DurationMs)
+	}
+}
+
+func TestCostEntryOutcomeFieldsOmitEmpty(t *testing.T) {
+	dir := t.TempDir()
+
+	entry := CostEntry{
+		Ticket:    "T-1",
+		Timestamp: time.Now().Truncate(time.Second),
+		Cost:      5.00,
+		Success:   true,
+	}
+	if err := AppendCostEntry(dir, entry); err != nil {
+		t.Fatalf("AppendCostEntry: %v", err)
+	}
+
+	data, err := os.ReadFile(CostLedgerPath(dir))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	raw := string(data)
+	for _, field := range []string{"rework_cycles", "patch_cycles", "escalated", "duration_ms"} {
+		if strings.Contains(raw, field) {
+			t.Errorf("cost.json should omit %q when zero/false, got:\n%s", field, raw)
+		}
+	}
+}
+
 func TestCostEntryComplexityOmitEmpty(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
## Summary

Implements `soda cost --outcomes` which breaks down pipeline cost by outcome category, giving visibility into the rework tax imposed by failed or repeated pipeline runs.

### Changes

**Ledger enrichment (`ledger.go`)**
- `CostEntry` gains four new fields: `ReworkCycles`, `PatchCycles`, `Escalated`, `DurationMs`
- `ClassifyOutcome()` maps these fields to one of five outcome categories using precedence rules: `failed > rework_2+ > rework_1 > patched > first_pass`
- `CostByOutcome()` aggregates `OutcomeStats` (sessions, total tokens, mean, lower-median) per category
- Fields are populated at ledger write on pipeline completion

**CLI flag (`cost.go`)**
- `--outcomes` flag added to `soda cost`
- `runCostByOutcome()` renders a table with sessions, mean, lower-median, total, and mean duration per category
- Rework tax line printed as `(rework_mean - first_pass_mean) / first_pass_mean * 100`
- `--outcomes` and `--by-complexity` flags are combinable

**Backward compatibility**
- Old entries with all zero fields classify as `first_pass` or `failed` correctly
- Mid-run sessions are excluded by design (no ledger write until completion)

### Test Plan

All tests pass via `CGO_ENABLED=0 go test ./...`.

New tests cover:
- `TestClassifyOutcome` — all five outcome states + backward-compat zero values
- `TestCostByOutcome_*` — aggregation, median calculation, escalation → rework
- `TestRunCostByOutcome` / `TestRunCostByOutcomeAndComplexity` — CLI table rendering and rework tax line

## Acceptance Criteria

- [x] `CostEntry` enriched with `ReworkCycles`, `PatchCycles`, `Escalated`, `DurationMs`
- [x] Fields populated at ledger write on pipeline completion
- [x] `soda cost --outcomes` implemented
- [x] Precedence: `failed > rework_2+ > rework_1 > patched > first_pass`
- [x] `EscalatedFromPatch` → rework classification
- [x] Sessions, mean, lower-median, total, mean duration per category
- [x] Rework tax line printed with correct formula
- [x] Backward compat: old zero-field entries → `first_pass`/`failed`
- [x] Mid-run sessions excluded (implicit, by design)
- [x] Combinable with `--by-complexity`
- [x] Tests covering all states, classification, and median

Assisted-by: SODA
