### PR TITLE
feat(prompts): improve context recall and faithfulness in triage and implement

### DIFF
--- a/cmd/soda/embeds/prompts/implement.md
+++ b/cmd/soda/embeds/prompts/implement.md
@@ -181,19 +181,27 @@ Base: {{.BaseBranch}}
 
 ## Your Task
 
+**Before writing any code:** read the files listed under Priority Files and at
+least one existing file in each package you will touch. Your implementation must
+match their style exactly — error handling patterns, naming conventions, struct
+layout, test structure. Do not introduce new patterns when existing ones serve
+the same purpose.
+
 Implement each task from the plan, in dependency order. For each task:
 
 1. **Read the relevant files** to understand current state.
 2. **Make the changes** described in the task.
-3. **Follow repo conventions** — formatting, naming, patterns.
-4. **Write or update tests** as specified in the plan.
+3. **Match existing patterns** — use the same error wrapping, naming, and
+   interface conventions as the surrounding code.
+4. **Follow repo conventions** — formatting, naming, patterns.
+5. **Write or update tests** as specified in the plan.
 {{- if .Config.Formatter}}
-5. **Run the formatter** if configured: `{{.Config.Formatter}}`
+6. **Run the formatter** if configured: `{{.Config.Formatter}}`
 {{- end}}
 {{- if .Config.TestCommand}}
-6. **Run the tests** if configured: `{{.Config.TestCommand}}`
+7. **Run the tests** if configured: `{{.Config.TestCommand}}`
 {{- end}}
-7. **Commit** with a descriptive message referencing the ticket key.
+8. **Commit** with a descriptive message referencing the ticket key.
 
 After all tasks are complete:
 

--- a/cmd/soda/embeds/prompts/triage.md
+++ b/cmd/soda/embeds/prompts/triage.md
@@ -48,7 +48,11 @@ Assess this ticket and produce a structured classification:
 
 1. **Identify the target repo** — which repository should this change land in? If unclear, flag it.
 2. **Identify the code area** — which packages, modules, or directories are likely affected.
-3. **List candidate files** — specific files that will likely need changes. Read the codebase to verify.
+3. **List candidate files** — be thorough. Include:
+   - Files that will **change** (direct modifications)
+   - Files that must be **read for context** (callers, interfaces, tests, related implementations)
+   - Files in the same package that establish patterns the implementation must follow
+   Err on the side of more files rather than fewer — a missed file in triage means implement works blind.
 4. **Assess complexity** — one of `low`, `medium`, or `high`:
    - `low`: 1-3 files, single concern, no architectural decisions
    - `medium`: 4-10 files, clear feature, may touch tests


### PR DESCRIPTION
## Summary

Motivated by raki v0.6.0 judge metrics (n=6): `context_recall=0.70` and `faithfulness=0.34`.

**Triage prompt** — expand `relevant_files` to include files needed for context (callers, interfaces, existing pattern examples), not just files that will change. Addresses the 30% of needed context that was missing from implement sessions because triage under-reported the read surface.

**Implement prompt** — add an explicit pre-task instruction to read priority files and match existing patterns *before* writing any code. Addresses the agent retrieving context but then diverging from existing conventions when producing new code.

## Expected impact

- `context_recall` ↑ (more relevant files surfaced by triage → injected into implement)
- `faithfulness` ↑ (explicit pattern-matching instruction before coding)

Measure with `raki run --judge` after 5+ sessions on this build.

## Test plan

- [ ] `soda run --dry-run` on a ticket to verify prompts render correctly
- [ ] Run raki after next batch of sessions to measure impact


💘 Generated with Crush