### PR TITLE
[548] Fix implement agent short-circuit on prior timed-out attempt

### DIFF
--- a/cmd/soda/embeds/prompts/implement.md
+++ b/cmd/soda/embeds/prompts/implement.md
@@ -212,6 +212,14 @@ After all tasks are complete:
 
 Do NOT skip tasks. Do NOT combine tasks into a single commit.
 If a task cannot be completed, explain why and move to the next.
+
+**IMPORTANT — Commit verification:** Before reporting your results, run
+`git log {{.BaseBranch}}..HEAD` and verify that your commits actually appear.
+Every commit hash you report **must** exist in the output of that command.
+If the worktree already contains files from a prior timed-out attempt, run
+`git status` to assess the state, make any necessary changes, and create fresh
+commits — do not report stale or nonexistent hashes. The pipeline will reject
+your output if reported commits do not match actual git history.
 {{- if .ReworkFeedback}}
 
 **IMPORTANT — Rework cycle:** You are re-running because reviewers or verification

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -195,6 +196,22 @@ func DeleteRemoteBranch(ctx context.Context, repoDir, remote, branch string) err
 		return fmt.Errorf("git: delete remote branch %s/%s: %s: %w", remote, branch, strings.TrimSpace(outStr), err)
 	}
 	return nil
+}
+
+// CommitsAheadOfBase returns the number of commits on HEAD that are not
+// reachable from the given base ref. Uses "git rev-list --count base..HEAD".
+func CommitsAheadOfBase(ctx context.Context, dir, base string) (int, error) {
+	cmd := exec.CommandContext(ctx, "git", "rev-list", "--count", base+"..HEAD")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		return 0, fmt.Errorf("git: rev-list --count %s..HEAD: %w", base, err)
+	}
+	count, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil {
+		return 0, fmt.Errorf("git: parse rev-list count: %w", err)
+	}
+	return count, nil
 }
 
 // Diff returns the output of "git diff <base>...HEAD" for the given

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -512,6 +513,64 @@ func TestRebase(t *testing.T) {
 		}
 		if string(content) != "feature version" {
 			t.Errorf("shared.txt = %q, want %q (should be restored after abort)", string(content), "feature version")
+		}
+	})
+}
+
+func TestCommitsAheadOfBase(t *testing.T) {
+	t.Run("zero_commits_ahead", func(t *testing.T) {
+		repoDir := initGitRepo(t)
+
+		count, err := CommitsAheadOfBase(context.Background(), repoDir, "main")
+		if err != nil {
+			t.Fatalf("CommitsAheadOfBase: %v", err)
+		}
+		if count != 0 {
+			t.Errorf("CommitsAheadOfBase = %d, want 0", count)
+		}
+	})
+
+	t.Run("one_commit_ahead", func(t *testing.T) {
+		repoDir := initGitRepo(t)
+
+		run(t, repoDir, "git", "checkout", "-b", "feat/ahead")
+		writeFile(t, repoDir, "new.txt", "content")
+		run(t, repoDir, "git", "add", "new.txt")
+		run(t, repoDir, "git", "commit", "-m", "add new file")
+
+		count, err := CommitsAheadOfBase(context.Background(), repoDir, "main")
+		if err != nil {
+			t.Fatalf("CommitsAheadOfBase: %v", err)
+		}
+		if count != 1 {
+			t.Errorf("CommitsAheadOfBase = %d, want 1", count)
+		}
+	})
+
+	t.Run("multiple_commits_ahead", func(t *testing.T) {
+		repoDir := initGitRepo(t)
+
+		run(t, repoDir, "git", "checkout", "-b", "feat/multi")
+		for idx := 0; idx < 3; idx++ {
+			writeFile(t, repoDir, fmt.Sprintf("file%d.txt", idx), "content")
+			run(t, repoDir, "git", "add", ".")
+			run(t, repoDir, "git", "commit", "-m", fmt.Sprintf("commit %d", idx))
+		}
+
+		count, err := CommitsAheadOfBase(context.Background(), repoDir, "main")
+		if err != nil {
+			t.Fatalf("CommitsAheadOfBase: %v", err)
+		}
+		if count != 3 {
+			t.Errorf("CommitsAheadOfBase = %d, want 3", count)
+		}
+	})
+
+	t.Run("errors_outside_git_repo", func(t *testing.T) {
+		dir := t.TempDir()
+		_, err := CommitsAheadOfBase(context.Background(), dir, "main")
+		if err == nil {
+			t.Fatal("expected error outside git repo")
 		}
 	})
 }

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -445,7 +445,7 @@ func (e *Engine) executePhases(ctx context.Context, phases []PhaseConfig, forceF
 
 			skipCheck := !(forceFirst && idx == 0)
 			if skipCheck && e.shouldSkip(phase) {
-				if err := e.gatePhase(phase); err != nil {
+				if err := e.gatePhase(ctx, phase); err != nil {
 					// Handle rework signal on skipped phases — can occur on
 					// Run() re-entry when a prior rework crashed mid-cycle.
 					var reworkSig *reworkSignal
@@ -930,7 +930,7 @@ func (e *Engine) runPhase(ctx context.Context, phase PhaseConfig) error {
 	})
 
 	// Domain gating.
-	if err := e.gatePhase(phase); err != nil {
+	if err := e.gatePhase(ctx, phase); err != nil {
 		var gateErr *PhaseGateError
 		if errors.As(err, &gateErr) {
 			_ = e.state.SetFailureCategory(phase.Name, "gate")

--- a/internal/pipeline/events.go
+++ b/internal/pipeline/events.go
@@ -90,6 +90,7 @@ const (
 	EventSchemaVersionMismatch    = "schema_version_mismatch"
 	EventAPISemaphoreWait         = "api_semaphore_wait"
 	EventImplementNoChanges       = "implement_no_changes"
+	EventImplementCommitMismatch  = "implement_commit_mismatch"
 	EventTokenBudgetWarning       = "token_budget_warning"
 	EventTokenBudgetCalibration   = "token_budget_calibration"
 	EventNotifySuccess            = "notify_success"

--- a/internal/pipeline/guardrails.go
+++ b/internal/pipeline/guardrails.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -97,7 +98,7 @@ func (e *Engine) checkPhaseBudget(phase PhaseConfig) error {
 }
 
 // gatePhase checks domain-specific rules after a phase completes.
-func (e *Engine) gatePhase(phase PhaseConfig) error {
+func (e *Engine) gatePhase(ctx context.Context, phase PhaseConfig) error {
 	raw, err := e.state.ReadResult(phase.Name)
 	if err != nil {
 		// No result means no gating rules apply.

--- a/internal/pipeline/guardrails.go
+++ b/internal/pipeline/guardrails.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+
+	"github.com/decko/soda/internal/git"
 )
 
 // checkBudget verifies the pipeline has budget remaining before running a phase.
@@ -197,6 +199,34 @@ func (e *Engine) gatePhase(ctx context.Context, phase PhaseConfig) error {
 				}
 			}
 		}
+		// Fake-commit detection: when the LLM reports commits in its JSON
+		// output but no actual commits exist ahead of the base branch, the
+		// hashes are fabricated. Gate with a clear error so the pipeline
+		// does not silently proceed with phantom work.
+		if len(result.Commits) > 0 {
+			baseBranch := e.config.BaseBranch
+			if baseBranch == "" {
+				baseBranch = "main"
+			}
+			ahead, gitErr := git.CommitsAheadOfBase(ctx, e.workDir(phase), baseBranch)
+			if gitErr == nil && ahead == 0 {
+				e.emit(Event{
+					Phase: phase.Name,
+					Kind:  EventImplementCommitMismatch,
+					Data: map[string]any{
+						"reported_commits": len(result.Commits),
+						"actual_ahead":     ahead,
+					},
+				})
+				return &PhaseGateError{
+					Phase:  phase.Name,
+					Reason: "implement reported commits but none exist ahead of base branch — likely fabricated",
+				}
+			}
+			// If the git call errors (e.g., non-git workDir, missing base ref),
+			// silently proceed to avoid false positives.
+		}
+
 		// Proceed to verify regardless — verify will catch test failures.
 
 	case "verify":

--- a/internal/pipeline/guardrails_test.go
+++ b/internal/pipeline/guardrails_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -2651,6 +2654,178 @@ func TestEngine_ImplementNoChanges_CommitsOnlyAllowed(t *testing.T) {
 
 	if err := engine2.Resume(context.Background(), "implement"); err != nil {
 		t.Fatalf("rework with commits-only should succeed, got: %v", err)
+	}
+}
+
+func TestEngine_ImplementCommitMismatch_GateFires(t *testing.T) {
+	// When implement reports commits but no actual commits exist ahead of the
+	// base branch (0 commits ahead), the gate should fire with a PhaseGateError
+	// and emit EventImplementCommitMismatch.
+	phases := []PhaseConfig{
+		{
+			Name:   "implement",
+			Prompt: "implement.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"implement": {{
+				result: &runner.RunResult{
+					Output: json.RawMessage(`{
+						"tests_passed": true,
+						"ticket_key": "TEST-1",
+						"branch": "soda/TEST-1",
+						"commits": [{"hash": "abc123", "message": "fake commit", "task_id": "T1"}],
+						"files_changed": [{"path": "handler.go", "action": "modified"}],
+						"task_results": [{"task_id": "T1", "status": "completed"}]
+					}`),
+					RawText: "Implementation done",
+					CostUSD: 0.50,
+				},
+			}},
+		},
+	}
+
+	var events []Event
+	engine, _ := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+		// Use a real git repo as workDir so CommitsAheadOfBase succeeds.
+		gitDir := t.TempDir()
+		initGitRepo(t, gitDir)
+		cfg.WorkDir = gitDir
+		cfg.BaseBranch = "main"
+		cfg.OnEvent = func(ev Event) {
+			events = append(events, ev)
+		}
+	})
+
+	err := engine.Run(context.Background())
+	if err == nil {
+		t.Fatal("expected PhaseGateError for commit mismatch")
+	}
+
+	var gateErr *PhaseGateError
+	if !errors.As(err, &gateErr) {
+		t.Fatalf("expected PhaseGateError, got: %v", err)
+	}
+	if gateErr.Phase != "implement" {
+		t.Errorf("gate error phase = %q, want %q", gateErr.Phase, "implement")
+	}
+	if !strings.Contains(gateErr.Reason, "fabricated") {
+		t.Errorf("gate error reason should mention fabricated, got: %q", gateErr.Reason)
+	}
+
+	hasMismatchEvent := false
+	for _, ev := range events {
+		if ev.Kind == EventImplementCommitMismatch {
+			hasMismatchEvent = true
+			if ev.Phase != "implement" {
+				t.Errorf("mismatch event phase = %q, want %q", ev.Phase, "implement")
+			}
+		}
+	}
+	if !hasMismatchEvent {
+		t.Error("EventImplementCommitMismatch event not emitted")
+	}
+}
+
+func TestEngine_ImplementCommitMismatch_RealCommitsPass(t *testing.T) {
+	// When implement reports commits and actual commits exist ahead of the
+	// base branch (1+ commits ahead), the gate should NOT fire.
+	phases := []PhaseConfig{
+		{
+			Name:   "implement",
+			Prompt: "implement.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+	}
+
+	gitDir := t.TempDir()
+	initGitRepo(t, gitDir)
+
+	// Create a branch with a real commit ahead of main.
+	runGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = gitDir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v: %s: %v", args, out, err)
+		}
+	}
+	runGit("git", "checkout", "-b", "soda/TEST-1")
+	if err := os.WriteFile(filepath.Join(gitDir, "new.go"), []byte("package main\n"), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	runGit("git", "add", "new.go")
+	runGit("git", "commit", "-m", "feat: real commit")
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"implement": {{
+				result: &runner.RunResult{
+					Output: json.RawMessage(`{
+						"tests_passed": true,
+						"ticket_key": "TEST-1",
+						"branch": "soda/TEST-1",
+						"commits": [{"hash": "abc123", "message": "feat: real commit", "task_id": "T1"}],
+						"files_changed": [{"path": "new.go", "action": "created"}],
+						"task_results": [{"task_id": "T1", "status": "completed"}]
+					}`),
+					RawText: "Implementation done",
+					CostUSD: 0.50,
+				},
+			}},
+		},
+	}
+
+	engine, _ := setupEngine(t, phases, mock, func(cfg *EngineConfig) {
+		cfg.WorkDir = gitDir
+		cfg.BaseBranch = "main"
+	})
+
+	err := engine.Run(context.Background())
+	if err != nil {
+		t.Fatalf("expected no error when real commits exist, got: %v", err)
+	}
+}
+
+func TestEngine_ImplementCommitMismatch_NonGitWorkDir(t *testing.T) {
+	// When the workDir is not a git repo, CommitsAheadOfBase returns an error
+	// and the gate should gracefully pass (no false positives).
+	phases := []PhaseConfig{
+		{
+			Name:   "implement",
+			Prompt: "implement.md",
+			Retry:  RetryConfig{Transient: 1, Parse: 1, Semantic: 1},
+		},
+	}
+
+	mock := &flexMockRunner{
+		responses: map[string][]flexResponse{
+			"implement": {{
+				result: &runner.RunResult{
+					Output: json.RawMessage(`{
+						"tests_passed": true,
+						"ticket_key": "TEST-1",
+						"branch": "soda/TEST-1",
+						"commits": [{"hash": "abc123", "message": "some commit", "task_id": "T1"}],
+						"files_changed": [{"path": "handler.go", "action": "modified"}],
+						"task_results": [{"task_id": "T1", "status": "completed"}]
+					}`),
+					RawText: "Implementation done",
+					CostUSD: 0.50,
+				},
+			}},
+		},
+	}
+
+	// WorkDir defaults to a plain temp dir (not a git repo) from setupEngine.
+	engine, _ := setupEngine(t, phases, mock)
+
+	err := engine.Run(context.Background())
+	if err != nil {
+		t.Fatalf("expected no error in non-git workDir, got: %v", err)
 	}
 }
 

--- a/internal/pipeline/review.go
+++ b/internal/pipeline/review.go
@@ -491,7 +491,7 @@ func (e *Engine) runParallelReview(ctx context.Context, phase PhaseConfig) error
 	})
 
 	// Domain gating.
-	return e.gatePhase(phase)
+	return e.gatePhase(ctx, phase)
 }
 
 // runReviewer executes a single specialist reviewer, sending events and results


### PR DESCRIPTION
## Summary

Fixes the implement agent short-circuiting when it encounters existing code from a prior timed-out attempt. The agent now detects pre-populated worktrees and correctly creates fresh commits rather than treating existing code as its own work.

## Changes

### T1 — `CommitsAheadOfBase` in `worktree.go` / git package
- Added `CommitsAheadOfBase(base string)` helper using `git rev-list --count base..HEAD`
- Returns the number of commits the current branch is ahead of the given base

### T2 — `EventImplementCommitMismatch` event constant
- Added new event constant adjacent to `EventImplementNoChanges` in `events.go`
- Used to signal when the agent claims commits exist but none are found ahead of base

### T3 — `gatePhase` context parameter
- Updated `gatePhase` signature to accept `ctx context.Context`
- Both call sites in `engine.go` pass `ctx` correctly

### T4 — Fake-commit detection logic in implement gate
- Added logic to detect when `result.Commits` is non-empty but no real commits exist ahead of base
- Defaults `baseBranch` to `"main"` when not set
- Gracefully handles git errors (non-git workDir)

### T5 — 3 new tests in `guardrails_test.go`
- Gate fires on fake-commit mismatch
- Real commits pass through the gate
- Non-git workDir handled gracefully

### T6 — Unconditional commit reminder in `implement.md`
- Added commit-verification paragraph **outside** the `{{- if .ReworkFeedback}}` block
- Instructs agent to run `git log {{.BaseBranch}}..HEAD` and `git status` before reporting
- Guides agent to handle pre-populated worktrees by creating fresh commits

## Test Plan

All existing tests continue to pass. New tests cover:
1. Gate fires when agent reports commits but none exist ahead of base
2. Gate does not fire when real commits exist ahead of base
3. Gate handles non-git work directories gracefully

Run tests:
```
go test ./...
```

## Acceptance Criteria

- [x] `CommitsAheadOfBase` helper correctly counts commits ahead of base branch
- [x] `EventImplementCommitMismatch` event constant added
- [x] `gatePhase` accepts and forwards `ctx`
- [x] Implement gate detects fake-commit scenarios and fires mismatch event
- [x] 3 new guardrails tests pass
- [x] Implement prompt unconditionally reminds agent to verify commits before reporting

Assisted-by: SODA