### PR TITLE
[516] test(cli): add table-driven unit tests for compareCLIVersions

### DIFF
--- a/internal/claude/args_test.go
+++ b/internal/claude/args_test.go
@@ -131,3 +131,23 @@ func TestBuildArgs(t *testing.T) {
 		})
 	}
 }
+
+func TestCompareCLIVersions(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"2.1.81", "2.1.81", 0},  // equal versions
+		{"2.1.80", "2.1.81", -1}, // patch-level less
+		{"2.1.82", "2.1.81", 1},  // patch-level greater
+		{"2.0.100", "2.1.0", -1}, // minor boundary crossing
+		{"3.0.0", "2.99.99", 1},  // major boundary crossing
+		{"1.0.0", "2.1.81", -1},  // large version gap
+	}
+	for _, tt := range tests {
+		got := compareCLIVersions(tt.a, tt.b)
+		if got != tt.want {
+			t.Errorf("compareCLIVersions(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds `TestCompareCLIVersions` to `internal/claude/args_test.go` with 6 table-driven test cases, mirroring the existing `TestCompareSemver` in `cmd/soda/doctor_test.go`.

The `compareCLIVersions` function is intentionally duplicated from `compareSemver` (same logic, different package). These new tests ensure the copy is independently exercised so any future divergence between the two implementations is caught immediately.

## Changes

- **`internal/claude/args_test.go`**: added `TestCompareCLIVersions` (lines 135–153) with 6 cases:
  - equal versions → 0
  - patch-level less → -1
  - patch-level greater → 1
  - minor-level less → -1
  - major-level greater → 1
  - major-level less → -1

No new imports were required (file already imports `slices` and `testing`).

## Test Plan

```
go test ./internal/claude/... -run TestCompareCLIVersions -v
```

Expected output:
```
--- PASS: TestCompareCLIVersions (0.00s)
PASS
```

Full package regression:
```
go test ./internal/claude/...
```

All 40+ tests pass with no regressions.

## Acceptance Criteria

- [x] `TestCompareCLIVersions` added to `internal/claude/args_test.go` in the same package
- [x] 6 table-driven test cases covering equal, less-than, and greater-than at patch, minor, and major levels
- [x] Cases mirror `TestCompareSemver` in `cmd/soda/doctor_test.go`
- [x] All 6 cases pass
- [x] No new imports needed
- [x] File is properly `gofmt`-formatted
- [x] No regressions in full package test suite

Ref: #516
Assisted-by: SODA