### PR TITLE
[517] fix(cli): set required: true in above-max doctor version check

### DIFF
--- a/cmd/soda/doctor.go
+++ b/cmd/soda/doctor.go
@@ -250,9 +250,10 @@ func checkClaudeVersion(env *doctorEnv) checkResult {
 
 	if compareSemver(ver, claude.MaxTestedCLIVersion) > 0 {
 		return checkResult{
-			name:   "claude-version",
-			passed: true,
-			detail: fmt.Sprintf("%s ⚠ newer than tested range (%s–%s); to pin: npm install -g @anthropic-ai/claude-code@%s", out, claude.MinCLIVersion, claude.MaxTestedCLIVersion, claude.MaxTestedCLIVersion),
+			name:     "claude-version",
+			passed:   true,
+			required: true,
+			detail:   fmt.Sprintf("%s ⚠ newer than tested range (%s–%s); to pin: npm install -g @anthropic-ai/claude-code@%s", out, claude.MinCLIVersion, claude.MaxTestedCLIVersion, claude.MaxTestedCLIVersion),
 		}
 	}
 

--- a/cmd/soda/doctor_test.go
+++ b/cmd/soda/doctor_test.go
@@ -326,8 +326,8 @@ func TestCheckClaudeVersion_AboveMax(t *testing.T) {
 	if !r.passed {
 		t.Error("expected claude-version check to pass (warning only) for version above max")
 	}
-	if r.required {
-		t.Error("expected claude-version check to be non-required for version above max")
+	if !r.required {
+		t.Error("expected claude-version check to be required for version above max")
 	}
 	if !strings.Contains(r.detail, "⚠") {
 		t.Errorf("expected ⚠ in detail for untested version, got: %q", r.detail)


### PR DESCRIPTION
## Summary

Fixes ticket **#517**: the  function in  was missing `required: true` in the `checkResult` returned when the Claude CLI version exceeds `MaxTestedCLIVersion`.

### Changes

**`cmd/soda/doctor.go`**
- Added `required: true` to the `checkResult` struct literal in the above-max branch of `checkClaudeVersion`.
- This achieves parity with:
  - the below-min failure branch (already had `required: true`)
  - the normal-pass branch (already had `required: true`)

**`cmd/soda/doctor_test.go`**
- Updated the `TestCheckClaudeVersion_AboveMax` assertion from `if r.required` (expecting `false`) to `if !r.required` (expecting `true`) to match the corrected behaviour.

### Test Plan

- `go test ./cmd/soda/ -run TestCheckClaudeVersion` — all 8 subtests pass including `AboveMax`
- `go test ./cmd/soda/` — full package test suite passes
- `gofmt -l cmd/soda/doctor.go` — no formatting issues
- `CGO_ENABLED=0 go vet ./cmd/soda/` — no vet issues

### Acceptance Criteria

- [x] `required: true` is explicitly set in the above-max branch of `checkClaudeVersion`
- [x] All three `checkResult` return paths for `claude-version` have consistent `required` field values
- [x] `TestCheckClaudeVersion_AboveMax` passes and asserts `required == true`
- [x] No regressions in existing tests