### PR TITLE
[524] fix(timeout): resolve failure_category discrepancy ('context' vs 'timeout')

### DIFF
--- a/cmd/soda/history.go
+++ b/cmd/soda/history.go
@@ -88,11 +88,10 @@ func renderEventsHistory(meta *pipeline.PipelineMeta, events []pipeline.Event, s
 			h.Entries[i].TransientRetries = ps.TransientRetries
 			h.Entries[i].ParseRetries = ps.ParseRetries
 			h.Entries[i].SemanticRetries = ps.SemanticRetries
-			// Fallback: use PhaseState's FailureCategory when the event-sourced
-			// value is empty. This covers gate errors (no EventPhaseFailed emitted)
-			// and timeout errors (state overwrites "context" → "timeout" after the
-			// event is emitted).
-			if h.Entries[i].FailureCategory == "" {
+			// Always prefer PhaseState's FailureCategory when set. Meta is
+			// written last — after wrapTimeoutError post-processing — so it
+			// carries the corrected value (e.g. "timeout" instead of "context").
+			if ps.FailureCategory != "" {
 				h.Entries[i].FailureCategory = ps.FailureCategory
 			}
 		}

--- a/cmd/soda/history_test.go
+++ b/cmd/soda/history_test.go
@@ -487,3 +487,62 @@ func TestRenderEventsHistory_FailureCategoryEventPreserved(t *testing.T) {
 		t.Errorf("'Failure Category:' should appear exactly once, appeared %d times\ngot:\n%s", count, output)
 	}
 }
+
+// TestRenderEventsHistory_FailureCategoryContextToTimeout verifies that when
+// the event carries failure_category="context" (set by emitPhaseFailed) but
+// meta.Phases has "timeout" (set by wrapTimeoutError after the event), the
+// meta value "timeout" takes precedence because it reflects the post-processed
+// classification.
+func TestRenderEventsHistory_FailureCategoryContextToTimeout(t *testing.T) {
+	dir := t.TempDir()
+
+	meta := &pipeline.PipelineMeta{
+		Ticket:    "TEST-CTX-TIMEOUT",
+		TotalCost: 1.50,
+		Phases: map[string]*pipeline.PhaseState{
+			"implement": {
+				Status:          pipeline.PhaseFailed,
+				Cost:            1.50,
+				FailureCategory: "timeout", // wrapTimeoutError overwrites "context" → "timeout"
+			},
+		},
+	}
+
+	// The EventPhaseFailed event carries failure_category="context" because
+	// emitPhaseFailed sees a context error. wrapTimeoutError later corrects
+	// the meta to "timeout", but the event is already written.
+	events := []pipeline.Event{
+		{Phase: "implement", Kind: pipeline.EventPhaseStarted, Data: map[string]any{"generation": float64(1)}},
+		{Phase: "implement", Kind: pipeline.EventPhaseFailed, Data: map[string]any{
+			"error":            "context deadline exceeded",
+			"duration_ms":      float64(60000),
+			"cost":             1.50,
+			"failure_category": "context", // event-sourced — should be overridden by meta
+		}},
+	}
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := renderEventsHistory(meta, events, dir, true /* detail */, "" /* phaseFilter */)
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	output := buf.String()
+
+	if err != nil {
+		t.Fatalf("renderEventsHistory error: %v", err)
+	}
+
+	if !strings.Contains(output, "Failure Category: timeout") {
+		t.Errorf("detail output should contain 'Failure Category: timeout' (meta overrides event 'context')\ngot:\n%s", output)
+	}
+
+	if strings.Contains(output, "Failure Category: context") {
+		t.Errorf("detail output should NOT contain 'Failure Category: context' (meta should override)\ngot:\n%s", output)
+	}
+}

--- a/cmd/soda/history_test.go
+++ b/cmd/soda/history_test.go
@@ -395,18 +395,16 @@ func TestRenderEventsHistory_FailureCategoryTimeoutOverride(t *testing.T) {
 		},
 	}
 
-	// The EventPhaseFailed event was emitted with failure_category="context"
-	// by emitPhaseFailed, but wrapTimeoutError later overwrites the state to
-	// "timeout". When the event carries "context", the fallback should NOT
-	// overwrite it (event-sourced value wins). But if the event doesn't carry
-	// failure_category at all, the meta fallback should fill it.
+	// The event has no failure_category; meta carries "timeout" (set by
+	// wrapTimeoutError after the event was emitted). The enrichment loop
+	// should fill it from meta.
 	events := []pipeline.Event{
 		{Phase: "implement", Kind: pipeline.EventPhaseStarted, Data: map[string]any{"generation": float64(1)}},
 		{Phase: "implement", Kind: pipeline.EventPhaseFailed, Data: map[string]any{
 			"error":       "context deadline exceeded",
 			"duration_ms": float64(60000),
 			"cost":        1.00,
-			// No failure_category in event — meta fallback should fill "timeout"
+			// No failure_category in event — meta should fill "timeout"
 		}},
 	}
 


### PR DESCRIPTION
## Summary

Fixes the `failure_category` discrepancy between pipeline events and meta state when a pipeline times out.

### Root Cause

When a pipeline times out, `wrapTimeoutError` corrects the raw Go context error into `'timeout'` and writes that into the PhaseState (meta). However, the event was already frozen with the raw value `'context'`. The merge logic in `history.go` was previously using the **event-sourced** value as the winner, causing `failure_category: 'context'` to leak into rendered history even though meta correctly said `'timeout'`.

### Changes

| File | Change |
|---|---|
| `history.go` | Guard changed from `if h.Entries[i].FailureCategory == ""` → `if ps.FailureCategory != ""`, so PhaseState (meta) always wins when it carries a value. |
| `history_test.go` | New test `TestRenderEventsHistory_FailureCategoryContextToTimeout` exercises the exact bug scenario (event=`'context'`, meta=`'timeout'`, expect `'timeout'`). Added as a failing test before the fix. |
| `history_test.go` | Removed misleading comment in `TestRenderEventsHistory_FailureCategoryTimeoutOverride` that described the old (incorrect) behavior. |

## Test Plan

- New regression test `TestRenderEventsHistory_FailureCategoryContextToTimeout` fails on the old code and passes after the fix.
- All 13 testable packages pass with `go test ./...`.
- `go vet ./...` is clean.

## Acceptance Criteria

- [x] `failure_category` in rendered history shows `'timeout'` (not `'context'`) when a pipeline times out
- [x] Meta (PhaseState) value takes precedence over the stale event value when meta is set
- [x] No regressions in existing tests
- [x] `Assisted-by: SODA` trailer present on all commits in this branch