### PR TITLE
[528] test(ledger): add missing table entry Escalated=true + ReworkCycles=1

### DIFF
--- a/internal/pipeline/ledger_test.go
+++ b/internal/pipeline/ledger_test.go
@@ -504,6 +504,11 @@ func TestClassifyOutcome(t *testing.T) {
 			expected: "rework_2+",
 		},
 		{
+			name:     "escalated with rework=1 stays rework_1",
+			entry:    CostEntry{Success: true, Escalated: true, ReworkCycles: 1},
+			expected: "rework_1",
+		},
+		{
 			name:     "rework overrides patch",
 			entry:    CostEntry{Success: true, ReworkCycles: 1, PatchCycles: 3},
 			expected: "rework_1",


### PR DESCRIPTION
## Summary

Adds the missing table entry in `TestClassifyOutcome` for the combination of `Escalated=true` with `ReworkCycles=1`, which should return `"rework_1"`.

### Changes

- **No production code touched.**
- Added one new sub-test: `escalated_with_rework=1_stays_rework_1` to the table-driven `TestClassifyOutcome` test in the ledger package.
- Sub-test count increases from **9 → 10**.
- The new entry exercises the `ClassifyOutcome` path where `Escalated=true` and `ReworkCycles=1` → `"rework_1"`, completing full coverage of the escalation sub-group (ReworkCycles 0, 1, and ≥2).

## Test Plan

```
go test ./... -run TestClassifyOutcome
```

All 10 sub-tests pass with no regressions.

## Acceptance Criteria

- [x] `TestClassifyOutcome/escalated_with_rework=1_stays_rework_1` is present and passes
- [x] Sub-test count increased from 9 → 10
- [x] No production code was touched
- [x] No regressions — full package passes cleanly
- [x] The new entry covers the exact scenario identified as missing in ticket #528

Refs: #528
Assisted-by: SODA