### PR TITLE
test(cost): rework-tax suppression when first-pass mean is zero [#530]

### DIFF
--- a/cmd/soda/cost_test.go
+++ b/cmd/soda/cost_test.go
@@ -319,6 +319,24 @@ func TestRunCostByOutcome_ReworkTaxAbsent(t *testing.T) {
 	}
 }
 
+func TestRunCostByOutcome_ZeroFirstPassMeanSuppressesReworkTax(t *testing.T) {
+	entries := []pipeline.CostEntry{
+		{Ticket: "T-1", Cost: 0.00, Success: true},                   // first_pass with zero cost
+		{Ticket: "T-2", Cost: 10.00, Success: true, ReworkCycles: 1}, // rework_1
+	}
+
+	output, err := captureStdout(t, func() error {
+		return runCostByOutcome(entries)
+	})
+	if err != nil {
+		t.Fatalf("runCostByOutcome error: %v", err)
+	}
+
+	if strings.Contains(output, "Rework tax:") {
+		t.Errorf("should not show rework tax when first_pass mean is zero:\n%s", output)
+	}
+}
+
 func TestRunCostByOutcomeAndComplexity_Empty(t *testing.T) {
 	output, err := captureStdout(t, func() error {
 		return runCostByOutcomeAndComplexity(nil)


### PR DESCRIPTION
## Summary

Adds `TestRunCostByOutcome_ZeroFirstPassMeanSuppressesReworkTax` to `cmd/soda/cost_test.go`, placed after `TestRunCostByOutcome_ReworkTaxAbsent` to maintain the logical grouping of rework-tax tests.

### What the test does

- Creates a `first_pass` entry with `Cost: 0.00` — gives the first_pass bucket a **mean of 0**
- Creates a `rework_1` entry with `Cost: 10.00` — satisfies the outer guard `hasClean && hasR1`
- Asserts that **"Rework tax:" is absent** from output

### Production code path exercised

`cost.go` lines 309–329 have a two-level guard:
1. **Outer guard** (`hasClean && (hasR1 || hasR2)`) → `true`
2. **Inner guard** (`cleanStats.Mean > 0`) → `false` (mean is 0.0)

The test exercises the inner guard being `false`, confirming the division-by-zero suppression path.

## Test Plan

- `go test ./cmd/soda/... -run TestRunCostByOutcome_ZeroFirstPassMeanSuppressesReworkTax` passes
- Full test suite passes with no regressions

## Acceptance Criteria

- [x] Test `TestRunCostByOutcome_ZeroFirstPassMeanSuppressesReworkTax` exists in `cost_test.go`
- [x] Entry construction is valid (`Success: true`, no rework/patch fields, `Cost: 0.00`)
- [x] Rework entry satisfies the outer guard
- [x] Assertion checks that output does **not** contain `"Rework tax:"`
- [x] Uses existing `captureStdout` helper
- [x] All tests pass, no regressions
- [x] File properly formatted per `gofmt`

Assisted-by: SODA