### PR TITLE
[533] test(schemas): simplify verbose nested struct unmarshal

### DIFF
--- a/schemas/schemas_test.go
+++ b/schemas/schemas_test.go
@@ -362,17 +362,15 @@ func TestReviewSchema_MatchesStruct(t *testing.T) {
 	}
 
 	// category should have enum constraint.
-	var itemProps map[string]json.RawMessage
-	if err := json.Unmarshal(findingsRaw, &struct {
+	var itemWrapper struct {
 		Items struct {
-			Properties *map[string]json.RawMessage `json:"properties"`
+			Properties map[string]json.RawMessage `json:"properties"`
 		} `json:"items"`
-	}{Items: struct {
-		Properties *map[string]json.RawMessage `json:"properties"`
-	}{Properties: &itemProps}}); err != nil {
+	}
+	if err := json.Unmarshal(findingsRaw, &itemWrapper); err != nil {
 		t.Fatalf("unmarshal item properties: %v", err)
 	}
-	assertEnum(t, itemProps["category"], "string", []string{
+	assertEnum(t, itemWrapper.Items.Properties["category"], "string", []string{
 		"retrieval", "convention", "logic", "test_pattern", "documentation",
 	})
 }


### PR DESCRIPTION
## Summary

Replaces the verbose pointer-to-map anonymous struct initialiser in `TestReviewSchema_MatchesStruct` with a named `itemWrapper` struct pattern. This matches the existing style used elsewhere in `schemas_test.go` (e.g. lines 314-323) and eliminates the awkward `*map[string]interface{}` pattern.

## Changes

- **`schemas/schemas_test.go`**: Introduce a local `itemWrapper` named struct for the category enum assertion inside `TestReviewSchema_MatchesStruct`, replacing the prior pointer-to-map anonymous struct initialiser (−7 lines, +5 lines).

## Test Plan

- `TestReviewSchema_MatchesStruct` passes ✅
- Full `./schemas/...` suite passes ✅
- `gofmt -l` reports no formatting issues ✅

## Acceptance Criteria

- [x] `TestReviewSchema_MatchesStruct` passes
- [x] Full `./schemas/...` suite passes
- [x] `gofmt -l` prints nothing (file is properly formatted)
- [x] Exactly one hunk changed in `git diff`
- [x] No `*map` pointer-to-map types remain
- [x] New code matches existing named-struct style (lines 314-323)
- [x] `assertEnum` still accesses `category` via the correct path

Ref: #533