### PR TITLE
[534] test(pipeline): validCategory parity with ReviewFinding.Category enum

### DIFF
--- a/internal/pipeline/feedback_test.go
+++ b/internal/pipeline/feedback_test.go
@@ -1097,6 +1097,43 @@ func TestCapToLine(t *testing.T) {
 	})
 }
 
+func TestValidCategory_CoversSchemaEnum(t *testing.T) {
+	// Parse ReviewSchema to extract the category enum from
+	// findings → items → properties → category → enum.
+	var parsed struct {
+		Properties map[string]json.RawMessage `json:"properties"`
+	}
+	if err := json.Unmarshal([]byte(schemas.ReviewSchema), &parsed); err != nil {
+		t.Fatalf("unmarshal ReviewSchema: %v", err)
+	}
+
+	var findings struct {
+		Items struct {
+			Properties map[string]json.RawMessage `json:"properties"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(parsed.Properties["findings"], &findings); err != nil {
+		t.Fatalf("unmarshal findings: %v", err)
+	}
+
+	var category struct {
+		Enum []string `json:"enum"`
+	}
+	if err := json.Unmarshal(findings.Items.Properties["category"], &category); err != nil {
+		t.Fatalf("unmarshal category: %v", err)
+	}
+
+	if len(category.Enum) == 0 {
+		t.Fatal("category enum is empty — schema navigation may be broken")
+	}
+
+	for _, categoryValue := range category.Enum {
+		if !validCategory(categoryValue) {
+			t.Errorf("validCategory(%q) = false, but %q is in the ReviewSchema category enum", categoryValue, categoryValue)
+		}
+	}
+}
+
 func TestExtractSnippet(t *testing.T) {
 	content := "line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\n"
 


### PR DESCRIPTION
## Summary

Adds `TestValidCategory_CoversSchemaEnum` to `internal/pipeline/feedback_test.go` to guard against drift between the `validCategory` switch statement and the `ReviewFinding.Category` enum in `schemas.ReviewSchema`.

## Changes

- **`internal/pipeline/feedback_test.go`**: New test `TestValidCategory_CoversSchemaEnum` that:
  1. Unmarshals `schemas.ReviewSchema` JSON into a `Properties` map
  2. Navigates three levels deep: `findings → items.Properties["category"] → Enum []string`
  3. Guards against an accidentally empty enum with `t.Fatal`
  4. Iterates each enum value with `t.Errorf` (not `t.Fatalf`), so all drifted values are reported in a single run

No production code changes. No new imports. No new files.

## Test Plan

- `go test ./internal/pipeline/... -run TestValidCategory_CoversSchemaEnum` — passes
- Adding a new value (e.g. `"security"`) to the schema enum without updating the switch causes a clear failure:
  ```
  feedback_test.go:1132: validCategory("security") = false, but "security" is in the ReviewSchema category enum
  ```

## Acceptance Criteria

- [x] Test added to `internal/pipeline/feedback_test.go`
- [x] Test parses the live `schemas.ReviewSchema` (no hard-coded strings)
- [x] Test fails when schema enum and switch are out of sync
- [x] Test passes on the current codebase with no regressions
- [x] `Assisted-by: SODA` trailer present on commit

Refs: #534