### PR TITLE
refactor(pipeline): move category validation into filter loop [#535]

### DIFF
--- a/internal/pipeline/feedback.go
+++ b/internal/pipeline/feedback.go
@@ -248,22 +248,20 @@ func (e *Engine) extractReviewFeedback() *ReworkFeedback {
 		return severityRank(result.Findings[i].Severity) < severityRank(result.Findings[j].Severity)
 	})
 
-	// Validate and default categories: invalid or empty → "unknown".
-	for idx := range result.Findings {
-		if !validCategory(result.Findings[idx].Category) {
-			result.Findings[idx].Category = "unknown"
-		}
-	}
-
 	workDir := e.workDir(PhaseConfig{})
 	budgetRemaining := maxFeedbackContextBytes
 	rawCache := make(map[string]string) // file path → raw file content
 
-	// Only include critical and major findings, enriched with code context.
+	// Only include critical and major findings; validate category then enrich with code context.
 	for _, finding := range result.Findings {
 		sev := strings.ToLower(finding.Severity)
 		if sev != "critical" && sev != "major" {
 			continue
+		}
+
+		// Validate and default category: invalid or empty → "unknown".
+		if !validCategory(finding.Category) {
+			finding.Category = "unknown"
 		}
 
 		ef := EnrichedFinding{ReviewFinding: finding}


### PR DESCRIPTION
## Summary

Collapses the standalone category-validation loop in `extractReviewFeedback()` (feedback.go) into the existing critical/major severity-filter loop.

### Changes

- **Removed** the second iteration over `result.Findings` that normalised invalid/empty categories.
- **Inlined** the `validCategory` guard immediately after the severity `continue` statement inside the existing loop.
- **Updated** the loop comment to accurately describe all three operations: severity filtering → category defaulting → enrichment.
- No change to external behaviour; the function produces identical output.

## Test Plan

- `go test ./pipeline/...` — all 3 category-validation tests pass, full suite 0 failures.
- `gofmt` clean.

## Acceptance Criteria

- [x] Standalone category-validation loop deleted
- [x] Single loop handles severity filtering, category defaulting, and enrichment
- [x] `validCategory` placed after severity `continue`
- [x] Loop comment updated accurately
- [x] `gofmt` clean
- [x] All 3 category tests pass
- [x] Full pipeline test suite passes (0 failures)

---
Assisted-by: SODA