### PR TITLE
[519] Fix stale phaseReductionOrder doc comment in budget.go

### DIFF
--- a/internal/pipeline/budget.go
+++ b/internal/pipeline/budget.go
@@ -43,10 +43,10 @@ type reductionStep struct {
 // the compact, high-value convention checklist available as long as possible.
 //
 // The order is phase-specific:
-//   - implement: siblings → exemplars → projectContext → extras → review comments → diff → (rework) → (artifacts) → conventions
+//   - implement: siblings → exemplars → triageFiles → projectContext → extras → review comments → diff → (rework) → (artifacts) → conventions
 //   - review:    siblings → exemplars → extras → Diff → projectContext → (rework) → (artifacts) → conventions
 //   - verify:    siblings → exemplars → extras → projectContext → diff → (rework) → (artifacts)  (no conventions — verify.md never renders RepoConventions)
-//   - patch:     diff → siblings → exemplars → extras → projectContext → (rework) → (artifacts) → conventions
+//   - patch:     diff → siblings → exemplars → triageFiles → extras → projectContext → (rework) → (artifacts) → conventions
 //
 // For unknown phases a sensible default order is used (conventions always last).
 func phaseReductionOrder(phase string) []reductionStep {


### PR DESCRIPTION
## Summary

Fixes stale GoDoc comment for `phaseReductionOrder` in `internal/pipeline/budget.go`.

The `triageFiles →` step was missing from the doc comment descriptions of both the `implement` and `patch` phase reduction orders, causing the comment to be out of sync with the actual code logic.

### Changes

- **Line 46** (`implement`): inserted `triageFiles →` between `exemplars →` and `projectContext →`
- **Line 49** (`patch`): inserted `triageFiles →` between `exemplars →` and `extras →`

No logic was changed — this is a pure documentation fix.

## Test Plan

- Verified comment order matches actual code at lines 198 and 219
- All `TestPhaseReductionOrder_*` tests pass (4/4)
- Full `./internal/pipeline/...` suite passes with no regressions
- File is `gofmt`-clean

## Acceptance Criteria

- [x] Line 46 (`implement`) has `triageFiles →` between `exemplars →` and `projectContext →`
- [x] Line 49 (`patch`) has `triageFiles →` between `exemplars →` and `extras →`
- [x] Comment order matches actual code (implement, line 198)
- [x] Comment order matches actual code (patch, line 219)
- [x] File is `gofmt`-clean
- [x] `TestPhaseReductionOrder_*` tests all pass (4/4)
- [x] Full `./internal/pipeline/...` suite passes with no regressions