### PR TITLE
[522] fix(retry): remove redundant SetFailureCategory call on exhaustion

### DIFF
--- a/internal/pipeline/retry.go
+++ b/internal/pipeline/retry.go
@@ -39,7 +39,6 @@ func (e *Engine) runWithRetry(ctx context.Context, phase PhaseConfig, opts runne
 
 		left, tracked := remaining[category]
 		if !tracked || left <= 0 {
-			_ = e.state.SetFailureCategory(phase.Name, category)
 			return nil, &RetriesExhaustedError{
 				Phase:    phase.Name,
 				Category: category,

--- a/internal/pipeline/retry_test.go
+++ b/internal/pipeline/retry_test.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -367,10 +368,18 @@ func TestRetry_FailureCategoryOnExhaustion(t *testing.T) {
 		t.Fatal("expected error from exhausted retries")
 	}
 
-	ps := state.Meta().Phases["triage"]
-	if ps.FailureCategory != "transient" {
-		t.Errorf("FailureCategory = %q, want %q", ps.FailureCategory, "transient")
+	var re *RetriesExhaustedError
+	if !errors.As(err, &re) {
+		t.Fatalf("expected *RetriesExhaustedError, got %T", err)
 	}
+	if re.Category != "transient" {
+		t.Errorf("RetriesExhaustedError.Category = %q, want %q", re.Category, "transient")
+	}
+	if re.Attempts != 2 {
+		t.Errorf("RetriesExhaustedError.Attempts = %d, want 2", re.Attempts)
+	}
+
+	ps := state.Meta().Phases["triage"]
 	if ps.TransientRetries != 1 {
 		t.Errorf("TransientRetries = %d, want 1 (one successful retry before exhaustion)", ps.TransientRetries)
 	}


### PR DESCRIPTION
## Summary

Removes a redundant `SetFailureCategory` call from the `runWithRetry` exhaustion branch in `internal/pipeline/retry.go`.

### Problem

On the retries-exhausted path, `SetFailureCategory` was called twice:
1. Explicitly in `runWithRetry` (the line being removed)
2. Via `emitPhaseFailed` → `recovery.go:82`, which handles all structured error types including `RetriesExhaustedError`

This caused a duplicate `meta.json` flush with no functional benefit.

### Changes

- **`internal/pipeline/retry.go`** — Delete the redundant `_ = e.state.SetFailureCategory(phase.Name, category)` call in the `!tracked || left <= 0` exhaustion branch.
- **`internal/pipeline/retry_test.go`** — Update `TestRetry_FailureCategoryOnExhaustion` to assert `RetriesExhaustedError` struct fields (`re.Category`, `re.Attempts`) via `errors.As` instead of relying on the now-removed disk write (`ps.FailureCategory`).

## Test Plan

- All 12 `TestRetry_*` tests pass
- All 13 `TestEmitPhaseFailed` tests pass
- Full package test suite passes
- `go vet` is clean

## Acceptance Criteria

- [ ] `SetFailureCategory` is called exactly once on exhaustion (via `emitPhaseFailed`)
- [ ] No duplicate `meta.json` I/O on the exhaustion path
- [ ] `TestRetry_FailureCategoryOnExhaustion` asserts `re.Category == "transient"` and `re.Attempts == 2`
- [ ] All existing retry tests continue to pass

Closes #522