### PR TITLE
chore(cost): remove always-false dead code guard in TOTAL footer width [#527]

### DIFF
--- a/cmd/soda/cost.go
+++ b/cmd/soda/cost.go
@@ -171,9 +171,6 @@ func runCostByComplexity(entries []pipeline.CostEntry) error {
 	// Also consider footer widths.
 	footerSessions := fmt.Sprintf("%d", totalSessions)
 	footerTotal := fmt.Sprintf("$%.2f", totalCost)
-	if len("TOTAL") > colW[0] {
-		colW[0] = len("TOTAL")
-	}
 	if len(footerSessions) > colW[1] {
 		colW[1] = len(footerSessions)
 	}
@@ -277,9 +274,6 @@ func runCostByOutcome(entries []pipeline.CostEntry) error {
 	// Consider footer widths.
 	footerSessions := fmt.Sprintf("%d", totalSessions)
 	footerTotal := fmt.Sprintf("$%.2f", totalCost)
-	if len("TOTAL") > colW[0] {
-		colW[0] = len("TOTAL")
-	}
 	if len(footerSessions) > colW[1] {
 		colW[1] = len(footerSessions)
 	}


### PR DESCRIPTION
## Summary

Removes dead-code  guards from the TOTAL footer width calculation in both `runCostByComplexity` and `runCostByOutcome` functions in `cmd/soda/cost.go`.

These conditions were always false:
- `len("TOTAL")` = 5
- `colW[0]` is always initialized to at least `len("COMPLEXITY")` = 10 (in `runCostByComplexity`) or `len("OUTCOME")` = 7 (in `runCostByOutcome`)

Since 5 < 10 and 5 < 7, the guard could never trigger, making the enclosed code unreachable.

## Changes

- **`cmd/soda/cost.go`**: Delete 6 lines (two 3-line dead-code blocks — one per function)

## Test Plan

- [x] `gofmt -l` produces no output (formatting clean)
- [x] `internal/pipeline` package builds successfully
- [x] No change in observable behavior (dead code removal only)
- [x] Surrounding footer guards for other columns (`footerSessions`, `footerTotal`) are untouched

## Acceptance Criteria

- [x] `if len("TOTAL") > colW[0]` block removed from `runCostByComplexity`
- [x] `if len("TOTAL") > colW[0]` block removed from `runCostByOutcome`
- [x] No other changes introduced
- [x] `Assisted-by: SODA` trailer present on commit