### PR TITLE
[#529] ux(cli): standardise cost flag — rename --outcomes to --by-outcome

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -697,6 +697,7 @@ If yes, include a "Docs to update" section in the issue body listing the files t
 | `soda validate` | Check config, phases, and prompts for errors without running |
 | `soda cost` | Show cumulative cost breakdown across all sessions |
 | `soda cost --by-complexity` | Show cost breakdown grouped by triage complexity band |
+| `soda cost --by-outcome` | Show cost breakdown grouped by pipeline outcome |
 | `soda plugin install [--global] [--force]` | Install the SODA Claude Code plugin |
 | `soda plugin uninstall [--global]` | Remove the SODA Claude Code plugin |
 | `soda spec <description>` | Generate a ticket specification from a short description |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`soda cost --outcomes` renamed to `--by-outcome`** (#529) — aligns flag naming
+  with `--by-complexity` for a uniform `by-<noun>` convention.
+
 ## [0.5.0] — "Sharp Review" - 2026-05-13
 
 ### Added

--- a/cmd/soda/cost.go
+++ b/cmd/soda/cost.go
@@ -14,7 +14,7 @@ import (
 
 func newCostCmd() *cobra.Command {
 	var byComplexity bool
-	var byOutcomes bool
+	var byOutcome bool
 
 	cmd := &cobra.Command{
 		Use:   "cost",
@@ -28,10 +28,10 @@ func newCostCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("cost: read ledger: %w", err)
 			}
-			if byOutcomes && byComplexity {
+			if byOutcome && byComplexity {
 				return runCostByOutcomeAndComplexity(entries)
 			}
-			if byOutcomes {
+			if byOutcome {
 				return runCostByOutcome(entries)
 			}
 			if byComplexity {
@@ -42,7 +42,7 @@ func newCostCmd() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&byComplexity, "by-complexity", false, "Show cost breakdown grouped by triage complexity band")
-	cmd.Flags().BoolVar(&byOutcomes, "outcomes", false, "Show cost breakdown grouped by pipeline outcome")
+	cmd.Flags().BoolVar(&byOutcome, "by-outcome", false, "Show cost breakdown grouped by pipeline outcome")
 	return cmd
 }
 


### PR DESCRIPTION
## Summary

Resolves ticket **#529** — asymmetry between `--by-complexity` and `--outcomes` flags on the `soda cost` sub-command.

### Changes

| File | What changed |
|------|-------------|
| `cmd/soda/cost.go` | Renamed `byOutcomes` variable → `byOutcome`; changed Cobra flag string `--outcomes` → `--by-outcome` |
| `AGENTS.md` | Added `soda cost --by-outcome` row to the CLI commands reference table, adjacent to the `--by-complexity` row |
| `CHANGELOG.md` | Added `### Changed` bullet under `[Unreleased]` documenting the rename |

### Before / After

```
# Before
soda cost --outcomes
soda cost --by-complexity

# After (consistent naming)
soda cost --by-outcome
soda cost --by-complexity
```

## Test Plan

1. Run `soda cost --by-outcome` and verify it produces the same output as the former `--outcomes` flag.
2. Run `soda cost --outcomes` and verify it is no longer recognised (unknown flag error).
3. Run `soda cost --by-complexity` to confirm existing flag is unaffected.
4. Run `go build ./...` to confirm no compilation errors.
5. Run `gofmt -l ./cmd/soda/cost.go` to confirm no formatting issues (expect empty output).

## Acceptance Criteria

- [x] `soda cost --by-outcome` groups results by pipeline outcome
- [x] `soda cost --outcomes` is no longer a valid flag
- [x] Naming follows the `--by-<noun>` convention, consistent with `--by-complexity`
- [x] AGENTS.md documents the new flag
- [x] CHANGELOG.md records the rename under `[Unreleased]`
- [x] No other usages of the old `byOutcomes` variable name remain in scope
- [x] Build is clean (pre-existing `arapuca` pkg-config failure is unrelated to this change)