### PR TITLE
[532] fix(pipeline): suppress 'Category: unknown' in implement.md

### DIFF
--- a/cmd/soda/embeds/prompts/implement.md
+++ b/cmd/soda/embeds/prompts/implement.md
@@ -92,7 +92,7 @@ Do NOT address multiple findings in a single edit. Fix one, verify it, then move
 ### Finding {{add $idx 1}} of {{len $.ReworkFeedback.ReviewFindings}}: {{$finding.Source}}
 - [{{$finding.Severity}}] {{$finding.File}}{{if $finding.Line}}:{{$finding.Line}}{{end}} — {{$finding.Issue}}
   Suggestion: {{$finding.Suggestion}}
-{{- if $finding.Category}}
+{{- if and $finding.Category (ne $finding.Category "unknown")}}
   Category: {{$finding.Category}}
 {{- end}}
 {{- if $finding.CodeSnippet}}

--- a/internal/pipeline/prompt_test.go
+++ b/internal/pipeline/prompt_test.go
@@ -1502,6 +1502,37 @@ Context: {{.}}
 		}
 	})
 
+	t.Run("omits_category_when_unknown", func(t *testing.T) {
+		tmplBytes, err := os.ReadFile(filepath.Join("..", "..", "cmd", "soda", "embeds", "prompts", "implement.md"))
+		if err != nil {
+			t.Skipf("skipping: cannot read embedded implement.md: %v", err)
+		}
+		tmpl := string(tmplBytes)
+
+		data := PromptData{
+			Ticket:       TicketData{Key: "TEST-532", Summary: "unknown category suppression"},
+			WorktreePath: "/tmp/wt",
+			Branch:       "soda/TEST-532",
+			BaseBranch:   "main",
+			Config:       PromptConfigData{Formatter: "gofmt -w .", TestCommand: "go test ./..."},
+			ReworkFeedback: &ReworkFeedback{
+				Source:  "review",
+				Verdict: "rework",
+				ReviewFindings: []EnrichedFinding{
+					{ReviewFinding: schemas.ReviewFinding{Severity: "critical", File: "x.go", Line: 1, Issue: "bug", Suggestion: "fix", Source: "go-specialist", Category: "unknown"}},
+				},
+			},
+		}
+
+		result, err := RenderPrompt(tmpl, data)
+		if err != nil {
+			t.Fatalf("RenderPrompt: %v", err)
+		}
+		if strings.Contains(result, "Category:") {
+			t.Errorf("implement prompt should NOT contain 'Category:' when category is 'unknown';\ngot: %s", result)
+		}
+	})
+
 	t.Run("omits_sibling_context_when_empty", func(t *testing.T) {
 		tmplBytes, err := os.ReadFile(filepath.Join("..", "..", "cmd", "soda", "embeds", "prompts", "implement.md"))
 		if err != nil {


### PR DESCRIPTION
## Summary

Suppresses the literal string `Category: unknown` from appearing in rendered `implement.md` prompt output.

When a review finding has its category set to the sentinel value `"unknown"`, the template previously emitted:

```
Category: unknown
```

This is noise — `unknown` signals absence of information, not a meaningful category. The fix extends the existing template guard to also exclude the `"unknown"` sentinel, consistent with how empty-string categories are already suppressed.

## Changes

- **`cmd/soda/embeds/prompts/implement.md`** — Updated template guard from `{{- if $finding.Category}}` to `{{- if and $finding.Category (ne $finding.Category "unknown")}}`
- **`internal/pipeline/prompt_test.go`** — Added `omits_category_when_unknown` test case mirroring the existing `omits_category_when_empty` test

## Test Plan

1. Run existing prompt template tests: `go test ./internal/pipeline/...`
2. Confirm the new `omits_category_when_unknown` test passes
3. Confirm no regression on other template rendering tests

## Acceptance Criteria

- [ ] `Category: unknown` no longer appears in rendered `implement.md` prompts
- [ ] `Category: <valid-value>` still renders correctly for non-empty, non-unknown categories
- [ ] Empty category (`""`) continues to be suppressed as before
- [ ] All prompt template tests pass