### PR TITLE
feat(cli): --max-cost flag for soda run [506]

### DIFF
--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -943,6 +943,17 @@ func handleEvent(ctx context.Context, cancel context.CancelFunc, engine *pipelin
 			errMsg = e
 		}
 		prog.Message(fmt.Sprintf("  ⚠️  Notification failed: %s", errMsg))
+
+	case pipeline.EventBudgetOverride:
+		var configValue float64
+		if cv, ok := event.Data["config_value"].(float64); ok {
+			configValue = cv
+		}
+		var cliValue float64
+		if cl, ok := event.Data["cli_value"].(float64); ok {
+			cliValue = cl
+		}
+		prog.Message(fmt.Sprintf("  ⚠️  --max-cost overrides config: $%.2f → $%.2f", configValue, cliValue))
 	}
 }
 
@@ -1352,6 +1363,8 @@ func formatNextSteps(w io.Writer, meta *pipeline.PipelineMeta, phases []pipeline
 		fmt.Fprintf(w, "  Budget limit ($%.2f) reached at $%.2f in phase %q.\n", be.Limit, be.Actual, be.Phase)
 		fmt.Fprintf(w, "  • Increase the limit in soda.yaml (limits.max_cost_per_ticket) and resume:\n")
 		fmt.Fprintf(w, "    soda run %s --from %s  (resume with higher budget)\n", ticket, be.Phase)
+		fmt.Fprintf(w, "  • Override the budget inline:\n")
+		fmt.Fprintf(w, "    soda run %s --from %s --max-cost %.2f\n", ticket, be.Phase, be.Limit*2)
 
 	case isTransientError(runErr):
 		fmt.Fprintf(w, "  A transient error occurred (network, rate-limit, or timeout).\n")

--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -402,6 +402,20 @@ func runPipeline(cfg *config.Config, opts pipelineOpts) error {
 		return fmt.Errorf("run: unknown transcript level %q (expected 'tools', 'full', or 'off')", transcriptLevel)
 	}
 
+	// Apply --max-cost override: CLI flag takes precedence over config.
+	if opts.maxCost < 0 {
+		return fmt.Errorf("run: --max-cost must be non-negative, got %.2f", opts.maxCost)
+	}
+	var emitBudgetOverride bool
+	var maxCostOriginalCfg float64
+	if opts.maxCostChanged {
+		if cfg.Limits.MaxCostPerTicket > 0 && cfg.Limits.MaxCostPerTicket != opts.maxCost {
+			maxCostOriginalCfg = cfg.Limits.MaxCostPerTicket
+			emitBudgetOverride = true
+		}
+		cfg.Limits.MaxCostPerTicket = opts.maxCost
+	}
+
 	engineCfg := pipeline.EngineConfig{
 		Pipeline:               pl,
 		Loader:                 loader,
@@ -459,6 +473,13 @@ func runPipeline(cfg *config.Config, opts pipelineOpts) error {
 	}
 
 	engine = pipeline.NewEngine(r, state, engineCfg)
+
+	if emitBudgetOverride {
+		engineCfg.OnEvent(pipeline.Event{
+			Kind: pipeline.EventBudgetOverride,
+			Data: map[string]any{"config_value": maxCostOriginalCfg, "cli_value": opts.maxCost},
+		})
+	}
 
 	// Snapshot cost before this run so the ledger records only the delta.
 	costBefore := state.Meta().TotalCost

--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -47,6 +47,8 @@ type pipelineOpts struct {
 	transcript        string // CLI override: "tools", "full", or "off"
 	transcriptChanged bool   // true when --transcript was explicitly passed
 	force             bool   // override schema version mismatch checks
+	maxCost           float64
+	maxCostChanged    bool // true when --max-cost was explicitly passed
 }
 
 // pipelineOptsFromCmd extracts pipelineOpts from Cobra flags registered on the
@@ -61,6 +63,7 @@ func pipelineOptsFromCmd(cmd *cobra.Command, ticketKey string) pipelineOpts {
 	useTUI, _ := cmd.Flags().GetBool("tui")
 	transcript, _ := cmd.Flags().GetString("transcript")
 	force, _ := cmd.Flags().GetBool("force")
+	maxCost, _ := cmd.Flags().GetFloat64("max-cost")
 
 	return pipelineOpts{
 		ticketKey:         ticketKey,
@@ -76,6 +79,8 @@ func pipelineOptsFromCmd(cmd *cobra.Command, ticketKey string) pipelineOpts {
 		transcript:        transcript,
 		transcriptChanged: cmd.Flags().Changed("transcript"),
 		force:             force,
+		maxCost:           maxCost,
+		maxCostChanged:    cmd.Flags().Changed("max-cost"),
 	}
 }
 
@@ -106,6 +111,7 @@ func newRunCmd() *cobra.Command {
 	cmd.Flags().String("query", "", "search filter for listing tickets (picker mode)")
 	cmd.Flags().String("transcript", "", "transcript capture level: tools, full, or off (overrides config)")
 	cmd.Flags().Bool("force", false, "override schema version mismatch checks on resume")
+	cmd.Flags().Float64("max-cost", 0, "maximum cost in USD for this pipeline run (overrides config); 0 means unlimited")
 
 	return cmd
 }

--- a/cmd/soda/run_test.go
+++ b/cmd/soda/run_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/decko/soda/internal/config"
 	"github.com/decko/soda/internal/pipeline"
 	"github.com/decko/soda/internal/progress"
+	"github.com/spf13/cobra"
 )
 
 func TestResolveLastPhase(t *testing.T) {
@@ -642,6 +643,15 @@ func TestPrintSummaryBudgetExceeded(t *testing.T) {
 	if !strings.Contains(output, "resume with higher budget") {
 		t.Error("expected parenthetical explaining --from suggestion")
 	}
+	if !strings.Contains(output, "--max-cost") {
+		t.Error("expected --max-cost suggestion in budget-exceeded next steps")
+	}
+	if !strings.Contains(output, "Override the budget inline") {
+		t.Error("expected 'Override the budget inline' suggestion")
+	}
+	if !strings.Contains(output, "--max-cost 10.00") {
+		t.Error("expected --max-cost with 2× limit (10.00) in suggestion")
+	}
 }
 
 func TestPrintSummaryPhaseBudgetExceeded(t *testing.T) {
@@ -1159,6 +1169,94 @@ func TestHandleEvent_SchemaVersionMismatchMissingVersion(t *testing.T) {
 	output := buf.String()
 	if !strings.Contains(output, "no schema version") {
 		t.Errorf("expected 'no schema version' in output, got %q", output)
+	}
+}
+
+func TestNewRunCmd_MaxCostFlag(t *testing.T) {
+	cmd := newRunCmd()
+	flag := cmd.Flags().Lookup("max-cost")
+	if flag == nil {
+		t.Fatal("--max-cost flag should be registered on run command")
+	}
+	if flag.DefValue != "0" {
+		t.Errorf("--max-cost default = %q, want %q", flag.DefValue, "0")
+	}
+}
+
+func TestPipelineOptsFromCmd_MaxCostSet(t *testing.T) {
+	cmd := newRunCmd()
+	cmd.SetArgs([]string{"TICKET-1", "--max-cost", "15.50"})
+	// Parse flags without executing RunE.
+	cmd.RunE = func(cmd *cobra.Command, args []string) error { return nil }
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	opts := pipelineOptsFromCmd(cmd, "TICKET-1")
+	if opts.maxCost != 15.5 {
+		t.Errorf("maxCost = %f, want 15.5", opts.maxCost)
+	}
+	if !opts.maxCostChanged {
+		t.Error("maxCostChanged should be true when --max-cost is set")
+	}
+}
+
+func TestPipelineOptsFromCmd_MaxCostNotSet(t *testing.T) {
+	cmd := newRunCmd()
+	cmd.SetArgs([]string{"TICKET-1"})
+	cmd.RunE = func(cmd *cobra.Command, args []string) error { return nil }
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	opts := pipelineOptsFromCmd(cmd, "TICKET-1")
+	if opts.maxCost != 0 {
+		t.Errorf("maxCost = %f, want 0", opts.maxCost)
+	}
+	if opts.maxCostChanged {
+		t.Error("maxCostChanged should be false when --max-cost is not set")
+	}
+}
+
+func TestPipelineOptsFromCmd_MaxCostZero(t *testing.T) {
+	cmd := newRunCmd()
+	cmd.SetArgs([]string{"TICKET-1", "--max-cost", "0"})
+	cmd.RunE = func(cmd *cobra.Command, args []string) error { return nil }
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	opts := pipelineOptsFromCmd(cmd, "TICKET-1")
+	if opts.maxCost != 0 {
+		t.Errorf("maxCost = %f, want 0", opts.maxCost)
+	}
+	if !opts.maxCostChanged {
+		t.Error("maxCostChanged should be true when --max-cost 0 is explicitly passed")
+	}
+}
+
+func TestHandleEvent_BudgetOverride(t *testing.T) {
+	dir := t.TempDir()
+	state, _ := pipeline.LoadOrCreate(dir, "T-1")
+
+	var buf bytes.Buffer
+	prog := progress.New(&buf, false)
+
+	event := pipeline.Event{
+		Kind: pipeline.EventBudgetOverride,
+		Data: map[string]any{
+			"config_value": 25.0,
+			"cli_value":    10.0,
+		},
+	}
+	handleEvent(context.Background(), nil, nil, state, prog, event)
+
+	output := buf.String()
+	if !strings.Contains(output, "--max-cost") {
+		t.Errorf("expected '--max-cost' in output, got %q", output)
+	}
+	if !strings.Contains(output, "25.00") {
+		t.Errorf("expected '25.00' (config value) in output, got %q", output)
+	}
+	if !strings.Contains(output, "10.00") {
+		t.Errorf("expected '10.00' (CLI value) in output, got %q", output)
 	}
 }
 

--- a/internal/pipeline/events.go
+++ b/internal/pipeline/events.go
@@ -105,6 +105,7 @@ const (
 	EventPhaseTimeoutResolved     = "phase_timeout_resolved"
 	EventPhaseModelResolved       = "phase_model_resolved"
 	EventModelFallback            = "model_fallback"
+	EventBudgetOverride           = "budget_override"
 )
 
 // FormatEvent formats an event as a compact, human-readable line:


### PR DESCRIPTION
## Summary

Implements the `--max-cost` flag for `soda run`, allowing users to cap the AI spend for a single ticket execution directly from the CLI.

## Changes

### New features
- **`--max-cost` flag** registered on the `soda run` command (e.g. `soda run TICKET --max-cost 10.00`)
- Flag value overrides `limits.max_cost_per_ticket` from `soda.yaml` when provided
- A value of `0` means unlimited (no cap applied)
- Negative values are rejected with a validation error
- **`EventBudgetOverride`** pipeline event emitted when the CLI flag overrides the configured limit — displayed as a warning in the terminal
- **`formatNextSteps`** now includes `--max-cost <2×limit>` in the budget-exceeded suggestion so users know how to retry with a larger budget
- Integrates with `--from` (resume a phase with a different budget) independently

### Files changed
| File | Change |
|------|--------|
| `internal/pipeline/events.go` | Add `EventBudgetOverride` constant |
| `cmd/soda/run.go` | Register flag, populate `pipelineOpts`, apply override, emit event |
| `cmd/soda/run_test.go` | 6 new tests covering flag registration, opts parsing, event handling, next-steps output |

## Test Plan

All new and existing tests pass:

```
go test ./cmd/soda/... ./internal/pipeline/...
```

New tests added:
- `TestNewRunCmd_MaxCostFlag` — flag is registered with correct default
- `TestPipelineOptsFromCmd_MaxCostSet` — flag value flows into `pipelineOpts.maxCost`
- `TestPipelineOptsFromCmd_MaxCostNotSet` — omitted flag leaves zero value (unlimited)
- `TestPipelineOptsFromCmd_MaxCostZero` — explicit `0` treated as unlimited
- `TestHandleEvent_BudgetOverride` — `EventBudgetOverride` renders warning with old/new values
- `TestPrintSummaryBudgetExceeded` (updated) — `--max-cost` appears in next-steps output

## Acceptance Criteria

- [x] `soda run <ticket> --max-cost 10.00` caps cost at $10
- [x] Flag overrides `limits.max_cost_per_ticket` from `soda.yaml`
- [x] Works with `--from` (resume with different budget)
- [x] Value of `0` means unlimited
- [x] Warning event emitted when overriding configured value
- [x] `formatNextSteps` includes `--max-cost` suggestion in budget-exceeded output
- [x] `soda run --help` documents the flag

Ref: 506
Assisted-by: SODA