### PR TITLE
feat(cli): soda gc — garbage collect old session data [505]

### DIFF
--- a/cmd/soda/gc.go
+++ b/cmd/soda/gc.go
@@ -1,0 +1,274 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/decko/soda/internal/pipeline"
+	"github.com/spf13/cobra"
+)
+
+// parseDuration parses a duration string that supports d (days) and w (weeks)
+// in addition to the standard Go time.Duration units. Compound durations like
+// "1w2d" and "1d12h" are supported.
+func parseDuration(s string) (time.Duration, error) {
+	// Try stdlib first — handles pure Go durations like "24h", "30m", etc.
+	if d, err := time.ParseDuration(s); err == nil {
+		return d, nil
+	}
+
+	// Tokenise (number)(unit) pairs. Examples: "30d", "1w2d", "1d12h".
+	var total time.Duration
+	remaining := strings.TrimSpace(s)
+	if remaining == "" {
+		return 0, fmt.Errorf("parseDuration: empty string")
+	}
+
+	parsed := false
+	for len(remaining) > 0 {
+		// Skip leading whitespace.
+		remaining = strings.TrimLeftFunc(remaining, unicode.IsSpace)
+		if len(remaining) == 0 {
+			break
+		}
+
+		// Find the numeric prefix.
+		numEnd := 0
+		for numEnd < len(remaining) && (remaining[numEnd] >= '0' && remaining[numEnd] <= '9' || remaining[numEnd] == '.') {
+			numEnd++
+		}
+		if numEnd == 0 {
+			return 0, fmt.Errorf("parseDuration: invalid duration %q", s)
+		}
+
+		numStr := remaining[:numEnd]
+		remaining = remaining[numEnd:]
+
+		// Find the unit suffix.
+		unitEnd := 0
+		for unitEnd < len(remaining) && unicode.IsLetter(rune(remaining[unitEnd])) {
+			unitEnd++
+		}
+		if unitEnd == 0 {
+			return 0, fmt.Errorf("parseDuration: missing unit in %q", s)
+		}
+
+		unit := remaining[:unitEnd]
+		remaining = remaining[unitEnd:]
+
+		num, err := strconv.ParseFloat(numStr, 64)
+		if err != nil {
+			return 0, fmt.Errorf("parseDuration: invalid number %q in %q", numStr, s)
+		}
+
+		switch unit {
+		case "d":
+			total += time.Duration(num * float64(24*time.Hour))
+		case "w":
+			total += time.Duration(num * float64(7*24*time.Hour))
+		default:
+			// Delegate non-custom units to stdlib (e.g. "h", "m", "s").
+			d, parseErr := time.ParseDuration(numStr + unit)
+			if parseErr != nil {
+				return 0, fmt.Errorf("parseDuration: unknown unit %q in %q", unit, s)
+			}
+			total += d
+		}
+		parsed = true
+	}
+
+	if !parsed {
+		return 0, fmt.Errorf("parseDuration: invalid duration %q", s)
+	}
+	return total, nil
+}
+
+// gcIsTerminal returns true if the pipeline is in a state safe for garbage
+// collection. Unlike isTerminal (used by clean), this rejects paused and
+// pending phases — a user may intend to resume those sessions.
+func gcIsTerminal(meta *pipeline.PipelineMeta) bool {
+	if len(meta.Phases) == 0 {
+		return true
+	}
+	for _, ps := range meta.Phases {
+		switch ps.Status {
+		case pipeline.PhaseRunning, pipeline.PhaseRetrying, pipeline.PhasePaused, pipeline.PhasePending:
+			return false
+		}
+	}
+	return true
+}
+
+// dirSize sums the sizes of all regular files under path via filepath.Walk.
+// Permission errors on individual files are silently skipped.
+func dirSize(path string) (int64, error) {
+	var total int64
+	err := filepath.Walk(path, func(_ string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			if os.IsPermission(walkErr) {
+				return nil
+			}
+			return walkErr
+		}
+		if info.Mode().IsRegular() {
+			total += info.Size()
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, fmt.Errorf("dirSize: %w", err)
+	}
+	return total, nil
+}
+
+// gcSessions iterates session directories in stateDir and removes those that
+// are older than olderThan, not locked, have no worktree, and are in a terminal
+// state. When dryRun is true it prints what would be removed without deleting.
+func gcSessions(ctx context.Context, stateDir string, olderThan time.Duration, dryRun bool) error {
+	entries, err := os.ReadDir(stateDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			fmt.Println("No sessions found.")
+			return nil
+		}
+		return fmt.Errorf("gc: read state dir: %w", err)
+	}
+
+	var removedCount int
+	var freedBytes int64
+
+	for _, entry := range entries {
+		// Check context cancellation at the top of every iteration.
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		// Skip non-directory entries (e.g. cost.json ledger).
+		if !entry.IsDir() {
+			continue
+		}
+
+		ticketDir := filepath.Join(stateDir, entry.Name())
+
+		// Age filter: check directory mtime.
+		if olderThan > 0 {
+			info, statErr := entry.Info()
+			if statErr != nil {
+				fmt.Fprintf(os.Stderr, "Warning: %s: stat: %v\n", entry.Name(), statErr)
+				continue
+			}
+			age := time.Since(info.ModTime())
+			if age < olderThan {
+				continue
+			}
+		}
+
+		// Lock check: skip if a pipeline is running.
+		lockPath := filepath.Join(ticketDir, "lock")
+		if !tryLock(lockPath) {
+			fmt.Fprintf(os.Stderr, "Skipping %s: pipeline is running\n", entry.Name())
+			continue
+		}
+
+		// Read meta.json — skip if unreadable.
+		metaPath := filepath.Join(ticketDir, "meta.json")
+		meta, metaErr := pipeline.ReadMeta(metaPath)
+		if metaErr != nil {
+			fmt.Fprintf(os.Stderr, "Skipping %s: %v\n", entry.Name(), metaErr)
+			continue
+		}
+
+		// Worktree check: skip sessions that still have an active worktree.
+		if meta.Worktree != "" {
+			fmt.Fprintf(os.Stderr, "Skipping %s: worktree still exists (%s)\n", entry.Name(), meta.Worktree)
+			continue
+		}
+
+		// Terminal check: only GC sessions in terminal state.
+		if !gcIsTerminal(meta) {
+			fmt.Fprintf(os.Stderr, "Skipping %s: not in terminal state\n", entry.Name())
+			continue
+		}
+
+		// Calculate size before removal.
+		size, sizeErr := dirSize(ticketDir)
+		if sizeErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: %s: cannot compute size: %v\n", entry.Name(), sizeErr)
+			size = 0
+		}
+
+		if dryRun {
+			fmt.Printf("Would remove %s (%s)\n", entry.Name(), formatBytes(size))
+		} else {
+			if rmErr := os.RemoveAll(ticketDir); rmErr != nil {
+				fmt.Fprintf(os.Stderr, "Warning: %s: remove: %v\n", entry.Name(), rmErr)
+				continue
+			}
+			fmt.Printf("Removed %s (%s)\n", entry.Name(), formatBytes(size))
+		}
+		removedCount++
+		freedBytes += size
+	}
+
+	if removedCount == 0 {
+		fmt.Println("Nothing to collect.")
+	} else {
+		verb := "Freed"
+		if dryRun {
+			verb = "Would free"
+		}
+		fmt.Printf("%s %d session(s), %s\n", verb, removedCount, formatBytes(freedBytes))
+	}
+	return nil
+}
+
+// formatBytes returns a human-readable byte count.
+func formatBytes(bytes int64) string {
+	const (
+		kb = 1024
+		mb = kb * 1024
+	)
+	switch {
+	case bytes >= mb:
+		return fmt.Sprintf("%.1f MB", float64(bytes)/float64(mb))
+	case bytes >= kb:
+		return fmt.Sprintf("%.1f KB", float64(bytes)/float64(kb))
+	default:
+		return fmt.Sprintf("%d B", bytes)
+	}
+}
+
+func newGcCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "gc",
+		Short: "Garbage collect old session data",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := loadConfig(cmd)
+			if err != nil {
+				return err
+			}
+			olderThanStr, _ := cmd.Flags().GetString("older-than")
+			dryRun, _ := cmd.Flags().GetBool("dry-run")
+
+			olderThan, parseErr := parseDuration(olderThanStr)
+			if parseErr != nil {
+				return fmt.Errorf("gc: invalid --older-than value: %w", parseErr)
+			}
+
+			return gcSessions(cmd.Context(), cfg.StateDir, olderThan, dryRun)
+		},
+	}
+
+	cmd.Flags().String("older-than", "30d", "minimum age of sessions to collect (e.g. 30d, 2w, 1w2d)")
+	cmd.Flags().Bool("dry-run", false, "show what would be collected without removing")
+
+	return cmd
+}

--- a/cmd/soda/gc_test.go
+++ b/cmd/soda/gc_test.go
@@ -1,0 +1,536 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/decko/soda/internal/pipeline"
+)
+
+func TestParseDuration(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    time.Duration
+		wantErr bool
+	}{
+		{
+			name:  "stdlib hours",
+			input: "24h",
+			want:  24 * time.Hour,
+		},
+		{
+			name:  "days",
+			input: "30d",
+			want:  30 * 24 * time.Hour,
+		},
+		{
+			name:  "weeks",
+			input: "2w",
+			want:  2 * 7 * 24 * time.Hour,
+		},
+		{
+			name:  "compound weeks and days",
+			input: "1w2d",
+			want:  (7 + 2) * 24 * time.Hour,
+		},
+		{
+			name:  "compound days and hours",
+			input: "1d12h",
+			want:  36 * time.Hour,
+		},
+		{
+			name:  "zero",
+			input: "0s",
+			want:  0,
+		},
+		{
+			name:  "zero days",
+			input: "0d",
+			want:  0,
+		},
+		{
+			name:  "stdlib minutes",
+			input: "30m",
+			want:  30 * time.Minute,
+		},
+		{
+			name:  "compound weeks days hours",
+			input: "1w1d1h",
+			want:  (8*24 + 1) * time.Hour,
+		},
+		{
+			name:    "empty string",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name:    "invalid unit",
+			input:   "10x",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseDuration(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("parseDuration(%q) = %v, want error", tc.input, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseDuration(%q) error: %v", tc.input, err)
+			}
+			if got != tc.want {
+				t.Errorf("parseDuration(%q) = %v, want %v", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGcIsTerminal(t *testing.T) {
+	tests := []struct {
+		name string
+		meta *pipeline.PipelineMeta
+		want bool
+	}{
+		{
+			name: "no phases → terminal",
+			meta: &pipeline.PipelineMeta{Phases: map[string]*pipeline.PhaseState{}},
+			want: true,
+		},
+		{
+			name: "all completed → terminal",
+			meta: &pipeline.PipelineMeta{Phases: map[string]*pipeline.PhaseState{
+				"triage":    {Status: pipeline.PhaseCompleted},
+				"implement": {Status: pipeline.PhaseCompleted},
+			}},
+			want: true,
+		},
+		{
+			name: "has failed → terminal",
+			meta: &pipeline.PipelineMeta{Phases: map[string]*pipeline.PhaseState{
+				"triage":    {Status: pipeline.PhaseCompleted},
+				"implement": {Status: pipeline.PhaseFailed},
+			}},
+			want: true,
+		},
+		{
+			name: "has running → not terminal",
+			meta: &pipeline.PipelineMeta{Phases: map[string]*pipeline.PhaseState{
+				"triage":    {Status: pipeline.PhaseCompleted},
+				"implement": {Status: pipeline.PhaseRunning},
+			}},
+			want: false,
+		},
+		{
+			name: "has retrying → not terminal",
+			meta: &pipeline.PipelineMeta{Phases: map[string]*pipeline.PhaseState{
+				"triage":    {Status: pipeline.PhaseCompleted},
+				"implement": {Status: pipeline.PhaseRetrying},
+			}},
+			want: false,
+		},
+		{
+			name: "has paused → not terminal",
+			meta: &pipeline.PipelineMeta{Phases: map[string]*pipeline.PhaseState{
+				"triage":    {Status: pipeline.PhaseCompleted},
+				"implement": {Status: pipeline.PhasePaused},
+			}},
+			want: false,
+		},
+		{
+			name: "has pending → not terminal",
+			meta: &pipeline.PipelineMeta{Phases: map[string]*pipeline.PhaseState{
+				"triage": {Status: pipeline.PhasePending},
+			}},
+			want: false,
+		},
+		{
+			name: "completed + paused → not terminal",
+			meta: &pipeline.PipelineMeta{Phases: map[string]*pipeline.PhaseState{
+				"triage":    {Status: pipeline.PhaseCompleted},
+				"implement": {Status: pipeline.PhasePaused},
+			}},
+			want: false,
+		},
+		{
+			name: "completed + pending → not terminal",
+			meta: &pipeline.PipelineMeta{Phases: map[string]*pipeline.PhaseState{
+				"triage":    {Status: pipeline.PhaseCompleted},
+				"implement": {Status: pipeline.PhasePending},
+			}},
+			want: false,
+		},
+		{
+			name: "completed + skipped → terminal",
+			meta: &pipeline.PipelineMeta{Phases: map[string]*pipeline.PhaseState{
+				"triage":    {Status: pipeline.PhaseCompleted},
+				"patch":     {Status: pipeline.PhaseSkipped},
+				"implement": {Status: pipeline.PhaseCompleted},
+			}},
+			want: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := gcIsTerminal(tc.meta)
+			if got != tc.want {
+				t.Errorf("gcIsTerminal() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// writeGcMeta creates a session directory with a meta.json file.
+func writeGcMeta(t *testing.T, dir string, meta *pipeline.PipelineMeta) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	data, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		t.Fatalf("MarshalIndent: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "meta.json"), data, 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}
+
+// setDirMtime sets the modification time of a directory.
+func setDirMtime(t *testing.T, dir string, mtime time.Time) {
+	t.Helper()
+	if err := os.Chtimes(dir, mtime, mtime); err != nil {
+		t.Fatalf("Chtimes: %v", err)
+	}
+}
+
+func TestGcSessions_RemovesOldTerminal(t *testing.T) {
+	stateDir := t.TempDir()
+	ticketDir := filepath.Join(stateDir, "TICKET-1")
+
+	writeGcMeta(t, ticketDir, &pipeline.PipelineMeta{
+		Ticket: "TICKET-1",
+		Phases: map[string]*pipeline.PhaseState{
+			"triage": {Status: pipeline.PhaseCompleted},
+		},
+	})
+
+	// Set mtime to 60 days ago.
+	setDirMtime(t, ticketDir, time.Now().Add(-60*24*time.Hour))
+
+	err := gcSessions(context.Background(), stateDir, 30*24*time.Hour, false)
+	if err != nil {
+		t.Fatalf("gcSessions: %v", err)
+	}
+
+	if _, statErr := os.Stat(ticketDir); !os.IsNotExist(statErr) {
+		t.Error("expected old terminal session to be removed")
+	}
+}
+
+func TestGcSessions_SkipsRecentSession(t *testing.T) {
+	stateDir := t.TempDir()
+	ticketDir := filepath.Join(stateDir, "TICKET-1")
+
+	writeGcMeta(t, ticketDir, &pipeline.PipelineMeta{
+		Ticket: "TICKET-1",
+		Phases: map[string]*pipeline.PhaseState{
+			"triage": {Status: pipeline.PhaseCompleted},
+		},
+	})
+
+	// Leave mtime as now (recent).
+	err := gcSessions(context.Background(), stateDir, 30*24*time.Hour, false)
+	if err != nil {
+		t.Fatalf("gcSessions: %v", err)
+	}
+
+	if _, statErr := os.Stat(ticketDir); statErr != nil {
+		t.Errorf("expected recent session to be preserved: %v", statErr)
+	}
+}
+
+func TestGcSessions_SkipsNonTerminal(t *testing.T) {
+	stateDir := t.TempDir()
+	ticketDir := filepath.Join(stateDir, "TICKET-1")
+
+	writeGcMeta(t, ticketDir, &pipeline.PipelineMeta{
+		Ticket: "TICKET-1",
+		Phases: map[string]*pipeline.PhaseState{
+			"triage": {Status: pipeline.PhasePending},
+		},
+	})
+
+	setDirMtime(t, ticketDir, time.Now().Add(-60*24*time.Hour))
+
+	err := gcSessions(context.Background(), stateDir, 30*24*time.Hour, false)
+	if err != nil {
+		t.Fatalf("gcSessions: %v", err)
+	}
+
+	if _, statErr := os.Stat(ticketDir); statErr != nil {
+		t.Errorf("expected non-terminal session to be preserved: %v", statErr)
+	}
+}
+
+func TestGcSessions_SkipsPaused(t *testing.T) {
+	stateDir := t.TempDir()
+	ticketDir := filepath.Join(stateDir, "TICKET-1")
+
+	writeGcMeta(t, ticketDir, &pipeline.PipelineMeta{
+		Ticket: "TICKET-1",
+		Phases: map[string]*pipeline.PhaseState{
+			"triage":    {Status: pipeline.PhaseCompleted},
+			"implement": {Status: pipeline.PhasePaused},
+		},
+	})
+
+	setDirMtime(t, ticketDir, time.Now().Add(-60*24*time.Hour))
+
+	err := gcSessions(context.Background(), stateDir, 30*24*time.Hour, false)
+	if err != nil {
+		t.Fatalf("gcSessions: %v", err)
+	}
+
+	if _, statErr := os.Stat(ticketDir); statErr != nil {
+		t.Errorf("expected paused session to be preserved: %v", statErr)
+	}
+}
+
+func TestGcSessions_SkipsLockedSession(t *testing.T) {
+	stateDir := t.TempDir()
+	ticketDir := filepath.Join(stateDir, "TICKET-1")
+
+	writeGcMeta(t, ticketDir, &pipeline.PipelineMeta{
+		Ticket: "TICKET-1",
+		Phases: map[string]*pipeline.PhaseState{
+			"triage": {Status: pipeline.PhaseCompleted},
+		},
+	})
+
+	setDirMtime(t, ticketDir, time.Now().Add(-60*24*time.Hour))
+
+	// Acquire an exclusive flock to simulate a running pipeline.
+	lockPath := filepath.Join(ticketDir, "lock")
+	fd, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		t.Fatalf("open lock file: %v", err)
+	}
+	defer fd.Close()
+	if err := syscall.Flock(int(fd.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		t.Fatalf("flock: %v", err)
+	}
+	defer syscall.Flock(int(fd.Fd()), syscall.LOCK_UN) //nolint:errcheck
+
+	gcErr := gcSessions(context.Background(), stateDir, 30*24*time.Hour, false)
+	if gcErr != nil {
+		t.Fatalf("gcSessions: %v", gcErr)
+	}
+
+	if _, statErr := os.Stat(ticketDir); statErr != nil {
+		t.Errorf("expected locked session to be preserved: %v", statErr)
+	}
+}
+
+func TestGcSessions_SkipsWorktreeSession(t *testing.T) {
+	stateDir := t.TempDir()
+	ticketDir := filepath.Join(stateDir, "TICKET-1")
+
+	writeGcMeta(t, ticketDir, &pipeline.PipelineMeta{
+		Ticket:   "TICKET-1",
+		Worktree: "/some/worktree/path",
+		Phases: map[string]*pipeline.PhaseState{
+			"triage": {Status: pipeline.PhaseCompleted},
+		},
+	})
+
+	setDirMtime(t, ticketDir, time.Now().Add(-60*24*time.Hour))
+
+	err := gcSessions(context.Background(), stateDir, 30*24*time.Hour, false)
+	if err != nil {
+		t.Fatalf("gcSessions: %v", err)
+	}
+
+	if _, statErr := os.Stat(ticketDir); statErr != nil {
+		t.Errorf("expected session with worktree to be preserved: %v", statErr)
+	}
+}
+
+func TestGcSessions_DryRun(t *testing.T) {
+	stateDir := t.TempDir()
+	ticketDir := filepath.Join(stateDir, "TICKET-1")
+
+	writeGcMeta(t, ticketDir, &pipeline.PipelineMeta{
+		Ticket: "TICKET-1",
+		Phases: map[string]*pipeline.PhaseState{
+			"triage": {Status: pipeline.PhaseCompleted},
+		},
+	})
+
+	setDirMtime(t, ticketDir, time.Now().Add(-60*24*time.Hour))
+
+	err := gcSessions(context.Background(), stateDir, 30*24*time.Hour, true)
+	if err != nil {
+		t.Fatalf("gcSessions dry-run: %v", err)
+	}
+
+	// Session should still exist after dry-run.
+	if _, statErr := os.Stat(ticketDir); statErr != nil {
+		t.Errorf("expected session to still exist after dry-run: %v", statErr)
+	}
+}
+
+func TestGcSessions_ZeroDuration(t *testing.T) {
+	stateDir := t.TempDir()
+	ticketDir := filepath.Join(stateDir, "TICKET-1")
+
+	writeGcMeta(t, ticketDir, &pipeline.PipelineMeta{
+		Ticket: "TICKET-1",
+		Phases: map[string]*pipeline.PhaseState{
+			"triage": {Status: pipeline.PhaseCompleted},
+		},
+	})
+
+	// --older-than 0 should bypass age check and remove all eligible sessions.
+	err := gcSessions(context.Background(), stateDir, 0, false)
+	if err != nil {
+		t.Fatalf("gcSessions: %v", err)
+	}
+
+	if _, statErr := os.Stat(ticketDir); !os.IsNotExist(statErr) {
+		t.Error("expected session to be removed with olderThan=0")
+	}
+}
+
+func TestGcSessions_NonexistentDir(t *testing.T) {
+	err := gcSessions(context.Background(), "/tmp/nonexistent-soda-gc-test", 30*24*time.Hour, false)
+	if err != nil {
+		t.Fatalf("gcSessions should not error for nonexistent dir: %v", err)
+	}
+}
+
+func TestGcSessions_PreservesCostJson(t *testing.T) {
+	stateDir := t.TempDir()
+
+	// Create a cost.json file at the stateDir root.
+	costPath := filepath.Join(stateDir, "cost.json")
+	if err := os.WriteFile(costPath, []byte(`[]`), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	// Create a session to collect.
+	ticketDir := filepath.Join(stateDir, "TICKET-1")
+	writeGcMeta(t, ticketDir, &pipeline.PipelineMeta{
+		Ticket: "TICKET-1",
+		Phases: map[string]*pipeline.PhaseState{
+			"triage": {Status: pipeline.PhaseCompleted},
+		},
+	})
+	setDirMtime(t, ticketDir, time.Now().Add(-60*24*time.Hour))
+
+	err := gcSessions(context.Background(), stateDir, 30*24*time.Hour, false)
+	if err != nil {
+		t.Fatalf("gcSessions: %v", err)
+	}
+
+	// cost.json must survive.
+	if _, statErr := os.Stat(costPath); statErr != nil {
+		t.Errorf("expected cost.json to be preserved: %v", statErr)
+	}
+}
+
+func TestGcSessions_ContextCancelled(t *testing.T) {
+	stateDir := t.TempDir()
+
+	// Create two sessions.
+	for _, ticket := range []string{"TICKET-1", "TICKET-2"} {
+		ticketDir := filepath.Join(stateDir, ticket)
+		writeGcMeta(t, ticketDir, &pipeline.PipelineMeta{
+			Ticket: ticket,
+			Phases: map[string]*pipeline.PhaseState{
+				"triage": {Status: pipeline.PhaseCompleted},
+			},
+		})
+		setDirMtime(t, ticketDir, time.Now().Add(-60*24*time.Hour))
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately.
+
+	err := gcSessions(ctx, stateDir, 30*24*time.Hour, false)
+	if err == nil {
+		t.Fatal("expected context cancellation error")
+	}
+}
+
+func TestNewGcCmd_Flags(t *testing.T) {
+	cmd := newGcCmd()
+
+	olderThanFlag := cmd.Flags().Lookup("older-than")
+	if olderThanFlag == nil {
+		t.Fatal("--older-than flag not found")
+	}
+	if olderThanFlag.DefValue != "30d" {
+		t.Errorf("--older-than default = %q, want %q", olderThanFlag.DefValue, "30d")
+	}
+
+	dryRunFlag := cmd.Flags().Lookup("dry-run")
+	if dryRunFlag == nil {
+		t.Fatal("--dry-run flag not found")
+	}
+	if dryRunFlag.DefValue != "false" {
+		t.Errorf("--dry-run default = %q, want %q", dryRunFlag.DefValue, "false")
+	}
+}
+
+func TestDirSize(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create some files with known sizes.
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), make([]byte, 100), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	subDir := filepath.Join(dir, "sub")
+	if err := os.MkdirAll(subDir, 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(subDir, "b.txt"), make([]byte, 200), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	size, err := dirSize(dir)
+	if err != nil {
+		t.Fatalf("dirSize: %v", err)
+	}
+	if size != 300 {
+		t.Errorf("dirSize = %d, want 300", size)
+	}
+}
+
+func TestFormatBytes(t *testing.T) {
+	tests := []struct {
+		input int64
+		want  string
+	}{
+		{0, "0 B"},
+		{512, "512 B"},
+		{1024, "1.0 KB"},
+		{1536, "1.5 KB"},
+		{1048576, "1.0 MB"},
+		{1572864, "1.5 MB"},
+	}
+	for _, tc := range tests {
+		got := formatBytes(tc.input)
+		if got != tc.want {
+			t.Errorf("formatBytes(%d) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}

--- a/cmd/soda/main.go
+++ b/cmd/soda/main.go
@@ -67,6 +67,7 @@ func newRootCmd() *cobra.Command {
 		newSpecCmd(),
 		newPluginCmd(),
 		newDoctorCmd(),
+		newGcCmd(),
 		newVersionCmd(),
 	)
 


### PR DESCRIPTION
## Summary

Implements `soda gc`, a new CLI subcommand that garbage-collects old session directories from the SODA state directory.

### Changes

- **`cmd/soda/gc.go`** — Core implementation:
  - `parseDuration` — extends Go's `time.ParseDuration` with `d` (days) and `w` (weeks) units; compound durations like `1w2d` and `1d12h` are supported
  - `gcIsTerminal` — like the existing `isTerminal` but also rejects `paused` and `pending` states (user may resume those sessions)
  - `gcSessions` — iterates state-dir entries and removes sessions older than `--older-than`, skipping locked, worktree-attached, or non-terminal sessions; respects `context.Context` cancellation
  - `formatBytes` — human-readable byte counts (B / KB / MB)
  - `newGcCmd` — Cobra command with `--older-than` (default `30d`) and `--dry-run` flags
- **`cmd/soda/gc_test.go`** — Comprehensive test suite using `t.TempDir()` and real files
- **`cmd/soda/root.go`** — Registers `newGcCmd()` in the root command (alphabetical order after `doctor`)

### Flags

| Flag | Default | Description |
|---|---|---|
| `--older-than` | `30d` | Minimum age of sessions to collect (`30d`, `2w`, `1w2d`, `24h`, …) |
| `--dry-run` | `false` | List what would be removed without deleting |

## Test Plan

All tests pass with `CGO_ENABLED=0 go test ./...`.

New tests cover:
- `TestParseDuration` — 11 cases: stdlib units, `d`/`w`, compound, zero, empty string, invalid unit
- `TestGcIsTerminal` — 10 cases across all phase statuses
- `TestGcSessions_RemovesOldTerminal` — removes 60-day-old completed session (threshold 30d)
- `TestGcSessions_SkipsRecentSession` — preserves fresh sessions
- `TestGcSessions_SkipsNonTerminal` — preserves pending sessions
- `TestGcSessions_SkipsPaused` — preserves paused sessions
- `TestGcSessions_SkipsLockedSession` — skips `flock`-held sessions
- `TestGcSessions_SkipsWorktreeSession` — skips sessions with an active worktree
- `TestGcSessions_DryRun` — sessions survive dry-run
- `TestGcSessions_ZeroDuration` — `--older-than 0` removes all eligible
- `TestGcSessions_NonexistentDir` — gracefully handles missing state dir
- `TestGcSessions_PreservesCostJson` — `cost.json` ledger is never touched
- `TestGcSessions_ContextCancelled` — returns error on cancelled context
- `TestNewGcCmd_Flags` — verifies flag names and defaults
- `TestDirSize` / `TestFormatBytes` — unit helpers

## Acceptance Criteria

- [x] Removes dirs older than `--older-than` (default 30d)
- [x] Parser supports `d`, `w`, and Go durations
- [x] `parseDuration` unit-tested independently (11 cases)
- [x] Skips locked sessions via reused `tryLock`
- [x] Skips sessions with worktrees
- [x] Skips non-terminal states (running/retrying/paused/pending)
- [x] `--dry-run` lists without deleting
- [x] `--older-than 0` removes all eligible
- [x] Per-session detail + final summary printed
- [x] Does NOT touch cost ledger
- [x] Permission errors handled gracefully
- [x] `context.Context` cancellation support
- [x] Registered in root command (cobra autocomplete works)
- [x] Tests use `t.TempDir()` with real files
- [x] `soda gc --help` documents all flags