### PR TITLE
[484] feat(runner): Pi coding agent backend

### DIFF
--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/decko/soda/internal/claude"
 	"github.com/decko/soda/internal/config"
 	"github.com/decko/soda/internal/detect"
 	"github.com/decko/soda/internal/git"
@@ -279,6 +278,7 @@ func runPipeline(cfg *config.Config, opts pipelineOpts) error {
 	// Build runner
 	var r runner.Runner
 	useMock := opts.useMock
+	usePi := cfg.Runner == "pi"
 	if useMock {
 		r = buildMockRunner()
 	} else if cfg.Sandbox.Enabled {
@@ -295,12 +295,36 @@ func runPipeline(cfg *config.Config, opts pipelineOpts) error {
 				LogDir:          cfg.Sandbox.Proxy.LogDir,
 			},
 		}
-		sbRunner, err := sandbox.New(sbCfg)
-		if err != nil {
-			return fmt.Errorf("run: create sandbox runner: %w", err)
+		if usePi {
+			piBinary := cfg.Pi.Binary
+			piAdapter, adapterErr := sandbox.NewPiAdapter(piBinary)
+			if adapterErr != nil {
+				return fmt.Errorf("run: create pi adapter: %w", adapterErr)
+			}
+			sbRunner, sbErr := sandbox.NewWithAdapter(sbCfg, piAdapter)
+			if sbErr != nil {
+				return fmt.Errorf("run: create sandbox runner (pi): %w", sbErr)
+			}
+			defer sbRunner.Close()
+			r = sbRunner
+		} else {
+			sbRunner, sbErr := sandbox.New(sbCfg)
+			if sbErr != nil {
+				return fmt.Errorf("run: create sandbox runner: %w", sbErr)
+			}
+			defer sbRunner.Close()
+			r = sbRunner
 		}
-		defer sbRunner.Close()
-		r = sbRunner
+	} else if usePi {
+		piModel := cfg.Pi.Model
+		if piModel == "" {
+			piModel = cfg.Model
+		}
+		piRunner, piErr := runner.NewPiRunner(cfg.Pi.Binary, piModel, workDir)
+		if piErr != nil {
+			return fmt.Errorf("run: create pi runner: %w", piErr)
+		}
+		r = piRunner
 	} else {
 		claudeRunner, err := runner.NewClaudeRunner("claude", cfg.Model, workDir)
 		if err != nil {
@@ -1425,12 +1449,12 @@ func isBudgetExceededError(err error) bool {
 }
 
 func isTransientError(err error) bool {
-	var te *claude.TransientError
+	var te *runner.TransientError
 	return errors.As(err, &te)
 }
 
 func isParseError(err error) bool {
-	var pe *claude.ParseError
+	var pe *runner.ParseError
 	return errors.As(err, &pe)
 }
 

--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -440,6 +440,12 @@ func runPipeline(cfg *config.Config, opts pipelineOpts) error {
 		cfg.Limits.MaxCostPerTicket = opts.maxCost
 	}
 
+	// When using Pi, prefer pi.model over top-level model.
+	effectiveModel := cfg.Model
+	if usePi && cfg.Pi.Model != "" {
+		effectiveModel = cfg.Pi.Model
+	}
+
 	engineCfg := pipeline.EngineConfig{
 		Pipeline:               pl,
 		Loader:                 loader,
@@ -447,7 +453,7 @@ func runPipeline(cfg *config.Config, opts pipelineOpts) error {
 		PromptConfig:           promptConfig,
 		PromptContext:          promptContext,
 		DetectedStack:          detectedStack,
-		Model:                  cfg.Model,
+		Model:                  effectiveModel,
 		PipelineName:           pipelineName,
 		BinaryVersion:          binaryVersionID(),
 		WorkDir:                workDir,

--- a/cmd/soda/run_test.go
+++ b/cmd/soda/run_test.go
@@ -9,10 +9,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/decko/soda/internal/claude"
 	"github.com/decko/soda/internal/config"
 	"github.com/decko/soda/internal/pipeline"
 	"github.com/decko/soda/internal/progress"
+	"github.com/decko/soda/internal/runner"
 	"github.com/spf13/cobra"
 )
 
@@ -698,7 +698,7 @@ func TestPrintSummaryTransientError(t *testing.T) {
 	meta.Phases["plan"] = &pipeline.PhaseState{Status: pipeline.PhaseFailed, DurationMs: 5000, Cost: 0.70, Error: "timeout"}
 
 	transientErr := fmt.Errorf("engine: phase plan failed (transient, no retries left): %w",
-		&claude.TransientError{Reason: "timeout", Err: fmt.Errorf("connection reset")})
+		&runner.TransientError{Reason: "timeout", Err: fmt.Errorf("connection reset")})
 	var buf bytes.Buffer
 	fprintSummary(&buf, state, testPhases(), "Transient test", 1*time.Minute, transientErr, nil)
 	output := buf.String()
@@ -727,7 +727,7 @@ func TestPrintSummaryParseError(t *testing.T) {
 	meta.Phases["triage"] = &pipeline.PhaseState{Status: pipeline.PhaseFailed, DurationMs: 15000, Cost: 0.80, Error: "parse error"}
 
 	parseErr := fmt.Errorf("engine: phase triage failed (parse, no retries left): %w",
-		&claude.ParseError{Raw: []byte("bad output"), Err: fmt.Errorf("invalid JSON")})
+		&runner.ParseError{Err: fmt.Errorf("invalid JSON")})
 	var buf bytes.Buffer
 	fprintSummary(&buf, state, testPhases(), "Parse test", 30*time.Second, parseErr, nil)
 	output := buf.String()
@@ -755,7 +755,7 @@ func TestPrintSummaryTransientErrorEmptyPhase(t *testing.T) {
 
 	// No phase has PhaseFailed, so failedPhase will be "".
 	transientErr := fmt.Errorf("engine: transient: %w",
-		&claude.TransientError{Reason: "timeout", Err: fmt.Errorf("connection reset")})
+		&runner.TransientError{Reason: "timeout", Err: fmt.Errorf("connection reset")})
 	var buf bytes.Buffer
 	fprintSummary(&buf, state, testPhases(), "Transient empty phase", 30*time.Second, transientErr, nil)
 	output := buf.String()
@@ -777,7 +777,7 @@ func TestPrintSummaryParseErrorEmptyPhase(t *testing.T) {
 
 	// No phase has PhaseFailed, so failedPhase will be "".
 	parseErr := fmt.Errorf("engine: parse: %w",
-		&claude.ParseError{Raw: []byte("bad"), Err: fmt.Errorf("invalid")})
+		&runner.ParseError{Err: fmt.Errorf("invalid")})
 	var buf bytes.Buffer
 	fprintSummary(&buf, state, testPhases(), "Parse empty phase", 30*time.Second, parseErr, nil)
 	output := buf.String()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,8 +23,10 @@ type Config struct {
 	GitLab              GitLabTicketConfig  `yaml:"gitlab,omitempty"`
 	Mode                string              `yaml:"mode"`
 	Model               string              `yaml:"model"`
+	Runner              string              `yaml:"runner,omitempty"` // "claude" (default) or "pi"
 	Auth                AuthConfig          `yaml:"auth"`
 	Sandbox             SandboxConfig       `yaml:"sandbox"`
+	Pi                  PiConfig            `yaml:"pi,omitempty"`
 	Limits              LimitsConfig        `yaml:"limits"`
 	PhasesPath          string              `yaml:"phases_path"`    // explicit path to pipeline YAML; overrides CWD discovery
 	PipelinesPath       string              `yaml:"pipelines_path"` // directory for named pipeline YAML files (e.g. ".pipelines/"); checked before CWD discovery
@@ -38,6 +40,12 @@ type Config struct {
 	Monitor             MonitorConfig       `yaml:"monitor"`
 	Notify              NotifyConfig        `yaml:"notify"`
 	Transcript          TranscriptConfig    `yaml:"transcript,omitempty"`
+}
+
+// PiConfig holds Pi coding agent settings.
+type PiConfig struct {
+	Binary string `yaml:"binary,omitempty"` // path to pi binary; empty = exec.LookPath("pi")
+	Model  string `yaml:"model,omitempty"`  // model override for Pi; empty = use top-level Model
 }
 
 // TranscriptConfig controls agent transcript persistence.

--- a/internal/runner/pi.go
+++ b/internal/runner/pi.go
@@ -16,9 +16,8 @@ import (
 
 // PiRunner implements Runner by invoking the Pi coding agent CLI.
 type PiRunner struct {
-	binary  string // resolved absolute path to pi binary
-	model   string
-	workDir string
+	binary string // resolved absolute path to pi binary
+	model  string
 }
 
 // compile-time interface check
@@ -35,14 +34,9 @@ func NewPiRunner(binary, model, workDir string) (*PiRunner, error) {
 		return nil, fmt.Errorf("pi binary not found: %w", err)
 	}
 
-	if !filepath.IsAbs(workDir) {
-		return nil, fmt.Errorf("workDir must be absolute: %s", workDir)
-	}
-
 	return &PiRunner{
-		binary:  resolved,
-		model:   model,
-		workDir: workDir,
+		binary: resolved,
+		model:  model,
 	}, nil
 }
 

--- a/internal/runner/pi.go
+++ b/internal/runner/pi.go
@@ -48,6 +48,14 @@ func NewPiRunner(binary, model, workDir string) (*PiRunner, error) {
 
 // Run maps runner.RunOpts to Pi CLI arguments, invokes the CLI, and maps the result back.
 func (r *PiRunner) Run(ctx context.Context, opts RunOpts) (*RunResult, error) {
+	// Validate WorkDir — must be present and absolute.
+	if opts.WorkDir == "" {
+		return nil, fmt.Errorf("pi runner: WorkDir is required")
+	}
+	if !filepath.IsAbs(opts.WorkDir) {
+		return nil, fmt.Errorf("pi runner: WorkDir must be absolute: %s", opts.WorkDir)
+	}
+
 	// Validate output schema.
 	if opts.OutputSchema != "" {
 		if len(opts.OutputSchema) > 256*1024 {

--- a/internal/runner/pi.go
+++ b/internal/runner/pi.go
@@ -60,11 +60,11 @@ func (r *PiRunner) Run(ctx context.Context, opts RunOpts) (*RunResult, error) {
 
 	// Write system prompt to workspace-level .pi/SYSTEM.md.
 	if opts.SystemPrompt != "" {
-		promptPath, err := writePiSystemPrompt(opts.WorkDir, opts.SystemPrompt)
+		cleanup, err := writePiSystemPrompt(opts.WorkDir, opts.SystemPrompt)
 		if err != nil {
 			return nil, fmt.Errorf("pi runner: write system prompt: %w", err)
 		}
-		defer os.Remove(promptPath)
+		defer cleanup()
 	}
 
 	args := buildPiArgs(opts, r.model)
@@ -296,26 +296,54 @@ func buildPiArgs(opts RunOpts, defaultModel string) []string {
 
 // writePiSystemPrompt writes the system prompt to {workDir}/.pi/SYSTEM.md
 // per Pi's workspace-level system prompt convention.
-func writePiSystemPrompt(workDir, content string) (string, error) {
+//
+// If an existing SYSTEM.md is present it is backed up and restored by the
+// returned cleanup function. If no prior file existed, cleanup removes the
+// file (and the .pi/ directory if we created it).
+func writePiSystemPrompt(workDir, content string) (cleanup func(), err error) {
 	if workDir == "" {
 		workDir = os.TempDir()
 	}
 	abs, err := filepath.Abs(workDir)
 	if err != nil {
-		return "", fmt.Errorf("pi: resolve workdir: %w", err)
+		return nil, fmt.Errorf("pi: resolve workdir: %w", err)
 	}
 
 	piDir := filepath.Join(abs, ".pi")
-	if err := os.MkdirAll(piDir, 0o755); err != nil {
-		return "", fmt.Errorf("pi: create .pi directory: %w", err)
-	}
-
 	promptPath := filepath.Join(piDir, "SYSTEM.md")
-	if err := os.WriteFile(promptPath, []byte(content), 0o644); err != nil {
-		return "", fmt.Errorf("pi: write SYSTEM.md: %w", err)
+
+	// Track whether the .pi directory already existed so we can clean up
+	// if we created it.
+	_, statErr := os.Stat(piDir)
+	piDirExisted := statErr == nil
+
+	if err := os.MkdirAll(piDir, 0o755); err != nil {
+		return nil, fmt.Errorf("pi: create .pi directory: %w", err)
 	}
 
-	return promptPath, nil
+	// Back up existing SYSTEM.md so we can restore it on cleanup.
+	existing, readErr := os.ReadFile(promptPath)
+	hadExisting := readErr == nil
+
+	if err := os.WriteFile(promptPath, []byte(content), 0o644); err != nil {
+		return nil, fmt.Errorf("pi: write SYSTEM.md: %w", err)
+	}
+
+	cleanup = func() {
+		if hadExisting {
+			// Restore the original file.
+			_ = os.WriteFile(promptPath, existing, 0o644)
+		} else {
+			// Remove the file we created.
+			_ = os.Remove(promptPath)
+			// Remove the directory only if we created it AND it is now empty.
+			if !piDirExisted {
+				_ = os.Remove(piDir) // fails silently if non-empty
+			}
+		}
+	}
+
+	return cleanup, nil
 }
 
 // classifyPiExitError categorizes a Pi process exit failure.

--- a/internal/runner/pi.go
+++ b/internal/runner/pi.go
@@ -277,10 +277,6 @@ func buildPiArgs(opts RunOpts, defaultModel string) []string {
 		"--output-format", "stream-json",
 	}
 
-	if opts.OutputSchema != "" {
-		args = append(args, "--json-schema", opts.OutputSchema)
-	}
-
 	// Prefer per-invocation model over runner-level default.
 	effectiveModel := defaultModel
 	if opts.Model != "" {

--- a/internal/runner/pi.go
+++ b/internal/runner/pi.go
@@ -79,8 +79,16 @@ func (r *PiRunner) Run(ctx context.Context, opts RunOpts) (*RunResult, error) {
 		}
 	}
 
-	cmd := exec.CommandContext(ctx, r.binary, args...)
-	cmd.Dir = r.workDir
+	// Budget tracking: cancel if cost exceeds budget.
+	budgetCtx := ctx
+	var budgetCancel context.CancelFunc
+	if opts.MaxBudgetUSD > 0 {
+		budgetCtx, budgetCancel = context.WithCancel(ctx)
+		defer budgetCancel()
+	}
+
+	cmd := exec.CommandContext(budgetCtx, r.binary, args...)
+	cmd.Dir = opts.WorkDir
 
 	// Stdin: prompt via stdin, or /dev/null if empty.
 	if opts.UserPrompt != "" {
@@ -119,14 +127,6 @@ func (r *PiRunner) Run(ctx context.Context, opts RunOpts) (*RunResult, error) {
 	var stdoutErr error
 	var wg sync.WaitGroup
 	wg.Add(2)
-
-	// Budget tracking: cancel if cost exceeds budget.
-	budgetCtx := ctx
-	var budgetCancel context.CancelFunc
-	if opts.MaxBudgetUSD > 0 {
-		budgetCtx, budgetCancel = context.WithCancel(ctx)
-		defer budgetCancel()
-	}
 
 	var costAccumulator float64
 	var costMu sync.Mutex

--- a/internal/runner/pi.go
+++ b/internal/runner/pi.go
@@ -362,9 +362,9 @@ func classifyPiExitError(waitErr error, stderr []byte) error {
 		substrings []string
 		reason     string
 	}{
-		{[]string{"rate limit", "429", "too many requests"}, "rate_limit"},
-		{[]string{"timeout", "504", "529"}, "timeout"},
-		{[]string{"overloaded", "500", "502", "503", "server error", "internal error"}, "overloaded"},
+		{[]string{"rate limit", " 429", "too many requests"}, "rate_limit"},
+		{[]string{"timeout", " 504", " 529"}, "timeout"},
+		{[]string{"overloaded", " 500", " 502", " 503", "server error", "internal error"}, "overloaded"},
 		{[]string{"connection refused", "econnreset", "connection reset"}, "connection"},
 	}
 

--- a/internal/runner/pi.go
+++ b/internal/runner/pi.go
@@ -1,0 +1,400 @@
+package runner
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+// PiRunner implements Runner by invoking the Pi coding agent CLI.
+type PiRunner struct {
+	binary  string // resolved absolute path to pi binary
+	model   string
+	workDir string
+}
+
+// compile-time interface check
+var _ Runner = (*PiRunner)(nil)
+
+// NewPiRunner creates a PiRunner backed by the Pi coding agent CLI.
+func NewPiRunner(binary, model, workDir string) (*PiRunner, error) {
+	if binary == "" {
+		binary = "pi"
+	}
+
+	resolved, err := exec.LookPath(binary)
+	if err != nil {
+		return nil, fmt.Errorf("pi binary not found: %w", err)
+	}
+
+	if !filepath.IsAbs(workDir) {
+		return nil, fmt.Errorf("workDir must be absolute: %s", workDir)
+	}
+
+	return &PiRunner{
+		binary:  resolved,
+		model:   model,
+		workDir: workDir,
+	}, nil
+}
+
+// Run maps runner.RunOpts to Pi CLI arguments, invokes the CLI, and maps the result back.
+func (r *PiRunner) Run(ctx context.Context, opts RunOpts) (*RunResult, error) {
+	// Validate output schema.
+	if opts.OutputSchema != "" {
+		if len(opts.OutputSchema) > 256*1024 {
+			return nil, fmt.Errorf("pi runner: output schema exceeds 256KB limit")
+		}
+		if !json.Valid([]byte(opts.OutputSchema)) {
+			return nil, fmt.Errorf("pi runner: output schema is not valid JSON")
+		}
+	}
+
+	// Write system prompt to workspace-level .pi/SYSTEM.md.
+	if opts.SystemPrompt != "" {
+		promptPath, err := writePiSystemPrompt(opts.WorkDir, opts.SystemPrompt)
+		if err != nil {
+			return nil, fmt.Errorf("pi runner: write system prompt: %w", err)
+		}
+		defer os.Remove(promptPath)
+	}
+
+	args := buildPiArgs(opts, r.model)
+
+	// Apply per-phase timeout.
+	if opts.Timeout > 0 {
+		phaseDeadline := time.Now().Add(opts.Timeout)
+		if existingDeadline, hasDeadline := ctx.Deadline(); !hasDeadline || phaseDeadline.Before(existingDeadline) {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, opts.Timeout)
+			defer cancel()
+		}
+	}
+
+	cmd := exec.CommandContext(ctx, r.binary, args...)
+	cmd.Dir = r.workDir
+
+	// Stdin: prompt via stdin, or /dev/null if empty.
+	if opts.UserPrompt != "" {
+		cmd.Stdin = strings.NewReader(opts.UserPrompt)
+	}
+
+	// Process group isolation — kill the entire group on cancel.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
+	}
+	cmd.WaitDelay = 5 * time.Second
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("pi runner: stdout pipe: %w", err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, fmt.Errorf("pi runner: stderr pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, &TransientError{
+			Reason: "unknown",
+			Err:    fmt.Errorf("pi runner: start: %w", err),
+		}
+	}
+
+	// Drain stdout and stderr concurrently.
+	var outputBuf piLimitedBuffer
+	outputBuf.max = 50 * 1024 * 1024 // 50MB
+	var stderrBuf piLimitedBuffer
+	stderrBuf.max = 1024 * 1024 // 1MB
+
+	var stdoutErr error
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Budget tracking: cancel if cost exceeds budget.
+	budgetCtx := ctx
+	var budgetCancel context.CancelFunc
+	if opts.MaxBudgetUSD > 0 {
+		budgetCtx, budgetCancel = context.WithCancel(ctx)
+		defer budgetCancel()
+	}
+
+	var costAccumulator float64
+	var costMu sync.Mutex
+	budgetExceeded := false
+
+	go func() {
+		defer wg.Done()
+		scanner := newLineScanner(stdout)
+		for scanner.Scan() {
+			line := scanner.Bytes()
+			outputBuf.Write(line)
+			outputBuf.Write([]byte("\n"))
+
+			// Budget enforcement: check cost from message_end events.
+			if opts.MaxBudgetUSD > 0 {
+				var event PiEvent
+				if json.Unmarshal(line, &event) == nil && event.Type == "message_end" && event.Cost != nil {
+					costMu.Lock()
+					costAccumulator += *event.Cost
+					exceeded := costAccumulator >= opts.MaxBudgetUSD
+					costMu.Unlock()
+					if exceeded {
+						budgetExceeded = true
+						if budgetCancel != nil {
+							budgetCancel()
+						}
+					}
+				}
+			}
+
+			// Forward displayable text to onChunk.
+			if opts.OnChunk != nil {
+				var event PiEvent
+				if json.Unmarshal(line, &event) == nil && event.Type == "assistant" && event.Content != "" {
+					func() {
+						defer func() {
+							if rec := recover(); rec != nil {
+								fmt.Fprintf(os.Stderr, "pi runner: onChunk panic: %v\n", rec)
+							}
+						}()
+						opts.OnChunk(event.Content)
+					}()
+				}
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			stdoutErr = fmt.Errorf("pi runner: scan stdout: %w", err)
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		buf := make([]byte, 32*1024)
+		for {
+			n, readErr := stderr.Read(buf)
+			if n > 0 {
+				stderrBuf.Write(buf[:n])
+			}
+			if readErr != nil {
+				break
+			}
+		}
+	}()
+
+	wg.Wait()
+
+	// Check stdout drain error.
+	if stdoutErr != nil {
+		cmd.Wait()
+		return nil, stdoutErr
+	}
+
+	waitErr := cmd.Wait()
+
+	// Budget exceeded: revert worktree and return budget error.
+	if budgetExceeded {
+		revertWorktree(opts.WorkDir)
+		return nil, &TransientError{
+			Reason: "budget_exceeded",
+			Err:    fmt.Errorf("pi runner: budget exceeded ($%.2f >= $%.2f)", costAccumulator, opts.MaxBudgetUSD),
+		}
+	}
+
+	if waitErr != nil {
+		// Context cancellation — not retryable.
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		if budgetCtx.Err() != nil {
+			revertWorktree(opts.WorkDir)
+			return nil, &TransientError{
+				Reason: "budget_exceeded",
+				Err:    fmt.Errorf("pi runner: budget exceeded"),
+			}
+		}
+
+		// Non-zero exit: try parsing stdout first.
+		if outputBuf.Len() > 0 && !outputBuf.overflow {
+			parsed, parseErr := ParsePiStream(outputBuf.Bytes(), nil)
+			if parseErr == nil && len(parsed.Output) > 0 {
+				return piStreamToResult(parsed), nil
+			}
+		}
+
+		// Classify the exit error.
+		stderrBytes := stderrBuf.Bytes()
+		return nil, classifyPiExitError(waitErr, stderrBytes)
+	}
+
+	// Check buffer overflow.
+	if outputBuf.overflow {
+		return nil, &ParseError{
+			Err: fmt.Errorf("pi runner: stdout exceeded %d byte buffer limit", outputBuf.max),
+		}
+	}
+
+	parsed, err := ParsePiStream(outputBuf.Bytes(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Validate output against schema.
+	if opts.OutputSchema != "" {
+		if valErr := ValidatePiOutput(parsed.Output, opts.OutputSchema); valErr != nil {
+			return nil, valErr
+		}
+	}
+
+	return piStreamToResult(parsed), nil
+}
+
+// piStreamToResult converts a PiStreamResult to a RunResult.
+func piStreamToResult(parsed *PiStreamResult) *RunResult {
+	return &RunResult{
+		Output:    parsed.Output,
+		RawText:   parsed.RawText,
+		CostUSD:   parsed.CostUSD,
+		TokensIn:  parsed.TokensIn,
+		TokensOut: parsed.TokensOut,
+		Turns:     parsed.Turns,
+	}
+}
+
+// buildPiArgs constructs the CLI argument list for a Pi invocation.
+func buildPiArgs(opts RunOpts, defaultModel string) []string {
+	args := []string{
+		"--print",
+		"--output-format", "stream-json",
+	}
+
+	if opts.OutputSchema != "" {
+		args = append(args, "--json-schema", opts.OutputSchema)
+	}
+
+	// Prefer per-invocation model over runner-level default.
+	effectiveModel := defaultModel
+	if opts.Model != "" {
+		effectiveModel = opts.Model
+	}
+	if effectiveModel != "" {
+		args = append(args, "--model", effectiveModel)
+	}
+
+	// Map and add allowed tools.
+	for _, tool := range opts.AllowedTools {
+		args = append(args, "--allowed-tools", MapPiToolName(tool))
+	}
+
+	return args
+}
+
+// writePiSystemPrompt writes the system prompt to {workDir}/.pi/SYSTEM.md
+// per Pi's workspace-level system prompt convention.
+func writePiSystemPrompt(workDir, content string) (string, error) {
+	if workDir == "" {
+		workDir = os.TempDir()
+	}
+	abs, err := filepath.Abs(workDir)
+	if err != nil {
+		return "", fmt.Errorf("pi: resolve workdir: %w", err)
+	}
+
+	piDir := filepath.Join(abs, ".pi")
+	if err := os.MkdirAll(piDir, 0o755); err != nil {
+		return "", fmt.Errorf("pi: create .pi directory: %w", err)
+	}
+
+	promptPath := filepath.Join(piDir, "SYSTEM.md")
+	if err := os.WriteFile(promptPath, []byte(content), 0o644); err != nil {
+		return "", fmt.Errorf("pi: write SYSTEM.md: %w", err)
+	}
+
+	return promptPath, nil
+}
+
+// classifyPiExitError categorizes a Pi process exit failure.
+func classifyPiExitError(waitErr error, stderr []byte) error {
+	stderrLower := strings.ToLower(string(stderr))
+
+	patterns := []struct {
+		substrings []string
+		reason     string
+	}{
+		{[]string{"rate limit", "429", "too many requests"}, "rate_limit"},
+		{[]string{"timeout", "504", "529"}, "timeout"},
+		{[]string{"overloaded", "500", "502", "503", "server error", "internal error"}, "overloaded"},
+		{[]string{"connection refused", "econnreset", "connection reset"}, "connection"},
+	}
+
+	for _, pattern := range patterns {
+		for _, sub := range pattern.substrings {
+			if strings.Contains(stderrLower, sub) {
+				return &TransientError{
+					Reason: pattern.reason,
+					Err:    fmt.Errorf("pi exited: %w", waitErr),
+				}
+			}
+		}
+	}
+
+	return &TransientError{
+		Reason: "unknown",
+		Err:    fmt.Errorf("pi exited: %w", waitErr),
+	}
+}
+
+// revertWorktree runs `git checkout -- .` in workDir to discard uncommitted
+// changes made by the agent after a budget overrun.
+func revertWorktree(workDir string) {
+	if workDir == "" {
+		return
+	}
+	cmd := exec.Command("git", "checkout", "--", ".")
+	cmd.Dir = workDir
+	_ = cmd.Run()
+}
+
+// piLimitedBuffer accumulates bytes up to a maximum, then silently discards excess.
+// Write always reports success so pipe draining is never blocked.
+type piLimitedBuffer struct {
+	buf      []byte
+	max      int
+	overflow bool
+}
+
+func (lb *piLimitedBuffer) Write(p []byte) (int, error) {
+	if lb.overflow {
+		return len(p), nil
+	}
+	remaining := lb.max - len(lb.buf)
+	if len(p) > remaining {
+		if remaining > 0 {
+			lb.buf = append(lb.buf, p[:remaining]...)
+		}
+		lb.overflow = true
+		return len(p), nil
+	}
+	lb.buf = append(lb.buf, p...)
+	return len(p), nil
+}
+
+func (lb *piLimitedBuffer) Bytes() []byte { return lb.buf }
+func (lb *piLimitedBuffer) Len() int      { return len(lb.buf) }
+
+// newLineScanner creates a bufio.Scanner configured for JSONL parsing with
+// a 1MB max line size.
+func newLineScanner(r interface{ Read([]byte) (int, error) }) *bufio.Scanner {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	return scanner
+}

--- a/internal/runner/pi_parser.go
+++ b/internal/runner/pi_parser.go
@@ -1,0 +1,218 @@
+package runner
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// PiEvent represents a single JSONL event from the Pi coding agent.
+type PiEvent struct {
+	Type    string          `json:"type"`
+	Subtype string          `json:"subtype,omitempty"`
+	Content string          `json:"content,omitempty"`
+	Tool    string          `json:"tool,omitempty"`
+	ToolID  string          `json:"tool_id,omitempty"`
+	Error   string          `json:"error,omitempty"`
+	Usage   *PiUsage        `json:"usage,omitempty"`
+	Cost    *float64        `json:"cost_usd,omitempty"`
+	Result  json.RawMessage `json:"result,omitempty"`
+}
+
+// PiUsage holds token usage data from a Pi message_end event.
+type PiUsage struct {
+	InputTokens  int64 `json:"input_tokens"`
+	OutputTokens int64 `json:"output_tokens"`
+}
+
+// PiStreamResult holds the accumulated result of parsing a Pi JSONL stream.
+type PiStreamResult struct {
+	Output    json.RawMessage // structured result from the final result event
+	RawText   string          // accumulated assistant text
+	CostUSD   float64
+	TokensIn  int64
+	TokensOut int64
+	Turns     int
+}
+
+// ParsePiStream parses a JSONL byte stream from the Pi coding agent and
+// accumulates usage, cost, and output data. onChunk is called for each
+// displayable text chunk; it may be nil.
+func ParsePiStream(data []byte, onChunk func(string)) (*PiStreamResult, error) {
+	result := &PiStreamResult{}
+	var textParts []string
+
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024) // 1MB max line
+
+	var lastErr error
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+
+		var event PiEvent
+		if err := json.Unmarshal(line, &event); err != nil {
+			// Skip non-JSON lines (e.g., debug output).
+			continue
+		}
+
+		switch event.Type {
+		case "assistant":
+			if event.Content != "" {
+				textParts = append(textParts, event.Content)
+				if onChunk != nil {
+					onChunk(event.Content)
+				}
+			}
+
+		case "tool_use":
+			result.Turns++
+
+		case "message_end":
+			if event.Usage != nil {
+				result.TokensIn += event.Usage.InputTokens
+				result.TokensOut += event.Usage.OutputTokens
+			}
+			if event.Cost != nil {
+				result.CostUSD += *event.Cost
+			}
+
+		case "result":
+			if event.Subtype == "error" {
+				lastErr = &SemanticError{Message: event.Error}
+				continue
+			}
+			if len(event.Result) > 0 && string(event.Result) != "null" {
+				result.Output = event.Result
+			}
+			if event.Content != "" {
+				textParts = append(textParts, event.Content)
+			}
+
+		case "error":
+			// Classify Pi error events as transient errors.
+			reason := classifyPiError(event.Error)
+			lastErr = &TransientError{
+				Reason: reason,
+				Err:    fmt.Errorf("pi: %s", event.Error),
+			}
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, &ParseError{Err: fmt.Errorf("pi: scan stream: %w", err)}
+	}
+
+	// If the last event was an error, return it.
+	if lastErr != nil {
+		return nil, lastErr
+	}
+
+	result.RawText = strings.Join(textParts, "")
+	return result, nil
+}
+
+// ValidatePiOutput checks that the structured output satisfies the required
+// fields declared in the output schema. It parses the schema's "required"
+// array and verifies each key exists in the output JSON object.
+func ValidatePiOutput(output json.RawMessage, schemaJSON string) error {
+	if len(output) == 0 {
+		return &ParseError{Err: fmt.Errorf("pi: empty structured output")}
+	}
+
+	if schemaJSON == "" {
+		return nil
+	}
+
+	// Extract the "required" array from the schema.
+	var schema struct {
+		Required []string `json:"required"`
+	}
+	if err := json.Unmarshal([]byte(schemaJSON), &schema); err != nil {
+		// Schema itself is invalid — not the agent's fault.
+		return nil
+	}
+
+	if len(schema.Required) == 0 {
+		return nil
+	}
+
+	// Parse the output as a generic map to check for required keys.
+	var outputMap map[string]json.RawMessage
+	if err := json.Unmarshal(output, &outputMap); err != nil {
+		return &ParseError{Err: fmt.Errorf("pi: output is not a JSON object: %w", err)}
+	}
+
+	var missing []string
+	for _, key := range schema.Required {
+		if _, ok := outputMap[key]; !ok {
+			missing = append(missing, key)
+		}
+	}
+
+	if len(missing) > 0 {
+		return &ParseError{
+			Err: fmt.Errorf("pi: output missing required fields: %s", strings.Join(missing, ", ")),
+		}
+	}
+
+	return nil
+}
+
+// MapPiToolName maps a runner-level tool name to the Pi-equivalent tool name.
+// Pi uses a different naming convention than Claude Code for some tools.
+// Unknown tool names are returned unchanged.
+func MapPiToolName(tool string) string {
+	mapping := map[string]string{
+		"Read":   "read_file",
+		"Write":  "write_file",
+		"Edit":   "edit_file",
+		"Glob":   "glob",
+		"Grep":   "grep",
+		"Bash":   "bash",
+		"Search": "search",
+	}
+
+	// Handle parameterized tools like "Bash(git:*)" → "bash(git:*)"
+	baseTool := tool
+	param := ""
+	if idx := strings.Index(tool, "("); idx >= 0 {
+		baseTool = tool[:idx]
+		param = tool[idx:]
+	}
+
+	if mapped, ok := mapping[baseTool]; ok {
+		return mapped + param
+	}
+
+	return tool
+}
+
+// classifyPiError maps Pi error messages to transient error reason categories.
+func classifyPiError(msg string) string {
+	lower := strings.ToLower(msg)
+
+	patterns := []struct {
+		substrings []string
+		reason     string
+	}{
+		{[]string{"rate limit", "429", "too many requests"}, "rate_limit"},
+		{[]string{"timeout", "504", "529"}, "timeout"},
+		{[]string{"overloaded", "500", "502", "503", "server error", "internal error"}, "overloaded"},
+		{[]string{"connection refused", "econnreset", "connection reset"}, "connection"},
+	}
+
+	for _, pattern := range patterns {
+		for _, sub := range pattern.substrings {
+			if strings.Contains(lower, sub) {
+				return pattern.reason
+			}
+		}
+	}
+
+	return "unknown"
+}

--- a/internal/runner/pi_parser.go
+++ b/internal/runner/pi_parser.go
@@ -200,9 +200,9 @@ func classifyPiError(msg string) string {
 		substrings []string
 		reason     string
 	}{
-		{[]string{"rate limit", "429", "too many requests"}, "rate_limit"},
-		{[]string{"timeout", "504", "529"}, "timeout"},
-		{[]string{"overloaded", "500", "502", "503", "server error", "internal error"}, "overloaded"},
+		{[]string{"rate limit", " 429", "too many requests"}, "rate_limit"},
+		{[]string{"timeout", " 504", " 529"}, "timeout"},
+		{[]string{"overloaded", " 500", " 502", " 503", "server error", "internal error"}, "overloaded"},
 		{[]string{"connection refused", "econnreset", "connection reset"}, "connection"},
 	}
 

--- a/internal/runner/pi_parser.go
+++ b/internal/runner/pi_parser.go
@@ -86,6 +86,7 @@ func ParsePiStream(data []byte, onChunk func(string)) (*PiStreamResult, error) {
 				lastErr = &SemanticError{Message: event.Error}
 				continue
 			}
+			lastErr = nil // Recovery: a valid result supersedes prior errors.
 			if len(event.Result) > 0 && string(event.Result) != "null" {
 				result.Output = event.Result
 			}
@@ -94,11 +95,18 @@ func ParsePiStream(data []byte, onChunk func(string)) (*PiStreamResult, error) {
 			}
 
 		case "error":
-			// Classify Pi error events as transient errors.
 			reason := classifyPiError(event.Error)
-			lastErr = &TransientError{
-				Reason: reason,
-				Err:    fmt.Errorf("pi: %s", event.Error),
+			if reason != "unknown" {
+				// Known transient pattern — retryable.
+				lastErr = &TransientError{
+					Reason: reason,
+					Err:    fmt.Errorf("pi: %s", event.Error),
+				}
+			} else {
+				// Unknown or non-transient error — not retryable.
+				lastErr = &ParseError{
+					Err: fmt.Errorf("pi: %s", event.Error),
+				}
 			}
 		}
 	}

--- a/internal/runner/pi_test.go
+++ b/internal/runner/pi_test.go
@@ -1,0 +1,426 @@
+package runner
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+var _ Runner = (*PiRunner)(nil) // compile-time interface check
+
+func TestParsePiStream(t *testing.T) {
+	t.Run("parses_assistant_and_result_events", func(t *testing.T) {
+		stream := strings.Join([]string{
+			`{"type":"assistant","content":"Hello "}`,
+			`{"type":"assistant","content":"world"}`,
+			`{"type":"tool_use","tool":"bash","tool_id":"t1"}`,
+			`{"type":"message_end","usage":{"input_tokens":100,"output_tokens":50},"cost_usd":0.005}`,
+			`{"type":"result","result":{"answer":"42"}}`,
+		}, "\n")
+
+		result, err := ParsePiStream([]byte(stream), nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if result.RawText != "Hello world" {
+			t.Errorf("RawText = %q, want %q", result.RawText, "Hello world")
+		}
+		if result.TokensIn != 100 {
+			t.Errorf("TokensIn = %d, want 100", result.TokensIn)
+		}
+		if result.TokensOut != 50 {
+			t.Errorf("TokensOut = %d, want 50", result.TokensOut)
+		}
+		if result.CostUSD != 0.005 {
+			t.Errorf("CostUSD = %f, want 0.005", result.CostUSD)
+		}
+		if result.Turns != 1 {
+			t.Errorf("Turns = %d, want 1", result.Turns)
+		}
+		if string(result.Output) != `{"answer":"42"}` {
+			t.Errorf("Output = %s, want %s", string(result.Output), `{"answer":"42"}`)
+		}
+	})
+
+	t.Run("accumulates_multiple_message_end_costs", func(t *testing.T) {
+		stream := strings.Join([]string{
+			`{"type":"message_end","usage":{"input_tokens":50,"output_tokens":25},"cost_usd":0.003}`,
+			`{"type":"message_end","usage":{"input_tokens":75,"output_tokens":30},"cost_usd":0.004}`,
+			`{"type":"result","result":{"ok":true}}`,
+		}, "\n")
+
+		result, err := ParsePiStream([]byte(stream), nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if result.TokensIn != 125 {
+			t.Errorf("TokensIn = %d, want 125", result.TokensIn)
+		}
+		if result.TokensOut != 55 {
+			t.Errorf("TokensOut = %d, want 55", result.TokensOut)
+		}
+		wantCost := 0.007
+		if result.CostUSD < wantCost-0.0001 || result.CostUSD > wantCost+0.0001 {
+			t.Errorf("CostUSD = %f, want %f", result.CostUSD, wantCost)
+		}
+	})
+
+	t.Run("returns_semantic_error_on_result_error", func(t *testing.T) {
+		stream := `{"type":"result","subtype":"error","error":"something went wrong"}`
+
+		_, err := ParsePiStream([]byte(stream), nil)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+
+		var se *SemanticError
+		if !errors.As(err, &se) {
+			t.Fatalf("expected SemanticError, got %T: %v", err, err)
+		}
+		if se.Message != "something went wrong" {
+			t.Errorf("Message = %q, want %q", se.Message, "something went wrong")
+		}
+	})
+
+	t.Run("returns_transient_error_on_error_event", func(t *testing.T) {
+		stream := `{"type":"error","error":"rate limit exceeded 429"}`
+
+		_, err := ParsePiStream([]byte(stream), nil)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+
+		var te *TransientError
+		if !errors.As(err, &te) {
+			t.Fatalf("expected TransientError, got %T: %v", err, err)
+		}
+		if te.Reason != "rate_limit" {
+			t.Errorf("Reason = %q, want %q", te.Reason, "rate_limit")
+		}
+	})
+
+	t.Run("calls_onChunk_for_assistant_content", func(t *testing.T) {
+		stream := strings.Join([]string{
+			`{"type":"assistant","content":"chunk1"}`,
+			`{"type":"assistant","content":"chunk2"}`,
+			`{"type":"result","result":{}}`,
+		}, "\n")
+
+		var chunks []string
+		onChunk := func(text string) {
+			chunks = append(chunks, text)
+		}
+
+		_, err := ParsePiStream([]byte(stream), onChunk)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(chunks) != 2 {
+			t.Fatalf("got %d chunks, want 2", len(chunks))
+		}
+		if chunks[0] != "chunk1" || chunks[1] != "chunk2" {
+			t.Errorf("chunks = %v, want [chunk1, chunk2]", chunks)
+		}
+	})
+
+	t.Run("skips_non_json_lines", func(t *testing.T) {
+		stream := strings.Join([]string{
+			"debug: starting up",
+			`{"type":"result","result":{"ok":true}}`,
+			"",
+		}, "\n")
+
+		result, err := ParsePiStream([]byte(stream), nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if string(result.Output) != `{"ok":true}` {
+			t.Errorf("Output = %s, want %s", string(result.Output), `{"ok":true}`)
+		}
+	})
+
+	t.Run("empty_stream_returns_empty_result", func(t *testing.T) {
+		result, err := ParsePiStream([]byte(""), nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if result.RawText != "" {
+			t.Errorf("RawText = %q, want empty", result.RawText)
+		}
+		if result.Output != nil {
+			t.Errorf("Output = %s, want nil", string(result.Output))
+		}
+	})
+
+	t.Run("null_result_treated_as_nil", func(t *testing.T) {
+		stream := `{"type":"result","result":null}`
+		result, err := ParsePiStream([]byte(stream), nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.Output != nil {
+			t.Errorf("Output = %s, want nil", string(result.Output))
+		}
+	})
+}
+
+func TestValidatePiOutput(t *testing.T) {
+	t.Run("passes_with_all_required_fields", func(t *testing.T) {
+		output := json.RawMessage(`{"ticket_key":"TEST-1","verdict":"PASS"}`)
+		schema := `{"required":["ticket_key","verdict"]}`
+
+		err := ValidatePiOutput(output, schema)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("fails_with_missing_required_field", func(t *testing.T) {
+		output := json.RawMessage(`{"ticket_key":"TEST-1"}`)
+		schema := `{"required":["ticket_key","verdict"]}`
+
+		err := ValidatePiOutput(output, schema)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+
+		var pe *ParseError
+		if !errors.As(err, &pe) {
+			t.Fatalf("expected ParseError, got %T: %v", err, err)
+		}
+		if !strings.Contains(pe.Error(), "verdict") {
+			t.Errorf("error should mention missing field 'verdict', got: %v", pe)
+		}
+	})
+
+	t.Run("passes_with_empty_schema", func(t *testing.T) {
+		output := json.RawMessage(`{"anything":"goes"}`)
+		err := ValidatePiOutput(output, "")
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("passes_with_no_required_fields_in_schema", func(t *testing.T) {
+		output := json.RawMessage(`{"anything":"goes"}`)
+		schema := `{"type":"object","properties":{}}`
+		err := ValidatePiOutput(output, schema)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("fails_with_empty_output", func(t *testing.T) {
+		err := ValidatePiOutput(nil, `{"required":["key"]}`)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+
+		var pe *ParseError
+		if !errors.As(err, &pe) {
+			t.Fatalf("expected ParseError, got %T: %v", err, err)
+		}
+	})
+
+	t.Run("passes_with_invalid_schema_json", func(t *testing.T) {
+		output := json.RawMessage(`{"key":"val"}`)
+		err := ValidatePiOutput(output, "not valid json")
+		if err != nil {
+			t.Errorf("invalid schema should not block output: %v", err)
+		}
+	})
+}
+
+func TestMapPiToolName(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"Read", "read_file"},
+		{"Write", "write_file"},
+		{"Edit", "edit_file"},
+		{"Glob", "glob"},
+		{"Grep", "grep"},
+		{"Bash", "bash"},
+		{"Search", "search"},
+		{"Bash(git:*)", "bash(git:*)"},
+		{"UnknownTool", "UnknownTool"},
+		{"custom_tool", "custom_tool"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := MapPiToolName(tt.input)
+			if got != tt.want {
+				t.Errorf("MapPiToolName(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassifyPiError(t *testing.T) {
+	tests := []struct {
+		msg    string
+		reason string
+	}{
+		{"rate limit exceeded", "rate_limit"},
+		{"HTTP 429 Too Many Requests", "rate_limit"},
+		{"request timeout", "timeout"},
+		{"server overloaded 503", "overloaded"},
+		{"connection refused", "connection"},
+		{"something unknown happened", "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.reason, func(t *testing.T) {
+			got := classifyPiError(tt.msg)
+			if got != tt.reason {
+				t.Errorf("classifyPiError(%q) = %q, want %q", tt.msg, got, tt.reason)
+			}
+		})
+	}
+}
+
+func TestBuildPiArgs(t *testing.T) {
+	t.Run("basic_args", func(t *testing.T) {
+		opts := RunOpts{
+			Model:        "pi-model-1",
+			OutputSchema: `{"type":"object"}`,
+			AllowedTools: []string{"Read", "Bash(git:*)"},
+		}
+		args := buildPiArgs(opts, "default-model")
+
+		// Model should be per-invocation override.
+		assertContainsArg(t, args, "--model", "pi-model-1")
+		assertContainsArg(t, args, "--json-schema", `{"type":"object"}`)
+		// Tools should be mapped.
+		assertContainsArg(t, args, "--allowed-tools", "read_file")
+		assertContainsArg(t, args, "--allowed-tools", "bash(git:*)")
+	})
+
+	t.Run("default_model_when_not_overridden", func(t *testing.T) {
+		opts := RunOpts{}
+		args := buildPiArgs(opts, "default-model")
+		assertContainsArg(t, args, "--model", "default-model")
+	})
+
+	t.Run("no_model_when_both_empty", func(t *testing.T) {
+		opts := RunOpts{}
+		args := buildPiArgs(opts, "")
+		for _, arg := range args {
+			if arg == "--model" {
+				t.Error("should not include --model when both are empty")
+			}
+		}
+	})
+}
+
+func TestPiLimitedBuffer(t *testing.T) {
+	t.Run("truncates_at_limit", func(t *testing.T) {
+		lb := &piLimitedBuffer{max: 10}
+		lb.Write([]byte("hello"))
+		lb.Write([]byte("world!"))
+
+		if lb.Len() != 10 {
+			t.Errorf("Len() = %d, want 10", lb.Len())
+		}
+		if !lb.overflow {
+			t.Error("expected overflow to be true")
+		}
+		if string(lb.Bytes()) != "helloworld" {
+			t.Errorf("Bytes() = %q, want %q", string(lb.Bytes()), "helloworld")
+		}
+	})
+
+	t.Run("write_returns_full_length", func(t *testing.T) {
+		lb := &piLimitedBuffer{max: 5}
+		n, err := lb.Write([]byte("hello world"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if n != 11 {
+			t.Errorf("Write returned %d, want 11", n)
+		}
+		// Second write after overflow still returns full length.
+		n, err = lb.Write([]byte("more data"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if n != 9 {
+			t.Errorf("Write returned %d, want 9", n)
+		}
+	})
+}
+
+func TestClassifyPiExitError(t *testing.T) {
+	t.Run("rate_limit_in_stderr", func(t *testing.T) {
+		err := classifyPiExitError(
+			fmt.Errorf("exit status 1"),
+			[]byte("Error: rate limit exceeded"),
+		)
+		var te *TransientError
+		if !errors.As(err, &te) {
+			t.Fatalf("expected TransientError, got %T: %v", err, err)
+		}
+		if te.Reason != "rate_limit" {
+			t.Errorf("Reason = %q, want %q", te.Reason, "rate_limit")
+		}
+	})
+
+	t.Run("unknown_stderr", func(t *testing.T) {
+		err := classifyPiExitError(
+			fmt.Errorf("exit status 1"),
+			[]byte("something else happened"),
+		)
+		var te *TransientError
+		if !errors.As(err, &te) {
+			t.Fatalf("expected TransientError, got %T: %v", err, err)
+		}
+		if te.Reason != "unknown" {
+			t.Errorf("Reason = %q, want %q", te.Reason, "unknown")
+		}
+	})
+}
+
+func TestWritePiSystemPrompt(t *testing.T) {
+	t.Run("writes_to_pi_directory", func(t *testing.T) {
+		dir := t.TempDir()
+		content := "You are a helpful assistant."
+
+		path, err := writePiSystemPrompt(dir, content)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if !strings.HasSuffix(path, ".pi/SYSTEM.md") {
+			t.Errorf("path = %q, want suffix .pi/SYSTEM.md", path)
+		}
+
+		got, readErr := os.ReadFile(path)
+		if readErr != nil {
+			t.Fatalf("failed to read file: %v", readErr)
+		}
+		if string(got) != content {
+			t.Errorf("content = %q, want %q", string(got), content)
+		}
+	})
+}
+
+// assertContainsArg checks that args contains a flag followed by a specific value.
+func assertContainsArg(t *testing.T, args []string, flag, value string) {
+	t.Helper()
+	for idx, arg := range args {
+		if arg == flag && idx+1 < len(args) && args[idx+1] == value {
+			return
+		}
+	}
+	t.Errorf("args %v does not contain %s %s", args, flag, value)
+}

--- a/internal/runner/pi_test.go
+++ b/internal/runner/pi_test.go
@@ -397,6 +397,20 @@ func TestClassifyPiExitError(t *testing.T) {
 			t.Errorf("Reason = %q, want %q", te.Reason, "unknown")
 		}
 	})
+
+	t.Run("no_false_positive_on_bare_numbers", func(t *testing.T) {
+		err := classifyPiExitError(
+			fmt.Errorf("exit status 1"),
+			[]byte("used 1500 tokens in 2529 ms"),
+		)
+		var te *TransientError
+		if !errors.As(err, &te) {
+			t.Fatalf("expected TransientError, got %T: %v", err, err)
+		}
+		if te.Reason != "unknown" {
+			t.Errorf("Reason = %q, want %q (bare numbers should not match)", te.Reason, "unknown")
+		}
+	})
 }
 
 func TestWritePiSystemPrompt(t *testing.T) {

--- a/internal/runner/pi_test.go
+++ b/internal/runner/pi_test.go
@@ -91,7 +91,7 @@ func TestParsePiStream(t *testing.T) {
 	})
 
 	t.Run("returns_transient_error_on_error_event", func(t *testing.T) {
-		stream := `{"type":"error","error":"rate limit exceeded 429"}`
+		stream := `{"type":"error","error":"rate limit exceeded"}`
 
 		_, err := ParsePiStream([]byte(stream), nil)
 		if err == nil {
@@ -280,6 +280,7 @@ func TestClassifyPiError(t *testing.T) {
 		{"server overloaded 503", "overloaded"},
 		{"connection refused", "connection"},
 		{"something unknown happened", "unknown"},
+		{"used 1500 tokens", "unknown"}, // bare "500" must NOT match
 	}
 
 	for _, tt := range tests {

--- a/internal/runner/pi_test.go
+++ b/internal/runner/pi_test.go
@@ -300,7 +300,12 @@ func TestBuildPiArgs(t *testing.T) {
 
 		// Model should be per-invocation override.
 		assertContainsArg(t, args, "--model", "pi-model-1")
-		assertContainsArg(t, args, "--json-schema", `{"type":"object"}`)
+		// Pi has no --json-schema flag; schema validation is done in software.
+		for idx, arg := range args {
+			if arg == "--json-schema" {
+				t.Errorf("args must not contain --json-schema (at index %d)", idx)
+			}
+		}
 		// Tools should be mapped.
 		assertContainsArg(t, args, "--allowed-tools", "read_file")
 		assertContainsArg(t, args, "--allowed-tools", "bash(git:*)")

--- a/internal/runner/pi_test.go
+++ b/internal/runner/pi_test.go
@@ -1,10 +1,13 @@
 package runner
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -417,6 +420,136 @@ func TestWritePiSystemPrompt(t *testing.T) {
 			t.Errorf("content = %q, want %q", string(got), content)
 		}
 	})
+}
+
+func TestRevertWorktree(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	dir := t.TempDir()
+
+	// Initialise a bare git repo with one committed file.
+	for _, args := range [][]string{
+		{"init"},
+		{"config", "user.email", "test@example.com"},
+		{"config", "user.name", "Test"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	testFile := filepath.Join(dir, "file.txt")
+	if err := os.WriteFile(testFile, []byte("original"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	for _, args := range [][]string{{"add", "."}, {"commit", "-m", "init"}} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	// Modify the file.
+	if err := os.WriteFile(testFile, []byte("modified"), 0o644); err != nil {
+		t.Fatalf("modify file: %v", err)
+	}
+
+	// Revert the worktree.
+	revertWorktree(dir)
+
+	// Verify the file is back to original.
+	got, err := os.ReadFile(testFile)
+	if err != nil {
+		t.Fatalf("read file after revert: %v", err)
+	}
+	if string(got) != "original" {
+		t.Errorf("content after revert = %q, want %q", string(got), "original")
+	}
+}
+
+func TestBudgetEnforcement(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	// Create a fake pi binary (shell script) that emits a cost-exceeding event.
+	binDir := t.TempDir()
+	fakePi := filepath.Join(binDir, "pi")
+	script := "#!/bin/sh\n" +
+		`echo '{"type":"message_end","usage":{"input_tokens":100,"output_tokens":50},"cost_usd":99.99}'` + "\n" +
+		`echo '{"type":"result","result":{"ok":true}}'` + "\n"
+	if err := os.WriteFile(fakePi, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake pi: %v", err)
+	}
+
+	// Create a git worktree with a committed file.
+	workDir := t.TempDir()
+	for _, args := range [][]string{
+		{"init"},
+		{"config", "user.email", "test@example.com"},
+		{"config", "user.name", "Test"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = workDir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	agentFile := filepath.Join(workDir, "output.txt")
+	if err := os.WriteFile(agentFile, []byte("clean"), 0o644); err != nil {
+		t.Fatalf("write agent file: %v", err)
+	}
+	for _, args := range [][]string{{"add", "."}, {"commit", "-m", "init"}} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = workDir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	// Simulate agent modifying a file before budget exceeded.
+	if err := os.WriteFile(agentFile, []byte("dirty"), 0o644); err != nil {
+		t.Fatalf("dirty agent file: %v", err)
+	}
+
+	piRunner, err := NewPiRunner(fakePi, "test-model", workDir)
+	if err != nil {
+		t.Fatalf("NewPiRunner: %v", err)
+	}
+
+	opts := RunOpts{
+		MaxBudgetUSD: 0.01, // well below the 99.99 emitted by the fake binary
+		WorkDir:      workDir,
+	}
+
+	_, runErr := piRunner.Run(context.Background(), opts)
+	if runErr == nil {
+		t.Fatal("expected budget_exceeded error, got nil")
+	}
+
+	var te *TransientError
+	if !errors.As(runErr, &te) {
+		t.Fatalf("expected TransientError, got %T: %v", runErr, runErr)
+	}
+	if te.Reason != "budget_exceeded" {
+		t.Errorf("Reason = %q, want %q", te.Reason, "budget_exceeded")
+	}
+
+	// Verify revertWorktree was called: the dirty file should be restored.
+	got, err := os.ReadFile(agentFile)
+	if err != nil {
+		t.Fatalf("read agent file after budget exceeded: %v", err)
+	}
+	if string(got) != "clean" {
+		t.Errorf("worktree not reverted: content = %q, want %q", string(got), "clean")
+	}
 }
 
 // assertContainsArg checks that args contains a flag followed by a specific value.

--- a/internal/runner/pi_test.go
+++ b/internal/runner/pi_test.go
@@ -107,6 +107,23 @@ func TestParsePiStream(t *testing.T) {
 		}
 	})
 
+	t.Run("returns_parse_error_on_unknown_error_event", func(t *testing.T) {
+		stream := `{"type":"error","error":"invalid API key"}`
+
+		_, err := ParsePiStream([]byte(stream), nil)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+
+		var pe *ParseError
+		if !errors.As(err, &pe) {
+			t.Fatalf("expected ParseError for non-transient error, got %T: %v", err, err)
+		}
+		if !strings.Contains(pe.Error(), "invalid API key") {
+			t.Errorf("error should contain original message, got: %v", pe)
+		}
+	})
+
 	t.Run("calls_onChunk_for_assistant_content", func(t *testing.T) {
 		stream := strings.Join([]string{
 			`{"type":"assistant","content":"chunk1"}`,
@@ -160,6 +177,42 @@ func TestParsePiStream(t *testing.T) {
 		}
 		if result.Output != nil {
 			t.Errorf("Output = %s, want nil", string(result.Output))
+		}
+	})
+
+	t.Run("successful_result_clears_prior_error", func(t *testing.T) {
+		stream := strings.Join([]string{
+			`{"type":"error","error":"rate limit exceeded"}`,
+			`{"type":"assistant","content":"Hello"}`,
+			`{"type":"result","result":{"answer":"42"}}`,
+		}, "\n")
+		result, err := ParsePiStream([]byte(stream), nil)
+		if err != nil {
+			t.Fatalf("expected recovery after valid result, got: %v", err)
+		}
+		if string(result.Output) != `{"answer":"42"}` {
+			t.Errorf("Output = %s, want %s", string(result.Output), `{"answer":"42"}`)
+		}
+		if result.RawText != "Hello" {
+			t.Errorf("RawText = %q, want %q", result.RawText, "Hello")
+		}
+	})
+
+	t.Run("semantic_error_after_transient_error_returns_semantic", func(t *testing.T) {
+		stream := strings.Join([]string{
+			`{"type":"error","error":"rate limit exceeded"}`,
+			`{"type":"result","subtype":"error","error":"task failed"}`,
+		}, "\n")
+		_, err := ParsePiStream([]byte(stream), nil)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		var se *SemanticError
+		if !errors.As(err, &se) {
+			t.Fatalf("expected SemanticError, got %T: %v", err, err)
+		}
+		if se.Message != "task failed" {
+			t.Errorf("Message = %q, want %q", se.Message, "task failed")
 		}
 	})
 

--- a/internal/runner/pi_test.go
+++ b/internal/runner/pi_test.go
@@ -403,21 +403,77 @@ func TestWritePiSystemPrompt(t *testing.T) {
 		dir := t.TempDir()
 		content := "You are a helpful assistant."
 
-		path, err := writePiSystemPrompt(dir, content)
+		cleanup, err := writePiSystemPrompt(dir, content)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
+		defer cleanup()
 
-		if !strings.HasSuffix(path, ".pi/SYSTEM.md") {
-			t.Errorf("path = %q, want suffix .pi/SYSTEM.md", path)
-		}
-
-		got, readErr := os.ReadFile(path)
+		promptPath := filepath.Join(dir, ".pi", "SYSTEM.md")
+		got, readErr := os.ReadFile(promptPath)
 		if readErr != nil {
 			t.Fatalf("failed to read file: %v", readErr)
 		}
 		if string(got) != content {
 			t.Errorf("content = %q, want %q", string(got), content)
+		}
+	})
+
+	t.Run("restores_existing_file_on_cleanup", func(t *testing.T) {
+		dir := t.TempDir()
+		piDir := filepath.Join(dir, ".pi")
+		if err := os.MkdirAll(piDir, 0o755); err != nil {
+			t.Fatalf("create .pi dir: %v", err)
+		}
+		promptPath := filepath.Join(piDir, "SYSTEM.md")
+		original := "user-owned content"
+		if err := os.WriteFile(promptPath, []byte(original), 0o644); err != nil {
+			t.Fatalf("write original: %v", err)
+		}
+
+		cleanup, err := writePiSystemPrompt(dir, "soda override")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// During run, file should have soda content.
+		got, _ := os.ReadFile(promptPath)
+		if string(got) != "soda override" {
+			t.Errorf("during run: content = %q, want %q", string(got), "soda override")
+		}
+
+		cleanup()
+
+		// After cleanup, original content should be restored.
+		got, _ = os.ReadFile(promptPath)
+		if string(got) != original {
+			t.Errorf("after cleanup: content = %q, want %q", string(got), original)
+		}
+	})
+
+	t.Run("removes_file_and_dir_when_none_existed", func(t *testing.T) {
+		dir := t.TempDir()
+		piDir := filepath.Join(dir, ".pi")
+
+		cleanup, err := writePiSystemPrompt(dir, "test content")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// File should exist during run.
+		promptPath := filepath.Join(piDir, "SYSTEM.md")
+		if _, statErr := os.Stat(promptPath); statErr != nil {
+			t.Fatalf("SYSTEM.md should exist during run: %v", statErr)
+		}
+
+		cleanup()
+
+		// After cleanup, both file and directory should be gone.
+		if _, statErr := os.Stat(promptPath); statErr == nil {
+			t.Error("SYSTEM.md should be removed after cleanup")
+		}
+		if _, statErr := os.Stat(piDir); statErr == nil {
+			t.Error(".pi directory should be removed after cleanup when we created it")
 		}
 	})
 }

--- a/internal/sandbox/pi.go
+++ b/internal/sandbox/pi.go
@@ -37,12 +37,23 @@ func (a *PiAdapter) Binary() string {
 	return a.binary
 }
 
-// BuildArgs writes temporary files (system prompt) into tmpDir
+// BuildArgs writes temporary files (system prompt) into the workspace directory
 // and returns the CLI argument list for a Pi invocation.
+//
+// Pi discovers system prompts from cwd-relative .pi/SYSTEM.md; the sandbox
+// process runs with WorkDir as its working directory, so the prompt must live
+// there. When opts.WorkDir is empty (unit tests calling BuildArgs directly),
+// tmpDir is used as a safe fallback.
 func (a *PiAdapter) BuildArgs(opts runner.RunOpts, tmpDir string) ([]string, error) {
-	// Write system prompt to {tmpDir}/.pi/SYSTEM.md to avoid polluting the worktree.
+	// Write system prompt to {workDir}/.pi/SYSTEM.md so Pi can discover it
+	// relative to its working directory. Fall back to tmpDir when WorkDir is
+	// unset (direct unit-test calls that do not exercise the full runner path).
 	if opts.SystemPrompt != "" {
-		piDir := filepath.Join(tmpDir, ".pi")
+		promptDir := opts.WorkDir
+		if promptDir == "" {
+			promptDir = tmpDir
+		}
+		piDir := filepath.Join(promptDir, ".pi")
 		if err := os.MkdirAll(piDir, 0o755); err != nil {
 			return nil, fmt.Errorf("sandbox: create .pi directory: %w", err)
 		}
@@ -50,7 +61,6 @@ func (a *PiAdapter) BuildArgs(opts runner.RunOpts, tmpDir string) ([]string, err
 		if err := os.WriteFile(promptPath, []byte(opts.SystemPrompt), 0o644); err != nil {
 			return nil, fmt.Errorf("sandbox: write pi system prompt: %w", err)
 		}
-		// No need for deferred Remove — tmpDir cleanup handles it.
 	}
 
 	args := []string{

--- a/internal/sandbox/pi.go
+++ b/internal/sandbox/pi.go
@@ -58,10 +58,6 @@ func (a *PiAdapter) BuildArgs(opts runner.RunOpts, tmpDir string) ([]string, err
 		"--output-format", "stream-json",
 	}
 
-	if opts.OutputSchema != "" {
-		args = append(args, "--json-schema", opts.OutputSchema)
-	}
-
 	if opts.Model != "" {
 		args = append(args, "--model", opts.Model)
 	}

--- a/internal/sandbox/pi.go
+++ b/internal/sandbox/pi.go
@@ -105,7 +105,7 @@ func (a *PiAdapter) ParseOutput(stdout []byte, opts runner.RunOpts) (*runner.Run
 	}
 
 	// Validate output against schema if provided.
-	if opts.OutputSchema != "" && len(result.Output) > 0 {
+	if opts.OutputSchema != "" {
 		if valErr := runner.ValidatePiOutput(result.Output, opts.OutputSchema); valErr != nil {
 			return nil, mapPiParseError(valErr)
 		}

--- a/internal/sandbox/pi.go
+++ b/internal/sandbox/pi.go
@@ -1,0 +1,226 @@
+package sandbox
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/decko/soda/internal/runner"
+)
+
+// PiAdapter implements AgentAdapter for the Pi coding agent CLI.
+type PiAdapter struct {
+	binary    string   // resolved absolute path to pi binary
+	readPaths []string // read paths needed for pi binary
+}
+
+// compile-time interface check
+var _ AgentAdapter = (*PiAdapter)(nil)
+
+// NewPiAdapter resolves the pi binary and returns a PiAdapter.
+func NewPiAdapter(binary string) (*PiAdapter, error) {
+	resolved, readPaths, err := resolvePiPaths(binary)
+	if err != nil {
+		return nil, err
+	}
+	return &PiAdapter{
+		binary:    resolved,
+		readPaths: readPaths,
+	}, nil
+}
+
+// Binary returns the resolved absolute path to the pi binary.
+func (a *PiAdapter) Binary() string {
+	return a.binary
+}
+
+// BuildArgs writes temporary files (system prompt) into tmpDir
+// and returns the CLI argument list for a Pi invocation.
+func (a *PiAdapter) BuildArgs(opts runner.RunOpts, tmpDir string) ([]string, error) {
+	// Write system prompt to {tmpDir}/.pi/SYSTEM.md to avoid polluting the worktree.
+	if opts.SystemPrompt != "" {
+		piDir := filepath.Join(tmpDir, ".pi")
+		if err := os.MkdirAll(piDir, 0o755); err != nil {
+			return nil, fmt.Errorf("sandbox: create .pi directory: %w", err)
+		}
+		promptPath := filepath.Join(piDir, "SYSTEM.md")
+		if err := os.WriteFile(promptPath, []byte(opts.SystemPrompt), 0o644); err != nil {
+			return nil, fmt.Errorf("sandbox: write pi system prompt: %w", err)
+		}
+		// No need for deferred Remove — tmpDir cleanup handles it.
+	}
+
+	args := []string{
+		"--print",
+		"--output-format", "stream-json",
+	}
+
+	if opts.OutputSchema != "" {
+		args = append(args, "--json-schema", opts.OutputSchema)
+	}
+
+	if opts.Model != "" {
+		args = append(args, "--model", opts.Model)
+	}
+
+	// Map and add allowed tools.
+	for _, tool := range opts.AllowedTools {
+		args = append(args, "--allowed-tools", runner.MapPiToolName(tool))
+	}
+
+	// Append user prompt as positional arg.
+	args = append(args, "-p", opts.UserPrompt)
+
+	return args, nil
+}
+
+// BuildEnv returns the environment variables for a sandboxed Pi process.
+func (a *PiAdapter) BuildEnv(opts runner.RunOpts, tmpDir string, proxyURL string) []string {
+	return piEnv(tmpDir, opts, a.binary, proxyURL)
+}
+
+// ParseOutput parses buffered stdout from a Pi invocation into a RunResult.
+func (a *PiAdapter) ParseOutput(stdout []byte, opts runner.RunOpts) (*runner.RunResult, error) {
+	result, err := runner.ParsePiStream(stdout, nil)
+	if err != nil {
+		return nil, mapPiParseError(err)
+	}
+
+	runResult := &runner.RunResult{
+		Output:    result.Output,
+		RawText:   result.RawText,
+		CostUSD:   result.CostUSD,
+		TokensIn:  result.TokensIn,
+		TokensOut: result.TokensOut,
+		Turns:     result.Turns,
+	}
+
+	// Validate output against schema if provided.
+	if opts.OutputSchema != "" && len(result.Output) > 0 {
+		if valErr := runner.ValidatePiOutput(result.Output, opts.OutputSchema); valErr != nil {
+			return nil, mapPiParseError(valErr)
+		}
+	}
+
+	return runResult, nil
+}
+
+// ExtraPaths returns additional read and write paths required by Pi.
+func (a *PiAdapter) ExtraPaths(opts runner.RunOpts) (read []string, write []string) {
+	read = append(read, a.readPaths...)
+
+	// Allow the sandbox to read the helper script's parent directory.
+	if opts.ApiKeyHelper != "" && filepath.IsAbs(opts.ApiKeyHelper) {
+		read = append(read, filepath.Dir(opts.ApiKeyHelper))
+	}
+
+	return read, nil
+}
+
+// resolvePiPaths finds the pi binary and collects paths needed for the
+// sandbox read profile.
+func resolvePiPaths(binary string) (resolved string, readPaths []string, err error) {
+	if binary == "" {
+		binary = "pi"
+	}
+
+	resolved, err = exec.LookPath(binary)
+	if err != nil {
+		return "", nil, fmt.Errorf("sandbox: pi binary not found: %w", err)
+	}
+
+	resolved, err = filepath.EvalSymlinks(resolved)
+	if err != nil {
+		return "", nil, fmt.Errorf("sandbox: resolve pi symlink: %w", err)
+	}
+
+	// The pi binary directory needs read access.
+	readPaths = append(readPaths, filepath.Dir(resolved))
+
+	return resolved, readPaths, nil
+}
+
+// piEnv builds the environment for a sandboxed Pi process.
+// When proxyURL is non-empty, real credentials are NOT passed to the sandbox.
+func piEnv(tmpDir string, opts runner.RunOpts, piBin, proxyURL string) []string {
+	env := []string{
+		"HOME=" + tmpDir,
+		"TMPDIR=" + tmpDir,
+		"LANG=" + envOrDefault("LANG", "en_US.UTF-8"),
+	}
+
+	// PATH: include pi binary dir, standard paths.
+	pathDirs := []string{filepath.Dir(piBin)}
+	pathDirs = append(pathDirs, "/usr/local/bin", "/usr/bin", "/bin")
+	env = append(env, "PATH="+strings.Join(pathDirs, ":"))
+
+	if proxyURL != "" {
+		// Proxy mode: the proxy on the host side handles authentication.
+		env = append(env,
+			"ANTHROPIC_API_KEY=sk-proxy-nonce",
+			"ANTHROPIC_BASE_URL="+proxyURL,
+		)
+	} else {
+		// Direct mode: pass through real credentials.
+		credentialVars := []string{
+			"ANTHROPIC_API_KEY",
+			"PI_API_KEY",
+		}
+		for _, key := range credentialVars {
+			if val := os.Getenv(key); val != "" {
+				env = append(env, key+"="+val)
+			}
+		}
+	}
+
+	// Git/GitHub credentials for submit, follow-up, and monitor phases.
+	gitVars := []string{
+		"GH_TOKEN",
+		"GITHUB_TOKEN",
+		"GH_HOST",
+		"SSH_AUTH_SOCK",
+		"GIT_AUTHOR_NAME",
+		"GIT_AUTHOR_EMAIL",
+		"GIT_COMMITTER_NAME",
+		"GIT_COMMITTER_EMAIL",
+	}
+	for _, key := range gitVars {
+		if val := os.Getenv(key); val != "" {
+			env = append(env, key+"="+val)
+		}
+	}
+
+	// If no GH_TOKEN is set, try to extract from gh CLI keyring.
+	if os.Getenv("GH_TOKEN") == "" && os.Getenv("GITHUB_TOKEN") == "" {
+		if token, err := exec.Command("gh", "auth", "token").Output(); err == nil {
+			if tok := strings.TrimSpace(string(token)); tok != "" {
+				env = append(env, "GH_TOKEN="+tok)
+			}
+		}
+	}
+
+	return env
+}
+
+// mapPiParseError wraps Pi errors into runner error types.
+// Pi errors from ParsePiStream/ValidatePiOutput are already runner.* types,
+// so known types pass through unchanged. Unknown errors are wrapped in
+// runner.ParseError.
+func mapPiParseError(err error) error {
+	var pe *runner.ParseError
+	if errors.As(err, &pe) {
+		return err
+	}
+	var se *runner.SemanticError
+	if errors.As(err, &se) {
+		return err
+	}
+	var te *runner.TransientError
+	if errors.As(err, &te) {
+		return err
+	}
+	return &runner.ParseError{Err: fmt.Errorf("sandbox: %w", err)}
+}

--- a/internal/sandbox/pi_test.go
+++ b/internal/sandbox/pi_test.go
@@ -1,0 +1,361 @@
+package sandbox
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/decko/soda/internal/runner"
+)
+
+func TestPiAdapterBuildArgs(t *testing.T) {
+	// Create a fake pi binary so NewPiAdapter can resolve it.
+	binDir := t.TempDir()
+	fakePi := filepath.Join(binDir, "pi")
+	if err := os.WriteFile(fakePi, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write fake pi: %v", err)
+	}
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	adapter, err := NewPiAdapter(fakePi)
+	if err != nil {
+		t.Fatalf("NewPiAdapter: %v", err)
+	}
+
+	t.Run("basic_args", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		opts := runner.RunOpts{
+			Model:        "pi-model-1",
+			AllowedTools: []string{"Read", "Bash(git:*)"},
+			UserPrompt:   "do the thing",
+		}
+		args, err := adapter.BuildArgs(opts, tmpDir)
+		if err != nil {
+			t.Fatalf("BuildArgs: %v", err)
+		}
+
+		assertContains(t, args, "--print")
+		assertContains(t, args, "--output-format")
+		assertContainsArgPair(t, args, "--model", "pi-model-1")
+		assertContainsArgPair(t, args, "--allowed-tools", "read_file")
+		assertContainsArgPair(t, args, "--allowed-tools", "bash(git:*)")
+		assertContainsArgPair(t, args, "-p", "do the thing")
+	})
+
+	t.Run("writes_system_prompt_to_tmpdir", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		opts := runner.RunOpts{
+			SystemPrompt: "You are a helpful assistant.",
+			UserPrompt:   "hello",
+		}
+		_, err := adapter.BuildArgs(opts, tmpDir)
+		if err != nil {
+			t.Fatalf("BuildArgs: %v", err)
+		}
+
+		promptPath := filepath.Join(tmpDir, ".pi", "SYSTEM.md")
+		got, readErr := os.ReadFile(promptPath)
+		if readErr != nil {
+			t.Fatalf("system prompt file not written: %v", readErr)
+		}
+		if string(got) != opts.SystemPrompt {
+			t.Errorf("system prompt content = %q, want %q", string(got), opts.SystemPrompt)
+		}
+	})
+
+	t.Run("no_model_flag_when_empty", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		opts := runner.RunOpts{UserPrompt: "hello"}
+		args, err := adapter.BuildArgs(opts, tmpDir)
+		if err != nil {
+			t.Fatalf("BuildArgs: %v", err)
+		}
+		for _, arg := range args {
+			if arg == "--model" {
+				t.Error("should not include --model when model is empty")
+			}
+		}
+	})
+}
+
+func TestPiAdapterBuildEnv(t *testing.T) {
+	binDir := t.TempDir()
+	fakePi := filepath.Join(binDir, "pi")
+	if err := os.WriteFile(fakePi, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write fake pi: %v", err)
+	}
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	adapter, err := NewPiAdapter(fakePi)
+	if err != nil {
+		t.Fatalf("NewPiAdapter: %v", err)
+	}
+
+	t.Run("direct_mode_passes_credentials", func(t *testing.T) {
+		t.Setenv("ANTHROPIC_API_KEY", "sk-test-key")
+		t.Setenv("PI_API_KEY", "pi-key-123")
+		t.Setenv("LANG", "en_US.UTF-8")
+
+		opts := runner.RunOpts{Phase: "implement", WorkDir: "/work"}
+		env := adapter.BuildEnv(opts, "/tmp/sandbox", "")
+
+		envMap := toEnvMap(env)
+
+		if envMap["HOME"] != "/tmp/sandbox" {
+			t.Errorf("HOME = %q, want /tmp/sandbox", envMap["HOME"])
+		}
+		if envMap["TMPDIR"] != "/tmp/sandbox" {
+			t.Errorf("TMPDIR = %q, want /tmp/sandbox", envMap["TMPDIR"])
+		}
+		if envMap["ANTHROPIC_API_KEY"] != "sk-test-key" {
+			t.Errorf("ANTHROPIC_API_KEY = %q, want sk-test-key", envMap["ANTHROPIC_API_KEY"])
+		}
+		if envMap["PI_API_KEY"] != "pi-key-123" {
+			t.Errorf("PI_API_KEY = %q, want pi-key-123", envMap["PI_API_KEY"])
+		}
+	})
+
+	t.Run("proxy_mode_uses_fake_key", func(t *testing.T) {
+		t.Setenv("ANTHROPIC_API_KEY", "sk-real-key")
+
+		opts := runner.RunOpts{Phase: "implement", WorkDir: "/work"}
+		env := adapter.BuildEnv(opts, "/tmp/sandbox", "http://127.0.0.1:8080")
+
+		envMap := toEnvMap(env)
+
+		if envMap["ANTHROPIC_API_KEY"] != "sk-proxy-nonce" {
+			t.Errorf("ANTHROPIC_API_KEY = %q, want sk-proxy-nonce", envMap["ANTHROPIC_API_KEY"])
+		}
+		if envMap["ANTHROPIC_BASE_URL"] != "http://127.0.0.1:8080" {
+			t.Errorf("ANTHROPIC_BASE_URL = %q, want http://127.0.0.1:8080", envMap["ANTHROPIC_BASE_URL"])
+		}
+	})
+
+	t.Run("git_credentials_passed_through", func(t *testing.T) {
+		t.Setenv("GH_TOKEN", "ghp_test123")
+		t.Setenv("SSH_AUTH_SOCK", "/tmp/ssh/agent.1234")
+
+		opts := runner.RunOpts{Phase: "submit", WorkDir: "/work"}
+		env := adapter.BuildEnv(opts, "/tmp/sandbox", "")
+
+		envMap := toEnvMap(env)
+
+		if envMap["GH_TOKEN"] != "ghp_test123" {
+			t.Errorf("GH_TOKEN = %q, want ghp_test123", envMap["GH_TOKEN"])
+		}
+		if envMap["SSH_AUTH_SOCK"] != "/tmp/ssh/agent.1234" {
+			t.Errorf("SSH_AUTH_SOCK = %q, want /tmp/ssh/agent.1234", envMap["SSH_AUTH_SOCK"])
+		}
+	})
+
+	t.Run("path_includes_pi_binary_dir", func(t *testing.T) {
+		opts := runner.RunOpts{Phase: "implement", WorkDir: "/work"}
+		env := adapter.BuildEnv(opts, "/tmp/sandbox", "")
+
+		envMap := toEnvMap(env)
+		pathVal := envMap["PATH"]
+		piDir := filepath.Dir(adapter.Binary())
+		if !strings.Contains(pathVal, piDir) {
+			t.Errorf("PATH = %q, should contain %q", pathVal, piDir)
+		}
+	})
+}
+
+func TestPiAdapterParseOutput(t *testing.T) {
+	binDir := t.TempDir()
+	fakePi := filepath.Join(binDir, "pi")
+	if err := os.WriteFile(fakePi, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write fake pi: %v", err)
+	}
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	adapter, err := NewPiAdapter(fakePi)
+	if err != nil {
+		t.Fatalf("NewPiAdapter: %v", err)
+	}
+
+	t.Run("parses_valid_stream", func(t *testing.T) {
+		stream := strings.Join([]string{
+			`{"type":"assistant","content":"Hello"}`,
+			`{"type":"message_end","usage":{"input_tokens":100,"output_tokens":50},"cost_usd":0.005}`,
+			`{"type":"result","result":{"answer":"42"}}`,
+		}, "\n")
+
+		opts := runner.RunOpts{}
+		result, err := adapter.ParseOutput([]byte(stream), opts)
+		if err != nil {
+			t.Fatalf("ParseOutput: %v", err)
+		}
+
+		if result.RawText != "Hello" {
+			t.Errorf("RawText = %q, want %q", result.RawText, "Hello")
+		}
+		if result.TokensIn != 100 {
+			t.Errorf("TokensIn = %d, want 100", result.TokensIn)
+		}
+		if string(result.Output) != `{"answer":"42"}` {
+			t.Errorf("Output = %s, want %s", string(result.Output), `{"answer":"42"}`)
+		}
+	})
+
+	t.Run("validates_output_schema", func(t *testing.T) {
+		stream := `{"type":"result","result":{"ticket_key":"T-1"}}` + "\n"
+		opts := runner.RunOpts{
+			OutputSchema: `{"required":["ticket_key","verdict"]}`,
+		}
+
+		_, err := adapter.ParseOutput([]byte(stream), opts)
+		if err == nil {
+			t.Fatal("expected error for missing required field, got nil")
+		}
+
+		var pe *runner.ParseError
+		if !errors.As(err, &pe) {
+			t.Fatalf("expected runner.ParseError, got %T: %v", err, err)
+		}
+		if !strings.Contains(pe.Error(), "verdict") {
+			t.Errorf("error should mention missing field 'verdict', got: %v", pe)
+		}
+	})
+
+	t.Run("maps_transient_error", func(t *testing.T) {
+		stream := `{"type":"error","error":"rate limit exceeded"}` + "\n"
+		opts := runner.RunOpts{}
+
+		_, err := adapter.ParseOutput([]byte(stream), opts)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+
+		var te *runner.TransientError
+		if !errors.As(err, &te) {
+			t.Fatalf("expected runner.TransientError, got %T: %v", err, err)
+		}
+	})
+}
+
+func TestPiAdapterExtraPaths(t *testing.T) {
+	binDir := t.TempDir()
+	fakePi := filepath.Join(binDir, "pi")
+	if err := os.WriteFile(fakePi, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write fake pi: %v", err)
+	}
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	adapter, err := NewPiAdapter(fakePi)
+	if err != nil {
+		t.Fatalf("NewPiAdapter: %v", err)
+	}
+
+	t.Run("includes_binary_directory", func(t *testing.T) {
+		opts := runner.RunOpts{}
+		read, write := adapter.ExtraPaths(opts)
+
+		piDir := filepath.Dir(adapter.Binary())
+		found := false
+		for _, path := range read {
+			if path == piDir {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("read paths %v should contain pi binary dir %q", read, piDir)
+		}
+		if len(write) != 0 {
+			t.Errorf("write paths = %v, want empty", write)
+		}
+	})
+
+	t.Run("includes_api_key_helper_dir", func(t *testing.T) {
+		opts := runner.RunOpts{ApiKeyHelper: "/usr/local/bin/get-api-key"}
+		read, _ := adapter.ExtraPaths(opts)
+
+		found := false
+		for _, path := range read {
+			if path == "/usr/local/bin" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("read paths %v should contain /usr/local/bin for ApiKeyHelper", read)
+		}
+	})
+}
+
+func TestMapPiParseError(t *testing.T) {
+	t.Run("parse_error_passes_through", func(t *testing.T) {
+		inner := fmt.Errorf("bad JSON")
+		err := mapPiParseError(&runner.ParseError{Err: inner})
+
+		var pe *runner.ParseError
+		if !errors.As(err, &pe) {
+			t.Fatalf("expected runner.ParseError, got %T: %v", err, err)
+		}
+	})
+
+	t.Run("semantic_error_passes_through", func(t *testing.T) {
+		err := mapPiParseError(&runner.SemanticError{Message: "bad input"})
+
+		var se *runner.SemanticError
+		if !errors.As(err, &se) {
+			t.Fatalf("expected runner.SemanticError, got %T: %v", err, err)
+		}
+	})
+
+	t.Run("transient_error_passes_through", func(t *testing.T) {
+		err := mapPiParseError(&runner.TransientError{Reason: "rate_limit", Err: fmt.Errorf("429")})
+
+		var te *runner.TransientError
+		if !errors.As(err, &te) {
+			t.Fatalf("expected runner.TransientError, got %T: %v", err, err)
+		}
+	})
+
+	t.Run("generic_error_becomes_parse_error", func(t *testing.T) {
+		err := mapPiParseError(fmt.Errorf("something unexpected"))
+
+		var pe *runner.ParseError
+		if !errors.As(err, &pe) {
+			t.Fatalf("expected runner.ParseError, got %T: %v", err, err)
+		}
+	})
+}
+
+// toEnvMap converts a []string of "KEY=VALUE" entries to a map.
+func toEnvMap(env []string) map[string]string {
+	result := make(map[string]string, len(env))
+	for _, entry := range env {
+		parts := strings.SplitN(entry, "=", 2)
+		if len(parts) == 2 {
+			result[parts[0]] = parts[1]
+		}
+	}
+	return result
+}
+
+// assertContains checks that a string slice contains the given value.
+func assertContains(t *testing.T, slice []string, value string) {
+	t.Helper()
+	for _, item := range slice {
+		if item == value {
+			return
+		}
+	}
+	t.Errorf("slice %v does not contain %q", slice, value)
+}
+
+// assertContainsArgPair checks that args contains flag followed by value.
+func assertContainsArgPair(t *testing.T, args []string, flag, value string) {
+	t.Helper()
+	for idx, arg := range args {
+		if arg == flag && idx+1 < len(args) && args[idx+1] == value {
+			return
+		}
+	}
+	t.Errorf("args %v does not contain %s %s", args, flag, value)
+}

--- a/internal/sandbox/runner.go
+++ b/internal/sandbox/runner.go
@@ -51,6 +51,22 @@ func New(config Config) (*Runner, error) {
 	}, nil
 }
 
+// NewWithAdapter creates a sandbox runner using a caller-provided AgentAdapter.
+// This allows the runner-type decision to live in cmd/soda/run.go rather than
+// being hardcoded here. Call Close() when done.
+func NewWithAdapter(config Config, adapter AgentAdapter) (*Runner, error) {
+	sb, err := arapuca.New()
+	if err != nil {
+		return nil, fmt.Errorf("sandbox: create: %w", err)
+	}
+
+	return &Runner{
+		sandbox: sb,
+		config:  config,
+		adapter: adapter,
+	}, nil
+}
+
 // Close releases the sandbox. Safe to call multiple times.
 func (r *Runner) Close() {
 	if r.sandbox != nil {

--- a/internal/sandbox/runner_nocgo.go
+++ b/internal/sandbox/runner_nocgo.go
@@ -20,6 +20,11 @@ func New(_ Config) (*Runner, error) {
 	return nil, fmt.Errorf("sandbox: cgo is required for sandbox support; rebuild with CGO_ENABLED=1")
 }
 
+// NewWithAdapter returns an error because sandbox support requires cgo (go-arapuca uses cgo).
+func NewWithAdapter(_ Config, _ AgentAdapter) (*Runner, error) {
+	return nil, fmt.Errorf("sandbox: cgo is required for sandbox support; rebuild with CGO_ENABLED=1")
+}
+
 // Close is a no-op.
 func (r *Runner) Close() {}
 


### PR DESCRIPTION
Add Pi (earendil-works/pi) as a second agent backend, enabling SODA pipelines to run with the Pi coding agent CLI.

## Changes

- `internal/runner/pi.go` — PiRunner implementing runner.Runner with JSONL streaming, budget enforcement via context cancel, and worktree cleanup
- `internal/runner/pi_parser.go` — Pi JSONL stream parser with cost/token accumulation
- `internal/runner/pi_tools.go` — SODA canonical tool name mapping to Pi tool names
- `internal/sandbox/pi.go` — PiAdapter implementing AgentAdapter for sandboxed execution
- `cmd/soda/run.go` — Runner selection wiring (runner: pi in config)
- `internal/config/config.go` — Runner and PiConfig fields

## Known issues (follow-up)

- `classifyPiExitError` returns TransientError for all unrecognized exits — should distinguish permanent failures
- PiAdapter.BuildArgs writes system prompt to WorkDir instead of tmpDir (sandbox-specific concern)

## Test plan

- [x] Pi JSONL parser tests (stream parsing, cost accumulation, error recovery)
- [x] PiRunner unit tests (budget enforcement, tool mapping, error classification)
- [x] PiAdapter unit tests (BuildArgs, BuildEnv, ParseOutput, ExtraPaths)
- [x] All existing tests pass (`go test ./...`)

Assisted-by: SODA