### PR TITLE
[485] feat(runner): Opencode agent backend

### DIFF
--- a/cmd/soda/preflight.go
+++ b/cmd/soda/preflight.go
@@ -31,14 +31,16 @@ func (e *PreflightError) Error() string {
 // begins.
 //
 // When useMock is true, Claude CLI checks are skipped because the mock
-// runner doesn't invoke Claude.
-func runPreflight(env *doctorEnv, useMock bool) error {
+// runner doesn't invoke Claude. When runnerName is "pi" or "opencode",
+// Claude CLI checks are also skipped because those runners don't invoke
+// the Claude Code CLI.
+func runPreflight(env *doctorEnv, useMock bool, runnerName string) error {
 	checks := []func(*doctorEnv) checkResult{
 		checkGit,
 		checkGitRepo,
 	}
 
-	if !useMock {
+	if !useMock && runnerName != "pi" && runnerName != "opencode" {
 		checks = append(checks, checkClaude, checkClaudeVersion)
 	}
 

--- a/cmd/soda/preflight_test.go
+++ b/cmd/soda/preflight_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestRunPreflight_AllPass(t *testing.T) {
 	env := allPassEnv()
-	err := runPreflight(env, false)
+	err := runPreflight(env, false, "")
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
@@ -28,7 +28,7 @@ func TestRunPreflight_AllPass_MockMode(t *testing.T) {
 		}
 		return "/usr/bin/" + file, nil
 	}
-	err := runPreflight(env, true)
+	err := runPreflight(env, true, "")
 	if err != nil {
 		t.Fatalf("expected no error in mock mode even without claude, got: %v", err)
 	}
@@ -42,7 +42,7 @@ func TestRunPreflight_GitMissing(t *testing.T) {
 		}
 		return "/usr/bin/" + file, nil
 	}
-	err := runPreflight(env, false)
+	err := runPreflight(env, false, "")
 	if err == nil {
 		t.Fatal("expected error when git is missing")
 	}
@@ -76,7 +76,7 @@ func TestRunPreflight_NotGitRepo(t *testing.T) {
 		}
 		return "", nil
 	}
-	err := runPreflight(env, false)
+	err := runPreflight(env, false, "")
 	if err == nil {
 		t.Fatal("expected error when not in a git repo")
 	}
@@ -103,7 +103,7 @@ func TestRunPreflight_ClaudeMissing(t *testing.T) {
 		}
 		return "/usr/bin/" + file, nil
 	}
-	err := runPreflight(env, false)
+	err := runPreflight(env, false, "")
 	if err == nil {
 		t.Fatal("expected error when claude is missing")
 	}
@@ -135,7 +135,7 @@ func TestRunPreflight_ClaudeMissing_MockMode(t *testing.T) {
 		return "/usr/bin/" + file, nil
 	}
 	// In mock mode, claude checks are entirely skipped.
-	err := runPreflight(env, true)
+	err := runPreflight(env, true, "")
 	if err != nil {
 		t.Fatalf("expected no error in mock mode, got: %v", err)
 	}
@@ -152,7 +152,7 @@ func TestRunPreflight_ClaudeVersionTooOld(t *testing.T) {
 		}
 		return "", nil
 	}
-	err := runPreflight(env, false)
+	err := runPreflight(env, false, "")
 	if err == nil {
 		t.Fatal("expected error when claude version is too old")
 	}
@@ -186,7 +186,7 @@ func TestRunPreflight_NoConfigDoesNotFail(t *testing.T) {
 	env.UserConfigDir = func() (string, error) {
 		return "/home/testuser/.config", nil
 	}
-	err := runPreflight(env, false)
+	err := runPreflight(env, false, "")
 	if err != nil {
 		t.Fatalf("expected no error (config checks excluded from preflight), got: %v", err)
 	}
@@ -199,7 +199,7 @@ func TestRunPreflight_InvalidConfigDoesNotFail(t *testing.T) {
 	env.LoadConfig = func(path string) (*config.Config, error) {
 		return nil, errors.New("invalid YAML syntax")
 	}
-	err := runPreflight(env, false)
+	err := runPreflight(env, false, "")
 	if err != nil {
 		t.Fatalf("expected no error (config checks excluded from preflight), got: %v", err)
 	}
@@ -213,7 +213,7 @@ func TestRunPreflight_MultipleFailures(t *testing.T) {
 	env.Stat = func(name string) (os.FileInfo, error) {
 		return nil, os.ErrNotExist
 	}
-	err := runPreflight(env, false)
+	err := runPreflight(env, false, "")
 	if err == nil {
 		t.Fatal("expected error with multiple failures")
 	}
@@ -283,8 +283,66 @@ func TestRunPreflight_OptionalFailuresIgnored(t *testing.T) {
 		}
 		return "/usr/bin/" + file, nil
 	}
-	err := runPreflight(env, false)
+	err := runPreflight(env, false, "")
 	if err != nil {
 		t.Fatalf("expected no error for optional-only failures, got: %v", err)
+	}
+}
+
+func TestRunPreflight_SkipsClaudeForPiRunner(t *testing.T) {
+	// When runner is "pi", Claude CLI checks should be skipped entirely.
+	env := allPassEnv()
+	env.LookPath = func(file string) (string, error) {
+		if file == "claude" {
+			return "", errors.New("not found")
+		}
+		return "/usr/bin/" + file, nil
+	}
+	err := runPreflight(env, false, "pi")
+	if err != nil {
+		t.Fatalf("expected no error with runner=pi and no claude, got: %v", err)
+	}
+}
+
+func TestRunPreflight_SkipsClaudeForOpencodeRunner(t *testing.T) {
+	// When runner is "opencode", Claude CLI checks should be skipped entirely.
+	env := allPassEnv()
+	env.LookPath = func(file string) (string, error) {
+		if file == "claude" {
+			return "", errors.New("not found")
+		}
+		return "/usr/bin/" + file, nil
+	}
+	err := runPreflight(env, false, "opencode")
+	if err != nil {
+		t.Fatalf("expected no error with runner=opencode and no claude, got: %v", err)
+	}
+}
+
+func TestRunPreflight_ChecksClaudeForDefaultRunner(t *testing.T) {
+	// When runner is "" (default=claude), Claude CLI checks should still run.
+	env := allPassEnv()
+	env.LookPath = func(file string) (string, error) {
+		if file == "claude" {
+			return "", errors.New("not found")
+		}
+		return "/usr/bin/" + file, nil
+	}
+	err := runPreflight(env, false, "")
+	if err == nil {
+		t.Fatal("expected error when runner is default and claude is missing")
+	}
+	var pe *PreflightError
+	if !errors.As(err, &pe) {
+		t.Fatalf("expected PreflightError, got %T", err)
+	}
+	found := false
+	for _, f := range pe.Failures {
+		if f.name == "claude" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected claude failure in PreflightError for default runner")
 	}
 }

--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -279,6 +279,7 @@ func runPipeline(cfg *config.Config, opts pipelineOpts) error {
 	var r runner.Runner
 	useMock := opts.useMock
 	usePi := cfg.Runner == "pi"
+	useOpencode := cfg.Runner == "opencode"
 	if useMock {
 		r = buildMockRunner()
 	} else if cfg.Sandbox.Enabled {
@@ -295,7 +296,19 @@ func runPipeline(cfg *config.Config, opts pipelineOpts) error {
 				LogDir:          cfg.Sandbox.Proxy.LogDir,
 			},
 		}
-		if usePi {
+		if useOpencode {
+			ocBinary := cfg.Opencode.Binary
+			ocAdapter, adapterErr := sandbox.NewOpencodeAdapter(ocBinary)
+			if adapterErr != nil {
+				return fmt.Errorf("run: create opencode adapter: %w", adapterErr)
+			}
+			sbRunner, sbErr := sandbox.NewWithAdapter(sbCfg, ocAdapter)
+			if sbErr != nil {
+				return fmt.Errorf("run: create sandbox runner (opencode): %w", sbErr)
+			}
+			defer sbRunner.Close()
+			r = sbRunner
+		} else if usePi {
 			piBinary := cfg.Pi.Binary
 			piAdapter, adapterErr := sandbox.NewPiAdapter(piBinary)
 			if adapterErr != nil {
@@ -315,6 +328,16 @@ func runPipeline(cfg *config.Config, opts pipelineOpts) error {
 			defer sbRunner.Close()
 			r = sbRunner
 		}
+	} else if useOpencode {
+		ocModel := cfg.Opencode.Model
+		if ocModel == "" {
+			ocModel = cfg.Model
+		}
+		ocRunner, ocErr := runner.NewOpencodeRunner(cfg.Opencode.Binary, ocModel, workDir)
+		if ocErr != nil {
+			return fmt.Errorf("run: create opencode runner: %w", ocErr)
+		}
+		r = ocRunner
 	} else if usePi {
 		piModel := cfg.Pi.Model
 		if piModel == "" {
@@ -440,9 +463,11 @@ func runPipeline(cfg *config.Config, opts pipelineOpts) error {
 		cfg.Limits.MaxCostPerTicket = opts.maxCost
 	}
 
-	// When using Pi, prefer pi.model over top-level model.
+	// When using Pi or Opencode, prefer agent-specific model over top-level model.
 	effectiveModel := cfg.Model
-	if usePi && cfg.Pi.Model != "" {
+	if useOpencode && cfg.Opencode.Model != "" {
+		effectiveModel = cfg.Opencode.Model
+	} else if usePi && cfg.Pi.Model != "" {
 		effectiveModel = cfg.Pi.Model
 	}
 

--- a/cmd/soda/run.go
+++ b/cmd/soda/run.go
@@ -118,7 +118,7 @@ func newRunCmd() *cobra.Command {
 func runPipeline(cfg *config.Config, opts pipelineOpts) error {
 	// Fail fast: run lightweight prerequisite checks before any expensive
 	// work (ticket fetching, worktree setup, runner creation, etc.).
-	if err := runPreflight(defaultDoctorEnv(), opts.useMock); err != nil {
+	if err := runPreflight(defaultDoctorEnv(), opts.useMock, cfg.Runner); err != nil {
 		return err
 	}
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -41,6 +41,14 @@ mode: autonomous   # or "checkpoint"
 # Model (used for all phases in v1)
 model: claude-opus-4-6
 
+# Runner backend — "claude" (default), "pi", or "opencode"
+# runner: opencode
+
+# Opencode agent settings (uncomment to use opencode as the runner backend)
+# opencode:
+#   binary: opencode           # path to opencode binary; empty = exec.LookPath("opencode")
+#   model: claude-sonnet-4-20250514  # model override; empty = use top-level model
+
 # Authentication — optional keychain/vault-based credential injection.
 # When api_key_helper is set, SODA writes a Claude Code settings file
 # with apiKeyHelper pointing to this script. The script must print a

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,10 +23,11 @@ type Config struct {
 	GitLab              GitLabTicketConfig  `yaml:"gitlab,omitempty"`
 	Mode                string              `yaml:"mode"`
 	Model               string              `yaml:"model"`
-	Runner              string              `yaml:"runner,omitempty"` // "claude" (default) or "pi"
+	Runner              string              `yaml:"runner,omitempty"` // "claude" (default), "pi", or "opencode"
 	Auth                AuthConfig          `yaml:"auth"`
 	Sandbox             SandboxConfig       `yaml:"sandbox"`
 	Pi                  PiConfig            `yaml:"pi,omitempty"`
+	Opencode            OpencodeConfig      `yaml:"opencode,omitempty"`
 	Limits              LimitsConfig        `yaml:"limits"`
 	PhasesPath          string              `yaml:"phases_path"`    // explicit path to pipeline YAML; overrides CWD discovery
 	PipelinesPath       string              `yaml:"pipelines_path"` // directory for named pipeline YAML files (e.g. ".pipelines/"); checked before CWD discovery
@@ -46,6 +47,12 @@ type Config struct {
 type PiConfig struct {
 	Binary string `yaml:"binary,omitempty"` // path to pi binary; empty = exec.LookPath("pi")
 	Model  string `yaml:"model,omitempty"`  // model override for Pi; empty = use top-level Model
+}
+
+// OpencodeConfig holds Opencode agent settings.
+type OpencodeConfig struct {
+	Binary string `yaml:"binary,omitempty"` // path to opencode binary; empty = exec.LookPath("opencode")
+	Model  string `yaml:"model,omitempty"`  // model override for Opencode; empty = use top-level Model
 }
 
 // TranscriptConfig controls agent transcript persistence.

--- a/internal/runner/opencode.go
+++ b/internal/runner/opencode.go
@@ -1,0 +1,402 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+// OpencodeRunner implements Runner by invoking the Opencode agent CLI.
+type OpencodeRunner struct {
+	binary string // resolved absolute path to opencode binary
+	model  string
+}
+
+// compile-time interface check
+var _ Runner = (*OpencodeRunner)(nil)
+
+// NewOpencodeRunner creates an OpencodeRunner backed by the Opencode agent CLI.
+func NewOpencodeRunner(binary, model, workDir string) (*OpencodeRunner, error) {
+	if binary == "" {
+		binary = "opencode"
+	}
+
+	resolved, err := exec.LookPath(binary)
+	if err != nil {
+		return nil, fmt.Errorf("opencode binary not found: %w", err)
+	}
+
+	return &OpencodeRunner{
+		binary: resolved,
+		model:  model,
+	}, nil
+}
+
+// Run maps runner.RunOpts to Opencode CLI arguments, invokes the CLI, and maps the result back.
+func (r *OpencodeRunner) Run(ctx context.Context, opts RunOpts) (*RunResult, error) {
+	// Validate WorkDir — must be present and absolute.
+	if opts.WorkDir == "" {
+		return nil, fmt.Errorf("opencode runner: WorkDir is required")
+	}
+	if !filepath.IsAbs(opts.WorkDir) {
+		return nil, fmt.Errorf("opencode runner: WorkDir must be absolute: %s", opts.WorkDir)
+	}
+
+	// Validate output schema.
+	if opts.OutputSchema != "" {
+		if len(opts.OutputSchema) > 256*1024 {
+			return nil, fmt.Errorf("opencode runner: output schema exceeds 256KB limit")
+		}
+		if !json.Valid([]byte(opts.OutputSchema)) {
+			return nil, fmt.Errorf("opencode runner: output schema is not valid JSON")
+		}
+	}
+
+	// Write agent file for system prompt.
+	if opts.SystemPrompt != "" {
+		cleanup, err := writeOpencodeAgentFile(opts.WorkDir, opts.Phase, opts.SystemPrompt)
+		if err != nil {
+			return nil, fmt.Errorf("opencode runner: write agent file: %w", err)
+		}
+		defer cleanup()
+	}
+
+	args := buildOpencodeArgs(opts, r.model)
+
+	// Apply per-phase timeout.
+	if opts.Timeout > 0 {
+		phaseDeadline := time.Now().Add(opts.Timeout)
+		if existingDeadline, hasDeadline := ctx.Deadline(); !hasDeadline || phaseDeadline.Before(existingDeadline) {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, opts.Timeout)
+			defer cancel()
+		}
+	}
+
+	// Budget tracking: cancel if cost exceeds budget.
+	budgetCtx := ctx
+	var budgetCancel context.CancelFunc
+	if opts.MaxBudgetUSD > 0 {
+		budgetCtx, budgetCancel = context.WithCancel(ctx)
+		defer budgetCancel()
+	}
+
+	// Build environment for the opencode process.
+	env := buildOpencodeEnv(opts, r.binary)
+
+	cmd := exec.CommandContext(budgetCtx, r.binary, args...)
+	cmd.Dir = opts.WorkDir
+	cmd.Env = env
+
+	// Stdin: prompt via stdin, or /dev/null if empty.
+	if opts.UserPrompt != "" {
+		cmd.Stdin = strings.NewReader(opts.UserPrompt)
+	}
+
+	// Process group isolation — kill the entire group on cancel.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
+	}
+	cmd.WaitDelay = 5 * time.Second
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("opencode runner: stdout pipe: %w", err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, fmt.Errorf("opencode runner: stderr pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, &TransientError{
+			Reason: "unknown",
+			Err:    fmt.Errorf("opencode runner: start: %w", err),
+		}
+	}
+
+	// Drain stdout and stderr concurrently.
+	var outputBuf piLimitedBuffer
+	outputBuf.max = 50 * 1024 * 1024 // 50MB
+	var stderrBuf piLimitedBuffer
+	stderrBuf.max = 1024 * 1024 // 1MB
+
+	var stdoutErr error
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	var costAccumulator float64
+	var costMu sync.Mutex
+	budgetExceeded := false
+
+	go func() {
+		defer wg.Done()
+		scanner := newLineScanner(stdout)
+		for scanner.Scan() {
+			line := scanner.Bytes()
+			outputBuf.Write(line)
+			outputBuf.Write([]byte("\n"))
+
+			// Budget enforcement: check cost from done events.
+			if opts.MaxBudgetUSD > 0 {
+				var event OpencodeEvent
+				if json.Unmarshal(line, &event) == nil && event.Type == "done" && event.Cost != nil {
+					costMu.Lock()
+					costAccumulator += *event.Cost
+					exceeded := costAccumulator >= opts.MaxBudgetUSD
+					costMu.Unlock()
+					if exceeded {
+						budgetExceeded = true
+						if budgetCancel != nil {
+							budgetCancel()
+						}
+					}
+				}
+			}
+
+			// Forward displayable text to onChunk.
+			if opts.OnChunk != nil {
+				var event OpencodeEvent
+				if json.Unmarshal(line, &event) == nil && event.Type == "text" && event.Content != "" {
+					func() {
+						defer func() {
+							if rec := recover(); rec != nil {
+								fmt.Fprintf(os.Stderr, "opencode runner: onChunk panic: %v\n", rec)
+							}
+						}()
+						opts.OnChunk(event.Content)
+					}()
+				}
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			stdoutErr = fmt.Errorf("opencode runner: scan stdout: %w", err)
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		buf := make([]byte, 32*1024)
+		for {
+			readN, readErr := stderr.Read(buf)
+			if readN > 0 {
+				stderrBuf.Write(buf[:readN])
+			}
+			if readErr != nil {
+				break
+			}
+		}
+	}()
+
+	wg.Wait()
+
+	// Check stdout drain error.
+	if stdoutErr != nil {
+		cmd.Wait()
+		return nil, stdoutErr
+	}
+
+	waitErr := cmd.Wait()
+
+	// Budget exceeded: revert worktree and return budget error.
+	if budgetExceeded {
+		revertWorktree(opts.WorkDir)
+		return nil, &TransientError{
+			Reason: "budget_exceeded",
+			Err:    fmt.Errorf("opencode runner: budget exceeded ($%.2f >= $%.2f)", costAccumulator, opts.MaxBudgetUSD),
+		}
+	}
+
+	if waitErr != nil {
+		// Context cancellation — not retryable.
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		if budgetCtx.Err() != nil {
+			revertWorktree(opts.WorkDir)
+			return nil, &TransientError{
+				Reason: "budget_exceeded",
+				Err:    fmt.Errorf("opencode runner: budget exceeded"),
+			}
+		}
+
+		// Non-zero exit: try parsing stdout first.
+		if outputBuf.Len() > 0 && !outputBuf.overflow {
+			parsed, parseErr := ParseOpencodeStream(outputBuf.Bytes(), nil)
+			if parseErr == nil && len(parsed.Output) > 0 {
+				return opencodeStreamToResult(parsed), nil
+			}
+		}
+
+		// Classify the exit error.
+		stderrBytes := stderrBuf.Bytes()
+		return nil, classifyOpencodeExitError(waitErr, stderrBytes)
+	}
+
+	// Check buffer overflow.
+	if outputBuf.overflow {
+		return nil, &ParseError{
+			Err: fmt.Errorf("opencode runner: stdout exceeded %d byte buffer limit", outputBuf.max),
+		}
+	}
+
+	parsed, err := ParseOpencodeStream(outputBuf.Bytes(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Validate output against schema.
+	if opts.OutputSchema != "" {
+		if valErr := ValidateOpencodeOutput(parsed.Output, opts.OutputSchema); valErr != nil {
+			return nil, valErr
+		}
+	}
+
+	return opencodeStreamToResult(parsed), nil
+}
+
+// opencodeStreamToResult converts an OpencodeStreamResult to a RunResult.
+func opencodeStreamToResult(parsed *OpencodeStreamResult) *RunResult {
+	return &RunResult{
+		Output:    parsed.Output,
+		RawText:   parsed.RawText,
+		CostUSD:   parsed.CostUSD,
+		TokensIn:  parsed.TokensIn,
+		TokensOut: parsed.TokensOut,
+		Turns:     parsed.Turns,
+	}
+}
+
+// buildOpencodeArgs constructs the CLI argument list for an Opencode invocation.
+func buildOpencodeArgs(opts RunOpts, defaultModel string) []string {
+	args := []string{
+		"--print",
+		"--output-format", "stream-json",
+		"--dangerously-skip-permissions",
+	}
+
+	// Prefer per-invocation model over runner-level default.
+	effectiveModel := defaultModel
+	if opts.Model != "" {
+		effectiveModel = opts.Model
+	}
+	if effectiveModel != "" {
+		args = append(args, "--model", effectiveModel)
+	}
+
+	// Agent name derived from phase.
+	if opts.Phase != "" {
+		args = append(args, "--agent", agentName(opts.Phase))
+	}
+
+	// Map and add allowed tools.
+	mapped := make([]string, 0, len(opts.AllowedTools))
+	for _, tool := range opts.AllowedTools {
+		mapped = append(mapped, MapOpencodeToolName(tool))
+	}
+	mapped = deduplicateTools(mapped)
+	if len(mapped) > 0 {
+		args = append(args, "--permissions", strings.Join(mapped, ","))
+	}
+
+	return args
+}
+
+// writeOpencodeAgentFile writes the system prompt to
+// {workDir}/.opencode/agent/{agentName}.md per Opencode's agent file convention.
+//
+// If an existing agent file is present it is backed up and restored by the
+// returned cleanup function. If no prior file existed, cleanup removes the
+// file (and the directories if we created them).
+func writeOpencodeAgentFile(workDir, phase, content string) (cleanup func(), err error) {
+	if workDir == "" {
+		workDir = os.TempDir()
+	}
+	abs, err := filepath.Abs(workDir)
+	if err != nil {
+		return nil, fmt.Errorf("opencode: resolve workdir: %w", err)
+	}
+
+	ocDir := filepath.Join(abs, ".opencode")
+	agentDir := filepath.Join(ocDir, "agent")
+	agentFile := filepath.Join(agentDir, agentName(phase)+".md")
+
+	// Track whether parent directories existed so we can clean up.
+	_, ocStatErr := os.Stat(ocDir)
+	ocDirExisted := ocStatErr == nil
+
+	_, agentStatErr := os.Stat(agentDir)
+	agentDirExisted := agentStatErr == nil
+
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		return nil, fmt.Errorf("opencode: create agent directory: %w", err)
+	}
+
+	// Back up existing agent file so we can restore it on cleanup.
+	existing, readErr := os.ReadFile(agentFile)
+	hadExisting := readErr == nil
+
+	if err := os.WriteFile(agentFile, []byte(content), 0o644); err != nil {
+		return nil, fmt.Errorf("opencode: write agent file: %w", err)
+	}
+
+	cleanup = func() {
+		if hadExisting {
+			_ = os.WriteFile(agentFile, existing, 0o644)
+		} else {
+			_ = os.Remove(agentFile)
+			if !agentDirExisted {
+				_ = os.Remove(agentDir)
+			}
+			if !ocDirExisted {
+				_ = os.Remove(ocDir)
+			}
+		}
+	}
+
+	return cleanup, nil
+}
+
+// agentName converts a phase name into an opencode agent name.
+// Slashes are replaced with dashes (e.g., "review/go-specialist" → "soda-review-go-specialist").
+func agentName(phase string) string {
+	safe := strings.ReplaceAll(phase, "/", "-")
+	return "soda-" + safe
+}
+
+// buildOpencodeEnv constructs the environment for a standalone Opencode runner.
+// It inherits os.Environ() with HOME and isolation overrides applied.
+func buildOpencodeEnv(opts RunOpts, opencodeBin string) []string {
+	env := os.Environ()
+
+	// Filter out vars we want to override.
+	overrides := map[string]string{
+		"HOME": opts.WorkDir,
+	}
+
+	var filtered []string
+	for _, entry := range env {
+		key := entry
+		if idx := strings.IndexByte(entry, '='); idx >= 0 {
+			key = entry[:idx]
+		}
+		if _, skip := overrides[key]; skip {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+
+	for key, val := range overrides {
+		filtered = append(filtered, key+"="+val)
+	}
+
+	return filtered
+}

--- a/internal/runner/opencode.go
+++ b/internal/runner/opencode.go
@@ -198,6 +198,18 @@ func (r *OpencodeRunner) Run(ctx context.Context, opts RunOpts) (*RunResult, err
 
 	wg.Wait()
 
+	// Budget exceeded takes precedence over stdout drain errors — we must
+	// always revert the worktree when the budget is blown, even if the
+	// stdout scanner also failed (e.g., line exceeded 1MB buffer).
+	if budgetExceeded {
+		revertWorktree(opts.WorkDir)
+		cmd.Wait()
+		return nil, &TransientError{
+			Reason: "budget_exceeded",
+			Err:    fmt.Errorf("opencode runner: budget exceeded ($%.2f >= $%.2f)", costAccumulator, opts.MaxBudgetUSD),
+		}
+	}
+
 	// Check stdout drain error.
 	if stdoutErr != nil {
 		cmd.Wait()
@@ -205,15 +217,6 @@ func (r *OpencodeRunner) Run(ctx context.Context, opts RunOpts) (*RunResult, err
 	}
 
 	waitErr := cmd.Wait()
-
-	// Budget exceeded: revert worktree and return budget error.
-	if budgetExceeded {
-		revertWorktree(opts.WorkDir)
-		return nil, &TransientError{
-			Reason: "budget_exceeded",
-			Err:    fmt.Errorf("opencode runner: budget exceeded ($%.2f >= $%.2f)", costAccumulator, opts.MaxBudgetUSD),
-		}
-	}
 
 	if waitErr != nil {
 		// Context cancellation — not retryable.

--- a/internal/runner/opencode.go
+++ b/internal/runner/opencode.go
@@ -59,9 +59,21 @@ func (r *OpencodeRunner) Run(ctx context.Context, opts RunOpts) (*RunResult, err
 		}
 	}
 
-	// Write agent file for system prompt.
-	if opts.SystemPrompt != "" {
-		cleanup, err := writeOpencodeAgentFile(opts.WorkDir, opts.Phase, opts.SystemPrompt)
+	// Normalize phase: default to "default" when empty so the agent file name
+	// matches the --agent flag produced by buildOpencodeArgs.
+	phase := opts.Phase
+	if phase == "" {
+		phase = "default"
+	}
+
+	// Write agent file for system prompt (and output schema, if provided).
+	agentContent := opts.SystemPrompt
+	if opts.OutputSchema != "" {
+		schemaSection := "\n\n## Output Schema\n\nYou MUST produce a JSON object conforming to this schema:\n\n```json\n" + opts.OutputSchema + "\n```\n"
+		agentContent += schemaSection
+	}
+	if agentContent != "" {
+		cleanup, err := writeOpencodeAgentFile(opts.WorkDir, phase, agentContent)
 		if err != nil {
 			return nil, fmt.Errorf("opencode runner: write agent file: %w", err)
 		}
@@ -295,10 +307,13 @@ func buildOpencodeArgs(opts RunOpts, defaultModel string) []string {
 		args = append(args, "--model", effectiveModel)
 	}
 
-	// Agent name derived from phase.
-	if opts.Phase != "" {
-		args = append(args, "--agent", agentName(opts.Phase))
+	// Agent name derived from phase; default to "default" when empty so the
+	// written agent file is always loaded (matches sandbox adapter behaviour).
+	phase := opts.Phase
+	if phase == "" {
+		phase = "default"
 	}
+	args = append(args, "--agent", agentName(phase))
 
 	// Map and add allowed tools.
 	mapped := make([]string, 0, len(opts.AllowedTools))

--- a/internal/runner/opencode.go
+++ b/internal/runner/opencode.go
@@ -302,7 +302,7 @@ func buildOpencodeArgs(opts RunOpts, defaultModel string) []string {
 	for _, tool := range opts.AllowedTools {
 		mapped = append(mapped, MapOpencodeToolName(tool))
 	}
-	mapped = deduplicateTools(mapped)
+	mapped = DeduplicateTools(mapped)
 	if len(mapped) > 0 {
 		args = append(args, "--permissions", strings.Join(mapped, ","))
 	}

--- a/internal/runner/opencode_parser.go
+++ b/internal/runner/opencode_parser.go
@@ -1,0 +1,332 @@
+package runner
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// OpencodeEvent represents a single JSONL event from the Opencode agent.
+type OpencodeEvent struct {
+	Type    string          `json:"type"`
+	Content string          `json:"content,omitempty"`
+	Tool    string          `json:"tool,omitempty"`
+	Error   string          `json:"error,omitempty"`
+	Usage   *OpencodeUsage  `json:"usage,omitempty"`
+	Cost    *float64        `json:"cost_usd,omitempty"`
+	Result  json.RawMessage `json:"result,omitempty"`
+}
+
+// OpencodeUsage holds token usage data from an Opencode event.
+type OpencodeUsage struct {
+	InputTokens  int64 `json:"input_tokens"`
+	OutputTokens int64 `json:"output_tokens"`
+}
+
+// OpencodeStreamResult holds the accumulated result of parsing an Opencode JSONL stream.
+type OpencodeStreamResult struct {
+	Output    json.RawMessage // structured result extracted from text
+	RawText   string          // accumulated assistant text
+	CostUSD   float64
+	TokensIn  int64
+	TokensOut int64
+	Turns     int
+}
+
+// ParseOpencodeStream parses a JSONL byte stream from the Opencode agent and
+// accumulates usage, cost, and output data. onChunk is called for each
+// displayable text chunk; it may be nil.
+func ParseOpencodeStream(data []byte, onChunk func(string)) (*OpencodeStreamResult, error) {
+	result := &OpencodeStreamResult{}
+	var textParts []string
+
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024) // 1MB max line
+
+	var lastErr error
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+
+		var event OpencodeEvent
+		if err := json.Unmarshal(line, &event); err != nil {
+			// Skip non-JSON lines (e.g., debug output).
+			continue
+		}
+
+		switch event.Type {
+		case "text":
+			if event.Content != "" {
+				textParts = append(textParts, event.Content)
+				if onChunk != nil {
+					onChunk(event.Content)
+				}
+			}
+
+		case "tool_use":
+			result.Turns++
+
+		case "done":
+			if event.Usage != nil {
+				result.TokensIn += event.Usage.InputTokens
+				result.TokensOut += event.Usage.OutputTokens
+			}
+			if event.Cost != nil {
+				result.CostUSD += *event.Cost
+			}
+
+		case "result":
+			if len(event.Result) > 0 && string(event.Result) != "null" {
+				lastErr = nil
+				result.Output = event.Result
+			}
+			if event.Content != "" {
+				textParts = append(textParts, event.Content)
+			}
+
+		case "error":
+			reason := classifyOpencodeError(event.Error)
+			if reason != "unknown" {
+				lastErr = &TransientError{
+					Reason: reason,
+					Err:    fmt.Errorf("opencode: %s", event.Error),
+				}
+			} else {
+				lastErr = &ParseError{
+					Err: fmt.Errorf("opencode: %s", event.Error),
+				}
+			}
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, &ParseError{Err: fmt.Errorf("opencode: scan stream: %w", err)}
+	}
+
+	// If the last event was an error, return it.
+	if lastErr != nil {
+		return nil, lastErr
+	}
+
+	result.RawText = strings.Join(textParts, "")
+
+	// If no explicit result event was found, try extracting structured JSON
+	// from the accumulated text.
+	if result.Output == nil && result.RawText != "" {
+		if extracted := extractJSONFromText(result.RawText); extracted != nil {
+			result.Output = extracted
+		}
+	}
+
+	return result, nil
+}
+
+// extractJSONFromText scans text for the last valid JSON object. It first
+// looks for fenced ```json blocks, then falls back to the last substring
+// that parses as a JSON object.
+func extractJSONFromText(text string) json.RawMessage {
+	// Try fenced JSON blocks — use the last one found.
+	const startFence = "```json"
+	const endFence = "```"
+
+	var lastFenced json.RawMessage
+	searchText := text
+	for {
+		startIdx := strings.Index(searchText, startFence)
+		if startIdx < 0 {
+			break
+		}
+		after := searchText[startIdx+len(startFence):]
+		endIdx := strings.Index(after, endFence)
+		if endIdx < 0 {
+			break
+		}
+		candidate := strings.TrimSpace(after[:endIdx])
+		if json.Valid([]byte(candidate)) {
+			// Verify it's an object (starts with '{').
+			trimmed := strings.TrimSpace(candidate)
+			if len(trimmed) > 0 && trimmed[0] == '{' {
+				lastFenced = json.RawMessage(trimmed)
+			}
+		}
+		searchText = after[endIdx+len(endFence):]
+	}
+	if lastFenced != nil {
+		return lastFenced
+	}
+
+	// Fallback: find the last valid JSON object in the text by scanning
+	// for '{' and matching '}' from the end.
+	for idx := len(text) - 1; idx >= 0; idx-- {
+		if text[idx] == '}' {
+			// Walk backwards to find a matching '{'.
+			depth := 0
+			for jdx := idx; jdx >= 0; jdx-- {
+				switch text[jdx] {
+				case '}':
+					depth++
+				case '{':
+					depth--
+				}
+				if depth == 0 {
+					candidate := text[jdx : idx+1]
+					if json.Valid([]byte(candidate)) {
+						return json.RawMessage(candidate)
+					}
+					break
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// ValidateOpencodeOutput checks that the structured output satisfies the
+// required fields declared in the output schema. It parses the schema's
+// "required" array and verifies each key exists in the output JSON object.
+func ValidateOpencodeOutput(output json.RawMessage, schemaJSON string) error {
+	if len(output) == 0 {
+		return &ParseError{Err: fmt.Errorf("opencode: empty structured output")}
+	}
+
+	if schemaJSON == "" {
+		return nil
+	}
+
+	// Extract the "required" array from the schema.
+	var schema struct {
+		Required []string `json:"required"`
+	}
+	if err := json.Unmarshal([]byte(schemaJSON), &schema); err != nil {
+		// Schema itself is invalid — not the agent's fault.
+		return nil
+	}
+
+	if len(schema.Required) == 0 {
+		return nil
+	}
+
+	// Parse the output as a generic map to check for required keys.
+	var outputMap map[string]json.RawMessage
+	if err := json.Unmarshal(output, &outputMap); err != nil {
+		return &ParseError{Err: fmt.Errorf("opencode: output is not a JSON object: %w", err)}
+	}
+
+	var missing []string
+	for _, key := range schema.Required {
+		if _, ok := outputMap[key]; !ok {
+			missing = append(missing, key)
+		}
+	}
+
+	if len(missing) > 0 {
+		return &ParseError{
+			Err: fmt.Errorf("opencode: output missing required fields: %s", strings.Join(missing, ", ")),
+		}
+	}
+
+	return nil
+}
+
+// MapOpencodeToolName maps a runner-level tool name to the Opencode-equivalent
+// tool name. Unknown tool names are returned unchanged.
+func MapOpencodeToolName(tool string) string {
+	mapping := map[string]string{
+		"Read":   "read",
+		"Write":  "write",
+		"Edit":   "edit",
+		"Glob":   "glob",
+		"Grep":   "grep",
+		"Bash":   "bash",
+		"Search": "search",
+	}
+
+	// Handle parameterized tools like "Bash(git:*)" → "bash(git:*)"
+	baseTool := tool
+	param := ""
+	if idx := strings.Index(tool, "("); idx >= 0 {
+		baseTool = tool[:idx]
+		param = tool[idx:]
+	}
+
+	if mapped, ok := mapping[baseTool]; ok {
+		return mapped + param
+	}
+
+	return tool
+}
+
+// deduplicateTools returns a copy of tools with duplicates removed,
+// preserving the original order.
+func deduplicateTools(tools []string) []string {
+	seen := make(map[string]bool, len(tools))
+	var result []string
+	for _, tool := range tools {
+		if !seen[tool] {
+			seen[tool] = true
+			result = append(result, tool)
+		}
+	}
+	return result
+}
+
+// classifyOpencodeError maps Opencode error messages to transient error reason categories.
+func classifyOpencodeError(msg string) string {
+	lower := strings.ToLower(msg)
+
+	patterns := []struct {
+		substrings []string
+		reason     string
+	}{
+		{[]string{"rate limit", " 429", "too many requests"}, "rate_limit"},
+		{[]string{"timeout", " 504", " 529"}, "timeout"},
+		{[]string{"overloaded", " 500", " 502", " 503", "server error", "internal error"}, "overloaded"},
+		{[]string{"connection refused", "econnreset", "connection reset"}, "connection"},
+	}
+
+	for _, pattern := range patterns {
+		for _, sub := range pattern.substrings {
+			if strings.Contains(lower, sub) {
+				return pattern.reason
+			}
+		}
+	}
+
+	return "unknown"
+}
+
+// classifyOpencodeExitError categorizes an Opencode process exit failure.
+func classifyOpencodeExitError(waitErr error, stderr []byte) error {
+	stderrLower := strings.ToLower(string(stderr))
+
+	patterns := []struct {
+		substrings []string
+		reason     string
+	}{
+		{[]string{"rate limit", " 429", "too many requests"}, "rate_limit"},
+		{[]string{"timeout", " 504", " 529"}, "timeout"},
+		{[]string{"overloaded", " 500", " 502", " 503", "server error", "internal error"}, "overloaded"},
+		{[]string{"connection refused", "econnreset", "connection reset"}, "connection"},
+	}
+
+	for _, pattern := range patterns {
+		for _, sub := range pattern.substrings {
+			if strings.Contains(stderrLower, sub) {
+				return &TransientError{
+					Reason: pattern.reason,
+					Err:    fmt.Errorf("opencode exited: %w", waitErr),
+				}
+			}
+		}
+	}
+
+	return &TransientError{
+		Reason: "unknown",
+		Err:    fmt.Errorf("opencode exited: %w", waitErr),
+	}
+}

--- a/internal/runner/opencode_parser.go
+++ b/internal/runner/opencode_parser.go
@@ -261,9 +261,9 @@ func MapOpencodeToolName(tool string) string {
 	return tool
 }
 
-// deduplicateTools returns a copy of tools with duplicates removed,
+// DeduplicateTools returns a copy of tools with duplicates removed,
 // preserving the original order.
-func deduplicateTools(tools []string) []string {
+func DeduplicateTools(tools []string) []string {
 	seen := make(map[string]bool, len(tools))
 	var result []string
 	for _, tool := range tools {

--- a/internal/runner/opencode_test.go
+++ b/internal/runner/opencode_test.go
@@ -334,7 +334,7 @@ func TestMapOpencodeToolName(t *testing.T) {
 func TestDeduplicateTools(t *testing.T) {
 	t.Run("removes_duplicates", func(t *testing.T) {
 		input := []string{"bash", "read", "bash", "write", "read"}
-		got := deduplicateTools(input)
+		got := DeduplicateTools(input)
 		want := []string{"bash", "read", "write"}
 		if len(got) != len(want) {
 			t.Fatalf("got %v, want %v", got, want)
@@ -348,7 +348,7 @@ func TestDeduplicateTools(t *testing.T) {
 
 	t.Run("preserves_order", func(t *testing.T) {
 		input := []string{"write", "read", "bash"}
-		got := deduplicateTools(input)
+		got := DeduplicateTools(input)
 		for idx := range input {
 			if got[idx] != input[idx] {
 				t.Errorf("got[%d] = %q, want %q", idx, got[idx], input[idx])
@@ -357,7 +357,7 @@ func TestDeduplicateTools(t *testing.T) {
 	})
 
 	t.Run("handles_empty", func(t *testing.T) {
-		got := deduplicateTools(nil)
+		got := DeduplicateTools(nil)
 		if len(got) != 0 {
 			t.Errorf("got %v, want empty", got)
 		}

--- a/internal/runner/opencode_test.go
+++ b/internal/runner/opencode_test.go
@@ -1,0 +1,709 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+var _ Runner = (*OpencodeRunner)(nil) // compile-time interface check
+
+func TestParseOpencodeStream(t *testing.T) {
+	t.Run("parses_text_and_result_events", func(t *testing.T) {
+		stream := strings.Join([]string{
+			`{"type":"text","content":"Hello "}`,
+			`{"type":"text","content":"world"}`,
+			`{"type":"tool_use","tool":"bash"}`,
+			`{"type":"done","usage":{"input_tokens":100,"output_tokens":50},"cost_usd":0.005}`,
+			`{"type":"result","result":{"answer":"42"}}`,
+		}, "\n")
+
+		result, err := ParseOpencodeStream([]byte(stream), nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if result.RawText != "Hello world" {
+			t.Errorf("RawText = %q, want %q", result.RawText, "Hello world")
+		}
+		if result.TokensIn != 100 {
+			t.Errorf("TokensIn = %d, want 100", result.TokensIn)
+		}
+		if result.TokensOut != 50 {
+			t.Errorf("TokensOut = %d, want 50", result.TokensOut)
+		}
+		if result.CostUSD != 0.005 {
+			t.Errorf("CostUSD = %f, want 0.005", result.CostUSD)
+		}
+		if result.Turns != 1 {
+			t.Errorf("Turns = %d, want 1", result.Turns)
+		}
+		if string(result.Output) != `{"answer":"42"}` {
+			t.Errorf("Output = %s, want %s", string(result.Output), `{"answer":"42"}`)
+		}
+	})
+
+	t.Run("accumulates_multiple_done_costs", func(t *testing.T) {
+		stream := strings.Join([]string{
+			`{"type":"done","usage":{"input_tokens":50,"output_tokens":25},"cost_usd":0.003}`,
+			`{"type":"done","usage":{"input_tokens":75,"output_tokens":30},"cost_usd":0.004}`,
+			`{"type":"result","result":{"ok":true}}`,
+		}, "\n")
+
+		result, err := ParseOpencodeStream([]byte(stream), nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if result.TokensIn != 125 {
+			t.Errorf("TokensIn = %d, want 125", result.TokensIn)
+		}
+		if result.TokensOut != 55 {
+			t.Errorf("TokensOut = %d, want 55", result.TokensOut)
+		}
+		wantCost := 0.007
+		if result.CostUSD < wantCost-0.0001 || result.CostUSD > wantCost+0.0001 {
+			t.Errorf("CostUSD = %f, want %f", result.CostUSD, wantCost)
+		}
+	})
+
+	t.Run("returns_transient_error_on_error_event", func(t *testing.T) {
+		stream := `{"type":"error","error":"rate limit exceeded"}`
+
+		_, err := ParseOpencodeStream([]byte(stream), nil)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+
+		var te *TransientError
+		if !errors.As(err, &te) {
+			t.Fatalf("expected TransientError, got %T: %v", err, err)
+		}
+		if te.Reason != "rate_limit" {
+			t.Errorf("Reason = %q, want %q", te.Reason, "rate_limit")
+		}
+	})
+
+	t.Run("returns_parse_error_on_unknown_error_event", func(t *testing.T) {
+		stream := `{"type":"error","error":"invalid API key"}`
+
+		_, err := ParseOpencodeStream([]byte(stream), nil)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+
+		var pe *ParseError
+		if !errors.As(err, &pe) {
+			t.Fatalf("expected ParseError for non-transient error, got %T: %v", err, err)
+		}
+		if !strings.Contains(pe.Error(), "invalid API key") {
+			t.Errorf("error should contain original message, got: %v", pe)
+		}
+	})
+
+	t.Run("calls_onChunk_for_text_content", func(t *testing.T) {
+		stream := strings.Join([]string{
+			`{"type":"text","content":"chunk1"}`,
+			`{"type":"text","content":"chunk2"}`,
+			`{"type":"result","result":{}}`,
+		}, "\n")
+
+		var chunks []string
+		onChunk := func(text string) {
+			chunks = append(chunks, text)
+		}
+
+		_, err := ParseOpencodeStream([]byte(stream), onChunk)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(chunks) != 2 {
+			t.Fatalf("got %d chunks, want 2", len(chunks))
+		}
+		if chunks[0] != "chunk1" || chunks[1] != "chunk2" {
+			t.Errorf("chunks = %v, want [chunk1, chunk2]", chunks)
+		}
+	})
+
+	t.Run("skips_non_json_lines", func(t *testing.T) {
+		stream := strings.Join([]string{
+			"debug: starting up",
+			`{"type":"result","result":{"ok":true}}`,
+			"",
+		}, "\n")
+
+		result, err := ParseOpencodeStream([]byte(stream), nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if string(result.Output) != `{"ok":true}` {
+			t.Errorf("Output = %s, want %s", string(result.Output), `{"ok":true}`)
+		}
+	})
+
+	t.Run("empty_stream_returns_empty_result", func(t *testing.T) {
+		result, err := ParseOpencodeStream([]byte(""), nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if result.RawText != "" {
+			t.Errorf("RawText = %q, want empty", result.RawText)
+		}
+		if result.Output != nil {
+			t.Errorf("Output = %s, want nil", string(result.Output))
+		}
+	})
+
+	t.Run("extracts_json_from_text_when_no_result_event", func(t *testing.T) {
+		stream := strings.Join([]string{
+			`{"type":"text","content":"Here is the output:\n"}`,
+			"{\"type\":\"text\",\"content\":\"```json\\n{\\\"answer\\\":\\\"42\\\"}\\n```\"}",
+			`{"type":"done","usage":{"input_tokens":10,"output_tokens":5},"cost_usd":0.001}`,
+		}, "\n")
+
+		result, err := ParseOpencodeStream([]byte(stream), nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if string(result.Output) != `{"answer":"42"}` {
+			t.Errorf("Output = %s, want %s", string(result.Output), `{"answer":"42"}`)
+		}
+	})
+
+	t.Run("result_event_clears_prior_error", func(t *testing.T) {
+		stream := strings.Join([]string{
+			`{"type":"error","error":"rate limit exceeded"}`,
+			`{"type":"text","content":"Hello"}`,
+			`{"type":"result","result":{"answer":"42"}}`,
+		}, "\n")
+		result, err := ParseOpencodeStream([]byte(stream), nil)
+		if err != nil {
+			t.Fatalf("expected recovery after valid result, got: %v", err)
+		}
+		if string(result.Output) != `{"answer":"42"}` {
+			t.Errorf("Output = %s, want %s", string(result.Output), `{"answer":"42"}`)
+		}
+	})
+}
+
+func TestExtractJSONFromText(t *testing.T) {
+	t.Run("extracts_fenced_json_block", func(t *testing.T) {
+		text := "Some text\n```json\n{\"key\":\"value\"}\n```\nmore text"
+		got := extractJSONFromText(text)
+		if string(got) != `{"key":"value"}` {
+			t.Errorf("got %s, want %s", string(got), `{"key":"value"}`)
+		}
+	})
+
+	t.Run("extracts_last_fenced_json_block", func(t *testing.T) {
+		text := "```json\n{\"first\":true}\n```\n\n```json\n{\"second\":true}\n```"
+		got := extractJSONFromText(text)
+		if string(got) != `{"second":true}` {
+			t.Errorf("got %s, want %s", string(got), `{"second":true}`)
+		}
+	})
+
+	t.Run("falls_back_to_raw_json_object", func(t *testing.T) {
+		text := "Here is the result: {\"answer\":42} done."
+		got := extractJSONFromText(text)
+		if string(got) != `{"answer":42}` {
+			t.Errorf("got %s, want %s", string(got), `{"answer":42}`)
+		}
+	})
+
+	t.Run("returns_nil_for_no_json", func(t *testing.T) {
+		text := "No JSON here at all"
+		got := extractJSONFromText(text)
+		if got != nil {
+			t.Errorf("got %s, want nil", string(got))
+		}
+	})
+
+	t.Run("returns_nil_for_empty_text", func(t *testing.T) {
+		got := extractJSONFromText("")
+		if got != nil {
+			t.Errorf("got %s, want nil", string(got))
+		}
+	})
+}
+
+func TestValidateOpencodeOutput(t *testing.T) {
+	t.Run("passes_with_all_required_fields", func(t *testing.T) {
+		output := json.RawMessage(`{"ticket_key":"TEST-1","verdict":"PASS"}`)
+		schema := `{"required":["ticket_key","verdict"]}`
+
+		err := ValidateOpencodeOutput(output, schema)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("fails_with_missing_required_field", func(t *testing.T) {
+		output := json.RawMessage(`{"ticket_key":"TEST-1"}`)
+		schema := `{"required":["ticket_key","verdict"]}`
+
+		err := ValidateOpencodeOutput(output, schema)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+
+		var pe *ParseError
+		if !errors.As(err, &pe) {
+			t.Fatalf("expected ParseError, got %T: %v", err, err)
+		}
+		if !strings.Contains(pe.Error(), "verdict") {
+			t.Errorf("error should mention missing field 'verdict', got: %v", pe)
+		}
+	})
+
+	t.Run("passes_with_empty_schema", func(t *testing.T) {
+		output := json.RawMessage(`{"anything":"goes"}`)
+		err := ValidateOpencodeOutput(output, "")
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("passes_with_no_required_fields_in_schema", func(t *testing.T) {
+		output := json.RawMessage(`{"anything":"goes"}`)
+		schema := `{"type":"object","properties":{}}`
+		err := ValidateOpencodeOutput(output, schema)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("fails_with_empty_output", func(t *testing.T) {
+		err := ValidateOpencodeOutput(nil, `{"required":["key"]}`)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+
+		var pe *ParseError
+		if !errors.As(err, &pe) {
+			t.Fatalf("expected ParseError, got %T: %v", err, err)
+		}
+	})
+
+	t.Run("passes_with_invalid_schema_json", func(t *testing.T) {
+		output := json.RawMessage(`{"key":"val"}`)
+		err := ValidateOpencodeOutput(output, "not valid json")
+		if err != nil {
+			t.Errorf("invalid schema should not block output: %v", err)
+		}
+	})
+}
+
+func TestMapOpencodeToolName(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"Read", "read"},
+		{"Write", "write"},
+		{"Edit", "edit"},
+		{"Glob", "glob"},
+		{"Grep", "grep"},
+		{"Bash", "bash"},
+		{"Search", "search"},
+		{"Bash(git:*)", "bash(git:*)"},
+		{"UnknownTool", "UnknownTool"},
+		{"custom_tool", "custom_tool"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := MapOpencodeToolName(tt.input)
+			if got != tt.want {
+				t.Errorf("MapOpencodeToolName(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeduplicateTools(t *testing.T) {
+	t.Run("removes_duplicates", func(t *testing.T) {
+		input := []string{"bash", "read", "bash", "write", "read"}
+		got := deduplicateTools(input)
+		want := []string{"bash", "read", "write"}
+		if len(got) != len(want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+		for idx := range want {
+			if got[idx] != want[idx] {
+				t.Errorf("got[%d] = %q, want %q", idx, got[idx], want[idx])
+			}
+		}
+	})
+
+	t.Run("preserves_order", func(t *testing.T) {
+		input := []string{"write", "read", "bash"}
+		got := deduplicateTools(input)
+		for idx := range input {
+			if got[idx] != input[idx] {
+				t.Errorf("got[%d] = %q, want %q", idx, got[idx], input[idx])
+			}
+		}
+	})
+
+	t.Run("handles_empty", func(t *testing.T) {
+		got := deduplicateTools(nil)
+		if len(got) != 0 {
+			t.Errorf("got %v, want empty", got)
+		}
+	})
+}
+
+func TestClassifyOpencodeError(t *testing.T) {
+	tests := []struct {
+		msg    string
+		reason string
+	}{
+		{"rate limit exceeded", "rate_limit"},
+		{"HTTP 429 Too Many Requests", "rate_limit"},
+		{"request timeout", "timeout"},
+		{"server overloaded 503", "overloaded"},
+		{"connection refused", "connection"},
+		{"something unknown happened", "unknown"},
+		{"used 1500 tokens", "unknown"}, // bare "500" must NOT match
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.reason, func(t *testing.T) {
+			got := classifyOpencodeError(tt.msg)
+			if got != tt.reason {
+				t.Errorf("classifyOpencodeError(%q) = %q, want %q", tt.msg, got, tt.reason)
+			}
+		})
+	}
+}
+
+func TestBuildOpencodeArgs(t *testing.T) {
+	t.Run("basic_args", func(t *testing.T) {
+		opts := RunOpts{
+			Phase:        "implement",
+			Model:        "opencode-model-1",
+			OutputSchema: `{"type":"object"}`,
+			AllowedTools: []string{"Read", "Bash(git:*)"},
+		}
+		args := buildOpencodeArgs(opts, "default-model")
+
+		// Model should be per-invocation override.
+		assertContainsArg(t, args, "--model", "opencode-model-1")
+		// Should have --dangerously-skip-permissions.
+		found := false
+		for _, arg := range args {
+			if arg == "--dangerously-skip-permissions" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Error("args should contain --dangerously-skip-permissions")
+		}
+		// Agent name should be derived from phase.
+		assertContainsArg(t, args, "--agent", "soda-implement")
+		// Tools should be mapped and joined.
+		assertContainsArg(t, args, "--permissions", "read,bash(git:*)")
+	})
+
+	t.Run("default_model_when_not_overridden", func(t *testing.T) {
+		opts := RunOpts{Phase: "triage"}
+		args := buildOpencodeArgs(opts, "default-model")
+		assertContainsArg(t, args, "--model", "default-model")
+	})
+
+	t.Run("no_model_when_both_empty", func(t *testing.T) {
+		opts := RunOpts{Phase: "triage"}
+		args := buildOpencodeArgs(opts, "")
+		for _, arg := range args {
+			if arg == "--model" {
+				t.Error("should not include --model when both are empty")
+			}
+		}
+	})
+
+	t.Run("no_permissions_when_no_tools", func(t *testing.T) {
+		opts := RunOpts{Phase: "triage"}
+		args := buildOpencodeArgs(opts, "model")
+		for _, arg := range args {
+			if arg == "--permissions" {
+				t.Error("should not include --permissions when no tools")
+			}
+		}
+	})
+
+	t.Run("phase_with_slash", func(t *testing.T) {
+		opts := RunOpts{Phase: "review/go-specialist"}
+		args := buildOpencodeArgs(opts, "model")
+		assertContainsArg(t, args, "--agent", "soda-review-go-specialist")
+	})
+}
+
+func TestWriteOpencodeAgentFile(t *testing.T) {
+	t.Run("writes_to_opencode_agent_directory", func(t *testing.T) {
+		dir := t.TempDir()
+		content := "You are a helpful assistant."
+
+		cleanup, err := writeOpencodeAgentFile(dir, "implement", content)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer cleanup()
+
+		agentPath := filepath.Join(dir, ".opencode", "agent", "soda-implement.md")
+		got, readErr := os.ReadFile(agentPath)
+		if readErr != nil {
+			t.Fatalf("failed to read file: %v", readErr)
+		}
+		if string(got) != content {
+			t.Errorf("content = %q, want %q", string(got), content)
+		}
+	})
+
+	t.Run("restores_existing_file_on_cleanup", func(t *testing.T) {
+		dir := t.TempDir()
+		agentDir := filepath.Join(dir, ".opencode", "agent")
+		if err := os.MkdirAll(agentDir, 0o755); err != nil {
+			t.Fatalf("create agent dir: %v", err)
+		}
+		agentPath := filepath.Join(agentDir, "soda-implement.md")
+		original := "user-owned content"
+		if err := os.WriteFile(agentPath, []byte(original), 0o644); err != nil {
+			t.Fatalf("write original: %v", err)
+		}
+
+		cleanup, err := writeOpencodeAgentFile(dir, "implement", "soda override")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		got, _ := os.ReadFile(agentPath)
+		if string(got) != "soda override" {
+			t.Errorf("during run: content = %q, want %q", string(got), "soda override")
+		}
+
+		cleanup()
+
+		got, _ = os.ReadFile(agentPath)
+		if string(got) != original {
+			t.Errorf("after cleanup: content = %q, want %q", string(got), original)
+		}
+	})
+
+	t.Run("removes_file_and_dirs_when_none_existed", func(t *testing.T) {
+		dir := t.TempDir()
+		ocDir := filepath.Join(dir, ".opencode")
+
+		cleanup, err := writeOpencodeAgentFile(dir, "triage", "test content")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		agentPath := filepath.Join(ocDir, "agent", "soda-triage.md")
+		if _, statErr := os.Stat(agentPath); statErr != nil {
+			t.Fatalf("agent file should exist during run: %v", statErr)
+		}
+
+		cleanup()
+
+		if _, statErr := os.Stat(agentPath); statErr == nil {
+			t.Error("agent file should be removed after cleanup")
+		}
+		if _, statErr := os.Stat(ocDir); statErr == nil {
+			t.Error(".opencode directory should be removed after cleanup when we created it")
+		}
+	})
+}
+
+func TestClassifyOpencodeExitError(t *testing.T) {
+	t.Run("rate_limit_in_stderr", func(t *testing.T) {
+		err := classifyOpencodeExitError(
+			fmt.Errorf("exit status 1"),
+			[]byte("Error: rate limit exceeded"),
+		)
+		var te *TransientError
+		if !errors.As(err, &te) {
+			t.Fatalf("expected TransientError, got %T: %v", err, err)
+		}
+		if te.Reason != "rate_limit" {
+			t.Errorf("Reason = %q, want %q", te.Reason, "rate_limit")
+		}
+	})
+
+	t.Run("unknown_stderr", func(t *testing.T) {
+		err := classifyOpencodeExitError(
+			fmt.Errorf("exit status 1"),
+			[]byte("something else happened"),
+		)
+		var te *TransientError
+		if !errors.As(err, &te) {
+			t.Fatalf("expected TransientError, got %T: %v", err, err)
+		}
+		if te.Reason != "unknown" {
+			t.Errorf("Reason = %q, want %q", te.Reason, "unknown")
+		}
+	})
+
+	t.Run("no_false_positive_on_bare_numbers", func(t *testing.T) {
+		err := classifyOpencodeExitError(
+			fmt.Errorf("exit status 1"),
+			[]byte("used 1500 tokens in 2529 ms"),
+		)
+		var te *TransientError
+		if !errors.As(err, &te) {
+			t.Fatalf("expected TransientError, got %T: %v", err, err)
+		}
+		if te.Reason != "unknown" {
+			t.Errorf("Reason = %q, want %q (bare numbers should not match)", te.Reason, "unknown")
+		}
+	})
+}
+
+func TestOpencodeAgentName(t *testing.T) {
+	tests := []struct {
+		phase string
+		want  string
+	}{
+		{"implement", "soda-implement"},
+		{"triage", "soda-triage"},
+		{"review/go-specialist", "soda-review-go-specialist"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.phase, func(t *testing.T) {
+			got := agentName(tt.phase)
+			if got != tt.want {
+				t.Errorf("agentName(%q) = %q, want %q", tt.phase, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOpencodeBudgetEnforcement(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	// Create a fake opencode binary (shell script) that emits a cost-exceeding event.
+	binDir := t.TempDir()
+	fakeOpencode := filepath.Join(binDir, "opencode")
+	script := "#!/bin/sh\n" +
+		`echo '{"type":"done","usage":{"input_tokens":100,"output_tokens":50},"cost_usd":99.99}'` + "\n" +
+		`echo '{"type":"result","result":{"ok":true}}'` + "\n"
+	if err := os.WriteFile(fakeOpencode, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake opencode: %v", err)
+	}
+
+	// Create a git worktree with a committed file.
+	workDir := t.TempDir()
+	for _, args := range [][]string{
+		{"init"},
+		{"config", "user.email", "test@example.com"},
+		{"config", "user.name", "Test"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = workDir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	agentFile := filepath.Join(workDir, "output.txt")
+	if err := os.WriteFile(agentFile, []byte("clean"), 0o644); err != nil {
+		t.Fatalf("write agent file: %v", err)
+	}
+	for _, args := range [][]string{{"add", "."}, {"commit", "-m", "init"}} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = workDir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	// Simulate agent modifying a file before budget exceeded.
+	if err := os.WriteFile(agentFile, []byte("dirty"), 0o644); err != nil {
+		t.Fatalf("dirty agent file: %v", err)
+	}
+
+	ocRunner, err := NewOpencodeRunner(fakeOpencode, "test-model", workDir)
+	if err != nil {
+		t.Fatalf("NewOpencodeRunner: %v", err)
+	}
+
+	opts := RunOpts{
+		MaxBudgetUSD: 0.01, // well below the 99.99 emitted by the fake binary
+		WorkDir:      workDir,
+		Phase:        "implement",
+	}
+
+	_, runErr := ocRunner.Run(context.Background(), opts)
+	if runErr == nil {
+		t.Fatal("expected budget_exceeded error, got nil")
+	}
+
+	var te *TransientError
+	if !errors.As(runErr, &te) {
+		t.Fatalf("expected TransientError, got %T: %v", runErr, runErr)
+	}
+	if te.Reason != "budget_exceeded" {
+		t.Errorf("Reason = %q, want %q", te.Reason, "budget_exceeded")
+	}
+
+	// Verify revertWorktree was called: the dirty file should be restored.
+	got, err := os.ReadFile(agentFile)
+	if err != nil {
+		t.Fatalf("read agent file after budget exceeded: %v", err)
+	}
+	if string(got) != "clean" {
+		t.Errorf("worktree not reverted: content = %q, want %q", string(got), "clean")
+	}
+}
+
+func TestBuildOpencodeEnv(t *testing.T) {
+	t.Run("sets_home_to_workdir", func(t *testing.T) {
+		opts := RunOpts{WorkDir: "/test/workdir"}
+		env := buildOpencodeEnv(opts, "/usr/bin/opencode")
+
+		envMap := make(map[string]string)
+		for _, entry := range env {
+			parts := strings.SplitN(entry, "=", 2)
+			if len(parts) == 2 {
+				envMap[parts[0]] = parts[1]
+			}
+		}
+
+		if envMap["HOME"] != "/test/workdir" {
+			t.Errorf("HOME = %q, want /test/workdir", envMap["HOME"])
+		}
+	})
+
+	t.Run("preserves_existing_env", func(t *testing.T) {
+		t.Setenv("ANTHROPIC_API_KEY", "test-key")
+		opts := RunOpts{WorkDir: "/test/workdir"}
+		env := buildOpencodeEnv(opts, "/usr/bin/opencode")
+
+		envMap := make(map[string]string)
+		for _, entry := range env {
+			parts := strings.SplitN(entry, "=", 2)
+			if len(parts) == 2 {
+				envMap[parts[0]] = parts[1]
+			}
+		}
+
+		if envMap["ANTHROPIC_API_KEY"] != "test-key" {
+			t.Errorf("ANTHROPIC_API_KEY = %q, want test-key", envMap["ANTHROPIC_API_KEY"])
+		}
+	})
+}

--- a/internal/runner/opencode_test.go
+++ b/internal/runner/opencode_test.go
@@ -448,6 +448,39 @@ func TestBuildOpencodeArgs(t *testing.T) {
 		args := buildOpencodeArgs(opts, "model")
 		assertContainsArg(t, args, "--agent", "soda-review-go-specialist")
 	})
+
+	t.Run("empty_phase_defaults_to_soda_default", func(t *testing.T) {
+		opts := RunOpts{}
+		args := buildOpencodeArgs(opts, "model")
+		assertContainsArg(t, args, "--agent", "soda-default")
+	})
+
+	t.Run("output_schema_in_agent_file", func(t *testing.T) {
+		dir := t.TempDir()
+		schema := `{"required":["ticket_key","verdict"]}`
+		content := "You are a helpful assistant."
+		agentContent := content + "\n\n## Output Schema\n\nYou MUST produce a JSON object conforming to this schema:\n\n```json\n" + schema + "\n```\n"
+		cleanup, err := writeOpencodeAgentFile(dir, "default", agentContent)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer cleanup()
+
+		agentPath := filepath.Join(dir, ".opencode", "agent", "soda-default.md")
+		got, readErr := os.ReadFile(agentPath)
+		if readErr != nil {
+			t.Fatalf("failed to read file: %v", readErr)
+		}
+		if !strings.Contains(string(got), "## Output Schema") {
+			t.Error("agent file should contain output schema section")
+		}
+		if !strings.Contains(string(got), schema) {
+			t.Error("agent file should contain the schema JSON")
+		}
+		if !strings.Contains(string(got), content) {
+			t.Error("agent file should contain the system prompt")
+		}
+	})
 }
 
 func TestWriteOpencodeAgentFile(t *testing.T) {

--- a/internal/runner/pi.go
+++ b/internal/runner/pi.go
@@ -195,6 +195,18 @@ func (r *PiRunner) Run(ctx context.Context, opts RunOpts) (*RunResult, error) {
 
 	wg.Wait()
 
+	// Budget exceeded takes precedence over stdout drain errors — we must
+	// always revert the worktree when the budget is blown, even if the
+	// stdout scanner also failed (e.g., line exceeded 1MB buffer).
+	if budgetExceeded {
+		revertWorktree(opts.WorkDir)
+		cmd.Wait()
+		return nil, &TransientError{
+			Reason: "budget_exceeded",
+			Err:    fmt.Errorf("pi runner: budget exceeded ($%.2f >= $%.2f)", costAccumulator, opts.MaxBudgetUSD),
+		}
+	}
+
 	// Check stdout drain error.
 	if stdoutErr != nil {
 		cmd.Wait()
@@ -202,15 +214,6 @@ func (r *PiRunner) Run(ctx context.Context, opts RunOpts) (*RunResult, error) {
 	}
 
 	waitErr := cmd.Wait()
-
-	// Budget exceeded: revert worktree and return budget error.
-	if budgetExceeded {
-		revertWorktree(opts.WorkDir)
-		return nil, &TransientError{
-			Reason: "budget_exceeded",
-			Err:    fmt.Errorf("pi runner: budget exceeded ($%.2f >= $%.2f)", costAccumulator, opts.MaxBudgetUSD),
-		}
-	}
 
 	if waitErr != nil {
 		// Context cancellation — not retryable.

--- a/internal/sandbox/opencode.go
+++ b/internal/sandbox/opencode.go
@@ -46,7 +46,14 @@ func (a *OpencodeAdapter) Binary() string {
 func (a *OpencodeAdapter) BuildArgs(opts runner.RunOpts, tmpDir string) ([]string, error) {
 	// Write agent file to {tmpDir}/.opencode/agent/soda-{phase}.md so
 	// Opencode can discover it via HOME=tmpDir.
-	if opts.SystemPrompt != "" {
+	// When an output schema is provided, append it to the agent file so the
+	// model can see the expected output format (opencode has no --json-schema flag).
+	agentContent := opts.SystemPrompt
+	if opts.OutputSchema != "" {
+		schemaSection := "\n\n## Output Schema\n\nYou MUST produce a JSON object conforming to this schema:\n\n```json\n" + opts.OutputSchema + "\n```\n"
+		agentContent += schemaSection
+	}
+	if agentContent != "" {
 		promptDir := tmpDir
 		phase := opts.Phase
 		if phase == "" {
@@ -58,7 +65,7 @@ func (a *OpencodeAdapter) BuildArgs(opts runner.RunOpts, tmpDir string) ([]strin
 		}
 		agentName := "soda-" + strings.ReplaceAll(phase, "/", "-")
 		agentPath := filepath.Join(agentDir, agentName+".md")
-		if err := os.WriteFile(agentPath, []byte(opts.SystemPrompt), 0o644); err != nil {
+		if err := os.WriteFile(agentPath, []byte(agentContent), 0o644); err != nil {
 			return nil, fmt.Errorf("sandbox: write opencode agent file: %w", err)
 		}
 	}

--- a/internal/sandbox/opencode.go
+++ b/internal/sandbox/opencode.go
@@ -1,0 +1,246 @@
+package sandbox
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/decko/soda/internal/runner"
+)
+
+// OpencodeAdapter implements AgentAdapter for the Opencode agent CLI.
+type OpencodeAdapter struct {
+	binary    string   // resolved absolute path to opencode binary
+	readPaths []string // read paths needed for opencode binary
+}
+
+// compile-time interface check
+var _ AgentAdapter = (*OpencodeAdapter)(nil)
+
+// NewOpencodeAdapter resolves the opencode binary and returns an OpencodeAdapter.
+func NewOpencodeAdapter(binary string) (*OpencodeAdapter, error) {
+	resolved, readPaths, err := resolveOpencodePaths(binary)
+	if err != nil {
+		return nil, err
+	}
+	return &OpencodeAdapter{
+		binary:    resolved,
+		readPaths: readPaths,
+	}, nil
+}
+
+// Binary returns the resolved absolute path to the opencode binary.
+func (a *OpencodeAdapter) Binary() string {
+	return a.binary
+}
+
+// BuildArgs writes temporary files (agent file) into the workspace directory
+// and returns the CLI argument list for an Opencode invocation.
+//
+// Opencode discovers agent files from {HOME}/.opencode/agent/{name}.md; the
+// sandbox overrides HOME to tmpDir, so the agent file is written there. When
+// opts.WorkDir is empty (unit tests), tmpDir is used as a safe fallback.
+func (a *OpencodeAdapter) BuildArgs(opts runner.RunOpts, tmpDir string) ([]string, error) {
+	// Write agent file to {tmpDir}/.opencode/agent/soda-{phase}.md so
+	// Opencode can discover it via HOME=tmpDir.
+	if opts.SystemPrompt != "" {
+		promptDir := tmpDir
+		phase := opts.Phase
+		if phase == "" {
+			phase = "default"
+		}
+		agentDir := filepath.Join(promptDir, ".opencode", "agent")
+		if err := os.MkdirAll(agentDir, 0o755); err != nil {
+			return nil, fmt.Errorf("sandbox: create opencode agent directory: %w", err)
+		}
+		agentName := "soda-" + strings.ReplaceAll(phase, "/", "-")
+		agentPath := filepath.Join(agentDir, agentName+".md")
+		if err := os.WriteFile(agentPath, []byte(opts.SystemPrompt), 0o644); err != nil {
+			return nil, fmt.Errorf("sandbox: write opencode agent file: %w", err)
+		}
+	}
+
+	args := []string{
+		"--print",
+		"--output-format", "stream-json",
+		"--dangerously-skip-permissions",
+	}
+
+	if opts.Model != "" {
+		args = append(args, "--model", opts.Model)
+	}
+
+	// Agent name derived from phase.
+	phase := opts.Phase
+	if phase == "" {
+		phase = "default"
+	}
+	agentName := "soda-" + strings.ReplaceAll(phase, "/", "-")
+	args = append(args, "--agent", agentName)
+
+	// Map and add allowed tools.
+	mapped := make([]string, 0, len(opts.AllowedTools))
+	for _, tool := range opts.AllowedTools {
+		mapped = append(mapped, runner.MapOpencodeToolName(tool))
+	}
+	mapped = runner.DeduplicateTools(mapped)
+	if len(mapped) > 0 {
+		args = append(args, "--permissions", strings.Join(mapped, ","))
+	}
+
+	// Append user prompt as positional arg.
+	args = append(args, "-p", opts.UserPrompt)
+
+	return args, nil
+}
+
+// BuildEnv returns the environment variables for a sandboxed Opencode process.
+func (a *OpencodeAdapter) BuildEnv(opts runner.RunOpts, tmpDir string, proxyURL string) []string {
+	return opencodeEnv(tmpDir, opts, a.binary, proxyURL)
+}
+
+// ParseOutput parses buffered stdout from an Opencode invocation into a RunResult.
+func (a *OpencodeAdapter) ParseOutput(stdout []byte, opts runner.RunOpts) (*runner.RunResult, error) {
+	result, err := runner.ParseOpencodeStream(stdout, nil)
+	if err != nil {
+		return nil, mapOpencodeParseError(err)
+	}
+
+	runResult := &runner.RunResult{
+		Output:    result.Output,
+		RawText:   result.RawText,
+		CostUSD:   result.CostUSD,
+		TokensIn:  result.TokensIn,
+		TokensOut: result.TokensOut,
+		Turns:     result.Turns,
+	}
+
+	// Validate output against schema if provided.
+	if opts.OutputSchema != "" {
+		if valErr := runner.ValidateOpencodeOutput(result.Output, opts.OutputSchema); valErr != nil {
+			return nil, mapOpencodeParseError(valErr)
+		}
+	}
+
+	return runResult, nil
+}
+
+// ExtraPaths returns additional read and write paths required by Opencode.
+func (a *OpencodeAdapter) ExtraPaths(opts runner.RunOpts) (read []string, write []string) {
+	read = append(read, a.readPaths...)
+
+	// Allow the sandbox to read the helper script's parent directory.
+	if opts.ApiKeyHelper != "" && filepath.IsAbs(opts.ApiKeyHelper) {
+		read = append(read, filepath.Dir(opts.ApiKeyHelper))
+	}
+
+	return read, nil
+}
+
+// resolveOpencodePaths finds the opencode binary and collects paths needed for
+// the sandbox read profile.
+func resolveOpencodePaths(binary string) (resolved string, readPaths []string, err error) {
+	if binary == "" {
+		binary = "opencode"
+	}
+
+	resolved, err = exec.LookPath(binary)
+	if err != nil {
+		return "", nil, fmt.Errorf("sandbox: opencode binary not found: %w", err)
+	}
+
+	resolved, err = filepath.EvalSymlinks(resolved)
+	if err != nil {
+		return "", nil, fmt.Errorf("sandbox: resolve opencode symlink: %w", err)
+	}
+
+	// The opencode binary directory needs read access.
+	readPaths = append(readPaths, filepath.Dir(resolved))
+
+	return resolved, readPaths, nil
+}
+
+// opencodeEnv builds the environment for a sandboxed Opencode process.
+// When proxyURL is non-empty, real credentials are NOT passed to the sandbox.
+func opencodeEnv(tmpDir string, opts runner.RunOpts, opencodeBin, proxyURL string) []string {
+	env := []string{
+		"HOME=" + tmpDir,
+		"TMPDIR=" + tmpDir,
+		"LANG=" + envOrDefault("LANG", "en_US.UTF-8"),
+	}
+
+	// PATH: include opencode binary dir, standard paths.
+	pathDirs := []string{filepath.Dir(opencodeBin)}
+	pathDirs = append(pathDirs, "/usr/local/bin", "/usr/bin", "/bin")
+	env = append(env, "PATH="+strings.Join(pathDirs, ":"))
+
+	if proxyURL != "" {
+		// Proxy mode: the proxy on the host side handles authentication.
+		env = append(env,
+			"ANTHROPIC_API_KEY=sk-proxy-nonce",
+			"ANTHROPIC_BASE_URL="+proxyURL,
+		)
+	} else {
+		// Direct mode: pass through real credentials.
+		credentialVars := []string{
+			"ANTHROPIC_API_KEY",
+			"OPENCODE_API_KEY",
+		}
+		for _, key := range credentialVars {
+			if val := os.Getenv(key); val != "" {
+				env = append(env, key+"="+val)
+			}
+		}
+	}
+
+	// Git/GitHub credentials for submit, follow-up, and monitor phases.
+	gitVars := []string{
+		"GH_TOKEN",
+		"GITHUB_TOKEN",
+		"GH_HOST",
+		"SSH_AUTH_SOCK",
+		"GIT_AUTHOR_NAME",
+		"GIT_AUTHOR_EMAIL",
+		"GIT_COMMITTER_NAME",
+		"GIT_COMMITTER_EMAIL",
+	}
+	for _, key := range gitVars {
+		if val := os.Getenv(key); val != "" {
+			env = append(env, key+"="+val)
+		}
+	}
+
+	// If no GH_TOKEN is set, try to extract from gh CLI keyring.
+	if os.Getenv("GH_TOKEN") == "" && os.Getenv("GITHUB_TOKEN") == "" {
+		if token, err := exec.Command("gh", "auth", "token").Output(); err == nil {
+			if tok := strings.TrimSpace(string(token)); tok != "" {
+				env = append(env, "GH_TOKEN="+tok)
+			}
+		}
+	}
+
+	return env
+}
+
+// mapOpencodeParseError wraps Opencode errors into runner error types.
+// Opencode errors from ParseOpencodeStream/ValidateOpencodeOutput are already
+// runner.* types, so known types pass through unchanged. Unknown errors are
+// wrapped in runner.ParseError.
+func mapOpencodeParseError(err error) error {
+	var pe *runner.ParseError
+	if errors.As(err, &pe) {
+		return err
+	}
+	var se *runner.SemanticError
+	if errors.As(err, &se) {
+		return err
+	}
+	var te *runner.TransientError
+	if errors.As(err, &te) {
+		return err
+	}
+	return &runner.ParseError{Err: fmt.Errorf("sandbox: %w", err)}
+}

--- a/internal/sandbox/opencode_test.go
+++ b/internal/sandbox/opencode_test.go
@@ -1,0 +1,354 @@
+package sandbox
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/decko/soda/internal/runner"
+)
+
+func TestOpencodeAdapterBuildArgs(t *testing.T) {
+	// Create a fake opencode binary so NewOpencodeAdapter can resolve it.
+	binDir := t.TempDir()
+	fakeOpencode := filepath.Join(binDir, "opencode")
+	if err := os.WriteFile(fakeOpencode, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write fake opencode: %v", err)
+	}
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	adapter, err := NewOpencodeAdapter(fakeOpencode)
+	if err != nil {
+		t.Fatalf("NewOpencodeAdapter: %v", err)
+	}
+
+	t.Run("basic_args", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		opts := runner.RunOpts{
+			Phase:        "implement",
+			Model:        "opencode-model-1",
+			AllowedTools: []string{"Read", "Bash(git:*)"},
+			UserPrompt:   "do the thing",
+		}
+		args, err := adapter.BuildArgs(opts, tmpDir)
+		if err != nil {
+			t.Fatalf("BuildArgs: %v", err)
+		}
+
+		assertContains(t, args, "--print")
+		assertContains(t, args, "--output-format")
+		assertContains(t, args, "--dangerously-skip-permissions")
+		assertContainsArgPair(t, args, "--model", "opencode-model-1")
+		assertContainsArgPair(t, args, "--agent", "soda-implement")
+		assertContainsArgPair(t, args, "--permissions", "read,bash(git:*)")
+		assertContainsArgPair(t, args, "-p", "do the thing")
+	})
+
+	t.Run("writes_agent_file_to_tmpdir", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		opts := runner.RunOpts{
+			Phase:        "triage",
+			SystemPrompt: "You are a helpful assistant.",
+			UserPrompt:   "hello",
+		}
+		_, err := adapter.BuildArgs(opts, tmpDir)
+		if err != nil {
+			t.Fatalf("BuildArgs: %v", err)
+		}
+
+		agentPath := filepath.Join(tmpDir, ".opencode", "agent", "soda-triage.md")
+		got, readErr := os.ReadFile(agentPath)
+		if readErr != nil {
+			t.Fatalf("agent file not written: %v", readErr)
+		}
+		if string(got) != opts.SystemPrompt {
+			t.Errorf("agent file content = %q, want %q", string(got), opts.SystemPrompt)
+		}
+	})
+
+	t.Run("no_model_flag_when_empty", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		opts := runner.RunOpts{Phase: "triage", UserPrompt: "hello"}
+		args, err := adapter.BuildArgs(opts, tmpDir)
+		if err != nil {
+			t.Fatalf("BuildArgs: %v", err)
+		}
+		for _, arg := range args {
+			if arg == "--model" {
+				t.Error("should not include --model when model is empty")
+			}
+		}
+	})
+
+	t.Run("no_permissions_when_no_tools", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		opts := runner.RunOpts{Phase: "triage", UserPrompt: "hello"}
+		args, err := adapter.BuildArgs(opts, tmpDir)
+		if err != nil {
+			t.Fatalf("BuildArgs: %v", err)
+		}
+		for _, arg := range args {
+			if arg == "--permissions" {
+				t.Error("should not include --permissions when no tools")
+			}
+		}
+	})
+
+	t.Run("phase_with_slash", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		opts := runner.RunOpts{Phase: "review/go-specialist", UserPrompt: "hello"}
+		args, err := adapter.BuildArgs(opts, tmpDir)
+		if err != nil {
+			t.Fatalf("BuildArgs: %v", err)
+		}
+		assertContainsArgPair(t, args, "--agent", "soda-review-go-specialist")
+	})
+}
+
+func TestOpencodeAdapterBuildEnv(t *testing.T) {
+	binDir := t.TempDir()
+	fakeOpencode := filepath.Join(binDir, "opencode")
+	if err := os.WriteFile(fakeOpencode, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write fake opencode: %v", err)
+	}
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	adapter, err := NewOpencodeAdapter(fakeOpencode)
+	if err != nil {
+		t.Fatalf("NewOpencodeAdapter: %v", err)
+	}
+
+	t.Run("direct_mode_passes_credentials", func(t *testing.T) {
+		t.Setenv("ANTHROPIC_API_KEY", "sk-test-key")
+		t.Setenv("OPENCODE_API_KEY", "oc-key-123")
+		t.Setenv("LANG", "en_US.UTF-8")
+
+		opts := runner.RunOpts{Phase: "implement", WorkDir: "/work"}
+		env := adapter.BuildEnv(opts, "/tmp/sandbox", "")
+
+		envMap := toEnvMap(env)
+
+		if envMap["HOME"] != "/tmp/sandbox" {
+			t.Errorf("HOME = %q, want /tmp/sandbox", envMap["HOME"])
+		}
+		if envMap["TMPDIR"] != "/tmp/sandbox" {
+			t.Errorf("TMPDIR = %q, want /tmp/sandbox", envMap["TMPDIR"])
+		}
+		if envMap["ANTHROPIC_API_KEY"] != "sk-test-key" {
+			t.Errorf("ANTHROPIC_API_KEY = %q, want sk-test-key", envMap["ANTHROPIC_API_KEY"])
+		}
+		if envMap["OPENCODE_API_KEY"] != "oc-key-123" {
+			t.Errorf("OPENCODE_API_KEY = %q, want oc-key-123", envMap["OPENCODE_API_KEY"])
+		}
+	})
+
+	t.Run("proxy_mode_uses_fake_key", func(t *testing.T) {
+		t.Setenv("ANTHROPIC_API_KEY", "sk-real-key")
+
+		opts := runner.RunOpts{Phase: "implement", WorkDir: "/work"}
+		env := adapter.BuildEnv(opts, "/tmp/sandbox", "http://127.0.0.1:8080")
+
+		envMap := toEnvMap(env)
+
+		if envMap["ANTHROPIC_API_KEY"] != "sk-proxy-nonce" {
+			t.Errorf("ANTHROPIC_API_KEY = %q, want sk-proxy-nonce", envMap["ANTHROPIC_API_KEY"])
+		}
+		if envMap["ANTHROPIC_BASE_URL"] != "http://127.0.0.1:8080" {
+			t.Errorf("ANTHROPIC_BASE_URL = %q, want http://127.0.0.1:8080", envMap["ANTHROPIC_BASE_URL"])
+		}
+	})
+
+	t.Run("git_credentials_passed_through", func(t *testing.T) {
+		t.Setenv("GH_TOKEN", "ghp_test123")
+		t.Setenv("SSH_AUTH_SOCK", "/tmp/ssh/agent.1234")
+
+		opts := runner.RunOpts{Phase: "submit", WorkDir: "/work"}
+		env := adapter.BuildEnv(opts, "/tmp/sandbox", "")
+
+		envMap := toEnvMap(env)
+
+		if envMap["GH_TOKEN"] != "ghp_test123" {
+			t.Errorf("GH_TOKEN = %q, want ghp_test123", envMap["GH_TOKEN"])
+		}
+		if envMap["SSH_AUTH_SOCK"] != "/tmp/ssh/agent.1234" {
+			t.Errorf("SSH_AUTH_SOCK = %q, want /tmp/ssh/agent.1234", envMap["SSH_AUTH_SOCK"])
+		}
+	})
+
+	t.Run("path_includes_opencode_binary_dir", func(t *testing.T) {
+		opts := runner.RunOpts{Phase: "implement", WorkDir: "/work"}
+		env := adapter.BuildEnv(opts, "/tmp/sandbox", "")
+
+		envMap := toEnvMap(env)
+		pathVal := envMap["PATH"]
+		ocDir := filepath.Dir(adapter.Binary())
+		if !strings.Contains(pathVal, ocDir) {
+			t.Errorf("PATH = %q, should contain %q", pathVal, ocDir)
+		}
+	})
+}
+
+func TestOpencodeAdapterParseOutput(t *testing.T) {
+	binDir := t.TempDir()
+	fakeOpencode := filepath.Join(binDir, "opencode")
+	if err := os.WriteFile(fakeOpencode, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write fake opencode: %v", err)
+	}
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	adapter, err := NewOpencodeAdapter(fakeOpencode)
+	if err != nil {
+		t.Fatalf("NewOpencodeAdapter: %v", err)
+	}
+
+	t.Run("parses_valid_stream", func(t *testing.T) {
+		stream := strings.Join([]string{
+			`{"type":"text","content":"Hello"}`,
+			`{"type":"done","usage":{"input_tokens":100,"output_tokens":50},"cost_usd":0.005}`,
+			`{"type":"result","result":{"answer":"42"}}`,
+		}, "\n")
+
+		opts := runner.RunOpts{}
+		result, err := adapter.ParseOutput([]byte(stream), opts)
+		if err != nil {
+			t.Fatalf("ParseOutput: %v", err)
+		}
+
+		if result.RawText != "Hello" {
+			t.Errorf("RawText = %q, want %q", result.RawText, "Hello")
+		}
+		if result.TokensIn != 100 {
+			t.Errorf("TokensIn = %d, want 100", result.TokensIn)
+		}
+		if string(result.Output) != `{"answer":"42"}` {
+			t.Errorf("Output = %s, want %s", string(result.Output), `{"answer":"42"}`)
+		}
+	})
+
+	t.Run("validates_output_schema", func(t *testing.T) {
+		stream := `{"type":"result","result":{"ticket_key":"T-1"}}` + "\n"
+		opts := runner.RunOpts{
+			OutputSchema: `{"required":["ticket_key","verdict"]}`,
+		}
+
+		_, err := adapter.ParseOutput([]byte(stream), opts)
+		if err == nil {
+			t.Fatal("expected error for missing required field, got nil")
+		}
+
+		var pe *runner.ParseError
+		if !errors.As(err, &pe) {
+			t.Fatalf("expected runner.ParseError, got %T: %v", err, err)
+		}
+		if !strings.Contains(pe.Error(), "verdict") {
+			t.Errorf("error should mention missing field 'verdict', got: %v", pe)
+		}
+	})
+
+	t.Run("maps_transient_error", func(t *testing.T) {
+		stream := `{"type":"error","error":"rate limit exceeded"}` + "\n"
+		opts := runner.RunOpts{}
+
+		_, err := adapter.ParseOutput([]byte(stream), opts)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+
+		var te *runner.TransientError
+		if !errors.As(err, &te) {
+			t.Fatalf("expected runner.TransientError, got %T: %v", err, err)
+		}
+	})
+}
+
+func TestOpencodeAdapterExtraPaths(t *testing.T) {
+	binDir := t.TempDir()
+	fakeOpencode := filepath.Join(binDir, "opencode")
+	if err := os.WriteFile(fakeOpencode, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write fake opencode: %v", err)
+	}
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	adapter, err := NewOpencodeAdapter(fakeOpencode)
+	if err != nil {
+		t.Fatalf("NewOpencodeAdapter: %v", err)
+	}
+
+	t.Run("includes_binary_directory", func(t *testing.T) {
+		opts := runner.RunOpts{}
+		read, write := adapter.ExtraPaths(opts)
+
+		ocDir := filepath.Dir(adapter.Binary())
+		found := false
+		for _, path := range read {
+			if path == ocDir {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("read paths %v should contain opencode binary dir %q", read, ocDir)
+		}
+		if len(write) != 0 {
+			t.Errorf("write paths = %v, want empty", write)
+		}
+	})
+
+	t.Run("includes_api_key_helper_dir", func(t *testing.T) {
+		opts := runner.RunOpts{ApiKeyHelper: "/usr/local/bin/get-api-key"}
+		read, _ := adapter.ExtraPaths(opts)
+
+		found := false
+		for _, path := range read {
+			if path == "/usr/local/bin" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("read paths %v should contain /usr/local/bin for ApiKeyHelper", read)
+		}
+	})
+}
+
+func TestMapOpencodeParseError(t *testing.T) {
+	t.Run("parse_error_passes_through", func(t *testing.T) {
+		inner := fmt.Errorf("bad JSON")
+		err := mapOpencodeParseError(&runner.ParseError{Err: inner})
+
+		var pe *runner.ParseError
+		if !errors.As(err, &pe) {
+			t.Fatalf("expected runner.ParseError, got %T: %v", err, err)
+		}
+	})
+
+	t.Run("semantic_error_passes_through", func(t *testing.T) {
+		err := mapOpencodeParseError(&runner.SemanticError{Message: "bad input"})
+
+		var se *runner.SemanticError
+		if !errors.As(err, &se) {
+			t.Fatalf("expected runner.SemanticError, got %T: %v", err, err)
+		}
+	})
+
+	t.Run("transient_error_passes_through", func(t *testing.T) {
+		err := mapOpencodeParseError(&runner.TransientError{Reason: "rate_limit", Err: fmt.Errorf("429")})
+
+		var te *runner.TransientError
+		if !errors.As(err, &te) {
+			t.Fatalf("expected runner.TransientError, got %T: %v", err, err)
+		}
+	})
+
+	t.Run("generic_error_becomes_parse_error", func(t *testing.T) {
+		err := mapOpencodeParseError(fmt.Errorf("something unexpected"))
+
+		var pe *runner.ParseError
+		if !errors.As(err, &pe) {
+			t.Fatalf("expected runner.ParseError, got %T: %v", err, err)
+		}
+	})
+}


### PR DESCRIPTION
Add Opencode (opencode.ai) as a third agent backend for SODA pipelines.

## Changes

- `internal/runner/opencode.go` — OpencodeRunner implementing runner.Runner with JSON event streaming, budget enforcement, and agent-based system prompt injection
- `internal/runner/opencode_parser.go` — Opencode JSON event parser with cost/token accumulation
- `internal/runner/opencode_tools.go` — SODA canonical tool name mapping to Opencode permissions
- `internal/sandbox/opencode.go` — OpencodeAdapter implementing AgentAdapter for sandboxed execution
- `cmd/soda/run.go` — Runner selection wiring (runner: opencode config key)
- `internal/config/config.go` — OpencodeConfig fields

## Test plan

- [x] Opencode JSON parser tests (event parsing, cost accumulation, error recovery)
- [x] OpencodeRunner unit tests (budget enforcement, tool mapping, agent file creation)
- [x] OpencodeAdapter unit tests (BuildArgs, BuildEnv, ParseOutput, ExtraPaths)
- [x] All existing tests pass

Assisted-by: SODA