### PR TITLE
[640] feat(sandbox): MCP server support inside arapuca sandbox

### DIFF
--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -80,6 +80,57 @@ When the proxy is enabled, API calls are bridged through a Unix socket. The
 host-side proxy injects credentials, so no API key is needed inside the
 sandbox.
 
+## MCP server support
+
+When a pipeline phase declares MCP servers (via `mcp_servers` in
+`soda.yaml`), the sandbox adapters write the appropriate config files
+into the sandbox temp directory so the agent discovers them
+automatically:
+
+- **Claude Code**: a temp `soda-mcp-config-*.json` file is written to
+  `tmpDir` and passed via `--mcp-config` / `--strict-mcp-config`.
+- **Opencode**: MCP server declarations are merged into
+  `{tmpDir}/.opencode.json` (since `HOME` is overridden to `tmpDir`).
+- **Pi**: MCP is not supported; MCP server declarations are ignored.
+
+### Network isolation trade-offs
+
+MCP servers typically need outbound network access to reach external
+APIs (Jira, GitHub, etc.). When MCP servers are configured for a phase,
+the sandbox **automatically disables network namespace isolation**
+(`UseNetNS` is forced to `false`) and emits a warning to stderr:
+
+```
+sandbox: warning: network isolation disabled for phase "implement" because MCP servers are configured
+```
+
+This means the sandboxed agent process can make arbitrary outbound
+network connections for that phase. The remaining sandbox controls
+(Landlock, seccomp, cgroups) are **not affected** — filesystem and
+resource isolation remain fully enforced.
+
+**Security implications:**
+
+| Control | With MCP | Without MCP |
+|---------|----------|-------------|
+| Landlock (filesystem) | ✅ enforced | ✅ enforced |
+| seccomp (syscalls) | ✅ enforced | ✅ enforced |
+| cgroups (resources) | ✅ enforced | ✅ enforced |
+| Network namespace | ❌ disabled | ✅ enforced |
+
+**Mitigations:**
+
+- MCP server binaries are resolved via `exec.LookPath` and their parent
+  directories are added as read paths — the sandbox does not grant
+  blanket filesystem access.
+- MCP config files go to `tmpDir` (cleaned up by `defer os.RemoveAll`),
+  not to `WorkDir` — they are not visible to the agent's Read tool.
+- The LLM proxy (if enabled) continues to meter API calls and enforce
+  token budgets even when the network namespace is disabled.
+
+**Recommendation:** only declare MCP servers for phases that genuinely
+need them. Phases without MCP servers retain full network isolation.
+
 ## Platform support
 
 | Platform | Sandbox available |

--- a/internal/runner/claude.go
+++ b/internal/runner/claude.go
@@ -57,7 +57,7 @@ func (r *ClaudeRunner) Run(ctx context.Context, opts RunOpts) (*RunResult, error
 	// path via --mcp-config + --strict-mcp-config. AllowedMCPTools are
 	// appended to the allowed-tools list so the CLI permits MCP tool calls.
 	if len(opts.MCPServers) > 0 {
-		mcpPath, mcpCleanup, mcpErr := writeMCPConfigFile(opts.WorkDir, opts.MCPServers)
+		mcpPath, mcpCleanup, mcpErr := WriteMCPConfigFile(opts.WorkDir, opts.MCPServers)
 		if mcpErr != nil {
 			fmt.Fprintf(os.Stderr, "claude runner: warning: MCP config write failed: %v; continuing without MCP\n", mcpErr)
 		} else {

--- a/internal/runner/mcp.go
+++ b/internal/runner/mcp.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 )
 
@@ -36,7 +37,9 @@ func WriteMCPConfigFile(dir string, servers map[string]MCPServerConfig) (string,
 		MCPServers: make(map[string]mcpServerEntry, len(servers)),
 	}
 	for name, srv := range servers {
-		envelope.MCPServers[name] = mcpServerEntry(srv)
+		entry := mcpServerEntry(srv)
+		entry.Command = resolveMCPCommand(srv.Command)
+		envelope.MCPServers[name] = entry
 	}
 
 	data, err := json.Marshal(envelope)
@@ -93,10 +96,13 @@ func WriteOpencodeMCPConfig(workDir string, servers map[string]MCPServerConfig) 
 	existing, readErr := os.ReadFile(configPath)
 	hadExisting := readErr == nil
 
-	// Build the MCP servers map.
+	// Build the MCP servers map. Resolve bare command names to absolute
+	// paths so the agent process can find them without relying on PATH.
 	mcpEntries := make(map[string]mcpServerEntry, len(servers))
 	for name, srv := range servers {
-		mcpEntries[name] = mcpServerEntry(srv)
+		entry := mcpServerEntry(srv)
+		entry.Command = resolveMCPCommand(srv.Command)
+		mcpEntries[name] = entry
 	}
 
 	// Merge into existing JSON or create fresh.
@@ -128,4 +134,25 @@ func WriteOpencodeMCPConfig(workDir string, servers map[string]MCPServerConfig) 
 		}
 	}
 	return cleanup, nil
+}
+
+// resolveMCPCommand resolves a bare MCP server command name to its absolute
+// path via exec.LookPath + filepath.EvalSymlinks. This ensures the agent
+// process inside the sandbox can execute the binary without relying on PATH
+// (the sandbox PATH may not include the directory containing the binary).
+// If the command is already absolute, empty, or cannot be resolved, the
+// original value is returned unchanged.
+func resolveMCPCommand(command string) string {
+	if command == "" || filepath.IsAbs(command) {
+		return command
+	}
+	resolved, err := exec.LookPath(command)
+	if err != nil {
+		return command
+	}
+	resolved, err = filepath.EvalSymlinks(resolved)
+	if err != nil {
+		return command
+	}
+	return resolved
 }

--- a/internal/runner/mcp.go
+++ b/internal/runner/mcp.go
@@ -19,11 +19,11 @@ type mcpServerEntry struct {
 	Env     map[string]string `json:"env,omitempty"`
 }
 
-// writeMCPConfigFile writes a Claude Code MCP config JSON file to dir and
+// WriteMCPConfigFile writes a Claude Code MCP config JSON file to dir and
 // returns the file path and a cleanup function. The cleanup function removes
 // the file. The file is created with mode 0600 because env fields may
 // contain API keys or other secrets.
-func writeMCPConfigFile(dir string, servers map[string]MCPServerConfig) (string, func(), error) {
+func WriteMCPConfigFile(dir string, servers map[string]MCPServerConfig) (string, func(), error) {
 	if dir == "" {
 		dir = os.TempDir()
 	}
@@ -72,13 +72,13 @@ func writeMCPConfigFile(dir string, servers map[string]MCPServerConfig) (string,
 // mcpServerEntry has the same fields as config.MCPServerConfig, enabling
 // direct type conversion. The separate type exists for JSON tag control.
 
-// writeOpencodeMCPConfig writes (or merges) MCP server declarations into
+// WriteOpencodeMCPConfig writes (or merges) MCP server declarations into
 // {workDir}/.opencode.json. If the file already exists, the mcpServers key
 // is merged into the existing JSON, preserving other keys (providers, models,
 // etc.). The file is created with mode 0600 because env fields may contain
 // secrets. The returned cleanup function restores the original file content
 // or removes it if it did not exist prior to the call.
-func writeOpencodeMCPConfig(workDir string, servers map[string]MCPServerConfig) (func(), error) {
+func WriteOpencodeMCPConfig(workDir string, servers map[string]MCPServerConfig) (func(), error) {
 	if workDir == "" {
 		workDir = os.TempDir()
 	}

--- a/internal/runner/mcp_test.go
+++ b/internal/runner/mcp_test.go
@@ -22,9 +22,9 @@ func TestWriteMCPConfigFile(t *testing.T) {
 
 	t.Run("creates_valid_json_file", func(t *testing.T) {
 		dir := t.TempDir()
-		path, cleanup, err := writeMCPConfigFile(dir, servers)
+		path, cleanup, err := WriteMCPConfigFile(dir, servers)
 		if err != nil {
-			t.Fatalf("writeMCPConfigFile: %v", err)
+			t.Fatalf("WriteMCPConfigFile: %v", err)
 		}
 		defer cleanup()
 
@@ -77,9 +77,9 @@ func TestWriteMCPConfigFile(t *testing.T) {
 
 	t.Run("file_has_restricted_permissions", func(t *testing.T) {
 		dir := t.TempDir()
-		path, cleanup, err := writeMCPConfigFile(dir, servers)
+		path, cleanup, err := WriteMCPConfigFile(dir, servers)
 		if err != nil {
-			t.Fatalf("writeMCPConfigFile: %v", err)
+			t.Fatalf("WriteMCPConfigFile: %v", err)
 		}
 		defer cleanup()
 
@@ -95,9 +95,9 @@ func TestWriteMCPConfigFile(t *testing.T) {
 
 	t.Run("cleanup_removes_file", func(t *testing.T) {
 		dir := t.TempDir()
-		path, cleanup, err := writeMCPConfigFile(dir, servers)
+		path, cleanup, err := WriteMCPConfigFile(dir, servers)
 		if err != nil {
-			t.Fatalf("writeMCPConfigFile: %v", err)
+			t.Fatalf("WriteMCPConfigFile: %v", err)
 		}
 
 		// File should exist before cleanup.
@@ -114,9 +114,9 @@ func TestWriteMCPConfigFile(t *testing.T) {
 	})
 
 	t.Run("falls_back_to_os_tempdir_when_dir_empty", func(t *testing.T) {
-		path, cleanup, err := writeMCPConfigFile("", servers)
+		path, cleanup, err := WriteMCPConfigFile("", servers)
 		if err != nil {
-			t.Fatalf("writeMCPConfigFile: %v", err)
+			t.Fatalf("WriteMCPConfigFile: %v", err)
 		}
 		defer cleanup()
 
@@ -137,9 +137,9 @@ func TestWriteOpencodeMCPConfig(t *testing.T) {
 
 	t.Run("creates_opencode_json", func(t *testing.T) {
 		dir := t.TempDir()
-		cleanup, err := writeOpencodeMCPConfig(dir, servers)
+		cleanup, err := WriteOpencodeMCPConfig(dir, servers)
 		if err != nil {
-			t.Fatalf("writeOpencodeMCPConfig: %v", err)
+			t.Fatalf("WriteOpencodeMCPConfig: %v", err)
 		}
 		defer cleanup()
 
@@ -161,9 +161,9 @@ func TestWriteOpencodeMCPConfig(t *testing.T) {
 
 	t.Run("file_has_restricted_permissions", func(t *testing.T) {
 		dir := t.TempDir()
-		cleanup, err := writeOpencodeMCPConfig(dir, servers)
+		cleanup, err := WriteOpencodeMCPConfig(dir, servers)
 		if err != nil {
-			t.Fatalf("writeOpencodeMCPConfig: %v", err)
+			t.Fatalf("WriteOpencodeMCPConfig: %v", err)
 		}
 		defer cleanup()
 
@@ -188,9 +188,9 @@ func TestWriteOpencodeMCPConfig(t *testing.T) {
 			t.Fatalf("WriteFile: %v", err)
 		}
 
-		cleanup, err := writeOpencodeMCPConfig(dir, servers)
+		cleanup, err := WriteOpencodeMCPConfig(dir, servers)
 		if err != nil {
-			t.Fatalf("writeOpencodeMCPConfig: %v", err)
+			t.Fatalf("WriteOpencodeMCPConfig: %v", err)
 		}
 		defer cleanup()
 
@@ -220,9 +220,9 @@ func TestWriteOpencodeMCPConfig(t *testing.T) {
 		dir := t.TempDir()
 		configPath := filepath.Join(dir, ".opencode.json")
 
-		cleanup, err := writeOpencodeMCPConfig(dir, servers)
+		cleanup, err := WriteOpencodeMCPConfig(dir, servers)
 		if err != nil {
-			t.Fatalf("writeOpencodeMCPConfig: %v", err)
+			t.Fatalf("WriteOpencodeMCPConfig: %v", err)
 		}
 
 		// File should exist before cleanup.
@@ -247,9 +247,9 @@ func TestWriteOpencodeMCPConfig(t *testing.T) {
 			t.Fatalf("WriteFile: %v", err)
 		}
 
-		cleanup, err := writeOpencodeMCPConfig(dir, servers)
+		cleanup, err := WriteOpencodeMCPConfig(dir, servers)
 		if err != nil {
-			t.Fatalf("writeOpencodeMCPConfig: %v", err)
+			t.Fatalf("WriteOpencodeMCPConfig: %v", err)
 		}
 
 		cleanup()

--- a/internal/runner/mcp_test.go
+++ b/internal/runner/mcp_test.go
@@ -4,18 +4,22 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
 func TestWriteMCPConfigFile(t *testing.T) {
+	// Use a command name that is guaranteed not to exist on PATH so
+	// resolveMCPCommand returns it unchanged (tests for resolution
+	// behaviour are in TestResolveMCPCommand / TestWriteMCPConfigFileResolvesCommands).
 	servers := map[string]MCPServerConfig{
 		"jira": {
-			Command: "wtmcp",
+			Command: "soda-test-fake-mcp-jira",
 			Args:    []string{"jira"},
 			Env:     map[string]string{"JIRA_URL": "https://jira.example.com"},
 		},
 		"github": {
-			Command: "wtmcp",
+			Command: "soda-test-fake-mcp-gh",
 			Args:    []string{"github"},
 		},
 	}
@@ -56,8 +60,8 @@ func TestWriteMCPConfigFile(t *testing.T) {
 		if !ok {
 			t.Fatal("jira server not found in JSON")
 		}
-		if jira.Command != "wtmcp" {
-			t.Errorf("jira.Command = %q, want %q", jira.Command, "wtmcp")
+		if jira.Command != "soda-test-fake-mcp-jira" {
+			t.Errorf("jira.Command = %q, want %q", jira.Command, "soda-test-fake-mcp-jira")
 		}
 		if len(jira.Args) != 1 || jira.Args[0] != "jira" {
 			t.Errorf("jira.Args = %v, want [jira]", jira.Args)
@@ -70,8 +74,8 @@ func TestWriteMCPConfigFile(t *testing.T) {
 		if !ok {
 			t.Fatal("github server not found in JSON")
 		}
-		if gh.Command != "wtmcp" {
-			t.Errorf("github.Command = %q, want %q", gh.Command, "wtmcp")
+		if gh.Command != "soda-test-fake-mcp-gh" {
+			t.Errorf("github.Command = %q, want %q", gh.Command, "soda-test-fake-mcp-gh")
 		}
 	})
 
@@ -129,7 +133,7 @@ func TestWriteMCPConfigFile(t *testing.T) {
 func TestWriteOpencodeMCPConfig(t *testing.T) {
 	servers := map[string]MCPServerConfig{
 		"jira": {
-			Command: "wtmcp",
+			Command: "soda-test-fake-mcp-jira",
 			Args:    []string{"jira"},
 			Env:     map[string]string{"JIRA_URL": "https://jira.example.com"},
 		},
@@ -262,4 +266,143 @@ func TestWriteOpencodeMCPConfig(t *testing.T) {
 			t.Errorf("restored content = %q, want %q", string(restored), original)
 		}
 	})
+}
+
+func TestResolveMCPCommand(t *testing.T) {
+	t.Run("resolves_bare_command_to_absolute_path", func(t *testing.T) {
+		binDir := t.TempDir()
+		fakeBin := filepath.Join(binDir, "test-mcp-server")
+		if err := os.WriteFile(fakeBin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+			t.Fatalf("write fake binary: %v", err)
+		}
+		t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+		resolved := resolveMCPCommand("test-mcp-server")
+		if !filepath.IsAbs(resolved) {
+			t.Errorf("resolved = %q, want absolute path", resolved)
+		}
+		if resolved != fakeBin {
+			t.Errorf("resolved = %q, want %q", resolved, fakeBin)
+		}
+	})
+
+	t.Run("returns_original_when_not_found", func(t *testing.T) {
+		t.Setenv("PATH", t.TempDir())
+		resolved := resolveMCPCommand("nonexistent-mcp-binary")
+		if resolved != "nonexistent-mcp-binary" {
+			t.Errorf("resolved = %q, want %q", resolved, "nonexistent-mcp-binary")
+		}
+	})
+
+	t.Run("returns_empty_for_empty_command", func(t *testing.T) {
+		resolved := resolveMCPCommand("")
+		if resolved != "" {
+			t.Errorf("resolved = %q, want empty", resolved)
+		}
+	})
+
+	t.Run("returns_absolute_path_unchanged", func(t *testing.T) {
+		resolved := resolveMCPCommand("/usr/local/bin/mcp-server")
+		if resolved != "/usr/local/bin/mcp-server" {
+			t.Errorf("resolved = %q, want /usr/local/bin/mcp-server", resolved)
+		}
+	})
+}
+
+func TestWriteMCPConfigFileResolvesCommands(t *testing.T) {
+	// Create a fake binary on PATH so resolveMCPCommand can find it.
+	binDir := t.TempDir()
+	fakeBin := filepath.Join(binDir, "resolvable-mcp")
+	if err := os.WriteFile(fakeBin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write fake binary: %v", err)
+	}
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	servers := map[string]MCPServerConfig{
+		"resolvable": {Command: "resolvable-mcp"},
+		"missing":    {Command: "unresolvable-mcp-xyz"},
+	}
+
+	dir := t.TempDir()
+	path, cleanup, err := WriteMCPConfigFile(dir, servers)
+	if err != nil {
+		t.Fatalf("WriteMCPConfigFile: %v", err)
+	}
+	defer cleanup()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+
+	var envelope struct {
+		MCPServers map[string]struct {
+			Command string `json:"command"`
+		} `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		t.Fatalf("JSON unmarshal: %v", err)
+	}
+
+	// Resolvable command should be written as an absolute path.
+	resolvable := envelope.MCPServers["resolvable"]
+	if !filepath.IsAbs(resolvable.Command) {
+		t.Errorf("resolvable.Command = %q, want absolute path", resolvable.Command)
+	}
+	if !strings.HasSuffix(resolvable.Command, "resolvable-mcp") {
+		t.Errorf("resolvable.Command = %q, should end with resolvable-mcp", resolvable.Command)
+	}
+
+	// Unresolvable command should remain as the bare name.
+	missing := envelope.MCPServers["missing"]
+	if missing.Command != "unresolvable-mcp-xyz" {
+		t.Errorf("missing.Command = %q, want %q (unchanged)", missing.Command, "unresolvable-mcp-xyz")
+	}
+}
+
+func TestWriteOpencodeMCPConfigResolvesCommands(t *testing.T) {
+	// Create a fake binary on PATH so resolveMCPCommand can find it.
+	binDir := t.TempDir()
+	fakeBin := filepath.Join(binDir, "oc-mcp-server")
+	if err := os.WriteFile(fakeBin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write fake binary: %v", err)
+	}
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	servers := map[string]MCPServerConfig{
+		"resolvable": {Command: "oc-mcp-server"},
+	}
+
+	dir := t.TempDir()
+	cleanup, err := WriteOpencodeMCPConfig(dir, servers)
+	if err != nil {
+		t.Fatalf("WriteOpencodeMCPConfig: %v", err)
+	}
+	defer cleanup()
+
+	configPath := filepath.Join(dir, ".opencode.json")
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+
+	var parsed map[string]json.RawMessage
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("JSON unmarshal: %v", err)
+	}
+
+	var servers2 map[string]struct {
+		Command string `json:"command"`
+	}
+	if err := json.Unmarshal(parsed["mcpServers"], &servers2); err != nil {
+		t.Fatalf("unmarshal mcpServers: %v", err)
+	}
+
+	srv := servers2["resolvable"]
+	if !filepath.IsAbs(srv.Command) {
+		t.Errorf("resolvable.Command = %q, want absolute path", srv.Command)
+	}
+	if !strings.HasSuffix(srv.Command, "oc-mcp-server") {
+		t.Errorf("resolvable.Command = %q, should end with oc-mcp-server", srv.Command)
+	}
 }

--- a/internal/runner/opencode.go
+++ b/internal/runner/opencode.go
@@ -82,7 +82,7 @@ func (r *OpencodeRunner) Run(ctx context.Context, opts RunOpts) (*RunResult, err
 
 	// When MCP servers are declared, write/merge them into .opencode.json.
 	if len(opts.MCPServers) > 0 {
-		mcpCleanup, mcpErr := writeOpencodeMCPConfig(opts.WorkDir, opts.MCPServers)
+		mcpCleanup, mcpErr := WriteOpencodeMCPConfig(opts.WorkDir, opts.MCPServers)
 		if mcpErr != nil {
 			fmt.Fprintf(os.Stderr, "opencode runner: warning: MCP config write failed: %v; continuing without MCP\n", mcpErr)
 		} else {

--- a/internal/sandbox/adapter.go
+++ b/internal/sandbox/adapter.go
@@ -10,4 +10,5 @@ type AgentAdapter interface {
 	BuildEnv(opts runner.RunOpts, tmpDir string, proxyURL string) []string
 	ParseOutput(stdout []byte, opts runner.RunOpts) (*runner.RunResult, error)
 	ExtraPaths(opts runner.RunOpts) (read []string, write []string)
+	MCPExtraPaths(servers map[string]runner.MCPServerConfig) (read []string, write []string)
 }

--- a/internal/sandbox/claude.go
+++ b/internal/sandbox/claude.go
@@ -87,6 +87,19 @@ func (a *ClaudeAdapter) BuildArgs(opts runner.RunOpts, tmpDir string) ([]string,
 		sf.Close()
 	}
 
+	// When MCP servers are declared, write a temp config file into tmpDir
+	// and pass its path via --mcp-config + --strict-mcp-config. The file
+	// is cleaned up when tmpDir is removed, so no explicit defer is needed.
+	var mcpConfigPath string
+	if len(opts.MCPServers) > 0 {
+		mcpPath, _, mcpErr := runner.WriteMCPConfigFile(tmpDir, opts.MCPServers)
+		if mcpErr != nil {
+			fmt.Fprintf(os.Stderr, "sandbox: warning: MCP config write failed: %v; continuing without MCP\n", mcpErr)
+		} else {
+			mcpConfigPath = mcpPath
+		}
+	}
+
 	// Build Claude CLI args via exported BuildArgs.
 	var budgetPtr *float64
 	if opts.MaxBudgetUSD > 0 {
@@ -95,12 +108,21 @@ func (a *ClaudeAdapter) BuildArgs(opts runner.RunOpts, tmpDir string) ([]string,
 	claudeOpts := claude.RunOpts{
 		SystemPromptPath: sysPromptPath,
 		SettingsPath:     settingsPath,
+		MCPConfigPath:    mcpConfigPath,
+		StrictMCPConfig:  mcpConfigPath != "",
 		OutputSchema:     opts.OutputSchema,
 		AllowedTools:     opts.AllowedTools,
 		MaxBudgetUSD:     budgetPtr,
 		Timeout:          opts.Timeout,
 		TranscriptLevel:  opts.TranscriptLevel,
 	}
+
+	// When MCP servers provide extra tool declarations, append them so
+	// Claude Code's allowlist permits MCP tool calls.
+	if len(opts.AllowedMCPTools) > 0 {
+		claudeOpts.AllowedTools = append(claudeOpts.AllowedTools, opts.AllowedMCPTools...)
+	}
+
 	args := claude.BuildArgs(claudeOpts, opts.Model)
 
 	// Append user prompt as positional arg (stdin workaround — see issue #2 Fix 4).

--- a/internal/sandbox/claude.go
+++ b/internal/sandbox/claude.go
@@ -87,12 +87,15 @@ func (a *ClaudeAdapter) BuildArgs(opts runner.RunOpts, tmpDir string) ([]string,
 		sf.Close()
 	}
 
-	// When MCP servers are declared, write a temp config file into tmpDir
-	// and pass its path via --mcp-config + --strict-mcp-config. The file
-	// is cleaned up when tmpDir is removed, so no explicit defer is needed.
+	// When MCP servers are declared, resolve commands to absolute paths so
+	// the agent spawns them without relying on the sandbox's restricted PATH,
+	// then write a temp config file into tmpDir and pass its path via
+	// --mcp-config + --strict-mcp-config. The file is cleaned up when tmpDir
+	// is removed, so no explicit defer is needed.
 	var mcpConfigPath string
 	if len(opts.MCPServers) > 0 {
-		mcpPath, _, mcpErr := runner.WriteMCPConfigFile(tmpDir, opts.MCPServers)
+		resolvedServers := resolveMCPCommands(opts.MCPServers)
+		mcpPath, _, mcpErr := runner.WriteMCPConfigFile(tmpDir, resolvedServers)
 		if mcpErr != nil {
 			fmt.Fprintf(os.Stderr, "sandbox: warning: MCP config write failed: %v; continuing without MCP\n", mcpErr)
 		} else {

--- a/internal/sandbox/claude.go
+++ b/internal/sandbox/claude.go
@@ -157,6 +157,13 @@ func (a *ClaudeAdapter) ExtraPaths(opts runner.RunOpts) (read []string, write []
 	return read, nil
 }
 
+// MCPExtraPaths returns additional read and write paths required for MCP
+// server binaries. Write paths are nil — MCP servers that need temp files
+// use tmpDir, which buildSandboxPaths already makes a write path.
+func (a *ClaudeAdapter) MCPExtraPaths(servers map[string]runner.MCPServerConfig) (read []string, write []string) {
+	return resolveMCPBinaryReadPaths(servers), nil
+}
+
 // resolveClaudePaths finds the claude binary and collects paths
 // needed for the sandbox read profile (node binary, node_modules, etc.).
 func resolveClaudePaths(binary string) (resolved string, readPaths []string, err error) {

--- a/internal/sandbox/config_build.go
+++ b/internal/sandbox/config_build.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/decko/soda/internal/runner"
 )
 
 // sandboxPaths holds the computed read and write paths for a sandbox profile.
@@ -34,6 +36,23 @@ func buildSandboxPaths(workDir, tmpDir string, extraRead, extraWrite []string) s
 	writePaths = append(writePaths, tmpDir)
 
 	return sandboxPaths{ReadPaths: readPaths, WritePaths: writePaths}
+}
+
+// effectiveUseNetNS returns the effective network namespace isolation flag.
+// When MCP servers are configured, network isolation is disabled because MCP
+// servers may need to make outbound connections (e.g. to Jira, GitHub APIs).
+func effectiveUseNetNS(configured bool, servers map[string]runner.MCPServerConfig) bool {
+	if len(servers) > 0 {
+		return false
+	}
+	return configured
+}
+
+// mcpNetworkWarning returns a warning message indicating that network
+// isolation has been disabled for the given phase because MCP servers are
+// configured.
+func mcpNetworkWarning(phase string) string {
+	return fmt.Sprintf("sandbox: warning: network isolation disabled for phase %q because MCP servers are configured\n", phase)
 }
 
 // buildProxyURL formats a proxy base URL from a listener address string

--- a/internal/sandbox/config_build_test.go
+++ b/internal/sandbox/config_build_test.go
@@ -166,6 +166,74 @@ func TestProxyConfigFields(t *testing.T) {
 	}
 }
 
+func TestEffectiveUseNetNS(t *testing.T) {
+	tests := []struct {
+		name       string
+		configured bool
+		servers    map[string]runner.MCPServerConfig
+		want       bool
+	}{
+		{
+			name:       "nil_servers_returns_configured_true",
+			configured: true,
+			servers:    nil,
+			want:       true,
+		},
+		{
+			name:       "nil_servers_returns_configured_false",
+			configured: false,
+			servers:    nil,
+			want:       false,
+		},
+		{
+			name:       "empty_servers_returns_configured_true",
+			configured: true,
+			servers:    map[string]runner.MCPServerConfig{},
+			want:       true,
+		},
+		{
+			name:       "non_empty_servers_forces_false",
+			configured: true,
+			servers: map[string]runner.MCPServerConfig{
+				"jira": {Command: "jira-mcp"},
+			},
+			want: false,
+		},
+		{
+			name:       "non_empty_servers_configured_false",
+			configured: false,
+			servers: map[string]runner.MCPServerConfig{
+				"github": {Command: "gh-mcp"},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := effectiveUseNetNS(tt.configured, tt.servers)
+			if got != tt.want {
+				t.Errorf("effectiveUseNetNS(%v, %v) = %v, want %v",
+					tt.configured, tt.servers, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMCPNetworkWarning(t *testing.T) {
+	warning := mcpNetworkWarning("implement")
+
+	if !strings.Contains(warning, "implement") {
+		t.Errorf("warning should contain phase name, got: %s", warning)
+	}
+	if !strings.Contains(warning, "network isolation") {
+		t.Errorf("warning should contain 'network isolation', got: %s", warning)
+	}
+	if !strings.Contains(warning, "MCP") {
+		t.Errorf("warning should contain 'MCP', got: %s", warning)
+	}
+}
+
 // containsPath returns true if paths contains target.
 func containsPath(paths []string, target string) bool {
 	for _, p := range paths {

--- a/internal/sandbox/mcp_test.go
+++ b/internal/sandbox/mcp_test.go
@@ -1,0 +1,262 @@
+package sandbox
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/decko/soda/internal/runner"
+)
+
+func TestClaudeAdapterBuildArgsMCP(t *testing.T) {
+	// Create a fake claude binary so NewClaudeAdapter can resolve it.
+	binDir := t.TempDir()
+	fakeClaude := filepath.Join(binDir, "claude")
+	if err := os.WriteFile(fakeClaude, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write fake claude: %v", err)
+	}
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+	t.Setenv("NODE_PATH", "")
+
+	adapter, err := NewClaudeAdapter(fakeClaude)
+	if err != nil {
+		t.Fatalf("NewClaudeAdapter: %v", err)
+	}
+
+	t.Run("writes_mcp_config_to_tmpdir", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		opts := runner.RunOpts{
+			UserPrompt: "do the thing",
+			MCPServers: map[string]runner.MCPServerConfig{
+				"jira": {
+					Command: "jira-mcp",
+					Args:    []string{"--port", "8080"},
+					Env:     map[string]string{"JIRA_URL": "https://jira.example.com"},
+				},
+			},
+		}
+		args, err := adapter.BuildArgs(opts, tmpDir)
+		if err != nil {
+			t.Fatalf("BuildArgs: %v", err)
+		}
+
+		// Verify --mcp-config flag is present and points into tmpDir.
+		mcpConfigPath := ""
+		for idx, arg := range args {
+			if arg == "--mcp-config" && idx+1 < len(args) {
+				mcpConfigPath = args[idx+1]
+				break
+			}
+		}
+		if mcpConfigPath == "" {
+			t.Fatal("--mcp-config flag not found in args")
+		}
+		if !strings.HasPrefix(mcpConfigPath, tmpDir) {
+			t.Errorf("MCP config path %q should be inside tmpDir %q", mcpConfigPath, tmpDir)
+		}
+
+		// Verify --strict-mcp-config is present.
+		assertContains(t, args, "--strict-mcp-config")
+
+		// Verify the config file contains valid JSON with the expected server.
+		data, readErr := os.ReadFile(mcpConfigPath)
+		if readErr != nil {
+			t.Fatalf("ReadFile(%s): %v", mcpConfigPath, readErr)
+		}
+		var envelope struct {
+			MCPServers map[string]struct {
+				Command string            `json:"command"`
+				Args    []string          `json:"args"`
+				Env     map[string]string `json:"env"`
+			} `json:"mcpServers"`
+		}
+		if err := json.Unmarshal(data, &envelope); err != nil {
+			t.Fatalf("JSON unmarshal: %v", err)
+		}
+		jira, ok := envelope.MCPServers["jira"]
+		if !ok {
+			t.Fatal("jira server not found in MCP config JSON")
+		}
+		if jira.Command != "jira-mcp" {
+			t.Errorf("jira.Command = %q, want %q", jira.Command, "jira-mcp")
+		}
+		if jira.Env["JIRA_URL"] != "https://jira.example.com" {
+			t.Errorf("jira.Env[JIRA_URL] = %q, want %q", jira.Env["JIRA_URL"], "https://jira.example.com")
+		}
+	})
+
+	t.Run("no_mcp_config_when_no_servers", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		opts := runner.RunOpts{
+			UserPrompt: "do the thing",
+		}
+		args, err := adapter.BuildArgs(opts, tmpDir)
+		if err != nil {
+			t.Fatalf("BuildArgs: %v", err)
+		}
+
+		for _, arg := range args {
+			if arg == "--mcp-config" {
+				t.Error("should not include --mcp-config when no MCP servers")
+			}
+			if arg == "--strict-mcp-config" {
+				t.Error("should not include --strict-mcp-config when no MCP servers")
+			}
+		}
+	})
+
+	t.Run("appends_allowed_mcp_tools", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		opts := runner.RunOpts{
+			UserPrompt:   "do the thing",
+			AllowedTools: []string{"Read"},
+			MCPServers: map[string]runner.MCPServerConfig{
+				"jira": {Command: "jira-mcp"},
+			},
+			AllowedMCPTools: []string{"mcp__jira__search", "mcp__jira__create"},
+		}
+		args, err := adapter.BuildArgs(opts, tmpDir)
+		if err != nil {
+			t.Fatalf("BuildArgs: %v", err)
+		}
+
+		// The allowed-tools list should contain both original and MCP tools.
+		argsStr := strings.Join(args, " ")
+		if !strings.Contains(argsStr, "mcp__jira__search") {
+			t.Errorf("args should contain mcp__jira__search, got: %v", args)
+		}
+		if !strings.Contains(argsStr, "mcp__jira__create") {
+			t.Errorf("args should contain mcp__jira__create, got: %v", args)
+		}
+	})
+}
+
+func TestOpencodeAdapterBuildArgsMCP(t *testing.T) {
+	// Create a fake opencode binary so NewOpencodeAdapter can resolve it.
+	binDir := t.TempDir()
+	fakeOpencode := filepath.Join(binDir, "opencode")
+	if err := os.WriteFile(fakeOpencode, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write fake opencode: %v", err)
+	}
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	adapter, err := NewOpencodeAdapter(fakeOpencode)
+	if err != nil {
+		t.Fatalf("NewOpencodeAdapter: %v", err)
+	}
+
+	t.Run("writes_opencode_json_to_tmpdir", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		opts := runner.RunOpts{
+			Phase:      "implement",
+			UserPrompt: "do the thing",
+			MCPServers: map[string]runner.MCPServerConfig{
+				"github": {
+					Command: "gh-mcp",
+					Args:    []string{"--org", "decko"},
+				},
+			},
+		}
+		_, err := adapter.BuildArgs(opts, tmpDir)
+		if err != nil {
+			t.Fatalf("BuildArgs: %v", err)
+		}
+
+		// Verify .opencode.json was written to tmpDir.
+		configPath := filepath.Join(tmpDir, ".opencode.json")
+		data, readErr := os.ReadFile(configPath)
+		if readErr != nil {
+			t.Fatalf("ReadFile(%s): %v", configPath, readErr)
+		}
+
+		var parsed map[string]json.RawMessage
+		if err := json.Unmarshal(data, &parsed); err != nil {
+			t.Fatalf("JSON unmarshal: %v", err)
+		}
+		if _, ok := parsed["mcpServers"]; !ok {
+			t.Fatal("mcpServers key not found in .opencode.json")
+		}
+
+		// Verify the server entry.
+		var servers map[string]struct {
+			Command string   `json:"command"`
+			Args    []string `json:"args"`
+		}
+		if err := json.Unmarshal(parsed["mcpServers"], &servers); err != nil {
+			t.Fatalf("unmarshal mcpServers: %v", err)
+		}
+		gh, ok := servers["github"]
+		if !ok {
+			t.Fatal("github server not found in .opencode.json")
+		}
+		if gh.Command != "gh-mcp" {
+			t.Errorf("github.Command = %q, want %q", gh.Command, "gh-mcp")
+		}
+	})
+
+	t.Run("no_opencode_json_when_no_servers", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		opts := runner.RunOpts{
+			Phase:      "implement",
+			UserPrompt: "do the thing",
+		}
+		_, err := adapter.BuildArgs(opts, tmpDir)
+		if err != nil {
+			t.Fatalf("BuildArgs: %v", err)
+		}
+
+		configPath := filepath.Join(tmpDir, ".opencode.json")
+		if _, statErr := os.Stat(configPath); !os.IsNotExist(statErr) {
+			t.Errorf(".opencode.json should not exist when no MCP servers, got err: %v", statErr)
+		}
+	})
+}
+
+func TestClaudeAdapterMCPExtraPaths(t *testing.T) {
+	binDir := t.TempDir()
+	fakeClaude := filepath.Join(binDir, "claude")
+	if err := os.WriteFile(fakeClaude, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write fake claude: %v", err)
+	}
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+	t.Setenv("NODE_PATH", "")
+
+	adapter, err := NewClaudeAdapter(fakeClaude)
+	if err != nil {
+		t.Fatalf("NewClaudeAdapter: %v", err)
+	}
+
+	t.Run("found_binary_in_read_paths", func(t *testing.T) {
+		mcpDir := t.TempDir()
+		fakeMCP := filepath.Join(mcpDir, "jira-mcp")
+		if err := os.WriteFile(fakeMCP, []byte("#!/bin/sh\n"), 0o755); err != nil {
+			t.Fatalf("write fake mcp binary: %v", err)
+		}
+		t.Setenv("PATH", mcpDir+":"+binDir+":"+os.Getenv("PATH"))
+
+		servers := map[string]runner.MCPServerConfig{
+			"jira": {Command: "jira-mcp"},
+		}
+		read, write := adapter.MCPExtraPaths(servers)
+
+		if !containsPath(read, mcpDir) {
+			t.Errorf("read paths %v should contain MCP binary dir %q", read, mcpDir)
+		}
+		if write != nil {
+			t.Errorf("write paths = %v, want nil", write)
+		}
+	})
+
+	t.Run("nil_input_returns_empty", func(t *testing.T) {
+		read, write := adapter.MCPExtraPaths(nil)
+
+		if len(read) != 0 {
+			t.Errorf("read paths = %v, want empty for nil input", read)
+		}
+		if write != nil {
+			t.Errorf("write paths = %v, want nil", write)
+		}
+	})
+}

--- a/internal/sandbox/mcp_test.go
+++ b/internal/sandbox/mcp_test.go
@@ -26,6 +26,14 @@ func TestClaudeAdapterBuildArgsMCP(t *testing.T) {
 	}
 
 	t.Run("writes_mcp_config_to_tmpdir", func(t *testing.T) {
+		// Create a fake MCP binary so resolveMCPCommands can resolve it.
+		mcpDir := t.TempDir()
+		fakeMCP := filepath.Join(mcpDir, "jira-mcp")
+		if err := os.WriteFile(fakeMCP, []byte("#!/bin/sh\n"), 0o755); err != nil {
+			t.Fatalf("write fake mcp binary: %v", err)
+		}
+		t.Setenv("PATH", mcpDir+":"+binDir+":"+os.Getenv("PATH"))
+
 		tmpDir := t.TempDir()
 		opts := runner.RunOpts{
 			UserPrompt: "do the thing",
@@ -79,8 +87,12 @@ func TestClaudeAdapterBuildArgsMCP(t *testing.T) {
 		if !ok {
 			t.Fatal("jira server not found in MCP config JSON")
 		}
-		if jira.Command != "jira-mcp" {
-			t.Errorf("jira.Command = %q, want %q", jira.Command, "jira-mcp")
+		// Command should be resolved to absolute path by resolveMCPCommands.
+		if !filepath.IsAbs(jira.Command) {
+			t.Errorf("jira.Command = %q, want absolute path", jira.Command)
+		}
+		if filepath.Base(jira.Command) != "jira-mcp" {
+			t.Errorf("jira.Command base = %q, want %q", filepath.Base(jira.Command), "jira-mcp")
 		}
 		if jira.Env["JIRA_URL"] != "https://jira.example.com" {
 			t.Errorf("jira.Env[JIRA_URL] = %q, want %q", jira.Env["JIRA_URL"], "https://jira.example.com")
@@ -148,6 +160,14 @@ func TestOpencodeAdapterBuildArgsMCP(t *testing.T) {
 	}
 
 	t.Run("writes_opencode_json_to_tmpdir", func(t *testing.T) {
+		// Create a fake MCP binary so resolveMCPCommands can resolve it.
+		mcpDir := t.TempDir()
+		fakeMCP := filepath.Join(mcpDir, "gh-mcp")
+		if err := os.WriteFile(fakeMCP, []byte("#!/bin/sh\n"), 0o755); err != nil {
+			t.Fatalf("write fake mcp binary: %v", err)
+		}
+		t.Setenv("PATH", mcpDir+":"+binDir+":"+os.Getenv("PATH"))
+
 		tmpDir := t.TempDir()
 		opts := runner.RunOpts{
 			Phase:      "implement",
@@ -191,8 +211,12 @@ func TestOpencodeAdapterBuildArgsMCP(t *testing.T) {
 		if !ok {
 			t.Fatal("github server not found in .opencode.json")
 		}
-		if gh.Command != "gh-mcp" {
-			t.Errorf("github.Command = %q, want %q", gh.Command, "gh-mcp")
+		// Command should be resolved to absolute path by resolveMCPCommands.
+		if !filepath.IsAbs(gh.Command) {
+			t.Errorf("github.Command = %q, want absolute path", gh.Command)
+		}
+		if filepath.Base(gh.Command) != "gh-mcp" {
+			t.Errorf("github.Command base = %q, want %q", filepath.Base(gh.Command), "gh-mcp")
 		}
 	})
 

--- a/internal/sandbox/opencode.go
+++ b/internal/sandbox/opencode.go
@@ -70,11 +70,14 @@ func (a *OpencodeAdapter) BuildArgs(opts runner.RunOpts, tmpDir string) ([]strin
 		}
 	}
 
-	// When MCP servers are declared, write them into {tmpDir}/.opencode.json
-	// so Opencode discovers them via HOME=tmpDir. The file is cleaned up
-	// when tmpDir is removed, so no explicit cleanup is needed.
+	// When MCP servers are declared, resolve commands to absolute paths so
+	// the agent spawns them without relying on the sandbox's restricted PATH,
+	// then write them into {tmpDir}/.opencode.json so Opencode discovers them
+	// via HOME=tmpDir. The file is cleaned up when tmpDir is removed, so no
+	// explicit cleanup is needed.
 	if len(opts.MCPServers) > 0 {
-		_, mcpErr := runner.WriteOpencodeMCPConfig(tmpDir, opts.MCPServers)
+		resolvedServers := resolveMCPCommands(opts.MCPServers)
+		_, mcpErr := runner.WriteOpencodeMCPConfig(tmpDir, resolvedServers)
 		if mcpErr != nil {
 			fmt.Fprintf(os.Stderr, "sandbox: warning: opencode MCP config write failed: %v; continuing without MCP\n", mcpErr)
 		}

--- a/internal/sandbox/opencode.go
+++ b/internal/sandbox/opencode.go
@@ -147,6 +147,13 @@ func (a *OpencodeAdapter) ExtraPaths(opts runner.RunOpts) (read []string, write 
 	return read, nil
 }
 
+// MCPExtraPaths returns additional read and write paths required for MCP
+// server binaries. Write paths are nil — MCP servers that need temp files
+// use tmpDir, which buildSandboxPaths already makes a write path.
+func (a *OpencodeAdapter) MCPExtraPaths(servers map[string]runner.MCPServerConfig) (read []string, write []string) {
+	return resolveMCPBinaryReadPaths(servers), nil
+}
+
 // resolveOpencodePaths finds the opencode binary and collects paths needed for
 // the sandbox read profile.
 func resolveOpencodePaths(binary string) (resolved string, readPaths []string, err error) {

--- a/internal/sandbox/opencode.go
+++ b/internal/sandbox/opencode.go
@@ -70,6 +70,16 @@ func (a *OpencodeAdapter) BuildArgs(opts runner.RunOpts, tmpDir string) ([]strin
 		}
 	}
 
+	// When MCP servers are declared, write them into {tmpDir}/.opencode.json
+	// so Opencode discovers them via HOME=tmpDir. The file is cleaned up
+	// when tmpDir is removed, so no explicit cleanup is needed.
+	if len(opts.MCPServers) > 0 {
+		_, mcpErr := runner.WriteOpencodeMCPConfig(tmpDir, opts.MCPServers)
+		if mcpErr != nil {
+			fmt.Fprintf(os.Stderr, "sandbox: warning: opencode MCP config write failed: %v; continuing without MCP\n", mcpErr)
+		}
+	}
+
 	args := []string{
 		"--print",
 		"--output-format", "stream-json",

--- a/internal/sandbox/opencode_test.go
+++ b/internal/sandbox/opencode_test.go
@@ -314,6 +314,52 @@ func TestOpencodeAdapterExtraPaths(t *testing.T) {
 	})
 }
 
+func TestOpencodeAdapterMCPExtraPaths(t *testing.T) {
+	binDir := t.TempDir()
+	fakeOpencode := filepath.Join(binDir, "opencode")
+	if err := os.WriteFile(fakeOpencode, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write fake opencode: %v", err)
+	}
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	adapter, err := NewOpencodeAdapter(fakeOpencode)
+	if err != nil {
+		t.Fatalf("NewOpencodeAdapter: %v", err)
+	}
+
+	t.Run("found_binary_in_read_paths", func(t *testing.T) {
+		mcpDir := t.TempDir()
+		fakeMCP := filepath.Join(mcpDir, "jira-mcp")
+		if err := os.WriteFile(fakeMCP, []byte("#!/bin/sh\n"), 0o755); err != nil {
+			t.Fatalf("write fake mcp binary: %v", err)
+		}
+		t.Setenv("PATH", mcpDir+":"+binDir+":"+os.Getenv("PATH"))
+
+		servers := map[string]runner.MCPServerConfig{
+			"jira": {Command: "jira-mcp"},
+		}
+		read, write := adapter.MCPExtraPaths(servers)
+
+		if !containsPath(read, mcpDir) {
+			t.Errorf("read paths %v should contain MCP binary dir %q", read, mcpDir)
+		}
+		if write != nil {
+			t.Errorf("write paths = %v, want nil", write)
+		}
+	})
+
+	t.Run("nil_input_returns_empty", func(t *testing.T) {
+		read, write := adapter.MCPExtraPaths(nil)
+
+		if len(read) != 0 {
+			t.Errorf("read paths = %v, want empty for nil input", read)
+		}
+		if write != nil {
+			t.Errorf("write paths = %v, want nil", write)
+		}
+	})
+}
+
 func TestMapOpencodeParseError(t *testing.T) {
 	t.Run("parse_error_passes_through", func(t *testing.T) {
 		inner := fmt.Errorf("bad JSON")

--- a/internal/sandbox/pi.go
+++ b/internal/sandbox/pi.go
@@ -126,6 +126,11 @@ func (a *PiAdapter) ExtraPaths(opts runner.RunOpts) (read []string, write []stri
 	return read, nil
 }
 
+// MCPExtraPaths returns empty paths — Pi does not support MCP servers.
+func (a *PiAdapter) MCPExtraPaths(_ map[string]runner.MCPServerConfig) (read []string, write []string) {
+	return nil, nil
+}
+
 // resolvePiPaths finds the pi binary and collects paths needed for the
 // sandbox read profile.
 func resolvePiPaths(binary string) (resolved string, readPaths []string, err error) {

--- a/internal/sandbox/pi_test.go
+++ b/internal/sandbox/pi_test.go
@@ -287,6 +287,46 @@ func TestPiAdapterExtraPaths(t *testing.T) {
 	})
 }
 
+func TestPiAdapterMCPExtraPaths(t *testing.T) {
+	binDir := t.TempDir()
+	fakePi := filepath.Join(binDir, "pi")
+	if err := os.WriteFile(fakePi, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write fake pi: %v", err)
+	}
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	adapter, err := NewPiAdapter(fakePi)
+	if err != nil {
+		t.Fatalf("NewPiAdapter: %v", err)
+	}
+
+	t.Run("always_returns_empty", func(t *testing.T) {
+		servers := map[string]runner.MCPServerConfig{
+			"jira":   {Command: "jira-mcp"},
+			"github": {Command: "gh-mcp"},
+		}
+		read, write := adapter.MCPExtraPaths(servers)
+
+		if len(read) != 0 {
+			t.Errorf("read paths = %v, want empty", read)
+		}
+		if len(write) != 0 {
+			t.Errorf("write paths = %v, want empty", write)
+		}
+	})
+
+	t.Run("nil_input_returns_empty", func(t *testing.T) {
+		read, write := adapter.MCPExtraPaths(nil)
+
+		if len(read) != 0 {
+			t.Errorf("read paths = %v, want empty for nil input", read)
+		}
+		if len(write) != 0 {
+			t.Errorf("write paths = %v, want empty for nil input", write)
+		}
+	})
+}
+
 func TestMapPiParseError(t *testing.T) {
 	t.Run("parse_error_passes_through", func(t *testing.T) {
 		inner := fmt.Errorf("bad JSON")

--- a/internal/sandbox/resolve.go
+++ b/internal/sandbox/resolve.go
@@ -57,6 +57,41 @@ func resolveMCPBinaryReadPaths(servers map[string]runner.MCPServerConfig) []stri
 	return paths
 }
 
+// resolveMCPCommands returns a copy of servers with each Command resolved to
+// an absolute path via exec.LookPath + filepath.EvalSymlinks. This ensures the
+// agent spawns MCP server binaries via absolute paths, avoiding PATH lookup
+// failures inside the sandbox (where PATH is constructed from scratch and may
+// not include the MCP binary directory). Missing binaries emit a warning to
+// stderr and retain their original (unresolved) command — the agent will fail
+// at spawn time with a clear error.
+func resolveMCPCommands(servers map[string]runner.MCPServerConfig) map[string]runner.MCPServerConfig {
+	if len(servers) == 0 {
+		return servers
+	}
+	resolved := make(map[string]runner.MCPServerConfig, len(servers))
+	for name, srv := range servers {
+		if srv.Command == "" {
+			resolved[name] = srv
+			continue
+		}
+		absPath, err := exec.LookPath(srv.Command)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "sandbox: warning: MCP server %q binary %q not found in PATH, keeping as-is\n", name, srv.Command)
+			resolved[name] = srv
+			continue
+		}
+		absPath, err = filepath.EvalSymlinks(absPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "sandbox: warning: MCP server %q binary %q symlink resolve failed, keeping as-is\n", name, srv.Command)
+			resolved[name] = srv
+			continue
+		}
+		srv.Command = absPath
+		resolved[name] = srv
+	}
+	return resolved
+}
+
 func envOrDefault(key, fallback string) string {
 	if val := os.Getenv(key); val != "" {
 		return val

--- a/internal/sandbox/resolve.go
+++ b/internal/sandbox/resolve.go
@@ -1,8 +1,13 @@
 package sandbox
 
 import (
+	"fmt"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
+
+	"github.com/decko/soda/internal/runner"
 )
 
 // systemReadPaths returns the standard OS paths required for process execution.
@@ -25,6 +30,31 @@ func systemReadPaths() []string {
 // for use in filesystem paths (e.g. "review/go-specialist" → "review-go-specialist").
 func sanitizePhase(phase string) string {
 	return strings.ReplaceAll(phase, "/", "-")
+}
+
+// resolveMCPBinaryReadPaths iterates MCP server configs, resolves each
+// command via exec.LookPath + filepath.EvalSymlinks, and returns the parent
+// directories as read paths. Missing binaries emit a warning to stderr and
+// are skipped — no hard failure.
+func resolveMCPBinaryReadPaths(servers map[string]runner.MCPServerConfig) []string {
+	var paths []string
+	for name, srv := range servers {
+		if srv.Command == "" {
+			continue
+		}
+		resolved, err := exec.LookPath(srv.Command)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "sandbox: warning: MCP server %q binary %q not found, skipping\n", name, srv.Command)
+			continue
+		}
+		resolved, err = filepath.EvalSymlinks(resolved)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "sandbox: warning: MCP server %q binary %q symlink resolve failed, skipping\n", name, srv.Command)
+			continue
+		}
+		paths = append(paths, filepath.Dir(resolved))
+	}
+	return paths
 }
 
 func envOrDefault(key, fallback string) string {

--- a/internal/sandbox/resolve_test.go
+++ b/internal/sandbox/resolve_test.go
@@ -337,6 +337,91 @@ func TestResolveMCPBinaryReadPaths(t *testing.T) {
 	})
 }
 
+func TestResolveMCPCommands(t *testing.T) {
+	t.Run("resolves_to_absolute_path", func(t *testing.T) {
+		binDir := t.TempDir()
+		fakeBin := filepath.Join(binDir, "jira-mcp")
+		if err := os.WriteFile(fakeBin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+			t.Fatalf("write fake binary: %v", err)
+		}
+		t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+		servers := map[string]runner.MCPServerConfig{
+			"jira": {
+				Command: "jira-mcp",
+				Args:    []string{"--port", "8080"},
+				Env:     map[string]string{"JIRA_URL": "https://jira.example.com"},
+			},
+		}
+		resolved := resolveMCPCommands(servers)
+
+		jira := resolved["jira"]
+		if !filepath.IsAbs(jira.Command) {
+			t.Errorf("resolved command %q should be absolute", jira.Command)
+		}
+		if filepath.Base(jira.Command) != "jira-mcp" {
+			t.Errorf("resolved command base = %q, want jira-mcp", filepath.Base(jira.Command))
+		}
+		// Args and Env should be preserved.
+		if len(jira.Args) != 2 || jira.Args[0] != "--port" {
+			t.Errorf("args = %v, want [--port 8080]", jira.Args)
+		}
+		if jira.Env["JIRA_URL"] != "https://jira.example.com" {
+			t.Errorf("env JIRA_URL = %q, want https://jira.example.com", jira.Env["JIRA_URL"])
+		}
+	})
+
+	t.Run("missing_binary_keeps_original", func(t *testing.T) {
+		t.Setenv("PATH", t.TempDir())
+
+		servers := map[string]runner.MCPServerConfig{
+			"missing": {Command: "nonexistent-mcp"},
+		}
+		resolved := resolveMCPCommands(servers)
+
+		if resolved["missing"].Command != "nonexistent-mcp" {
+			t.Errorf("command = %q, want original 'nonexistent-mcp'", resolved["missing"].Command)
+		}
+	})
+
+	t.Run("empty_command_preserved", func(t *testing.T) {
+		servers := map[string]runner.MCPServerConfig{
+			"empty": {Command: ""},
+		}
+		resolved := resolveMCPCommands(servers)
+
+		if resolved["empty"].Command != "" {
+			t.Errorf("command = %q, want empty", resolved["empty"].Command)
+		}
+	})
+
+	t.Run("nil_input_returns_nil", func(t *testing.T) {
+		resolved := resolveMCPCommands(nil)
+		if resolved != nil {
+			t.Errorf("resolved = %v, want nil", resolved)
+		}
+	})
+
+	t.Run("does_not_mutate_original", func(t *testing.T) {
+		binDir := t.TempDir()
+		fakeBin := filepath.Join(binDir, "jira-mcp")
+		if err := os.WriteFile(fakeBin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+			t.Fatalf("write fake binary: %v", err)
+		}
+		t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+		servers := map[string]runner.MCPServerConfig{
+			"jira": {Command: "jira-mcp"},
+		}
+		_ = resolveMCPCommands(servers)
+
+		// Original should be unchanged.
+		if servers["jira"].Command != "jira-mcp" {
+			t.Errorf("original command mutated to %q, want jira-mcp", servers["jira"].Command)
+		}
+	})
+}
+
 func TestSetEnvForLaunchDistinguishesUnsetFromEmpty(t *testing.T) {
 	// Set a variable to empty string — restore should keep it empty, not unset it.
 	t.Setenv("SODA_EMPTY_VAR", "")

--- a/internal/sandbox/resolve_test.go
+++ b/internal/sandbox/resolve_test.go
@@ -2,6 +2,7 @@ package sandbox
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -257,6 +258,83 @@ func TestEnvOrDefault(t *testing.T) {
 	if got := envOrDefault("SODA_EMPTY", "fallback"); got != "fallback" {
 		t.Errorf("envOrDefault = %q, want fallback", got)
 	}
+}
+
+func TestResolveMCPBinaryReadPaths(t *testing.T) {
+	t.Run("found_binary_adds_dir", func(t *testing.T) {
+		binDir := t.TempDir()
+		fakeBin := filepath.Join(binDir, "jira-mcp")
+		if err := os.WriteFile(fakeBin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+			t.Fatalf("write fake binary: %v", err)
+		}
+		t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+		servers := map[string]runner.MCPServerConfig{
+			"jira": {Command: "jira-mcp"},
+		}
+		paths := resolveMCPBinaryReadPaths(servers)
+
+		if !containsPath(paths, binDir) {
+			t.Errorf("paths %v should contain binary dir %q", paths, binDir)
+		}
+	})
+
+	t.Run("missing_binary_skipped", func(t *testing.T) {
+		// Point PATH at an empty dir so no binary can be found.
+		t.Setenv("PATH", t.TempDir())
+
+		servers := map[string]runner.MCPServerConfig{
+			"missing": {Command: "nonexistent-mcp-server"},
+		}
+		paths := resolveMCPBinaryReadPaths(servers)
+
+		if len(paths) != 0 {
+			t.Errorf("paths = %v, want empty for missing binary", paths)
+		}
+	})
+
+	t.Run("empty_command_skipped", func(t *testing.T) {
+		servers := map[string]runner.MCPServerConfig{
+			"empty": {Command: ""},
+		}
+		paths := resolveMCPBinaryReadPaths(servers)
+
+		if len(paths) != 0 {
+			t.Errorf("paths = %v, want empty for empty command", paths)
+		}
+	})
+
+	t.Run("nil_input_returns_empty", func(t *testing.T) {
+		paths := resolveMCPBinaryReadPaths(nil)
+
+		if len(paths) != 0 {
+			t.Errorf("paths = %v, want empty for nil input", paths)
+		}
+	})
+
+	t.Run("multiple_servers", func(t *testing.T) {
+		binDir := t.TempDir()
+		for _, name := range []string{"jira-mcp", "gh-mcp"} {
+			fakeBin := filepath.Join(binDir, name)
+			if err := os.WriteFile(fakeBin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+				t.Fatalf("write fake binary %s: %v", name, err)
+			}
+		}
+		t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+		servers := map[string]runner.MCPServerConfig{
+			"jira":   {Command: "jira-mcp"},
+			"github": {Command: "gh-mcp"},
+		}
+		paths := resolveMCPBinaryReadPaths(servers)
+
+		if len(paths) != 2 {
+			t.Errorf("paths = %v (len %d), want 2 entries", paths, len(paths))
+		}
+		if !containsPath(paths, binDir) {
+			t.Errorf("paths %v should contain binary dir %q", paths, binDir)
+		}
+	})
 }
 
 func TestSetEnvForLaunchDistinguishesUnsetFromEmpty(t *testing.T) {

--- a/internal/sandbox/runner.go
+++ b/internal/sandbox/runner.go
@@ -105,9 +105,20 @@ func (r *Runner) Run(ctx context.Context, opts runner.RunOpts) (*runner.RunResul
 	combinedExtraWrite := append([]string{}, r.config.ExtraWritePaths...)
 	combinedExtraWrite = append(combinedExtraWrite, adapterWrite...)
 
+	// Add MCP server binary directories to the read path list so the
+	// sandbox can execute them.
+	mcpRead, mcpWrite := r.adapter.MCPExtraPaths(opts.MCPServers)
+	combinedExtraRead = append(combinedExtraRead, mcpRead...)
+	combinedExtraWrite = append(combinedExtraWrite, mcpWrite...)
+
 	sp := buildSandboxPaths(opts.WorkDir, tmpDir, combinedExtraRead, combinedExtraWrite)
 
-	useNetNS := r.config.UseNetNS
+	// Disable network isolation when MCP servers are configured — they
+	// may need outbound connectivity (e.g. Jira, GitHub APIs).
+	useNetNS := effectiveUseNetNS(r.config.UseNetNS, opts.MCPServers)
+	if len(opts.MCPServers) > 0 {
+		fmt.Fprintf(os.Stderr, "%s", mcpNetworkWarning(opts.Phase))
+	}
 	var llmProxy *proxy.Proxy
 	var proxyBaseURL string
 


### PR DESCRIPTION
## Summary

Adds full MCP (Model Context Protocol) server support inside the arapuca sandbox, enabling coding agents to use MCP servers while remaining sandboxed.

### Changes

1. ** on  interface** (`adapter.go`) — All three adapters (Claude, Opencode, Pi) implement it with compile-time interface checks. Returns the read paths needed by MCP server binaries.

2. ** auto-disabled** (`config_build.go` + `runner.go`) — `effectiveUseNetNS()` forces `false` when any MCP servers are configured; network namespace isolation is incompatible with MCP servers that need outbound connections.

3. **Security warning** — `mcpNetworkWarning()` generates a message; `runner.go` emits it to stderr via `fmt.Fprintf` whenever MCP servers are configured, informing users of the network trade-off.

4. **MCP binary read paths** — `resolveMCPBinaryReadPaths()` in `resolve.go` resolves each command and collects parent dirs; called via `MCPExtraPaths` and merged before Landlock profile construction.

5. **MCP config writing** — Claude adapter writes `--mcp-config` temp file; Opencode adapter writes `{tmpDir}/.opencode.json`; Pi adapter no-ops.

6. **Exported helpers** — `WriteMCPConfigFile` and `WriteOpencodeMCPConfig` were capitalized in `runner/mcp.go` to be usable from the sandbox package.

7. **Absolute path resolution** — MCP server commands are resolved to absolute paths before writing config files, so agents use absolute paths and skip PATH lookup.

8. **Documentation** — `docs/sandbox.md` covers the MCP section with a security trade-off table, mitigations, and recommendations.

## Test Plan

- Unit tests added for `MCPExtraPaths` on all adapters
- Unit tests added for MCP config writing in `BuildArgs`
- Unit tests added for sandbox runner MCP server support
- Run `go test ./internal/sandbox/... ./internal/runner/...`

## Acceptance Criteria

- [x] `MCPExtraPaths` method on `AgentAdapter` interface, implemented by all adapters
- [x] `UseNetNS` auto-disabled when MCP servers are configured
- [x] Security warning emitted to stderr when MCP servers are configured
- [x] MCP binary directories added to Landlock read paths
- [x] MCP config written to temp file/dir in `BuildArgs` for Claude and Opencode adapters
- [x] `WriteMCPConfigFile` and `WriteOpencodeMCPConfig` exported from runner package
- [x] MCP commands resolved to absolute paths before config writing
- [x] Documentation updated in `docs/sandbox.md`

Refs: #640