### PR TITLE
chore: v0.8.0 release prep

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -156,7 +156,7 @@ jobs:
         run: |
           git clone https://github.com/sergio-correia/arapuca /tmp/arapuca
           cd /tmp/arapuca
-          git checkout de97447cec63161bf4a209ac1a45cf4f40693099
+          git checkout 124265dde855cbaf369bd8e10c9dc138ed766c60  # v0.2.4
           cargo install cbindgen
           make install PREFIX=$HOME/.local
           echo "PKG_CONFIG_PATH=$HOME/.local/lib/pkgconfig" >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -160,6 +160,8 @@ jobs:
           cargo install cbindgen
           make package
           make install PREFIX=$HOME/.local
+          cargo build --release --bin arapuca
+          cp target/release/arapuca $HOME/.local/bin/arapuca
           echo "PKG_CONFIG_PATH=$HOME/.local/lib/pkgconfig" >> "$GITHUB_ENV"
 
       - name: Run sandbox integration tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -158,6 +158,7 @@ jobs:
           cd /tmp/arapuca
           git checkout 124265dde855cbaf369bd8e10c9dc138ed766c60  # v0.2.4
           cargo install cbindgen
+          make package
           make install PREFIX=$HOME/.local
           echo "PKG_CONFIG_PATH=$HOME/.local/lib/pkgconfig" >> "$GITHUB_ENV"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -161,8 +161,9 @@ jobs:
           make package
           make install PREFIX=$HOME/.local
           cargo build --release --bin arapuca
-          cp target/release/arapuca $HOME/.local/bin/arapuca
+          mkdir -p $HOME/.local/bin && cp target/release/arapuca $HOME/.local/bin/arapuca
           echo "PKG_CONFIG_PATH=$HOME/.local/lib/pkgconfig" >> "$GITHUB_ENV"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Run sandbox integration tests
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,116 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] — "Many Hands" - 2026-07-01
+
+### Added
+
+#### Multi-backend agent support
+- **Pi coding agent backend** (#484) — `runner: pi` in `soda.yaml` routes pipeline
+  phases through the Pi CLI (`earendil-works/pi`). Includes JSONL streaming parser,
+  budget enforcement via context cancel, worktree cleanup, and sandboxed execution
+  via `PiAdapter`.
+- **Opencode agent backend** (#485) — `runner: opencode` routes phases through
+  Opencode. Agent-based system prompt injection, JSON event streaming, tool mapping,
+  and sandbox adapter. Provider/model configured as `openai/gpt-4o` style strings in
+  `opencode.model`.
+- **Agent bootstrap** (#481) — `soda doctor` and `soda validate` check for the
+  configured runner binary, report install hints for missing agents, and surface
+  available alternatives when the configured runner is not found.
+- **AgentAdapter interface** (#482) — refactors sandbox isolation from Claude-specific
+  arg building. `ClaudeAdapter`, `PiAdapter`, and `OpencodeAdapter` each implement
+  `AgentAdapter`, enabling runner-agnostic sandboxing.
+
+#### MCP tool injection
+- **MCP config declaration and arg injection** (#639) — declare MCP servers globally
+  in `soda.yaml` and enable per-phase in `phases.yaml`. Claude Code receives
+  `--mcp-config` + `--strict-mcp-config`; Opencode gets `mcpServers` merged into
+  `.opencode.json`; Pi logs a warning (unsupported). Startup failures are
+  non-blocking — pipeline continues without MCP.
+- **MCP server health checks** (#642) — `soda doctor` runs `claude mcp list` /
+  `opencode mcp list` to verify configured servers start and connect. `soda validate`
+  checks server commands exist in PATH and warns on unknown server references.
+- **MCP server support inside sandbox** (#640) — when a phase declares `mcp_servers`,
+  `UseNetNS` is automatically disabled for that phase so MCP servers retain host
+  network access. Security warning emitted. MCP server binary paths added to sandbox
+  read paths via `MCPExtraPaths` on `AgentAdapter`.
+
+#### Pipeline organization
+- **`.pipelines/` directory convention** (#563) — named pipelines can live in
+  `.pipelines/*.yaml` instead of root-level `phases-*.yaml` files. Discovery searches
+  `.pipelines/` first, then project root. `pipelines_path` config key for custom
+  locations. `soda init --phases` generates `.pipelines/` structure.
+
+#### Prompt template versioning
+- **Prompt drift detection** (#491) — embedded prompts carry
+  `{{/* soda:prompt-version=N */}}` headers. `soda validate` checks user override
+  prompts for version mismatch and missing field coverage. Engine emits
+  `prompt_version_mismatch` events (non-blocking). `ScanPromptDataFields` uses reflect
+  to filter against actual `PromptData` struct fields, avoiding false positives from
+  range variable accesses.
+
+#### Sandbox security
+- **Wrapper binary requirement** (#643) — `soda run`, `soda validate`, and `soda
+  doctor` all enforce that the `arapuca` wrapper binary is installed when
+  `sandbox.enabled: true`. Without the wrapper, Landlock filesystem isolation and
+  seccomp syscall filtering are not applied. Clear error with install instructions.
+- **Baseline seccomp profile** — upgraded to go-arapuca v0.2.2 (libarapuca v0.2.4).
+  Sets `SeccompProfileBaseline` for all sandboxed sessions, allowing Claude Code
+  (Bun runtime) to run without SIGSYS. Baseline blocks only sandbox-escape syscalls;
+  Landlock and netns remain the primary confinement layers.
+- **Wrapper version check** — `soda doctor` compares the installed `arapuca` wrapper
+  version against the linked library version and warns when mismatched.
+
 ### Changed
 
 - **`soda cost --outcomes` renamed to `--by-outcome`** (#529) — aligns flag naming
   with `--by-complexity` for a uniform `by-<noun>` convention.
+- **Monitor phase removed from default pipeline** — monitor is no longer in `phases.yaml`
+  by default. Users who need it can add it via a named pipeline in `.pipelines/`.
+  Eliminates the `phases-no-monitor.yaml` drift problem.
+- **Triage timeout bumped to 8m** — was 3m in the embedded default, which was too tight
+  under API latency. Plan and patch timeouts also bumped to 15m.
+- **go-arapuca upgraded to v0.2.2** — exposes `SeccompProfileKind`, `UsePidNS`,
+  `DnsCapture`, `MaxOpenFiles` fields on the Go sandbox `Profile` struct.
+
+## [0.7.0] — "Open Doors" - 2026-05-25
+
+### Added
+
+- **`soda gc`** (#505) — garbage-collect completed worktrees and session data
+  older than a configurable age.
+- **`--max-cost` CLI flag** (#506) — override the per-ticket cost limit inline
+  without editing `soda.yaml`.
+- **`soda demo`** (#508) — guided first-run experience with a `StaticSource`
+  ticket that doesn't require GitHub/Jira credentials.
+- **GitLab ticket source** (#510) — `ticket_source: gitlab` fetches issues via
+  `glab`. Includes comment extraction, smoke tests, and `soda doctor` / `soda init`
+  integration.
+- **`soda doctor` commit-signing check** (#553) — validates git commit signing
+  config (SSH inline key, GPG) and key reachability.
+- **Phases reference docs** (#567) — `docs/phases.md` comprehensive reference for
+  all built-in phases, config fields, and extension points.
+
+## [0.6.0] — "Deep Context" - 2026-05-15
+
+### Added
+
+- **Triage context bridge** (#504) — inject triage `relevant_files` into implement
+  prompt so the agent sees the files triage identified without spending tokens on
+  rediscovery.
+- **Error classification telemetry** (#507) — structured `failure_category` field
+  on phase failure events. Categories: `timeout`, `budget`, `parse`, `semantic`,
+  `context`, `unknown`.
+- **Rework root cause tagging** (#509) — review findings carry a `category` field
+  (`logic`, `test_pattern`, `convention`, `documentation`, `unknown`). Engine emits
+  category distribution in `rework_feedback_injected` events.
+- **Cost by outcome** (#511) — `soda cost --by-outcome` groups cumulative cost by
+  pipeline result (success, rework, exhausted, failed).
+- **Claude CLI version pin** (#512) — `soda doctor` checks `MinCLIVersion` and
+  `MaxTestedCLIVersion` and warns when the installed CLI falls outside the tested
+  range.
+- **Docs overhaul** (#514) — README, AGENTS.md, and `config.example.yaml` updated
+  to reflect v0.5.0+ features.
 
 ## [0.5.0] — "Sharp Review" - 2026-05-13
 

--- a/cmd/soda/doctor_test.go
+++ b/cmd/soda/doctor_test.go
@@ -2612,7 +2612,7 @@ func TestCheckArapucaWrapperVersion_PassesWhenVersionCurrent(t *testing.T) {
 	env.ArapucaWrapperPath = func() string { return "/usr/bin/arapuca" }
 	env.RunCmd = func(name string, args ...string) (string, error) {
 		if name == "arapuca" {
-			return "arapuca 0.2.0", nil
+			return "arapuca 0.2.2", nil
 		}
 		return allPassEnv().RunCmd(name, args...)
 	}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/mattn/go-isatty v0.0.22
-	github.com/sergio-correia/go-arapuca v0.2.0
+	github.com/sergio-correia/go-arapuca v0.2.2
 	github.com/spf13/cobra v1.10.2
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,6 @@ github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/sergio-correia/go-arapuca v0.2.0 h1:uQa5J4i2xBtHjxffbBcXHcGp+AS0WeuZ9GJP+XWw/UI=
-github.com/sergio-correia/go-arapuca v0.2.0/go.mod h1:n3QwYrcRa8hGT5Xc6T1OAogHNzn/lTm5XaQmQhOJhuM=
 github.com/sergio-correia/go-arapuca v0.2.2 h1:NinN0AqOgiMR9kRBHGJcisDACRmKvyy9Mto9az31SIc=
 github.com/sergio-correia/go-arapuca v0.2.2/go.mod h1:n3QwYrcRa8hGT5Xc6T1OAogHNzn/lTm5XaQmQhOJhuM=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUc
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergio-correia/go-arapuca v0.2.0 h1:uQa5J4i2xBtHjxffbBcXHcGp+AS0WeuZ9GJP+XWw/UI=
 github.com/sergio-correia/go-arapuca v0.2.0/go.mod h1:n3QwYrcRa8hGT5Xc6T1OAogHNzn/lTm5XaQmQhOJhuM=
+github.com/sergio-correia/go-arapuca v0.2.2 h1:NinN0AqOgiMR9kRBHGJcisDACRmKvyy9Mto9az31SIc=
+github.com/sergio-correia/go-arapuca v0.2.2/go.mod h1:n3QwYrcRa8hGT5Xc6T1OAogHNzn/lTm5XaQmQhOJhuM=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=

--- a/internal/sandbox/runner.go
+++ b/internal/sandbox/runner.go
@@ -180,13 +180,14 @@ func (r *Runner) Run(ctx context.Context, opts runner.RunOpts) (*runner.RunResul
 	}
 
 	profile := arapuca.Profile{
-		ReadPaths:     sp.ReadPaths,
-		WritePaths:    sp.WritePaths,
-		MaxMemoryMB:   r.config.MemoryMB,
-		MaxCPUPct:     r.config.CPUPercent,
-		MaxPIDs:       r.config.MaxPIDs,
-		MaxFileSizeMB: r.config.MaxFileSizeMB,
-		UseNetNS:      useNetNS,
+		ReadPaths:      sp.ReadPaths,
+		WritePaths:     sp.WritePaths,
+		MaxMemoryMB:    r.config.MemoryMB,
+		MaxCPUPct:      r.config.CPUPercent,
+		MaxPIDs:        r.config.MaxPIDs,
+		MaxFileSizeMB:  r.config.MaxFileSizeMB,
+		UseNetNS:       useNetNS,
+		SeccompProfile: arapuca.SeccompProfileBaseline,
 	}
 
 	// Set up stdout/stderr pipes. Defer closing both ends as safety net

--- a/internal/sandbox/runner_integration_test.go
+++ b/internal/sandbox/runner_integration_test.go
@@ -213,8 +213,9 @@ func TestIntegration_ProxyRoundTrip(t *testing.T) {
 
 	cfg := arapuca.Config{
 		Profile: arapuca.Profile{
-			ReadPaths:  readPaths,
-			WritePaths: []string{workDir, tmpDir},
+			ReadPaths:      readPaths,
+			WritePaths:     []string{workDir, tmpDir},
+			SeccompProfile: arapuca.SeccompProfileBaseline, // curl needs AF_INET (blocked by Strict)
 		},
 		TaskID:  "proxy-test",
 		Phase:   "test",

--- a/internal/sandbox/version.go
+++ b/internal/sandbox/version.go
@@ -2,4 +2,4 @@ package sandbox
 
 // ArapucaLibraryVersion is the version of the go-arapuca module that soda is
 // linked against. Keep in sync with the entry in go.mod.
-const ArapucaLibraryVersion = "0.2.0"
+const ArapucaLibraryVersion = "0.2.2"

--- a/phases.yaml
+++ b/phases.yaml
@@ -42,7 +42,7 @@ phases:
       - Grep
       - Bash(git:*)
       - Bash(ls:*)
-    timeout: 8m
+    timeout: 15m
     retry:
       transient: 2
       parse: 1
@@ -100,7 +100,7 @@ phases:
       - Glob
       - Grep
       - Bash
-    timeout: 8m
+    timeout: 15m
     retry:
       transient: 2
       parse: 1
@@ -118,7 +118,7 @@ phases:
       - Glob
       - Grep
       - Bash
-    timeout: 8m
+    timeout: 15m
     retry:
       transient: 2
       parse: 1
@@ -174,7 +174,7 @@ phases:
       - Bash(git:*)
       - Bash(gh:*)
       - Bash(glab:*)
-    timeout: 8m
+    timeout: 3m
     retry:
       transient: 2
       parse: 1


### PR DESCRIPTION
CHANGELOG entries for v0.8.0, v0.7.0, v0.6.0, go-arapuca v0.2.2 upgrade, seccomp Baseline profile, version constant sync, phase timeout bumps.