### PR TITLE
packaging: require arapuca-devel >= 0.2.4

### DIFF
--- a/packaging/rpm/soda.spec
+++ b/packaging/rpm/soda.spec
@@ -15,8 +15,8 @@ ExclusiveArch:  x86_64
 BuildRequires:  golang >= 1.24
 BuildRequires:  gcc
 BuildRequires:  git-core
-BuildRequires:  arapuca-devel
-Requires:       arapuca
+BuildRequires:  arapuca-devel >= 0.2.4
+Requires:       arapuca >= 0.2.4
 
 Conflicts:      soda-minimal
 


### PR DESCRIPTION
COPR build for soda v0.8.0 failed because go-arapuca v0.2.2 expects libarapuca v0.2.4 symbols. arapuca-devel 0.2.4 is available in both f43 and f44 stable repos. Adds minimum version constraint and triggers a rebuild.